### PR TITLE
Add package.json with Jest testing setup

### DIFF
--- a/__tests__/numbers.test.js
+++ b/__tests__/numbers.test.js
@@ -1,0 +1,17 @@
+const { formatNumber, formatBigInteger } = require('../numbers.js');
+
+describe('formatNumber', () => {
+  test('formats thousands with suffix k', () => {
+    expect(formatNumber(1500)).toBe('1.5k');
+  });
+
+  test('formats millions with suffix M', () => {
+    expect(formatNumber(2500000)).toBe('2.5M');
+  });
+});
+
+describe('formatBigInteger', () => {
+  test('adds commas', () => {
+    expect(formatBigInteger(1234567)).toBe('1,234,567');
+  });
+});

--- a/numbers.js
+++ b/numbers.js
@@ -36,3 +36,10 @@ function formatNumber(value, integer = false, precision = 1) {
     // Convert the number to a string and use regex to add commas
     return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      formatNumber,
+      formatBigInteger,
+    };
+  }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "terraforming-titans",
+  "version": "1.0.0",
+  "description": "Terraforming Titans game",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.5.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with Jest as dev dependency
- expose number utilities for Node
- write basic Jest tests for formatting helpers

## Testing
- `npm test` *(fails: jest not found)*