### PR TITLE
Fix planetary overrides when loading saves

### DIFF
--- a/save.js
+++ b/save.js
@@ -42,6 +42,16 @@ function loadGame(slotOrCustomString) {
 
       const gameState = JSON.parse(savedState);
 
+      // Load space state first so planet parameters are correct
+      if (gameState.spaceManager) {
+        spaceManager.loadState(gameState.spaceManager);
+        const key = spaceManager.getCurrentPlanetKey();
+        if (planetParameters[key]) {
+          defaultPlanet = key; // keep global consistent
+          currentPlanetParameters = planetParameters[key];
+        }
+      }
+
       // Restore day/night cycle progress
       if (gameState.dayNightCycle) {
           dayNightCycle.loadState(gameState.dayNightCycle);
@@ -141,10 +151,6 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.milestonesManager){
       milestonesManager.loadState(gameState.milestonesManager);
-    }
-
-    if(gameState.spaceManager){
-      spaceManager.loadState(gameState.spaceManager);
     }
 
     if(gameState.settings){


### PR DESCRIPTION
## Summary
- set `currentPlanetParameters` according to the saved planet before restoring other objects
- remove redundant late call to `spaceManager.loadState`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68459e8a03c083278a8114aa60364920