### PR TITLE
Fix missing rate types in resource updates

### DIFF
--- a/building.js
+++ b/building.js
@@ -412,7 +412,11 @@ class Building extends EffectableEntity {
         accumulatedChanges[category][resource] = (accumulatedChanges[category][resource] || 0) + scaledProduction;
 
         // Update production rate for the resource
-        resources[category][resource].modifyRate(scaledProduction * (1000 / deltaTime), this.displayName);
+        resources[category][resource].modifyRate(
+          scaledProduction * (1000 / deltaTime),
+          this.displayName,
+          'building'
+        );
       }
     }
   }
@@ -440,7 +444,11 @@ class Building extends EffectableEntity {
         accumulatedChanges[category][resource] = (accumulatedChanges[category][resource] || 0) - scaledConsumption;
 
         // Update consumption rate for the resource
-        resources[category][resource].modifyRate(- scaledConsumption * (1000 / deltaTime), this.displayName);
+        resources[category][resource].modifyRate(
+          -scaledConsumption * (1000 / deltaTime),
+          this.displayName,
+          'building'
+        );
       }
     }
   }
@@ -462,7 +470,11 @@ class Building extends EffectableEntity {
         accumulatedChanges['colony'][resource] = (accumulatedChanges['colony'][resource] || 0) - maintenanceCost;
 
         // Update consumption rate for maintenance costs
-        resources['colony'][resource].modifyRate(-(maintenanceCost * (1000 / deltaTime)), this.displayName);
+        resources['colony'][resource].modifyRate(
+          -(maintenanceCost * (1000 / deltaTime)),
+          this.displayName,
+          'building'
+        );
 
         // Accumulate maintenance costs in the accumulatedMaintenance object
         accumulatedMaintenance[resource] = (accumulatedMaintenance[resource] || 0) + maintenanceCost;
@@ -482,7 +494,11 @@ class Building extends EffectableEntity {
                 (accumulatedChanges[targetCategory][targetResourceName] || 0) + convertedAmount;
 
               // Update production rate for the converted resource
-              resources[targetCategory][targetResourceName].modifyRate(convertedAmount * (1000 / deltaTime), this.displayName);
+              resources[targetCategory][targetResourceName].modifyRate(
+                convertedAmount * (1000 / deltaTime),
+                this.displayName,
+                'building'
+              );
             }
           }
         }

--- a/colony.js
+++ b/colony.js
@@ -127,7 +127,11 @@ class Colony extends Building {
         accumulatedChanges[category][resource] = (accumulatedChanges[category][resource] || 0) - scaledConsumption;
   
         // Update consumption rate for the resource
-        resources[category][resource].modifyRate(- (scaledConsumption * (1000 / deltaTime)), this.displayName);
+        resources[category][resource].modifyRate(
+          - (scaledConsumption * (1000 / deltaTime)),
+          this.displayName,
+          'building'
+        );
       }
     }
   }

--- a/funding.js
+++ b/funding.js
@@ -26,6 +26,10 @@ class FundingModule extends EffectableEntity {
   update(deltaTime) {
     const baseFundingIncrease = this.fundingRate * this.getEffectiveProductionMultiplier();
     const fundingIncrease = baseFundingIncrease * deltaTime / 1000; // Calculate the increase in funding based on the rate
-    resources.colony.funding.modifyRate(baseFundingIncrease, 'Funding');
+      resources.colony.funding.modifyRate(
+        baseFundingIncrease,
+        'Funding',
+        'funding'
+      );
   }
 }

--- a/population.js
+++ b/population.js
@@ -72,10 +72,18 @@ class PopulationModule extends EffectableEntity {
       // Apply the population change and update production/consumption rates
       if (populationChange > 0) {
         this.populationResource.increase(populationChange);
-        this.populationResource.modifyRate(populationChange * (1000 / deltaTime), 'Growth');
+          this.populationResource.modifyRate(
+            populationChange * (1000 / deltaTime),
+            'Growth',
+            'population'
+          );
       } else if (populationChange < 0) {
         this.populationResource.decrease(-populationChange);
-        this.populationResource.modifyRate(populationChange * (1000 / deltaTime), 'Decay');
+          this.populationResource.modifyRate(
+            populationChange * (1000 / deltaTime),
+            'Decay',
+            'population'
+          );
       }
 
       if(currentPopulation < 1)

--- a/projects.js
+++ b/projects.js
@@ -477,20 +477,32 @@ class Project extends EffectableEntity {
       const totalCost = this.calculateSpaceshipTotalCost();
       for (const category in totalCost) {
         for (const resource in totalCost[category]){
-          resources[category][resource].modifyRate(- 1000*totalCost[category][resource] / this.getEffectiveDuration(), 'Spaceship Cost') / this.getEffectiveDuration();
+          resources[category][resource].modifyRate(
+            -1000 * totalCost[category][resource] / this.getEffectiveDuration(),
+            'Spaceship Cost',
+            'project'
+          );
         }
       }
 
       const totalDisposal = this.calculateSpaceshipTotalDisposal();
       for (const category in totalDisposal) {
         for (const resource in totalDisposal[category]){
-          resources[category][resource].modifyRate(- 1000*totalDisposal[category][resource] / this.getEffectiveDuration(), 'Spaceship Export');
+          resources[category][resource].modifyRate(
+            -1000 * totalDisposal[category][resource] / this.getEffectiveDuration(),
+            'Spaceship Export',
+            'project'
+          );
         }
       }
 
       const totalGain = this.pendingResourceGains;
       totalGain.forEach((gain) => {
-            resources[gain.category][gain.resource].modifyRate(gain.quantity, this.attributes.spaceMining ? 'Spaceship Mining' : 'Spaceship Export') / this.getEffectiveDuration();
+            resources[gain.category][gain.resource].modifyRate(
+              gain.quantity,
+              this.attributes.spaceMining ? 'Spaceship Mining' : 'Spaceship Export',
+              'project'
+            );
         });
       }
 
@@ -498,12 +510,20 @@ class Project extends EffectableEntity {
         const totalGain = this.pendingResourceGains;
         if(totalGain){
         totalGain.forEach((gain) => {
-              resources[gain.category][gain.resource].modifyRate(1000*gain.quantity / this.getEffectiveDuration(), 'Cargo Rockets');
+              resources[gain.category][gain.resource].modifyRate(
+                1000 * gain.quantity / this.getEffectiveDuration(),
+                'Cargo Rockets',
+                'project'
+              );
           });
         }
 
         const fundingCost = 1000*this.getResourceChoiceGainCost() / this.getEffectiveDuration();
-        resources.colony.funding.modifyRate(-fundingCost, 'Cargo Rockets');
+        resources.colony.funding.modifyRate(
+          -fundingCost,
+          'Cargo Rockets',
+          'project'
+        );
         }
     }
   }


### PR DESCRIPTION
## Summary
- propagate rateType when modifying resource rates
- ensure buildings, colonies, funding, projects, and population specify their source type

## Testing
- `npm test` *(fails: could not find package.json)*