### PR TITLE
Add unit tests for terraforming modules and cycles

### DIFF
--- a/__tests__/dryIceCycle.test.js
+++ b/__tests__/dryIceCycle.test.js
@@ -1,0 +1,31 @@
+const physics = require('../physics.js');
+Object.assign(global, {
+  C_P_AIR: 1004,
+  EPSILON: 0.622,
+  R_AIR: 287,
+  airDensity: physics.airDensity
+});
+const dry = require('../dry-ice-cycle.js');
+
+describe('dry-ice-cycle helpers', () => {
+  test('calculateSaturationPressureCO2 reasonable value', () => {
+    const val = dry.calculateSaturationPressureCO2(200);
+    expect(val).toBeGreaterThan(8e5);
+    expect(val).toBeLessThan(9e5);
+  });
+
+  test('sublimationRateCO2 positive', () => {
+    const rate = dry.sublimationRateCO2(200, 1000, 100000, 100);
+    expect(rate).toBeGreaterThan(0);
+  });
+
+  test('calculateCO2CondensationRateFactor scales with temperature', () => {
+    const res = dry.calculateCO2CondensationRateFactor({
+      zoneArea: 1000,
+      co2VaporPressure: 500,
+      dayTemperature: 180,
+      nightTemperature: 170
+    });
+    expect(res).toBeCloseTo(187.5, 1);
+  });
+});

--- a/__tests__/terraforming.main.test.js
+++ b/__tests__/terraforming.main.test.js
@@ -1,0 +1,66 @@
+const { getZoneRatio, getZonePercentage } = require('../zones.js');
+const EffectableEntity = require('../effectable-entity.js');
+const lifeParameters = require('../life-parameters.js');
+const physics = require('../physics.js');
+
+global.getZoneRatio = getZoneRatio;
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+// stub heavy physics functions
+global.calculateAtmosphericPressure = () => 0;
+global.calculateEmissivity = () => 0;
+global.dayNightTemperaturesModel = () => ({mean:0, day:0, night:0});
+global.effectiveTemp = () => 0;
+global.surfaceAlbedoMix = () => 0;
+
+global.buildings = { spaceMirror: { surfaceArea: 1e6, active: 1 } };
+global.resources = { atmospheric:{}, special:{ albedoUpgrades:{ value:0 } } };
+
+const Terraforming = require('../terraforming.js');
+Terraforming.prototype.updateLuminosity = function() {};
+Terraforming.prototype.updateSurfaceTemperature = function() {};
+
+const AU_METER = 149597870700;
+
+describe('Terraforming solar calculations', () => {
+  test('calculateSolarFlux at 1 AU', () => {
+    const terra = new Terraforming(global.resources, { radius: 1000, distanceFromSun: 1 });
+    const expected = 3.828e26 / (4 * Math.PI * Math.pow(AU_METER, 2));
+    expect(terra.calculateSolarFlux(AU_METER)).toBeCloseTo(expected, 5);
+  });
+
+  test('calculateMirrorEffect returns power values', () => {
+    const terra = new Terraforming(global.resources, { radius: 1000, distanceFromSun: 1 });
+    const baseFlux = terra.calculateSolarFlux(AU_METER);
+    const effect = terra.calculateMirrorEffect();
+    const intercepted = baseFlux * global.buildings.spaceMirror.surfaceArea;
+    expect(effect.interceptedPower).toBeCloseTo(intercepted, 5);
+    expect(effect.powerPerUnitArea).toBeCloseTo(intercepted / terra.celestialParameters.surfaceArea, 5);
+  });
+
+  test('calculateModifiedSolarFlux adds mirror contribution', () => {
+    const terra = new Terraforming(global.resources, { radius: 1000, distanceFromSun: 1 });
+    const base = terra.calculateSolarFlux(AU_METER);
+    const mirror = terra.calculateMirrorEffect().powerPerUnitArea;
+    expect(terra.calculateModifiedSolarFlux(AU_METER)).toBeCloseTo(base + mirror, 5);
+  });
+
+  test('calculateSolarPanelMultiplier uses modified flux', () => {
+    const terra = new Terraforming(global.resources, { radius: 1000, distanceFromSun: 1 });
+    terra.luminosity.modifiedSolarFlux = 2000;
+    expect(terra.calculateSolarPanelMultiplier()).toBeCloseTo(2, 5);
+  });
+
+  test('calculateColonyEnergyPenalty reacts to temperature', () => {
+    const terra = new Terraforming(global.resources, { radius: 1000, distanceFromSun: 1 });
+    terra.temperature.zones.tropical.value = 295.15;
+    terra.temperature.zones.temperate.value = 295.15;
+    terra.temperature.zones.polar.value = 295.15;
+    expect(terra.calculateColonyEnergyPenalty()).toBe(1);
+    terra.temperature.zones.tropical.value = 305.15;
+    terra.temperature.zones.temperate.value = 305.15;
+    terra.temperature.zones.polar.value = 305.15;
+    expect(terra.calculateColonyEnergyPenalty()).toBeCloseTo(2,5);
+  });
+});

