### PR TITLE
Implement x10 /10 build count control

### DIFF
--- a/__tests__/buildCount.test.js
+++ b/__tests__/buildCount.test.js
@@ -1,0 +1,17 @@
+const { multiplyByTen, divideByTen } = require('../buildCount.js');
+
+describe('multiplyByTen', () => {
+  test('multiplies the count by 10', () => {
+    expect(multiplyByTen(2)).toBe(20);
+  });
+});
+
+describe('divideByTen', () => {
+  test('divides the count by 10', () => {
+    expect(divideByTen(50)).toBe(5);
+  });
+
+  test('does not go below 1', () => {
+    expect(divideByTen(1)).toBe(1);
+  });
+});

--- a/buildCount.js
+++ b/buildCount.js
@@ -1,0 +1,14 @@
+function multiplyByTen(count) {
+  return count * 10;
+}
+
+function divideByTen(count) {
+  return Math.max(1, Math.floor(count / 10));
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    multiplyByTen,
+    divideByTen,
+  };
+}

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
 
     <!-- Core Scripts -->
     <script src="numbers.js"></script>
+    <script src="buildCount.js"></script>
     <script src="effectable-entity.js"></script>
     <script src="tab.js"></script>
     <script src="save.js"></script>

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -98,21 +98,37 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   buildCountLabel.textContent = 'Amount: ';
   buildCountButtons.appendChild(buildCountLabel);
 
-  const buildCounts = [1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000];
-  buildCounts.forEach((count) => {
-    const countButton = document.createElement('button');
-    countButton.textContent = formatNumber(count, true);
-    countButton.addEventListener('click', function () {
-      selectedBuildCounts[structure.name] = count;
-      updateStructureButtonText(button, structure, selectedBuildCounts[structure.name]);
-      updateStructureCostDisplay(costElement, structure, selectedBuildCounts[structure.name]);
-      if (structure.canBeToggled) {
-        updateIncreaseButtonText(increaseButton, selectedBuildCounts[structure.name]);
-        updateDecreaseButtonText(decreaseButton, selectedBuildCounts[structure.name]);
-      }
-    });
-    buildCountButtons.appendChild(countButton);
+  const buildCountDisplay = document.createElement('span');
+  buildCountDisplay.textContent = formatNumber(selectedBuildCount, true);
+  buildCountButtons.appendChild(buildCountDisplay);
+
+  const multiplyButton = document.createElement('button');
+  multiplyButton.textContent = 'x10';
+  multiplyButton.addEventListener('click', function () {
+    selectedBuildCounts[structure.name] = multiplyByTen(selectedBuildCounts[structure.name]);
+    buildCountDisplay.textContent = formatNumber(selectedBuildCounts[structure.name], true);
+    updateStructureButtonText(button, structure, selectedBuildCounts[structure.name]);
+    updateStructureCostDisplay(costElement, structure, selectedBuildCounts[structure.name]);
+    if (structure.canBeToggled) {
+      updateIncreaseButtonText(increaseButton, selectedBuildCounts[structure.name]);
+      updateDecreaseButtonText(decreaseButton, selectedBuildCounts[structure.name]);
+    }
   });
+  buildCountButtons.appendChild(multiplyButton);
+
+  const divideButton = document.createElement('button');
+  divideButton.textContent = '/10';
+  divideButton.addEventListener('click', function () {
+    selectedBuildCounts[structure.name] = divideByTen(selectedBuildCounts[structure.name]);
+    buildCountDisplay.textContent = formatNumber(selectedBuildCounts[structure.name], true);
+    updateStructureButtonText(button, structure, selectedBuildCounts[structure.name]);
+    updateStructureCostDisplay(costElement, structure, selectedBuildCounts[structure.name]);
+    if (structure.canBeToggled) {
+      updateIncreaseButtonText(increaseButton, selectedBuildCounts[structure.name]);
+      updateDecreaseButtonText(decreaseButton, selectedBuildCounts[structure.name]);
+    }
+  });
+  buildCountButtons.appendChild(divideButton);
 
   leftContainer.appendChild(buildCountButtons);
 


### PR DESCRIPTION
## Summary
- allow structures to increment build count in powers of 10 via multiply/divide buttons
- support build count adjustments with new `buildCount.js` helper
- load `buildCount.js` from `index.html`
- test build count helpers

## Testing
- `npm test`