### PR TITLE
Fix build count layout shift

### DIFF
--- a/structure.css
+++ b/structure.css
@@ -99,6 +99,12 @@
     font-size: 0.85em;
 }
 
+.build-count-display {
+    display: inline-block;
+    min-width: 5ch;
+    text-align: right;
+}
+
 .building-controls .label {
     font-size: 0.85em;
 }

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -99,6 +99,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   buildCountButtons.appendChild(buildCountLabel);
 
   const buildCountDisplay = document.createElement('span');
+  buildCountDisplay.classList.add('build-count-display');
   buildCountDisplay.textContent = formatNumber(selectedBuildCount, true);
   buildCountButtons.appendChild(buildCountDisplay);
 


### PR DESCRIPTION
## Summary
- add `.build-count-display` CSS class with a fixed width
- apply that class to the build count span in structures UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843873f8a4083279aa832c119848eb8