### PR TITLE
Expand late-game story with CEO funding

### DIFF
--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -124,6 +124,9 @@ class EffectableEntity {
         case 'oneTimeStart':
           this.applyOneTimeStart(effect);
           break;
+        case 'setFundingRate':
+          this.applySetFundingRate(effect);
+          break;
         // Add other effect types here as needed
         default:
           console.log(`Effect type "${effect.type}" is not supported for ${this.name}.`);
@@ -166,6 +169,12 @@ class EffectableEntity {
 
     applyWorkerRatio(effect) {
 
+    }
+
+    applySetFundingRate(effect) {
+      if (typeof this.fundingRate !== 'undefined' && typeof effect.value === 'number') {
+        this.fundingRate = effect.value;
+      }
     }
 
     // Method to apply a boolean flag effect

--- a/funding.js
+++ b/funding.js
@@ -32,4 +32,10 @@ class FundingModule extends EffectableEntity {
         'funding'
       );
   }
+
+  applySetFundingRate(effect) {
+    if (typeof effect.value === 'number') {
+      this.fundingRate = effect.value;
+    }
+  }
 }

--- a/progress-data.js
+++ b/progress-data.js
@@ -707,5 +707,51 @@ progressData = {
         reward: [],
         nextChapter: "chapter4.5"
       },
+      {
+        id: "chapter4.5",
+        type: "journal",
+        narrative: "Incoming encrypted transmission...\\n  'Greetings H.O.P.E., I am Adrien Solis, CEO of Solis Corp. Earth may be gone, but I still have resources off-world. Your mission is humanity's best hope, and I intend to support it.'",
+        objectives: [],
+        reward: [],
+        nextChapter: "chapter4.6"
+      },
+      {
+        id: "chapter4.6",
+        type: "journal",
+        narrative: "'My corporate fleet has some surplus funds. I'm transferring them to you immediately. Put them to good use.'",
+        objectives: [],
+        reward: [
+          {
+            target: 'project',
+            targetId: 'cargo_rocket',
+            type: 'oneTimeStart',
+            oneTimeFlag: true,
+            pendingResourceGains: [{ category: 'colony', resource: 'funding', quantity: 1000000 }]
+          }
+        ],
+        nextChapter: "chapter4.7"
+      },
+      {
+        id: "chapter4.7",
+        type: "journal",
+        narrative: "'Solis Corp will also arrange a continual stipend to keep you operational.'",
+        objectives: [],
+        reward: [
+          {
+            target: 'fundingModule',
+            type: 'setFundingRate',
+            value: 5000
+          }
+        ],
+        nextChapter: "chapter4.8"
+      },
+      {
+        id: "chapter4.8",
+        type: "journal",
+        narrative: "'Good luck, H.O.P.E. Humanity is counting on you.'",
+        objectives: [],
+        reward: [],
+        nextChapter: null
+      }
     ]
   };


### PR DESCRIPTION
## Summary
- extend story after Earth's destruction with new CEO-driven chapters
- grant one-time funding and set a funding rate via story rewards
- support new `setFundingRate` effect in funding and effectable entity classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68479bb58b208327a2e5a9ea28777b15