### PR TITLE
Fix autobuild recalculation bug

### DIFF
--- a/__tests__/autoBuildRecalc.test.js
+++ b/__tests__/autoBuildRecalc.test.js
@@ -1,0 +1,39 @@
+const { autoBuild } = require('../autobuild.js');
+
+describe('autoBuild recalculates max buildable after each build', () => {
+  test('later buildings use updated resource amounts', () => {
+    const resource = { value: 10 };
+    global.resources = {
+      colony: {
+        colonists: { value: 10 },
+        metal: resource,
+      }
+    };
+
+    const buildingA = {
+      autoBuildEnabled: true,
+      autoBuildPercent: 10,
+      count: 0,
+      canAfford: () => resource.value >= 5,
+      maxBuildable: () => Math.floor(resource.value / 5),
+      build: jest.fn(() => { resource.value -= 5; }),
+      autoBuildPriority: true,
+    };
+
+    const buildingB = {
+      autoBuildEnabled: true,
+      autoBuildPercent: 10,
+      count: 0,
+      canAfford: () => resource.value >= 10,
+      maxBuildable: jest.fn(() => Math.floor(resource.value / 10)),
+      build: jest.fn(() => { resource.value -= 10; }),
+      autoBuildPriority: false,
+    };
+
+    autoBuild({ A: buildingA, B: buildingB });
+
+    expect(buildingA.build).toHaveBeenCalledWith(1);
+    expect(buildingB.maxBuildable).toHaveBeenCalled();
+    expect(buildingB.build).not.toHaveBeenCalled();
+  });
+});

--- a/autobuild.js
+++ b/autobuild.js
@@ -11,15 +11,10 @@ function autoBuild(buildings) {
             const requiredAmount = targetCount - building.count;
 
             if (requiredAmount > 0) {
-                // Pre-compute affordability to minimize redundant checks
-                const canBuildFull = building.canAfford(requiredAmount);
-                const maxBuildable = building.maxBuildable(); // Assume this method exists for efficiency
                 buildableBuildings.push({
                     building,
                     currentRatio,
                     requiredAmount,
-                    canBuildFull,
-                    maxBuildable,
                 });
             }
         }
@@ -33,11 +28,15 @@ function autoBuild(buildings) {
     });
 
     // Step 3: Efficiently allocate builds
-    buildableBuildings.forEach(({ building, requiredAmount, canBuildFull, maxBuildable }) => {
+    buildableBuildings.forEach(({ building, requiredAmount }) => {
+        const canBuildFull = building.canAfford(requiredAmount);
         if (canBuildFull) {
             building.build(requiredAmount); // Build all at once if affordable
-        } else if (maxBuildable > 0) {
-            building.build(maxBuildable); // Build the maximum number affordable
+        } else {
+            const maxBuildable = building.maxBuildable();
+            if (maxBuildable > 0) {
+                building.build(maxBuildable); // Build the maximum number affordable
+            }
         }
         // Skip incremental building as it significantly impacts performance
     });


### PR DESCRIPTION
## Summary
- recalc available builds after each autobuild step
- test that autobuild recalculates maximum buildable buildings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684505eefe6c83279b97f148dd34a4c6