### PR TITLE
Implement basic skill system

### DIFF
--- a/__tests__/skills.test.js
+++ b/__tests__/skills.test.js
@@ -1,0 +1,71 @@
+const { SkillManager } = require('../skills.js');
+
+describe('SkillManager save/load', () => {
+  beforeEach(() => {
+    global.addEffect = jest.fn();
+  });
+
+  test('saves and loads skill ranks', () => {
+    const data = {
+      test: {
+        id: 'test',
+        name: 'Test Skill',
+        description: 'desc',
+        cost: 1,
+        maxRank: 3,
+        effect: { target: 'global', type: 'dummy', value: 1 }
+      }
+    };
+    const manager = new SkillManager(data);
+    manager.unlockSkill('test');
+    manager.upgradeSkill('test');
+    const state = manager.saveState();
+
+    const manager2 = new SkillManager(data);
+    global.addEffect = jest.fn();
+    manager2.loadState(state);
+
+    expect(manager2.skills.test.rank).toBe(2);
+    expect(manager2.skills.test.unlocked).toBe(true);
+  });
+
+  test('upgrade cost scales with rank', () => {
+    const data = {
+      test: {
+        id: 'test',
+        name: 'Test Skill',
+        description: 'desc',
+        cost: 1,
+        maxRank: 3,
+        effect: { target: 'global', type: 'dummy', baseValue: 1, perRank: true }
+      }
+    };
+    const manager = new SkillManager(data);
+    expect(manager.getUpgradeCost('test')).toBe(1);
+    manager.unlockSkill('test');
+    expect(manager.getUpgradeCost('test')).toBe(2);
+    manager.upgradeSkill('test');
+    expect(manager.getUpgradeCost('test')).toBe(3);
+  });
+
+  test('reapplyEffects re-adds effects based on rank', () => {
+    const data = {
+      test: {
+        id: 'test',
+        name: 'Test Skill',
+        description: 'desc',
+        cost: 1,
+        maxRank: 3,
+        effect: { target: 'global', type: 'dummy', baseValue: 1, perRank: true }
+      }
+    };
+    const manager = new SkillManager(data);
+    manager.unlockSkill('test');
+    manager.upgradeSkill('test');
+    global.addEffect.mockClear();
+    manager.reapplyEffects();
+    expect(global.addEffect).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 2, sourceId: 'test' })
+    );
+  });
+});

--- a/game.js
+++ b/game.js
@@ -57,6 +57,9 @@ function create() {
   researchManager = new ResearchManager(researchParameters);
   initializeResearchUI();
 
+  // Initialize skills
+  skillManager = new SkillManager(skillParameters);
+
   //Initialize funding
   const fundingRate = currentPlanetParameters.fundingRate || 0;
   fundingModule = new FundingModule(resources, fundingRate);
@@ -108,6 +111,9 @@ function initializeGameState(options = {}) {
   colonies = initializeColonies(colonyParameters);
   structures = { ...buildings, ...colonies };
   researchManager = new ResearchManager(researchParameters);
+  if (!preserveManagers || !skillManager) {
+    skillManager = new SkillManager(skillParameters);
+  }
   const fundingRate = currentPlanetParameters.fundingRate || 0;
   fundingModule = new FundingModule(resources, fundingRate);
   populationModule = new PopulationModule(resources, currentPlanetParameters.populationParameters);
@@ -144,6 +150,9 @@ function initializeGameState(options = {}) {
   // target the newly created game objects for this planet.
   if (preserveManagers && storyManager && typeof storyManager.reapplyEffects === 'function') {
     storyManager.reapplyEffects();
+  }
+  if (preserveManagers && skillManager && typeof skillManager.reapplyEffects === 'function') {
+    skillManager.reapplyEffects();
   }
 }
 

--- a/globals.js
+++ b/globals.js
@@ -27,3 +27,4 @@ let colonySliderSettings = {
 };
 
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
+let skillManager;

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <script src="colony-parameters.js"></script>
     <script src="project-parameters.js"></script>
     <script src="research-parameters.js"></script>
+    <script src="skills-parameters.js"></script>
     <script src="progress-data.js"></script>
 
     <!-- Core Scripts -->
@@ -56,6 +57,7 @@
     <script src="spaceship.js"></script>
     <script src="spaceshipUI.js"></script>
     <script src="research.js"></script>
+    <script src="skills.js"></script>
     <script src="researchUI.js"></script>
     <script src="funding.js"></script>
     <script src="population.js"></script>

--- a/save.js
+++ b/save.js
@@ -15,6 +15,7 @@ function getGameState() {
     goldenAsteroid: goldenAsteroid.saveState(),
     lifeDesigner: lifeDesigner.saveState(),
     milestonesManager: milestonesManager.saveState(),
+    skills: skillManager.saveState(),
     spaceManager: spaceManager.saveState(),
     settings: gameSettings,
     colonySliderSettings: colonySliderSettings
@@ -154,6 +155,10 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.milestonesManager){
       milestonesManager.loadState(gameState.milestonesManager);
+    }
+
+    if(gameState.skills){
+      skillManager.loadState(gameState.skills);
     }
 
     if(gameState.settings){

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -1,0 +1,46 @@
+const skillParameters = {
+  build_cost: {
+    id: 'build_cost',
+    name: 'Efficient Architecture',
+    description: 'Reduces Building Costs by 10%',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'global',
+      type: 'costReduction',
+      baseValue: 0.1,
+      perRank: true
+    },
+    unlocks: ['pop_growth', 'worker_reduction']
+  },
+  pop_growth: {
+    id: 'pop_growth',
+    name: 'Population Boom',
+    description: 'Increases population growth by 10%',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'population',
+      type: 'populationGrowth',
+      baseValue: 0.1,
+      perRank: true
+    }
+  },
+  worker_reduction: {
+    id: 'worker_reduction',
+    name: 'Automation',
+    description: 'Reduces worker requirements by 10%',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'building',
+      type: 'workerReduction',
+      baseValue: 0.1,
+      perRank: true
+    }
+  }
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = skillParameters;
+}

