### PR TITLE
Fix build count display alignment

### DIFF
--- a/structure.css
+++ b/structure.css
@@ -100,7 +100,10 @@
 }
 
 .build-count-display {
-    margin-right: 5em;
+    display: inline-block; /* Reserve consistent space for the count */
+    width: 5em;           /* Keep x10 and /10 buttons aligned */
+    margin-right: 0;      /* Rely on container gap for spacing */
+    text-align: right;    /* Numbers align nicely inside the width */
 }
 
 .building-controls .label {


### PR DESCRIPTION
## Summary
- keep build count width fixed
- let build count buttons align on all structures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68438cfa3fc08327ba536a94b13d6f8c