### PR TITLE
Add collapsible journal

### DIFF
--- a/__tests__/journalToggle.test.js
+++ b/__tests__/journalToggle.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('journal toggle functionality', () => {
+  test('collapses journal and shows alert on new entry', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal" class="journal"><div id="journal-entries"></div></div>
+      <button id="toggle-journal-button"></button>
+      <span id="journal-alert" class="journal-alert"></span>
+    </body></html>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+    ctx.toggleJournal();
+    expect(dom.window.document.getElementById('journal').classList.contains('collapsed')).toBe(true);
+
+    jest.useFakeTimers();
+    ctx.addJournalEntry('Hi');
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    expect(dom.window.document.getElementById('journal-alert').style.display).toBe('inline');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -99,9 +99,13 @@
     <div class="tab active" id="settings-tab" data-tab="settings">Save and Settings</div>
   </div>
 
-  <div class="day-night-progress-bar-container">
-    <span id="progress-text" class="progress-text">Day Progress</span>
-    <div id="day-night-progress-bar" class="day-night-progress-bar"></div>
+  <div class="top-bar">
+    <div class="day-night-progress-bar-container">
+      <span id="progress-text" class="progress-text">Day Progress</span>
+      <div id="day-night-progress-bar" class="day-night-progress-bar"></div>
+    </div>
+    <button id="toggle-journal-button" class="journal-toggle">Hide Journal</button>
+    <span id="journal-alert" class="journal-alert">!</span>
   </div>
 
     <!-- Game Content Tabs -->

--- a/journal.js
+++ b/journal.js
@@ -1,4 +1,6 @@
 let journalEntriesData = []; // Array to store journal entries
+let journalCollapsed = false;
+let journalUnread = false;
 
 function addJournalEntry(text) {
   const journalEntries = document.getElementById('journal-entries');
@@ -33,6 +35,11 @@ function addJournalEntry(text) {
   }
 
   typeLetter();
+
+  if (journalCollapsed) {
+    journalUnread = true;
+    updateJournalAlert();
+  }
 }
 
 function loadJournalEntries(entries) {
@@ -64,3 +71,32 @@ function clearJournal() {
   journalEntries.innerHTML = ''; // Remove all entries from the display
   journalEntriesData = []; // Clear the stored data array
 }
+
+function updateJournalAlert() {
+  const alertEl = document.getElementById('journal-alert');
+  if (alertEl) {
+    alertEl.style.display = journalUnread ? 'inline' : 'none';
+  }
+}
+
+function toggleJournal() {
+  const journal = document.getElementById('journal');
+  const button = document.getElementById('toggle-journal-button');
+  journalCollapsed = !journalCollapsed;
+  if (journalCollapsed) {
+    journal.classList.add('collapsed');
+    if (button) button.textContent = 'Show Journal';
+  } else {
+    journal.classList.remove('collapsed');
+    if (button) button.textContent = 'Hide Journal';
+    journalUnread = false;
+    updateJournalAlert();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleButton = document.getElementById('toggle-journal-button');
+  if (toggleButton) {
+    toggleButton.addEventListener('click', toggleJournal);
+  }
+});

--- a/style.css
+++ b/style.css
@@ -131,3 +131,29 @@ body {
 #special-messages {
     min-height: 65px;
 }
+
+/* Top bar holding progress and journal toggle */
+.top-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.top-bar .day-night-progress-bar-container {
+    flex: 1;
+}
+
+.journal-toggle {
+    padding: 5px 10px;
+}
+
+.journal-alert {
+    color: red;
+    font-weight: bold;
+    display: none;
+}
+
+.journal.collapsed {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- allow journal section to be collapsed
- add toggle button beside the day/night progress bar
- display alert if new journal entries arrive while collapsed
- style the top bar and journal alert
- test journal toggle behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b95c531a883278a9dfac1cca3d459