### PR TITLE
Refine fastForwardToEquilibrium

### DIFF
--- a/__tests__/fastForwardToEquilibrium.test.js
+++ b/__tests__/fastForwardToEquilibrium.test.js
@@ -1,0 +1,27 @@
+const { fastForwardToEquilibrium } = require('../debug-tools.js');
+
+describe('fastForwardToEquilibrium', () => {
+  test('reduces step size when stable', () => {
+    global.resources = {
+      surface: { ice: { value: 0 }, liquidWater: { value: 0 }, dryIce: { value: 0 } },
+      atmospheric: { carbonDioxide: { value: 0 }, atmosphericWater: { value: 0 } }
+    };
+    global.ZONES = [];
+    global.terraforming = { zonalWater: {}, zonalSurface: {} };
+
+    const steps = [];
+    global.updateLogic = ms => steps.push(ms);
+
+    fastForwardToEquilibrium({
+      stepMs: 10,
+      minStepMs: 3,
+      refineFactor: 0.5,
+      stableSteps: 1,
+      threshold: 0,
+      maxSteps: 10
+    });
+
+    expect(steps.length).toBeGreaterThan(1);
+    expect(Math.min(...steps)).toBeLessThan(Math.max(...steps));
+  });
+});

--- a/debug-tools.js
+++ b/debug-tools.js
@@ -34,29 +34,42 @@
   }
 
   function fastForwardToEquilibrium(options = {}) {
-    const stepMs = options.stepMs || 1000;
+    let stepMs = options.stepMs || 1000;
     const maxSteps = options.maxSteps || 100000;
     const stableSteps = options.stableSteps || 10;
     const threshold = options.threshold || 1;
+    const refineFactor = options.refineFactor || 0.5;
+    const minStepMs = options.minStepMs || 1;
+
     let prev = captureValues();
     let stable = 0;
     let step;
+
     for (step = 0; step < maxSteps; step++) {
       updateLogic(stepMs);
       const cur = captureValues();
+
       if (isStable(prev, cur, threshold)) {
         stable++;
       } else {
         stable = 0;
       }
+
       if (stable >= stableSteps) {
-        console.log('Equilibrium reached after', step + 1, 'steps');
-        console.log('Global values:', cur.global);
-        console.log('Zonal values:', cur.zones);
-        return cur;
+        if (stepMs > minStepMs) {
+          stepMs = Math.max(minStepMs, stepMs * refineFactor);
+          stable = 0;
+        } else {
+          console.log('Equilibrium reached after', step + 1, 'steps');
+          console.log('Global values:', cur.global);
+          console.log('Zonal values:', cur.zones);
+          return cur;
+        }
       }
+
       prev = cur;
     }
+
     console.log('Max steps reached without clear equilibrium');
     console.log('Global values:', prev.global);
     console.log('Zonal values:', prev.zones);


### PR DESCRIPTION
## Summary
- refine the debug fastForwardToEquilibrium logic so it gradually reduces step size
- stop once a smaller step size also hits equilibrium
- add unit test verifying that step size is reduced when conditions are stable

## Testing
- `npm test`