### PR TITLE
Fix terraforming completion status

### DIFF
--- a/__tests__/terraformingCompletionButton.test.js
+++ b/__tests__/terraformingCompletionButton.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('complete terraforming button', () => {
+  test('updates space manager and refreshes UI', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><body><div id="terraforming-container"></div><div id="planet-selection-options"></div><div id="travel-status"></div></body>`);
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    global.terraforming = { completed: false, readyForCompletion: true };
+    global.spaceManager = {
+      updateCurrentPlanetTerraformedStatus: jest.fn(),
+    };
+    global.updateSpaceUI = jest.fn();
+
+    const ctx = vm.createContext(global);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const container = document.getElementById('terraforming-container');
+    ctx.createCompleteTerraformingButton(container);
+    const button = document.getElementById('complete-terraforming-button');
+    button.disabled = false;
+    button.click();
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+
+    expect(terraforming.completed).toBe(true);
+    expect(spaceManager.updateCurrentPlanetTerraformedStatus).toHaveBeenCalledWith(true);
+    expect(updateSpaceUI).toHaveBeenCalled();
+  });
+});

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -564,6 +564,14 @@ function createCompleteTerraformingButton(container) {
         if (typeof spaceManager !== 'undefined') {
             spaceManager.updateCurrentPlanetTerraformedStatus(true);
         }
+        // Refresh the space UI so the new status is displayed immediately
+        if (typeof updateSpaceUI === 'function') {
+            updateSpaceUI();
+        }
+        // Re-evaluate the button state after completing terraforming
+        if (typeof updateCompleteTerraformingButton === 'function') {
+            updateCompleteTerraformingButton();
+        }
     }
   });
 }


### PR DESCRIPTION
## Summary
- refresh planet status in Space UI when completing terraforming
- add test covering the Complete Terraforming button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845951b225c83278ad7a1b07b8b500d