### PR TITLE
Enhance skill branching and ore scanner

### DIFF
--- a/__tests__/oreScanningEffectable.test.js
+++ b/__tests__/oreScanningEffectable.test.js
@@ -1,0 +1,19 @@
+const EffectableEntity = require('../effectable-entity.js');
+// expose globally so OreScanning can extend it when required
+global.EffectableEntity = EffectableEntity;
+const OreScanning = require('../ore-scanning.js');
+
+describe('OreScanning integration with EffectableEntity', () => {
+  const params = {
+    resources: {
+      underground: {
+        ore: { initialValue: 0, maxDeposits: 1, areaTotal: 100 }
+      }
+    }
+  };
+
+  test('instance inherits addEffect method', () => {
+    const scanner = new OreScanning(params);
+    expect(typeof scanner.addEffect).toBe('function');
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -232,7 +232,8 @@ function addOrRemoveEffect(effect, action) {
     'global': globalEffects,
     'terraforming': terraforming,
     'lifeDesigner': lifeDesigner,
-    'lifeManager': lifeManager
+    'lifeManager': lifeManager,
+    'oreScanner': oreScanner
   };
 
   if (effect.target in targetHandlers) {

--- a/ore-scanning.js
+++ b/ore-scanning.js
@@ -1,5 +1,6 @@
-class OreScanning {
+class OreScanning extends EffectableEntity {
     constructor(planetParameters) {
+      super({ description: 'Ore Scanner' });
       this.underground = planetParameters.resources.underground;
       // Extract all deposit parameters from marsParameters
       // Track progress and scanning strength for each deposit type
@@ -158,4 +159,8 @@ class OreScanning {
       const scanData = this.scanData[depositType];
       return scanData ? scanData.D_current : null;
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = OreScanning;
 }

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -11,7 +11,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    unlocks: ['pop_growth', 'worker_reduction']
+    unlocks: ['pop_growth', 'research_boost']
   },
   pop_growth: {
     id: 'pop_growth',
@@ -24,7 +24,8 @@ const skillParameters = {
       type: 'globalPopulationGrowth',
       baseValue: 0.1,
       perRank: true
-    }
+    },
+    unlocks: ['worker_reduction']
   },
   worker_reduction: {
     id: 'worker_reduction',
@@ -33,9 +34,65 @@ const skillParameters = {
     cost: 1,
     maxRank: 5,
     effect: {
-      target: 'building',
+      target: 'global',
       type: 'globalWorkerReduction',
       baseValue: 0.1,
+      perRank: true
+    },
+    unlocks: ['maintenance_reduction']
+  },
+  research_boost: {
+    id: 'research_boost',
+    name: 'Innovation Initiative',
+    description: 'Boosts research output by 20% per rank',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'global',
+      type: 'researchBoost',
+      baseValue: 0.2,
+      perRank: true
+    },
+    unlocks: ['scanning_speed']
+  },
+  maintenance_reduction: {
+    id: 'maintenance_reduction',
+    name: 'Streamlined Operations',
+    description: 'Reduces maintenance costs by 10% per rank',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'global',
+      type: 'maintenanceReduction',
+      baseValue: 0.1,
+      perRank: true
+    },
+    unlocks: ['ship_efficiency']
+  },
+  scanning_speed: {
+    id: 'scanning_speed',
+    name: 'Rapid Prospecting',
+    description: 'Doubles ore scanning speed each rank',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'oreScanner',
+      type: 'scanningSpeedMultiplier',
+      baseValue: 2,
+      perRank: true
+    },
+    unlocks: ['ship_efficiency']
+  },
+  ship_efficiency: {
+    id: 'ship_efficiency',
+    name: 'Advanced Logistics',
+    description: 'Ships import and export 20% more per rank',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'global',
+      type: 'shipEfficiency',
+      baseValue: 0.2,
       perRank: true
     }
   }


### PR DESCRIPTION
## Summary
- make `OreScanning` inherit from `EffectableEntity`
- allow effects to target the ore scanner
- reshape skill tree with branching unlocks
- update worker reduction and scanning speed targets
- test ore scanner inherits effect handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68479b6092688327b189747cbd93a798