### PR TITLE
Hook terraforming completion to button

### DIFF
--- a/progress.js
+++ b/progress.js
@@ -230,7 +230,10 @@ class StoryManager {
                  if (!terraforming) return false;
                  switch(objective.terraformingParameter){
                     case 'complete':
-                        return terraforming.completed;
+                        if (typeof spaceManager !== 'undefined') {
+                            return spaceManager.isPlanetTerraformed(spaceManager.getCurrentPlanetKey());
+                        }
+                        return false;
                     case 'tropicalTemperature':
                          return terraforming.temperature?.zones?.tropical?.value >= objective.value;
                     case 'tropicalNightTemperature':

--- a/terraforming.js
+++ b/terraforming.js
@@ -57,7 +57,10 @@ class Terraforming extends EffectableEntity{
     this.equilibriumPrecipitationMultiplier = EQUILIBRIUM_WATER_PARAMETER; // Default, will be calculated
     this.equilibriumCondensationParameter = EQUILIBRIUM_CO2_PARAMETER; // Default, will be calculated
 
-    this.completed = false;
+      this.completed = false;
+      // Indicates whether all terraforming parameters are within target ranges
+      // but completion has not yet been confirmed by the player
+      this.readyForCompletion = false;
     // Add properties to store total rates for UI display
     this.totalEvaporationRate = 0;
     this.totalWaterSublimationRate = 0;
@@ -858,14 +861,9 @@ class Terraforming extends EffectableEntity{
       this.applyTerraformingEffects();
 
       // --- Check and Update Overall Status ---
-      const newStatus = this.getTerraformingStatus(); // Calculate based on current state
-
-      // Check if the status has changed compared to the last known status
-      if (newStatus !== this.completed) {
-            this.completed = newStatus; // Update the internal flag
-            // Notify SpaceManager about the status change for the CURRENT planet
-            spaceManager.updateCurrentPlanetTerraformedStatus(this.completed);
-      } // <-- Correct closing brace for the 'if' block
+      // Determine if all parameters meet completion conditions
+      // This value is used by the UI to enable the "Complete Terraforming" button
+      this.readyForCompletion = this.getTerraformingStatus();
 
       // --- End of Status Update Logic ---
 

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -557,11 +557,14 @@ function createCompleteTerraformingButton(container) {
 
   container.appendChild(button);
 
-    // Add an event listener for the button
-    button.addEventListener('click', () => {
-      if (!button.disabled) {
-          terraforming.completed = true;
-      }
+  // Add an event listener for the button
+  button.addEventListener('click', () => {
+    if (!button.disabled) {
+        terraforming.completed = true;
+        if (typeof spaceManager !== 'undefined') {
+            spaceManager.updateCurrentPlanetTerraformedStatus(true);
+        }
+    }
   });
 }
 
@@ -571,7 +574,7 @@ function updateCompleteTerraformingButton() {
 
   if (!button) return;
 
-  if (terraforming.getTerraformingStatus()) {
+  if (terraforming.readyForCompletion) {
       button.style.backgroundColor = 'green';
       button.style.cursor = 'pointer';
       button.disabled = false; // Enable the button


### PR DESCRIPTION
## Summary
- track when all terraforming parameters meet goals without auto-completing
- only mark a planet terraformed when the "Complete Terraforming" button is clicked
- enable the completion button based on the new `readyForCompletion` flag
- have story events check planet status through `SpaceManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68458de165d08327b90d898ee93be866