### PR TITLE
Implement acceleration for fastForwardToEquilibrium

### DIFF
--- a/__tests__/fastForwardToEquilibrium.test.js
+++ b/__tests__/fastForwardToEquilibrium.test.js
@@ -1,4 +1,4 @@
-const { fastForwardToEquilibrium } = require('../debug-tools.js');
+const { fastForwardToEquilibrium, generateOverrideSnippet } = require('../debug-tools.js');
 
 describe('fastForwardToEquilibrium', () => {
   test('reduces step size when stable', () => {
@@ -23,5 +23,52 @@ describe('fastForwardToEquilibrium', () => {
 
     expect(steps.length).toBeGreaterThan(1);
     expect(Math.min(...steps)).toBeLessThan(Math.max(...steps));
+  });
+
+  test('increases step size when unstable for many steps', () => {
+    global.resources = {
+      surface: { ice: { value: 0 }, liquidWater: { value: 0 }, dryIce: { value: 0 } },
+      atmospheric: { carbonDioxide: { value: 0 }, atmosphericWater: { value: 0 } }
+    };
+    global.ZONES = [];
+    global.terraforming = { zonalWater: {}, zonalSurface: {} };
+
+    const steps = [];
+    global.updateLogic = ms => {
+      steps.push(ms);
+      global.resources.surface.ice.value += 1;
+    };
+
+    fastForwardToEquilibrium({
+      stepMs: 1,
+      maxSteps: 5,
+      stableSteps: 100,
+      accelerateThreshold: 1,
+      accelerateFactor: 2,
+      threshold: 0,
+      minStepMs: 1
+    });
+
+    expect(steps.length).toBeGreaterThan(1);
+    expect(Math.max(...steps)).toBeGreaterThan(Math.min(...steps));
+  });
+
+  test('generateOverrideSnippet includes buried ice', () => {
+    const snippet = generateOverrideSnippet({
+      global: {
+        ice: 10,
+        liquidWater: 5,
+        dryIce: 2,
+        co2: 1,
+        waterVapor: 1,
+        buriedIce: 7
+      },
+      zones: {
+        polar: { ice: 3, buriedIce: 4, liquidWater: 1, dryIce: 2 }
+      }
+    });
+
+    const obj = JSON.parse(snippet);
+    expect(obj.zonalWater.polar.buriedIce).toBe(4);
   });
 });

--- a/debug-tools.js
+++ b/debug-tools.js
@@ -5,13 +5,17 @@
       liquidWater: resources.surface.liquidWater?.value || 0,
       dryIce: resources.surface.dryIce?.value || 0,
       co2: resources.atmospheric.carbonDioxide?.value || 0,
-      waterVapor: resources.atmospheric.atmosphericWater?.value || 0
+      waterVapor: resources.atmospheric.atmosphericWater?.value || 0,
+      buriedIce: 0
     };
     const zonalVals = {};
     if (typeof ZONES !== 'undefined' && terraforming) {
       ZONES.forEach(zone => {
+        const bIce = terraforming.zonalWater[zone]?.buriedIce || 0;
+        globalVals.buriedIce += bIce;
         zonalVals[zone] = {
           ice: terraforming.zonalWater[zone]?.ice || 0,
+          buriedIce: bIce,
           liquidWater: terraforming.zonalWater[zone]?.liquid || 0,
           dryIce: terraforming.zonalSurface[zone]?.dryIce || 0
         };
@@ -21,28 +25,61 @@
   }
 
   function isStable(prev, cur, threshold) {
-    const keys = ['ice', 'liquidWater', 'dryIce', 'co2', 'waterVapor'];
+    const keys = ['ice', 'buriedIce', 'liquidWater', 'dryIce', 'co2', 'waterVapor'];
     for (const k of keys) {
       if (Math.abs(cur.global[k] - prev.global[k]) > threshold) return false;
     }
     for (const zone in cur.zones) {
-      for (const k of ['ice', 'liquidWater', 'dryIce']) {
+      for (const k of ['ice', 'buriedIce', 'liquidWater', 'dryIce']) {
         if (Math.abs(cur.zones[zone][k] - prev.zones[zone][k]) > threshold) return false;
       }
     }
     return true;
   }
 
+  function buildOverrideObject(values) {
+    const surface = {
+      ice: { initialValue: values.global.ice },
+      liquidWater: { initialValue: values.global.liquidWater },
+      dryIce: { initialValue: values.global.dryIce }
+    };
+    const atmospheric = {
+      carbonDioxide: { initialValue: values.global.co2 },
+      atmosphericWater: { initialValue: values.global.waterVapor }
+    };
+    const zonalWater = {};
+    const zonalSurface = {};
+    for (const zone in values.zones) {
+      zonalWater[zone] = {
+        liquid: values.zones[zone].liquidWater,
+        ice: values.zones[zone].ice,
+        buriedIce: values.zones[zone].buriedIce
+      };
+      zonalSurface[zone] = {
+        dryIce: values.zones[zone].dryIce
+      };
+    }
+    return { resources: { surface, atmospheric }, zonalWater, zonalSurface };
+  }
+
+  function generateOverrideSnippet(values) {
+    return JSON.stringify(buildOverrideObject(values), null, 2);
+  }
+
   function fastForwardToEquilibrium(options = {}) {
     let stepMs = options.stepMs || 1000;
     const maxSteps = options.maxSteps || 100000;
     const stableSteps = options.stableSteps || 10;
-    const threshold = options.threshold || 1;
+    const threshold = options.threshold ?? 1;
     const refineFactor = options.refineFactor || 0.5;
     const minStepMs = options.minStepMs || 1;
+    const accelerateFactor = options.accelerateFactor || 2;
+    const accelerateThreshold = options.accelerateThreshold || 100;
+    const maxStepMs = options.maxStepMs || Infinity;
 
     let prev = captureValues();
     let stable = 0;
+    let unstable = 0;
     let step;
 
     for (step = 0; step < maxSteps; step++) {
@@ -51,8 +88,10 @@
 
       if (isStable(prev, cur, threshold)) {
         stable++;
+        unstable = 0;
       } else {
         stable = 0;
+        unstable++;
       }
 
       if (stable >= stableSteps) {
@@ -63,8 +102,14 @@
           console.log('Equilibrium reached after', step + 1, 'steps');
           console.log('Global values:', cur.global);
           console.log('Zonal values:', cur.zones);
+          console.log('Override snippet:\n' + generateOverrideSnippet(cur));
           return cur;
         }
+      } else if (unstable >= accelerateThreshold) {
+        if (stepMs < maxStepMs) {
+          stepMs = Math.min(maxStepMs, stepMs * accelerateFactor);
+        }
+        unstable = 0;
       }
 
       prev = cur;
@@ -73,12 +118,14 @@
     console.log('Max steps reached without clear equilibrium');
     console.log('Global values:', prev.global);
     console.log('Zonal values:', prev.zones);
+    console.log('Override snippet:\n' + generateOverrideSnippet(prev));
     return prev;
   }
 
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { fastForwardToEquilibrium };
+    module.exports = { fastForwardToEquilibrium, generateOverrideSnippet };
   } else {
     globalThis.fastForwardToEquilibrium = fastForwardToEquilibrium;
+    globalThis.generateOverrideSnippet = generateOverrideSnippet;
   }
 })();


### PR DESCRIPTION
## Summary
- improve `fastForwardToEquilibrium` so step size can increase when stability takes too long
- support `threshold` value of 0
- test acceleration behaviour
- print override snippets with buried ice support

## Testing
- `npm test`
