### PR TITLE
Fix melt rates from ice flow

### DIFF
--- a/__tests__/flowMeltRate.test.js
+++ b/__tests__/flowMeltRate.test.js
@@ -1,0 +1,72 @@
+const { getPlanetParameters } = require('../planet-parameters.js');
+const { getZoneRatio, getZonePercentage } = require('../zones.js');
+const EffectableEntity = require('../effectable-entity.js');
+const lifeParameters = require('../life-parameters.js');
+const physics = require('../physics.js');
+const dryIce = require('../dry-ice-cycle.js');
+
+// set up required globals for terraforming.js
+global.getZoneRatio = getZoneRatio;
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+global.calculateEmissivity = physics.calculateEmissivity;
+global.dayNightTemperaturesModel = physics.dayNightTemperaturesModel;
+global.effectiveTemp = physics.effectiveTemp;
+global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
+global.airDensity = physics.airDensity;
+
+global.sublimationRateCO2 = dryIce.sublimationRateCO2;
+global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+global.EQUILIBRIUM_CO2_PARAMETER = dryIce.EQUILIBRIUM_CO2_PARAMETER;
+
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+global.R_AIR = 287;
+
+const Terraforming = require('../terraforming.js');
+
+// dummy buildings
+global.buildings = { spaceMirror: { surfaceArea: 0, active: 0 } };
+
+function createResources() {
+  return {
+    atmospheric: {
+      atmosphericWater: { value: 0, modifyRate: jest.fn() },
+      carbonDioxide: { value: 0, modifyRate: jest.fn() }
+    },
+    surface: {
+      liquidWater: { value: 0, modifyRate: jest.fn() },
+      ice: { value: 0, modifyRate: jest.fn() },
+      dryIce: { value: 0, modifyRate: jest.fn() }
+    },
+    colony: {},
+    special: { albedoUpgrades: { value: 0 } }
+  };
+}
+
+describe('flow melt tracking', () => {
+  test('updateResources counts melt from flow', () => {
+    const params = getPlanetParameters('mars');
+    global.currentPlanetParameters = params;
+    const res = createResources();
+    global.resources = res;
+    const terra = new Terraforming(res, params.celestialParameters);
+    terra.calculateInitialValues();
+
+    // remove initial water to avoid other melt
+    for (const z of ['tropical','temperate','polar']) {
+      terra.zonalWater[z].liquid = 0;
+      terra.zonalWater[z].ice = 0;
+      terra.zonalWater[z].buriedIce = 0;
+      terra.zonalSurface[z] = { dryIce: 0 };
+    }
+
+    terra.flowMeltAmount = 10;
+    terra.updateResources(1000);
+
+    expect(res.surface.liquidWater.modifyRate).toHaveBeenCalledWith(10, 'Melt', 'terraforming');
+    expect(res.surface.ice.modifyRate).toHaveBeenCalledWith(-10, 'Melt', 'terraforming');
+  });
+});

--- a/__tests__/hydrology.test.js
+++ b/__tests__/hydrology.test.js
@@ -20,16 +20,21 @@ describe('hydrology melting with buried ice', () => {
     expect(res.meltingRate).toBeCloseTo(expected);
   });
 
-  test('simulateSurfaceWaterFlow melts ice to warmer neighbour', () => {
+  test('simulateSurfaceWaterFlow melts ice proportionally to warmer neighbour', () => {
     const zonalWater = {
       polar: { liquid: 0, ice: 100, buriedIce: 50 },
       temperate: { liquid: 0, ice: 0, buriedIce: 0 },
       tropical: { liquid: 0, ice: 0, buriedIce: 0 }
     };
     const temps = { polar: 250, temperate: 274, tropical: 260 };
-    simulateSurfaceWaterFlow(zonalWater, 1000, temps);
+    const melt = simulateSurfaceWaterFlow(zonalWater, 1000, temps);
     const expectedMelt = (100 + 50) * 0.005 * 0.01 * 1;
-    expect(zonalWater.polar.ice).toBeCloseTo(100 - expectedMelt);
+    const surfaceFraction = 100 / (100 + 50);
+    const meltFromIce = expectedMelt * surfaceFraction;
+    const meltFromBuried = expectedMelt - meltFromIce;
+    expect(melt).toBeCloseTo(expectedMelt);
+    expect(zonalWater.polar.ice).toBeCloseTo(100 - meltFromIce);
+    expect(zonalWater.polar.buriedIce).toBeCloseTo(50 - meltFromBuried);
     expect(zonalWater.temperate.liquid).toBeCloseTo(expectedMelt);
   });
 });

