### PR TITLE
Add HOPE tab placeholder

### DIFF
--- a/hope.css
+++ b/hope.css
@@ -1,0 +1,5 @@
+/* hope.css - placeholder for HOPE tab styles */
+
+.hope-container {
+    padding: 15px;
+}

--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
     <link rel="stylesheet" href="day-night-cycleUI.css">
     <!-- Add CSS for the new Space tab if needed -->
     <link rel="stylesheet" href="space.css">
+    <!-- Add CSS for the new HOPE tab -->
+    <link rel="stylesheet" href="hope.css">
 
     <!-- Parameter Scripts -->
     <script src="planet-parameters.js"></script>
@@ -99,6 +101,9 @@
     <!-- *** NEW SPACE TAB BUTTON *** -->
     <div class="tab hidden" id="space-tab" data-tab="space">Space</div>
     <!-- *************************** -->
+    <!-- *** NEW HOPE TAB BUTTON *** -->
+    <div class="tab hidden" id="hope-tab" data-tab="hope">H.O.P.E.</div>
+    <!-- ***************************** -->
     <div class="tab active" id="settings-tab" data-tab="settings">Save and Settings</div>
   </div>
 
@@ -280,6 +285,14 @@
         </div>
     </div>
     <!-- *************************** -->
+
+    <!-- *** NEW HOPE TAB CONTENT *** -->
+    <div id="hope" class="tab-content">
+        <div class="container hope-container">
+            <!-- Content will be added in future updates -->
+        </div>
+    </div>
+    <!-- ***************************** -->
 
     <!-- Settings Tab Content -->
     <div id="settings" class="tab-content active">

--- a/tab.js
+++ b/tab.js
@@ -37,6 +37,12 @@ const tabParameters = {
         isHidden: true   // Start hidden
       },
       {
+        id: "hope-tab",
+        label: "H.O.P.E.",
+        isActive: false,
+        isHidden: true // Hidden initially
+      },
+      {
         id: "settings-tab",
         label: "Settings",
         isActive: false,


### PR DESCRIPTION
## Summary
- insert a new hidden `H.O.P.E.` tab between Space and Settings
- create a placeholder `hope.css`
- wire the tab into TabManager configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684794b966d08327b1ac4ef1f5c6a995