### PR TITLE
Add planet selection reset feature

### DIFF
--- a/__tests__/planetSelection.test.js
+++ b/__tests__/planetSelection.test.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('planet selection', () => {
+  test('selecting another planet preserves managers and loads new parameters', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) {
+        this.config = config;
+      },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+
+    const oldStory = vm.runInContext('storyManager', ctx);
+    const oldSpace = vm.runInContext('spaceManager', ctx);
+    const marsDryIce = vm.runInContext('resources.surface.dryIce.value', ctx);
+
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const newName = vm.runInContext('currentPlanetParameters.name', ctx);
+    const newDryIce = vm.runInContext('resources.surface.dryIce.value', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(newName).toBe('Titan');
+    expect(oldStory).toBe(vm.runInContext('storyManager', ctx));
+    expect(oldSpace).toBe(vm.runInContext('spaceManager', ctx));
+    expect(marsDryIce).not.toBe(newDryIce);
+    expect(newDryIce).toBe(0);
+  });
+});

--- a/game.js
+++ b/game.js
@@ -88,7 +88,8 @@ function create() {
   }
 }
 
-function initializeGameState() {
+function initializeGameState(options = {}) {
+  const preserveManagers = options.preserveManagers || false;
   tabManager = new TabManager({
     description: 'Manages game tabs and unlocks them based on effects.',
   }, tabParameters);
@@ -121,10 +122,11 @@ function initializeGameState() {
   lifeManager = new LifeManager();
 
   milestonesManager = new MilestonesManager();
-  storyManager = new StoryManager(progressData);  // Pass the progressData object
-  storyManager.initializeStory();
-
-  spaceManager = new SpaceManager(planetParameters);
+  if (!preserveManagers) {
+    storyManager = new StoryManager(progressData);  // Pass the progressData object
+    storyManager.initializeStory();
+    spaceManager = new SpaceManager(planetParameters);
+  }
 
   // Regenerate UI elements to bind to new objects
   createResourceDisplay(resources); // Also need to update resource display
@@ -132,6 +134,11 @@ function initializeGameState() {
   createColonyButtons(colonies);
   initializeColonySlidersUI();
   initializeResearchUI(); // Reinitialize research UI as well
+  if (preserveManagers && typeof updateSpaceUI === 'function') {
+    updateSpaceUI();
+  } else if (!preserveManagers && typeof initializeSpaceUI === 'function') {
+    initializeSpaceUI(spaceManager);
+  }
 }
 
 function updateLogic(delta) {

--- a/space.js
+++ b/space.js
@@ -89,6 +89,16 @@ class SpaceManager {
         return false;
     }
 
+    /**
+     * Public wrapper for setting the current planet.
+     * Allows external callers (like the UI) to change planets safely.
+     * @param {string} key - The planet key to switch to.
+     * @returns {boolean} - True if the planet was changed.
+     */
+    changeCurrentPlanet(key) {
+        return this._setCurrentPlanetKey(key);
+    }
+
     // --- Save/Load ---
     saveState() {
         return {

--- a/spaceUI.js
+++ b/spaceUI.js
@@ -99,11 +99,40 @@ function updateSpaceUI() {
             //    selectButton.disabled = true;
             //} else {
                 selectButton.textContent = `Select ${data.name}`;
-                selectButton.disabled = true; // Still disabled until selection implemented
-                selectButton.title = "Planet selection not yet implemented.";
+                selectButton.disabled = false; // Enable selection
+                selectButton.title = `Travel to ${data.name}`;
             //}
         }
         planetDiv.appendChild(selectButton);
         optionsContainer.appendChild(planetDiv);
     });
+}
+
+// Handle click events for selecting planets
+document.addEventListener('click', function(evt){
+    const btn = evt.target.closest('.select-planet-button');
+    if(btn){
+        const key = btn.dataset.planetKey;
+        selectPlanet(key);
+    }
+});
+
+/**
+ * Select a planet and reset the game state for it.
+ * @param {string} planetKey
+ */
+function selectPlanet(planetKey){
+    if(!_spaceManagerInstance) {
+        console.error('SpaceManager not initialized');
+        return;
+    }
+    if(!_spaceManagerInstance.changeCurrentPlanet(planetKey)) return;
+
+    if(planetParameters[planetKey]){
+        defaultPlanet = planetKey;
+        currentPlanetParameters = planetParameters[planetKey];
+    }
+
+    initializeGameState({preserveManagers: true});
+    updateSpaceUI();
 }


### PR DESCRIPTION
## Summary
- allow resetting game state for a newly selected planet
- expose planet change through `SpaceManager.changeCurrentPlanet`
- refresh UI and data when selecting a planet
- support preserving managers in `initializeGameState`
- test planet selection behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68459105bd5c8327abc82ff35a82471a