### PR TITLE
Fix build count layout shift

### DIFF
--- a/structure.css
+++ b/structure.css
@@ -99,6 +99,19 @@
     font-size: 0.85em;
 }
 
+.build-count-display {
+    display: inline-block;
+    min-width: 5ch;
+    text-align: right;
+}
+
+/* Keep build count inside build button from shifting width */
+.build-button-count {
+    display: inline-block;
+    min-width: 5ch;
+    text-align: right;
+}
+
 .building-controls .label {
     font-size: 0.85em;
 }

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -77,10 +77,13 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   const button = document.createElement('button');
   button.id = `build-${structure.name}`;
   button.classList.add('building-button');
-  button.textContent = `Build ${structure.displayName}`;
+  // Initial button text with a span for the build count to keep width stable
+  button.innerHTML = `Build <span class="build-button-count">1</span> ${structure.displayName}`;
 
   let selectedBuildCount = 1;
   selectedBuildCounts[structure.name] = selectedBuildCount;
+  // Set initial button text and color based on affordability
+  updateStructureButtonText(button, structure, selectedBuildCount);
 
   button.addEventListener('click', function () {
     buildCallback(structure.name, selectedBuildCounts[structure.name]);
@@ -99,6 +102,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   buildCountButtons.appendChild(buildCountLabel);
 
   const buildCountDisplay = document.createElement('span');
+  buildCountDisplay.classList.add('build-count-display');
   buildCountDisplay.textContent = formatNumber(selectedBuildCount, true);
   buildCountButtons.appendChild(buildCountDisplay);
 
@@ -319,10 +323,9 @@ function updateDecreaseButtonText(button, buildCount) {
   }
   
   function updateStructureButtonText(button, structure, buildCount = 1) {
-    let buttonText = `Build ${formatNumber(buildCount, true)} ${structure.displayName}`;
-    let canAfford = structure.canAfford(buildCount);
-  
-    button.textContent = buttonText;
+    const canAfford = structure.canAfford(buildCount);
+    const countSpan = `<span class="build-button-count">${formatNumber(buildCount, true)}</span>`;
+    button.innerHTML = `Build ${countSpan} ${structure.displayName}`;
     button.style.color = canAfford ? 'inherit' : 'red';
   }
   


### PR DESCRIPTION
## Summary
- add `.build-button-count` CSS class for fixed width
- use a span inside building buttons to keep the width constant
- update button text with `updateStructureButtonText`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843873f8a4083279aa832c119848eb8