### PR TITLE
Fix dynamic base albedo display

### DIFF
--- a/__tests__/luminosityBaseAlbedoUpdate.test.js
+++ b/__tests__/luminosityBaseAlbedoUpdate.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('updateLuminosityBox', () => {
+  test('updates base albedo from celestial parameters', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div class="row"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.terraforming = {
+      luminosity: { name: 'Luminosity', albedo: 0, solarFlux: 0, modifiedSolarFlux: 0 },
+      celestialParameters: { albedo: 0.25 },
+      getLuminosityStatus: () => true,
+      calculateSolarPanelMultiplier: () => 1
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const row = dom.window.document.querySelector('.row');
+    ctx.createLuminosityBox(row);
+
+    ctx.terraforming.celestialParameters.albedo = 0.37;
+    ctx.updateLuminosityBox();
+
+    const text = dom.window.document.getElementById('base-albedo').textContent;
+    expect(text).toBe('0.37');
+  });
+});

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -541,6 +541,11 @@ function updateLifeBox() {
       luminosityBox.style.borderColor = 'red';
     }
 
+    const baseAlbedo = document.getElementById('base-albedo');
+    if (baseAlbedo) {
+      baseAlbedo.textContent = terraforming.celestialParameters.albedo.toFixed(2);
+    }
+
     const effectiveAlbedo = document.getElementById('effective-albedo');
     effectiveAlbedo.textContent = terraforming.luminosity.albedo.toFixed(2);
   


### PR DESCRIPTION
## Summary
- refresh base albedo in the luminosity box using current celestial parameters
- add a regression test ensuring base albedo updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845c9ed45e4832782205902fbdc7407