### PR TITLE
Add toggle-all buttons for structures

### DIFF
--- a/__tests__/toggleAllButtons.test.js
+++ b/__tests__/toggleAllButtons.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('structure toggle 0 and Max buttons', () => {
+  test('buttons trigger correct toggle callbacks', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'structuresUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const structure = { name: 'test', displayName: 'Test', canBeToggled: true, active: 2, count: 5 };
+    const calls = [];
+    const callback = (s, change) => calls.push(change);
+
+    const { structureControls } = ctx.createStructureControls(structure, callback);
+    dom.window.document.body.appendChild(structureControls);
+
+    const zeroBtn = [...structureControls.querySelectorAll('button')].find(b => b.textContent === '0');
+    const maxBtn = [...structureControls.querySelectorAll('button')].find(b => b.textContent === 'Max');
+
+    zeroBtn.click();
+    maxBtn.click();
+
+    expect(calls[0]).toBe(-2);
+    expect(calls[1]).toBe(3);
+  });
+});

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -284,6 +284,8 @@ function createStructureControls(structure, toggleCallback) {
 
   let increaseButton = null;
   let decreaseButton = null;
+  let zeroButton = null;
+  let maxButton = null;
 
   if (structure.canBeToggled) {
 
@@ -303,9 +305,23 @@ function createStructureControls(structure, toggleCallback) {
 
     structureControls.appendChild(decreaseButton);
     structureControls.appendChild(increaseButton);
+
+    zeroButton = document.createElement('button');
+    zeroButton.textContent = '0';
+    zeroButton.addEventListener('click', function () {
+      toggleCallback(structure, -structure.active);
+    });
+    structureControls.appendChild(zeroButton);
+
+    maxButton = document.createElement('button');
+    maxButton.textContent = 'Max';
+    maxButton.addEventListener('click', function () {
+      toggleCallback(structure, structure.count - structure.active);
+    });
+    structureControls.appendChild(maxButton);
   }
 
-  return { structureControls, increaseButton, decreaseButton };
+  return { structureControls, increaseButton, decreaseButton, zeroButton, maxButton };
 }
 
 // Update the text of the increase button based on the selected build count


### PR DESCRIPTION
## Summary
- add `0` and `Max` toggle buttons to structure controls
- test that new buttons call the toggle callback correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844d91260948327819435ea7a9a08e1