### PR TITLE
Enable cross-zone ice melt

### DIFF
--- a/__tests__/hydrology.test.js
+++ b/__tests__/hydrology.test.js
@@ -1,4 +1,4 @@
-const { calculateMeltingFreezingRates } = require('../hydrology.js');
+const { calculateMeltingFreezingRates, simulateSurfaceWaterFlow } = require('../hydrology.js');
 const { calculateMeltingFreezingRates: zonalRates } = require('../terraforming-utils.js');
 
 describe('hydrology melting with buried ice', () => {
@@ -18,5 +18,18 @@ describe('hydrology melting with buried ice', () => {
     const res = zonalRates(terra, 'polar', T);
     const expected = (5 + 3) * 0.0000001 * diff;
     expect(res.meltingRate).toBeCloseTo(expected);
+  });
+
+  test('simulateSurfaceWaterFlow melts ice to warmer neighbour', () => {
+    const zonalWater = {
+      polar: { liquid: 0, ice: 100, buriedIce: 50 },
+      temperate: { liquid: 0, ice: 0, buriedIce: 0 },
+      tropical: { liquid: 0, ice: 0, buriedIce: 0 }
+    };
+    const temps = { polar: 250, temperate: 274, tropical: 260 };
+    simulateSurfaceWaterFlow(zonalWater, 1000, temps);
+    const expectedMelt = (100 + 50) * 0.005 * 0.01 * 1;
+    expect(zonalWater.polar.ice).toBeCloseTo(100 - expectedMelt);
+    expect(zonalWater.temperate.liquid).toBeCloseTo(expectedMelt);
   });
 });

--- a/terraforming.js
+++ b/terraforming.js
@@ -833,7 +833,11 @@ class Terraforming extends EffectableEntity{
       // calculateCoverage function.
 
       // Simulate atmospheric and water flow between zones
-      simulateSurfaceWaterFlow(this.zonalWater, deltaTime); // Call for Step 4
+      const tempMap = {};
+      for (const z of ZONES) {
+        tempMap[z] = this.temperature.zones[z].value;
+      }
+      simulateSurfaceWaterFlow(this.zonalWater, deltaTime, tempMap); // Call for Step 4
 
       this.applyTerraformingEffects();
 


### PR DESCRIPTION
## Summary
- allow zones to melt some ice/buried ice to a warmer neighbour
- pass zone temperatures to `simulateSurfaceWaterFlow`
- test surface water flow melting behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844f10680ec832783f3e40276bf08eb