### PR TITLE
Fix colony sliders visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ body {
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 .tabs,


### PR DESCRIPTION
## Summary
- force `.hidden` to override ID styling so colony sliders stay hidden until colony_sliders research is purchased

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6844c5e954e08327bb5488d9da9ea9e9