--- a/hydrology.js
+++ b/hydrology.js
@@ -1,6 +1,7 @@
 function simulateSurfaceWaterFlow(zonalWater, deltaTime, zonalTemperatures = {}) {
     const flowRateCoefficient = 0.005; // Adjust to control flow speed (fraction per second)
     const secondsMultiplier = deltaTime / 1000;
+    let totalMelt = 0;
 
     const zones = (typeof ZONES !== 'undefined') ? ZONES : ['tropical', 'temperate', 'polar'];
     // Define flow direction: Polar -> Temperate -> Tropical
@@ -44,12 +45,14 @@ function simulateSurfaceWaterFlow(zonalWater, deltaTime, zonalTemperatures = {})
                 if (totalIce > 0) {
                     const meltCoefficient = flowRateCoefficient * 0.01;
                     const meltAmount = Math.min(totalIce * meltCoefficient * secondsMultiplier, totalIce);
-                    let meltFromIce = Math.min(meltAmount, availableIce);
-                    let meltFromBuried = meltAmount - meltFromIce;
+                    const surfaceFraction = totalIce > 0 ? availableIce / totalIce : 0;
+                    const meltFromIce = meltAmount * surfaceFraction;
+                    const meltFromBuried = meltAmount - meltFromIce;
 
                     flowChanges[zone].ice -= meltFromIce;
                     flowChanges[zone].buriedIce -= meltFromBuried;
                     flowChanges[outflowTarget].liquid += meltAmount;
+                    totalMelt += meltAmount;
                 }
             }
         }
@@ -73,6 +76,8 @@ function simulateSurfaceWaterFlow(zonalWater, deltaTime, zonalTemperatures = {})
             zonalWater[zone].buriedIce = Math.max(0, zonalWater[zone].buriedIce || 0);
         }
     });
+
+    return totalMelt;
 }
 
 // Compute melting and freezing rates for a surface zone based on temperature

--- a/terraforming.js
+++ b/terraforming.js
@@ -66,6 +66,7 @@ class Terraforming extends EffectableEntity{
     this.totalCo2CondensationRate = 0;
     this.totalMeltRate = 0;
     this.totalFreezeRate = 0;
+    this.flowMeltAmount = 0;
 
     // Zonal Water Data - Replaces global this.water
     this.zonalWater = {};
@@ -535,6 +536,9 @@ class Terraforming extends EffectableEntity{
             totalFreezeAmount += freezeAmount;
         }
 
+        // Include melt from zonal water flow
+        totalMeltAmount += this.flowMeltAmount || 0;
+
         // --- 2. Aggregate global atmospheric changes and apply limits ---
         let totalPotentialAtmosphericWaterLoss = 0;
         let totalPotentialAtmosphericCO2Loss = 0;
@@ -721,6 +725,9 @@ class Terraforming extends EffectableEntity{
             resources.surface.dryIce.modifyRate(-co2SublimationRate, 'CO2 Sublimation', rateType);
             resources.surface.dryIce.modifyRate(co2CondensationRate, 'CO2 Condensation', rateType);
         }
+
+        // reset stored melt from flow for next tick
+        this.flowMeltAmount = 0;
     }
 
     // Function to update luminosity properties
@@ -837,7 +844,7 @@ class Terraforming extends EffectableEntity{
       for (const z of ZONES) {
         tempMap[z] = this.temperature.zones[z].value;
       }
-      simulateSurfaceWaterFlow(this.zonalWater, deltaTime, tempMap); // Call for Step 4
+      this.flowMeltAmount = simulateSurfaceWaterFlow(this.zonalWater, deltaTime, tempMap); // Call for Step 4
 
       this.applyTerraformingEffects();
 


### PR DESCRIPTION
## Summary
- track total melt from water flow and return it
- include flow-driven melt in terraforming resource rates
- melt during flow now splits proportionally between surface and buried ice
- test hydrology flow melt distribution and new rate tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844f3f6984c8327b901f1186cf9b0f0