--- a/skills.js
+++ b/skills.js
@@ -1,0 +1,100 @@
+class Skill {
+  constructor(config) {
+    this.id = config.id;
+    this.name = config.name;
+    this.description = config.description;
+    this.baseCost = config.cost; // base cost for rank 1
+    this.maxRank = config.maxRank || 1;
+    this.effect = config.effect || null;
+    this.unlocks = config.unlocks || [];
+    this.rank = 0;
+    this.unlocked = false;
+  }
+
+  getCostForRank(rank) {
+    return this.baseCost * rank;
+  }
+}
+
+class SkillManager {
+  constructor(skillData) {
+    this.skills = {};
+    if (skillData) {
+      for (const key in skillData) {
+        this.skills[key] = new Skill(skillData[key]);
+      }
+    }
+  }
+
+  unlockSkill(id) {
+    const skill = this.skills[id];
+    if (skill && !skill.unlocked) {
+      skill.unlocked = true;
+      skill.rank = 1;
+      this.applySkillEffect(skill);
+    }
+  }
+
+  upgradeSkill(id) {
+    const skill = this.skills[id];
+    if (skill && skill.unlocked && skill.rank < skill.maxRank) {
+      skill.rank += 1;
+      this.applySkillEffect(skill);
+    }
+  }
+
+  getUpgradeCost(id) {
+    const skill = this.skills[id];
+    if (!skill) return 0;
+    const nextRank = skill.rank + 1;
+    return skill.getCostForRank(nextRank);
+  }
+
+  applySkillEffect(skill) {
+    if (!skill.effect) return;
+    const effect = Object.assign({}, skill.effect, {
+      sourceId: skill.id,
+      effectId: skill.id,
+    });
+    if (skill.effect.perRank) {
+      effect.value = skill.effect.baseValue * skill.rank;
+    }
+    addEffect(effect);
+  }
+
+  saveState() {
+    const state = {};
+    for (const id in this.skills) {
+      const skill = this.skills[id];
+      state[id] = { rank: skill.rank, unlocked: skill.unlocked };
+    }
+    return state;
+  }
+
+  loadState(state) {
+    if (!state) return;
+    for (const id in state) {
+      const skill = this.skills[id];
+      if (skill) {
+        skill.rank = state[id].rank || 0;
+        skill.unlocked = state[id].unlocked || false;
+        if (skill.unlocked && skill.rank > 0) {
+          this.applySkillEffect(skill);
+        }
+      }
+    }
+  }
+
+  reapplyEffects() {
+    for (const id in this.skills) {
+      const skill = this.skills[id];
+      if (skill.unlocked && skill.rank > 0) {
+        this.applySkillEffect(skill);
+      }
+    }
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { Skill, SkillManager };
+}


### PR DESCRIPTION
## Summary
- add skills with cost scaling and new placeholder effects
- preserve SkillManager across planet resets
- support reapplying skill effects after reset
- compute upgrade cost per rank
- test new cost and reapply behaviours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684795ecd0a083279eb45c8d668a49d9