### PR TITLE
Fix zone percentage redeclaration

### DIFF
--- a/terraforming-utils.js
+++ b/terraforming-utils.js
@@ -1,6 +1,7 @@
 // Utility functions for terraforming calculations
 
-let ZONES, getZonePercentage;
+let ZONES;
+var getZonePercentage;
 let baseCalculateEvapSubl, baseCalculatePrecipFactor, baseCalculateMeltFreeze;
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/terraforming.js
+++ b/terraforming.js
@@ -215,6 +215,10 @@ class Terraforming extends EffectableEntity{
     return (this.getTemperatureStatus() && this.getAtmosphereStatus() && this.getWaterStatus() && this.getLuminosityStatus() && this.getLifeStatus() && this.getMagnetosphereStatus());
   }
 
+  _calculateZonalCoverage(zone, resourceType) {
+    return calculateZonalCoverage(this, zone, resourceType);
+  }
+
   calculateInitialValues() {
       // Store initial zonal temperatures
       for (const zone of ['tropical', 'temperate', 'polar']) {


### PR DESCRIPTION
## Summary
- avoid redeclaring `getZonePercentage` by using `var`
- expose `_calculateZonalCoverage` on the `Terraforming` class to satisfy tests

## Testing
- `npm test`