### PR TITLE
Add targeted maintenance multiplier effect

### DIFF
--- a/__tests__/maintenanceMultiplier.test.js
+++ b/__tests__/maintenanceMultiplier.test.js
@@ -1,0 +1,44 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../building.js');
+
+function createBuilding() {
+  const config = {
+    name: 'Test',
+    category: 'test',
+    cost: { colony: { metal: 100 } },
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: false,
+    requiresMaintenance: true,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new Building(config, 'testBuilding');
+}
+
+describe('maintenanceCostMultiplier effect', () => {
+  beforeEach(() => {
+    global.maintenanceFraction = 0.1;
+  });
+
+  test('applies multiplier to maintenance cost', () => {
+    const building = createBuilding();
+    const base = building.calculateMaintenanceCost().metal;
+    expect(base).toBeCloseTo(10);
+
+    building.addEffect({
+      type: 'maintenanceCostMultiplier',
+      resourceCategory: 'colony',
+      resourceId: 'metal',
+      value: 0.5
+    });
+
+    const modified = building.calculateMaintenanceCost().metal;
+    expect(modified).toBeCloseTo(5);
+  });
+});

--- a/building.js
+++ b/building.js
@@ -220,7 +220,8 @@ class Building extends EffectableEntity {
     const effectiveCost = this.getEffectiveCost();
     for (const resource in effectiveCost.colony) {
       const resourceCost = effectiveCost.colony[resource];
-      maintenanceCost[resource] = resourceCost * maintenanceFraction * this.maintenanceFactor;
+      const multiplier = this.getEffectiveMaintenanceCostMultiplier('colony', resource);
+      maintenanceCost[resource] = resourceCost * maintenanceFraction * this.maintenanceFactor * multiplier;
     }
     return maintenanceCost;
   }
@@ -534,4 +535,8 @@ function initializeBuildings(buildingsParameters) {
   }
   initializeBuildingTabs();
   return buildings;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { Building, initializeBuildings };
 }

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -97,6 +97,9 @@ class EffectableEntity {
         case 'resourceCostMultiplier':
           this.applyResourceCostMultiplier(effect);
           break;
+        case 'maintenanceCostMultiplier':
+          this.applyMaintenanceCostMultiplier(effect);
+          break;
         case 'workerMultiplier':
           this.applyWorkerMultiplier(effect);
           break;
@@ -146,6 +149,10 @@ class EffectableEntity {
 
     }
 
+    applyMaintenanceCostMultiplier(effect) {
+
+    }
+
     applyWorkerMultiplier(effect) {
 
     }
@@ -184,6 +191,22 @@ class EffectableEntity {
           effect.resourceId === resourceId
         ) {
           // Apply the effect multiplier
+          multiplier *= effect.value;
+        }
+      });
+
+      return multiplier;
+    }
+
+    getEffectiveMaintenanceCostMultiplier(resourceCategory, resourceId) {
+      let multiplier = 1;
+
+      this.activeEffects.forEach((effect) => {
+        if (
+          effect.type === 'maintenanceCostMultiplier' &&
+          effect.resourceCategory === resourceCategory &&
+          effect.resourceId === resourceId
+        ) {
           multiplier *= effect.value;
         }
       });


### PR DESCRIPTION
## Summary
- introduce `maintenanceCostMultiplier` effect type
- adjust building maintenance calculation to use the new multiplier
- export `Building` class for tests
- test targeted maintenance multiplier logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844b7c953288327945bcdf47073d68d