--- a/__tests__/terraformingUtils.extra.test.js
+++ b/__tests__/terraformingUtils.extra.test.js
@@ -1,0 +1,32 @@
+const utils = require('../terraforming-utils.js');
+const zones = require('../zones.js');
+const hydrology = require('../hydrology.js');
+
+const terra = {
+  celestialParameters: { surfaceArea: 1000 },
+  zonalWater: {
+    tropical: { liquid: 10, ice: 100 },
+    temperate: { liquid: 0, ice: 0 },
+    polar: { liquid: 0, ice: 0 }
+  },
+  zonalSurface: {
+    tropical: { dryIce: 0, biomass: 0 },
+    temperate: { dryIce: 0, biomass: 0 },
+    polar: { dryIce: 0, biomass: 0 }
+  }
+};
+
+describe('terraforming-utils wrappers', () => {
+  test('calculateAverageCoverage sums zonal coverage', () => {
+    const avg = utils.calculateAverageCoverage(terra, 'liquidWater');
+    const expected = zones.ZONES.reduce((sum, z) => sum + utils.calculateZonalCoverage(terra, z, 'liquidWater') * zones.getZonePercentage(z), 0);
+    expect(avg).toBeCloseTo(expected, 5);
+  });
+
+  test('calculateMeltingFreezingRates delegates to hydrology', () => {
+    const result = utils.calculateMeltingFreezingRates(terra, 'tropical', 280);
+    const base = hydrology.calculateMeltingFreezingRates(280, 100, 10);
+    expect(result.meltingRate).toBeCloseTo(base.meltingRate,5);
+    expect(result.freezingRate).toBeCloseTo(base.freezingRate,5);
+  });
+});

--- a/__tests__/waterCycle.test.js
+++ b/__tests__/waterCycle.test.js
@@ -1,0 +1,53 @@
+const physics = require('../physics.js');
+Object.assign(global, {
+  C_P_AIR: 1004,
+  EPSILON: 0.622,
+  R_AIR: 287,
+  airDensity: physics.airDensity
+});
+const water = require('../water-cycle.js');
+const dry = require('../dry-ice-cycle.js');
+Object.assign(global, { sublimationRateCO2: dry.sublimationRateCO2 });
+
+describe('water-cycle helpers', () => {
+  test('saturationVaporPressureBuck matches expected values', () => {
+    expect(water.saturationVaporPressureBuck(273.15)).toBeCloseTo(611.21, 2);
+    expect(water.saturationVaporPressureBuck(300)).toBeCloseTo(3535.24, 2);
+  });
+
+  test('evaporationRateWater positive and finite', () => {
+    const rate = water.evaporationRateWater(300, 1000, 100000, 500, 100);
+    expect(rate).toBeGreaterThan(0);
+    expect(Number.isFinite(rate)).toBe(true);
+  });
+
+  test('calculateEvaporationSublimationRates returns averages', () => {
+    const res = water.calculateEvaporationSublimationRates({
+      zoneArea: 1000,
+      liquidWaterCoverage: 0.5,
+      iceCoverage: 0.3,
+      dryIceCoverage: 0,
+      dayTemperature: 300,
+      nightTemperature: 290,
+      waterVaporPressure: 500,
+      co2VaporPressure: 100,
+      avgAtmPressure: 100000,
+      zonalSolarFlux: 200
+    });
+    expect(res.evaporationRate).toBeGreaterThan(0);
+    expect(res.waterSublimationRate).toBeGreaterThan(0);
+    expect(res.co2SublimationRate).toBe(0);
+  });
+
+  test('calculatePrecipitationRateFactor yields snow when cold', () => {
+    const res = water.calculatePrecipitationRateFactor({
+      zoneArea: 1000,
+      waterVaporPressure: 1000,
+      gravity: 10,
+      dayTemperature: 280,
+      nightTemperature: 270
+    });
+    expect(res.snowfallRateFactor).toBeGreaterThan(0);
+    expect(res.rainfallRateFactor).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add new jest tests for core terraforming calculations
- test water and dry ice cycle helpers
- extend terraforming-utils test coverage

## Testing
- `npm test`