### PR TITLE
Add optical depth warning

### DIFF
--- a/game.js
+++ b/game.js
@@ -172,7 +172,7 @@ function updateRender() {
   renderProjects();                  // Render project information (handled in projects.js)
   updateResearchUI();
   updateTerraformingUI();
-  updateColonistWarning();
+  updateWarnings();
   updateMilestonesUI();
 }
 

--- a/terraforming.js
+++ b/terraforming.js
@@ -69,6 +69,7 @@ class Terraforming extends EffectableEntity{
       targetMax: 293.15,
       effectiveTempNoAtmosphere: 0,
       emissivity: 0,
+      opticalDepth: 0,
       unlocked: false,
       zones: {
         tropical: {
@@ -923,6 +924,8 @@ class Terraforming extends EffectableEntity{
 
       const emissivity = calculateEmissivity(composition, surfacePressureBar);
       this.temperature.emissivity = emissivity;
+      const tau = emissivity < 1 ? -Math.log(1 - emissivity) : Infinity;
+      this.temperature.opticalDepth = tau;
 
       const surfaceFractions = {
         ocean: this._calculateAverageCoverage('liquidWater'),
@@ -1355,6 +1358,7 @@ synchronizeGlobalResources() {
           this.temperature.value = terraformingState.temperature.value || 0;
           this.temperature.emissivity = terraformingState.temperature.emissivity || 0;
           this.temperature.effectiveTempNoAtmosphere = terraformingState.temperature.effectiveTempNoAtmosphere || 0;
+          this.temperature.opticalDepth = terraformingState.temperature.opticalDepth || 0;
           this.temperature.unlocked = terraformingState.temperature.unlocked || false;
           if (terraformingState.temperature.zones) {
               for (const zone of ['tropical', 'temperate', 'polar']) {

--- a/warning.css
+++ b/warning.css
@@ -1,5 +1,5 @@
 #warning-container {
-    height: 15px;
+    min-height: 15px;
     border-radius: 5px; /* Adds rounded corners */
     display: flex;
     align-items: center;

--- a/warning.js
+++ b/warning.js
@@ -1,10 +1,14 @@
-function updateColonistWarning() {
+function updateWarnings() {
     const warningContainer = document.getElementById('warning-container');
     const colonists = resources.colony.colonists;
-  
+    const tau = terraforming?.temperature?.opticalDepth || 0;
+
     if (colonists.consumptionRate > colonists.productionRate) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Colonists are dying!</div>';
+    } else if (tau > 10) {
+      warningContainer.innerHTML = '<div class="warning-message">Warning: Excess greenhouse gases!</div>';
     } else {
       warningContainer.innerHTML = '';
     }
-  }
+}
+


### PR DESCRIPTION
## Summary
- store opticalDepth on the temperature object
- surface temperature updates compute and store optical depth
- show a warning when colonists are dying or optical depth is >10
- call the new warning update in the main render loop
- tweak warning CSS to allow taller messages

## Testing
- `npm test`