### PR TITLE
Fix CO2 parameter redeclaration

### DIFF
--- a/terraforming.js
+++ b/terraforming.js
@@ -15,7 +15,9 @@ if (typeof module !== 'undefined' && module.exports) {
 
     const dryIceCycle = require('./dry-ice-cycle.js');
     var calculateCO2CondensationRateFactor = dryIceCycle.calculateCO2CondensationRateFactor;
-    var EQUILIBRIUM_CO2_PARAMETER = dryIceCycle.EQUILIBRIUM_CO2_PARAMETER;
+    if (typeof globalThis.EQUILIBRIUM_CO2_PARAMETER === 'undefined') {
+        globalThis.EQUILIBRIUM_CO2_PARAMETER = dryIceCycle.EQUILIBRIUM_CO2_PARAMETER;
+    }
 }
 
 const SOLAR_PANEL_BASE_LUMINOSITY = 1000;


### PR DESCRIPTION
## Summary
- avoid redefining `EQUILIBRIUM_CO2_PARAMETER` when terraforming.js is loaded

## Testing
- `npm test`