### PR TITLE
Fix global zone exposure

### DIFF
--- a/zones.js
+++ b/zones.js
@@ -84,5 +84,10 @@ function sphericalSegmentArea(phi1, phi2) {
   }
 if (typeof module !== "undefined" && module.exports) {
   module.exports = { ZONES, getZoneRatio, getZonePercentage };
+} else {
+  // Expose constants and helpers on the global object for browser usage
+  globalThis.ZONES = ZONES;
+  globalThis.getZoneRatio = getZoneRatio;
+  globalThis.getZonePercentage = getZonePercentage;
 }
 


### PR DESCRIPTION
## Summary
- ensure `zones.js` attaches constants and helper functions to the global object when running in a browser

## Testing
- `npm test`