### PR TITLE
Fix precipitation saturation uses day/night temps

### DIFF
--- a/terraforming.js
+++ b/terraforming.js
@@ -359,11 +359,11 @@ class Terraforming extends EffectableEntity{
       const avgZoneTemp = (dayTemperature + nightTemperature) / 2;
 
       // Function to calculate potential rate factor for a given temperature
-      const calculatePotential = (temp) => {
-          let rainFactor = 0;
-          let snowFactor = 0;
-          if (zoneArea > 0 && typeof temp === 'number') {
-              const saturationPressure = saturationVaporPressureBuck(this.temperature.value);
+        const calculatePotential = (temp) => {
+            let rainFactor = 0;
+            let snowFactor = 0;
+            if (zoneArea > 0 && typeof temp === 'number') {
+                const saturationPressure = saturationVaporPressureBuck(temp);
 
               if (waterVaporPressure > saturationPressure) { // Only proceed if there's some effective pressure
                   const excessPressure = waterVaporPressure - saturationPressure;


### PR DESCRIPTION
## Summary
- calculate precipitation saturation using local day/night temperature

## Testing
- `npm test` *(fails: jest not found)*