### PR TITLE
Add new colony consumption sliders

### DIFF
--- a/__tests__/colonySliders.test.js
+++ b/__tests__/colonySliders.test.js
@@ -1,11 +1,16 @@
-const { setWorkforceRatio, resetColonySliders } = require('../colonySliders.js');
+const {
+  setWorkforceRatio,
+  setFoodConsumptionMultiplier,
+  setLuxuryWaterMultiplier,
+  resetColonySliders
+} = require('../colonySliders.js');
 
 const researchColonies = ['t1_colony','t2_colony','t3_colony','t4_colony','t5_colony','t6_colony'];
 
 describe('colony sliders', () => {
   beforeEach(() => {
     global.addEffect = jest.fn();
-    global.colonySliderSettings = { workerRatio: 0.5 };
+    global.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1 };
   });
 
   test('setWorkforceRatio stores value and adds effect', () => {
@@ -37,10 +42,56 @@ describe('colony sliders', () => {
     expect(colonySliderSettings.workerRatio).toBe(0.9);
   });
 
+  test('setFoodConsumptionMultiplier adds effects', () => {
+    setFoodConsumptionMultiplier(2);
+    expect(colonySliderSettings.foodConsumption).toBe(2);
+    const growth = 1 + (2 - 1) * 0.02;
+    expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
+      target: 'population',
+      type: 'growthMultiplier',
+      value: growth
+    }));
+    researchColonies.forEach(colonyId => {
+      expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
+        target: 'colony',
+        targetId: colonyId,
+        type: 'resourceConsumptionMultiplier',
+        resourceCategory: 'colony',
+        resourceTarget: 'food',
+        value: 2
+      }));
+    });
+  });
+
+  test('setLuxuryWaterMultiplier adds effects', () => {
+    setLuxuryWaterMultiplier(3);
+    expect(colonySliderSettings.luxuryWater).toBe(3);
+    const growth = 1 + (3 - 1) * 0.01;
+    expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
+      target: 'population',
+      type: 'growthMultiplier',
+      value: growth
+    }));
+    researchColonies.forEach(colonyId => {
+      expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
+        target: 'colony',
+        targetId: colonyId,
+        type: 'maintenanceCostMultiplier',
+        resourceCategory: 'colony',
+        resourceId: 'water',
+        value: 3
+      }));
+    });
+  });
+
   test('resetColonySliders resets to default', () => {
     colonySliderSettings.workerRatio = 0.7;
+    colonySliderSettings.foodConsumption = 2;
+    colonySliderSettings.luxuryWater = 3;
     resetColonySliders();
     expect(colonySliderSettings.workerRatio).toBe(0.5);
+    expect(colonySliderSettings.foodConsumption).toBe(1);
+    expect(colonySliderSettings.luxuryWater).toBe(1);
   });
 
   test('initializeColonySlidersUI sets text with worker and scientist ratios', () => {
@@ -52,7 +103,7 @@ describe('colony sliders', () => {
 
     const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>` , { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
-    ctx.colonySliderSettings = { workerRatio: 0.5 };
+    ctx.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1 };
     const code = fs.readFileSync(path.join(__dirname, '..', 'colonySliders.js'), 'utf8');
     vm.runInContext(code, ctx);
 

--- a/colonySliders.js
+++ b/colonySliders.js
@@ -73,6 +73,108 @@ function initializeColonySlidersUI() {
     if (isNaN(v)) v = colonySliderSettings.workerRatio * 100;
     setWorkforceRatio(v / 100);
   });
+
+  // Food consumption slider
+  const foodRow = document.createElement('div');
+  foodRow.classList.add('colony-slider');
+  const foodLabel = document.createElement('label');
+  foodLabel.htmlFor = 'food-slider';
+  foodLabel.textContent = 'Food Consumption: ';
+  const foodValue = document.createElement('span');
+  foodValue.id = 'food-slider-value';
+  foodLabel.appendChild(foodValue);
+  foodRow.appendChild(foodLabel);
+  const foodInput = document.createElement('input');
+  foodInput.type = 'range';
+  foodInput.min = 1;
+  foodInput.max = 6;
+  foodInput.step = 0.5;
+  foodInput.id = 'food-slider';
+  foodInput.value = colonySliderSettings.foodConsumption;
+  foodInput.setAttribute('list', 'food-slider-ticks');
+  foodRow.appendChild(foodInput);
+  const foodList = document.createElement('datalist');
+  foodList.id = 'food-slider-ticks';
+  for (let i = 1; i <= 6; i += 0.5) {
+    const option = document.createElement('option');
+    option.value = i;
+    foodList.appendChild(option);
+  }
+  container.appendChild(foodList);
+  box.appendChild(foodRow);
+
+  const updateFoodValue = (val) => {
+    if (foodValue) {
+      foodValue.textContent = `${val.toFixed(1)}x`;
+    }
+  };
+  let initialFood;
+  try { initialFood = parseFloat(foodInput.value); } catch (e) { initialFood = NaN; }
+  if (isNaN(initialFood)) initialFood = colonySliderSettings.foodConsumption;
+  updateFoodValue(initialFood);
+  foodInput.addEventListener('input', () => {
+    let v;
+    try { v = parseFloat(foodInput.value); } catch (e) { v = NaN; }
+    if (isNaN(v)) v = colonySliderSettings.foodConsumption;
+    updateFoodValue(v);
+  });
+  foodInput.addEventListener('change', () => {
+    let v;
+    try { v = parseFloat(foodInput.value); } catch (e) { v = NaN; }
+    if (isNaN(v)) v = colonySliderSettings.foodConsumption;
+    setFoodConsumptionMultiplier(v);
+  });
+
+  // Luxury water slider
+  const waterRow = document.createElement('div');
+  waterRow.classList.add('colony-slider');
+  const waterLabel = document.createElement('label');
+  waterLabel.htmlFor = 'water-slider';
+  waterLabel.textContent = 'Luxury Water Use: ';
+  const waterValue = document.createElement('span');
+  waterValue.id = 'water-slider-value';
+  waterLabel.appendChild(waterValue);
+  waterRow.appendChild(waterLabel);
+  const waterInput = document.createElement('input');
+  waterInput.type = 'range';
+  waterInput.min = 1;
+  waterInput.max = 6;
+  waterInput.step = 0.5;
+  waterInput.id = 'water-slider';
+  waterInput.value = colonySliderSettings.luxuryWater;
+  waterInput.setAttribute('list', 'water-slider-ticks');
+  waterRow.appendChild(waterInput);
+  const waterList = document.createElement('datalist');
+  waterList.id = 'water-slider-ticks';
+  for (let i = 1; i <= 6; i += 0.5) {
+    const option = document.createElement('option');
+    option.value = i;
+    waterList.appendChild(option);
+  }
+  container.appendChild(waterList);
+  box.appendChild(waterRow);
+
+  const updateWaterValue = (val) => {
+    if (waterValue) {
+      waterValue.textContent = `${val.toFixed(1)}x`;
+    }
+  };
+  let initialWater;
+  try { initialWater = parseFloat(waterInput.value); } catch (e) { initialWater = NaN; }
+  if (isNaN(initialWater)) initialWater = colonySliderSettings.luxuryWater;
+  updateWaterValue(initialWater);
+  waterInput.addEventListener('input', () => {
+    let v;
+    try { v = parseFloat(waterInput.value); } catch (e) { v = NaN; }
+    if (isNaN(v)) v = colonySliderSettings.luxuryWater;
+    updateWaterValue(v);
+  });
+  waterInput.addEventListener('change', () => {
+    let v;
+    try { v = parseFloat(waterInput.value); } catch (e) { v = NaN; }
+    if (isNaN(v)) v = colonySliderSettings.luxuryWater;
+    setLuxuryWaterMultiplier(v);
+  });
 }
 
 const researchColonies = ['t1_colony', 't2_colony', 't3_colony', 't4_colony', 't5_colony', 't6_colony'];
@@ -104,8 +206,64 @@ function setWorkforceRatio(value) {
   });
 }
 
+function setFoodConsumptionMultiplier(value) {
+  value = Math.min(6, Math.max(1, value));
+  colonySliderSettings.foodConsumption = value;
+  const growth = 1 + (value - 1) * 0.02;
+
+  addEffect({
+    target: 'population',
+    type: 'growthMultiplier',
+    value: growth,
+    effectId: 'foodGrowth',
+    sourceId: 'foodGrowth'
+  });
+
+  researchColonies.forEach(colonyId => {
+    addEffect({
+      target: 'colony',
+      targetId: colonyId,
+      type: 'resourceConsumptionMultiplier',
+      resourceCategory: 'colony',
+      resourceTarget: 'food',
+      value: value,
+      effectId: 'foodConsumption',
+      sourceId: 'foodConsumption'
+    });
+  });
+}
+
+function setLuxuryWaterMultiplier(value) {
+  value = Math.min(6, Math.max(1, value));
+  colonySliderSettings.luxuryWater = value;
+  const growth = 1 + (value - 1) * 0.01;
+
+  addEffect({
+    target: 'population',
+    type: 'growthMultiplier',
+    value: growth,
+    effectId: 'waterGrowth',
+    sourceId: 'waterGrowth'
+  });
+
+  researchColonies.forEach(colonyId => {
+    addEffect({
+      target: 'colony',
+      targetId: colonyId,
+      type: 'maintenanceCostMultiplier',
+      resourceCategory: 'colony',
+      resourceId: 'water',
+      value: value,
+      effectId: 'luxuryWaterMaintenance',
+      sourceId: 'luxuryWaterMaintenance'
+    });
+  });
+}
+
 function resetColonySliders() {
   setWorkforceRatio(0.5);
+  setFoodConsumptionMultiplier(1);
+  setLuxuryWaterMultiplier(1);
   if (typeof document !== 'undefined') {
     const input = document.getElementById('workforce-slider');
     if (input) {
@@ -113,9 +271,26 @@ function resetColonySliders() {
       const valueSpan = document.getElementById('workforce-slider-value');
       if (valueSpan) valueSpan.textContent = 'Workers: 50% | Scientists: 50%';
     }
+    const foodInput = document.getElementById('food-slider');
+    if (foodInput) {
+      foodInput.value = 1;
+      const foodSpan = document.getElementById('food-slider-value');
+      if (foodSpan) foodSpan.textContent = '1.0x';
+    }
+    const waterInput = document.getElementById('water-slider');
+    if (waterInput) {
+      waterInput.value = 1;
+      const waterSpan = document.getElementById('water-slider-value');
+      if (waterSpan) waterSpan.textContent = '1.0x';
+    }
   }
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { setWorkforceRatio, resetColonySliders };
+  module.exports = {
+    setWorkforceRatio,
+    setFoodConsumptionMultiplier,
+    setLuxuryWaterMultiplier,
+    resetColonySliders
+  };
 }

--- a/globals.js
+++ b/globals.js
@@ -18,6 +18,10 @@ let lifeManager;
 
 let gameSettings = { useCelsius: false };
 
-let colonySliderSettings = { workerRatio: 0.5 };
+let colonySliderSettings = {
+  workerRatio: 0.5,
+  foodConsumption: 1,
+  luxuryWater: 1
+};
 
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});

--- a/save.js
+++ b/save.js
@@ -158,6 +158,8 @@ function loadGame(slotOrCustomString) {
     if(gameState.colonySliderSettings){
       Object.assign(colonySliderSettings, gameState.colonySliderSettings);
       setWorkforceRatio(colonySliderSettings.workerRatio);
+      setFoodConsumptionMultiplier(colonySliderSettings.foodConsumption);
+      setLuxuryWaterMultiplier(colonySliderSettings.luxuryWater);
     }
 
     tabManager.activateTab('buildings');


### PR DESCRIPTION
## Summary
- expand `colonySliderSettings` to hold food and luxury water multipliers
- add UI and logic for food and luxury water sliders
- apply population growth and colony effects when sliders change
- persist and restore slider settings in save game
- test new slider functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844ba92eddc8327b805f5d1f9e38914