### PR TITLE
Add prioritization option to auto-build

### DIFF
--- a/__tests__/autoBuildPriority.test.js
+++ b/__tests__/autoBuildPriority.test.js
@@ -1,0 +1,30 @@
+const { autoBuild } = require('../autobuild.js');
+
+describe('autoBuild prioritization', () => {
+  test('prioritized buildings are processed first', () => {
+    const order = [];
+    const buildingA = {
+      autoBuildEnabled: true,
+      autoBuildPercent: 1,
+      count: 0,
+      canAfford: () => true,
+      maxBuildable: () => 1,
+      build: () => order.push('A'),
+      autoBuildPriority: false,
+    };
+    const buildingB = {
+      autoBuildEnabled: true,
+      autoBuildPercent: 1,
+      count: 0,
+      canAfford: () => true,
+      maxBuildable: () => 1,
+      build: () => order.push('B'),
+      autoBuildPriority: true,
+    };
+    global.resources = { colony: { colonists: { value: 10 } } };
+
+    autoBuild({ A: buildingA, B: buildingB });
+
+    expect(order[0]).toBe('B');
+  });
+});

--- a/autobuild.js
+++ b/autobuild.js
@@ -25,8 +25,12 @@ function autoBuild(buildings) {
         }
     }
 
-    // Step 2: Sort buildable buildings by their current ratio (ascending)
-    buildableBuildings.sort((a, b) => a.currentRatio - b.currentRatio);
+    // Step 2: Sort buildable buildings by priority then current ratio (ascending)
+    buildableBuildings.sort((a, b) => {
+        if (a.building.autoBuildPriority && !b.building.autoBuildPriority) return -1;
+        if (!a.building.autoBuildPriority && b.building.autoBuildPriority) return 1;
+        return a.currentRatio - b.currentRatio;
+    });
 
     // Step 3: Efficiently allocate builds
     buildableBuildings.forEach(({ building, requiredAmount, canBuildFull, maxBuildable }) => {
@@ -37,4 +41,8 @@ function autoBuild(buildings) {
         }
         // Skip incremental building as it significantly impacts performance
     });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { autoBuild };
 }

--- a/building.js
+++ b/building.js
@@ -14,6 +14,7 @@ class Building extends EffectableEntity {
 
     this.autoBuildEnabled = false;
     this.autoBuildPercent = 0.1;
+    this.autoBuildPriority = false;
 
     this.maintenanceCost = this.calculateMaintenanceCost();
     this.currentProduction = {};

--- a/structure.css
+++ b/structure.css
@@ -129,3 +129,14 @@
     margin-top: 5px; /* Adds spacing above the target */
     font-size: 12px;
 }
+
+.auto-build-target-container {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 5px;
+}
+
+.auto-build-priority {
+    margin-left: 5px;
+}

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -266,11 +266,28 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   autoBuildContainer.appendChild(autoBuildInputContainer);
 
   const autoBuildTarget = document.createElement('span');
+  const autoBuildTargetContainer = document.createElement('div');
+  autoBuildTargetContainer.classList.add('auto-build-target-container');
+
   autoBuildTarget.classList.add('auto-build-target');
   autoBuildTarget.id = `${structure.name}-auto-build-target`;
   autoBuildTarget.textContent = 'Target : 0';
+  autoBuildTargetContainer.appendChild(autoBuildTarget);
 
-  autoBuildContainer.appendChild(autoBuildTarget);
+  const autoBuildPriorityLabel = document.createElement('label');
+  autoBuildPriorityLabel.textContent = 'Prioritize';
+  const autoBuildPriority = document.createElement('input');
+  autoBuildPriority.type = 'checkbox';
+  autoBuildPriority.classList.add('auto-build-priority');
+  autoBuildPriority.id = `${structure.name}-auto-build-priority`;
+  autoBuildPriority.checked = structure.autoBuildPriority;
+  autoBuildPriority.addEventListener('change', () => {
+    structure.autoBuildPriority = autoBuildPriority.checked;
+  });
+  autoBuildPriorityLabel.prepend(autoBuildPriority);
+  autoBuildTargetContainer.appendChild(autoBuildPriorityLabel);
+
+  autoBuildContainer.appendChild(autoBuildTargetContainer);
 
   combinedStructureRow.append(autoBuildContainer);
 
@@ -470,6 +487,11 @@ function updateDecreaseButtonText(button, buildCount) {
         const autoBuildCheckbox = autoBuildContainer.querySelector('.auto-build-checkbox');
         if (autoBuildCheckbox) {
           autoBuildCheckbox.checked = structure.autoBuildEnabled;
+        }
+
+        const priorityCheckbox = autoBuildContainer.querySelector('.auto-build-priority');
+        if (priorityCheckbox) {
+          priorityCheckbox.checked = structure.autoBuildPriority;
         }
 
         const targetCount = Math.ceil((structure.autoBuildPercent * population) / 100);


### PR DESCRIPTION
## Summary
- add `autoBuildPriority` field to `Building`
- prioritize structures first in `autoBuild`
- expose the prioritize checkbox in UI
- update styles to align new checkbox
- export `autoBuild` for testing
- test prioritization behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845023229d0832788cdb35ca43035d6