### PR TITLE
Improve runaway greenhouse warning logic

### DIFF
--- a/__tests__/runawayGreenhouseWarning.test.js
+++ b/__tests__/runawayGreenhouseWarning.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('runaway greenhouse warning', () => {
+  test('only displays when optical depth high and temperature above 40C', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="warning-container"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.resources = { colony: { colonists: { consumptionRate: 0, productionRate: 1 } } };
+    ctx.terraforming = { temperature: { opticalDepth: 11, value: 314 } };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'warning.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.updateWarnings();
+    const container = dom.window.document.getElementById('warning-container');
+    expect(container.textContent).toContain('Runaway Greenhouse Effect');
+
+    ctx.terraforming.temperature.value = 300;
+    container.innerHTML = '';
+
+    ctx.updateWarnings();
+    expect(container.textContent).toBe('');
+  });
+});

--- a/warning.js
+++ b/warning.js
@@ -2,10 +2,11 @@ function updateWarnings() {
     const warningContainer = document.getElementById('warning-container');
     const colonists = resources.colony.colonists;
     const tau = terraforming?.temperature?.opticalDepth || 0;
+    const tempK = terraforming?.temperature?.value || 0;
 
     if (colonists.consumptionRate > colonists.productionRate) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Colonists are dying!</div>';
-    } else if (tau > 10) {
+    } else if (tau > 10 && tempK > 313.15) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Runaway Greenhouse Effect!</div>';
     } else {
       warningContainer.innerHTML = '';


### PR DESCRIPTION
## Summary
- adjust warning to only show the runaway greenhouse message when optical depth is high **and** temperature exceeds 40 °C
- add a Jest test covering the new warning behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68459d0c5e708327bdfe6e9452fb15e0