### PR TITLE
Fix milestone button text color

### DIFF
--- a/milestones.css
+++ b/milestones.css
@@ -33,25 +33,26 @@
 /* Milestone description */
 .milestone-description {
     font-size: 12px; /* Smaller font size for description */
-    color: #000;
+    color: inherit; /* Use the color defined by the button state */
     text-align: center;
 }
 
 /* Button states */
+
 .milestone-button.completed {
-    background-color: green;
-    color: white;
+    background-color: #28a745; /* Green for completed */
+    color: #fff;
     cursor: not-allowed;
 }
 
 .milestone-button.completable {
-    background-color: blue;
-    color: white;
+    background-color: #007bff; /* Blue for available */
+    color: #fff;
 }
 
 .milestone-button.not-completable {
-    background-color: gray;
-    color: white;
+    background-color: #b0b0b0; /* Gray for locked */
+    color: #333;
     cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary
- update milestone description text color to inherit from button state
- define background and text colors for milestone states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68442aba2bcc83279378799000b210d4