### PR TITLE
Add zonal surface dry ice override

### DIFF
--- a/__tests__/zonalSurfaceOverride.test.js
+++ b/__tests__/zonalSurfaceOverride.test.js
@@ -1,0 +1,45 @@
+const { getPlanetParameters } = require('../planet-parameters.js');
+const { getZonePercentage } = require('../zones.js');
+const EffectableEntity = require('../effectable-entity.js');
+const lifeParameters = require('../life-parameters.js');
+
+// Globals required by terraforming.js
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+
+const Terraforming = require('../terraforming.js');
+
+// Disable expensive updates
+Terraforming.prototype.updateLuminosity = function() {};
+Terraforming.prototype.updateSurfaceTemperature = function() {};
+
+function createResources(config) {
+  const res = {};
+  for (const cat in config) {
+    res[cat] = {};
+    for (const name in config[cat]) {
+      const val = config[cat][name].initialValue || 0;
+      res[cat][name] = { value: val, modifyRate: () => {} };
+    }
+  }
+  return res;
+}
+
+describe('zonal surface overrides', () => {
+  test('dry ice values from parameters are used', () => {
+    const params = getPlanetParameters('titan');
+    global.currentPlanetParameters = params;
+    const resources = createResources(params.resources);
+    global.resources = resources;
+
+    const terra = new Terraforming(resources, params.celestialParameters);
+    terra.calculateInitialValues();
+
+    expect(terra.zonalSurface.tropical.dryIce).toBeCloseTo(params.zonalSurface.tropical.dryIce);
+    expect(terra.zonalSurface.temperate.dryIce).toBeCloseTo(params.zonalSurface.temperate.dryIce);
+    expect(terra.zonalSurface.polar.dryIce).toBeCloseTo(params.zonalSurface.polar.dryIce);
+    // Biomass not provided in parameters should default to 0
+    expect(terra.zonalSurface.tropical.biomass).toBe(0);
+  });
+});

--- a/terraforming.js
+++ b/terraforming.js
@@ -295,6 +295,19 @@ class Terraforming extends EffectableEntity{
         this.zonalHydrocarbons = structuredClone(currentPlanetParameters.zonalHydrocarbons);
     }
 
+    // Override defaults if planet parameters specify zonal surface amounts
+    if (currentPlanetParameters.zonalSurface) {
+        this.zonalSurface = structuredClone(currentPlanetParameters.zonalSurface);
+        zones.forEach(z => {
+            if (!this.zonalSurface[z].hasOwnProperty('biomass')) {
+                this.zonalSurface[z].biomass = 0;
+            }
+            if (!this.zonalSurface[z].hasOwnProperty('dryIce')) {
+                this.zonalSurface[z].dryIce = 0;
+            }
+        });
+    }
+
     // Initialize global atmospheric resource amounts (no longer storing in this.atmosphere.gases)
     for (const gas in currentPlanetParameters.resources.atmospheric) {
         const initialTotalGasAmount = currentPlanetParameters.resources.atmospheric[gas]?.initialValue || 0;


### PR DESCRIPTION
## Summary
- allow planet parameters to specify zonal dry ice amounts
- test zonal surface overrides for dry ice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846087447848327b94fc997133c3982