### PR TITLE
Support buried ice in terraforming

### DIFF
--- a/__tests__/terraformingUtilsIntegration.test.js
+++ b/__tests__/terraformingUtilsIntegration.test.js
@@ -3,7 +3,8 @@ const { getZoneRatio, getZonePercentage } = require('../zones.js');
 const EffectableEntity = require('../effectable-entity.js');
 const lifeParameters = require('../life-parameters.js');
 const physics = require('../physics.js');
-const { calculateAverageCoverage, calculateZonalCoverage } = require('../terraforming-utils.js');
+const dryIce = require('../dry-ice-cycle.js');
+const { calculateAverageCoverage, calculateZonalCoverage, calculateEvaporationSublimationRates } = require('../terraforming-utils.js');
 
 // globals expected by terraforming.js
 global.getZoneRatio = getZoneRatio;
@@ -16,6 +17,13 @@ global.dayNightTemperaturesModel = physics.dayNightTemperaturesModel;
 global.effectiveTemp = physics.effectiveTemp;
 global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
 global.buildings = { spaceMirror: { surfaceArea: 0, active: 0 } };
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+global.R_AIR = 287;
+global.airDensity = physics.airDensity;
+global.sublimationRateCO2 = dryIce.sublimationRateCO2;
+global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+global.EQUILIBRIUM_CO2_PARAMETER = dryIce.EQUILIBRIUM_CO2_PARAMETER;
 
 const Terraforming = require('../terraforming.js');
 
@@ -25,7 +33,7 @@ function createResources(config) {
     res[cat] = {};
     for (const name in config[cat]) {
       const val = config[cat][name].initialValue || 0;
-      res[cat][name] = { value: val };
+      res[cat][name] = { value: val, modifyRate: () => {} };
     }
   }
   return res;
@@ -56,5 +64,40 @@ describe('terraforming-utils integration', () => {
     const cov = calculateZonalCoverage(terra, 'tropical', 'liquidWater');
     expect(cov).toBeGreaterThanOrEqual(0);
     expect(cov).toBeLessThanOrEqual(1);
+  });
+
+  test('coverage and evaporation ignore buried ice', () => {
+    const params = getPlanetParameters('mars');
+    global.currentPlanetParameters = params;
+    const res = createResources(params.resources);
+    global.resources = res;
+    const terra = new Terraforming(res, params.celestialParameters);
+
+    terra.calculateInitialValues();
+
+    terra.zonalWater.polar.ice = 1000;
+    const initialCov = calculateZonalCoverage(terra, 'polar', 'ice');
+
+    terra.zonalWater.polar.buriedIce = 5000;
+    const covWithBuried = calculateZonalCoverage(terra, 'polar', 'ice');
+    expect(covWithBuried).toBeCloseTo(initialCov, 5);
+
+    // remove all surface water and ice so only buried ice remains
+    for (const z of ['tropical','temperate','polar']) {
+      terra.zonalWater[z].ice = 0;
+      terra.zonalWater[z].liquid = 0;
+    }
+
+    const rates = calculateEvaporationSublimationRates(
+      terra,
+      'polar',
+      260,
+      250,
+      0,
+      0,
+      600,
+      1000
+    );
+    expect(rates.waterSublimationRate).toBe(0);
   });
 });

--- a/terraforming-utils.js
+++ b/terraforming-utils.js
@@ -37,7 +37,9 @@ function calculateZonalCoverage(terraforming, zone, resourceType) {
   if (resourceType === 'liquidWater') {
     zonalAmount = terraforming.zonalWater[zone]?.liquid || 0;
   } else if (resourceType === 'ice') {
-    zonalAmount = terraforming.zonalWater[zone]?.ice || 0;
+    zonalAmount = terraforming.zonalWater[zone]?.ice || 0; // exclude buried ice from coverage
+  } else if (resourceType === 'buriedIce') {
+    zonalAmount = terraforming.zonalWater[zone]?.buriedIce || 0;
   } else if (resourceType === 'biomass') {
     zonalAmount = terraforming.zonalSurface[zone]?.biomass || 0;
   } else if (resourceType === 'dryIce') {


### PR DESCRIPTION
## Summary
- add `buriedIce` field to zonal water initialization
- distribute initial ice between surface ice and buried ice
- ignore buried ice in coverage calculations
- ensure buried ice does not affect sublimation calculations
- test buried ice handling

## Testing
- `npm test`