### PR TITLE
Implement instant funding reward

### DIFF
--- a/__tests__/fundingRewards.test.js
+++ b/__tests__/fundingRewards.test.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../effectable-entity.js');
+
+class DummyResource extends EffectableEntity {
+  constructor() {
+    super({});
+    this.value = 0;
+  }
+  increase(amount) {
+    this.value += amount;
+  }
+}
+
+describe('funding rewards', () => {
+  let context;
+  beforeEach(() => {
+    context = {
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      window: {},
+      document: { addEventListener: () => {}, removeEventListener: () => {} },
+      clearJournal: () => {},
+      createPopup: () => {},
+      addJournalEntry: () => {},
+      buildings: {},
+      colonies: {},
+      terraforming: {},
+      projectManager: { projects: {} },
+      populationModule: { addAndReplace: () => {}, removeEffect: () => {} },
+      tabManager: {},
+      globalEffects: new EffectableEntity({ description: 'global' }),
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {}
+    };
+    vm.createContext(context);
+    context.EffectableEntity = EffectableEntity;
+    const fundingCode = fs.readFileSync(path.join(__dirname, '..', 'funding.js'), 'utf8');
+    vm.runInContext(fundingCode + '; this.FundingModule = FundingModule;', context);
+    const progressCode = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    vm.runInContext(`${progressCode}; this.StoryManager = StoryManager;`, context);
+    context.addEffect = (effect) => {
+      if (effect.target === 'fundingModule') {
+        context.fundingModule.applySetFundingRate(effect);
+      } else if (effect.target === 'resource') {
+        context.resources[effect.resourceType][effect.targetId].increase(effect.quantity);
+      }
+    };
+
+    context.resources = { colony: { funding: new DummyResource() } };
+    context.fundingModule = new context.FundingModule(context.resources, 100);
+  });
+
+  test('setFundingRate reward adds to funding rate', () => {
+    const manager = new context.StoryManager({ chapters: [] });
+    context.window.storyManager = manager;
+    const event = { id: 'e1', reward: [{ target: 'fundingModule', type: 'setFundingRate', value: 50, oneTimeFlag: true }], rewardDelay: 0 };
+
+    manager.applyRewards(event);
+
+    expect(context.fundingModule.fundingRate).toBe(150);
+  });
+
+  test('instantResourceGain increases resource immediately', () => {
+    const manager = new context.StoryManager({ chapters: [] });
+    context.window.storyManager = manager;
+    const event = { id: 'e2', reward: [{ target: 'resource', resourceType: 'colony', targetId: 'funding', type: 'instantResourceGain', quantity: 200, oneTimeFlag: true }], rewardDelay: 0 };
+
+    manager.applyRewards(event);
+
+    expect(context.resources.colony.funding.value).toBe(200);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -124,6 +124,9 @@ class EffectableEntity {
         case 'oneTimeStart':
           this.applyOneTimeStart(effect);
           break;
+        case 'instantResourceGain':
+          this.applyInstantResourceGain(effect);
+          break;
         case 'setFundingRate':
           this.applySetFundingRate(effect);
           break;
@@ -136,6 +139,15 @@ class EffectableEntity {
 
     applyOneTimeStart(effect) {
       //No logic needed for now
+    }
+
+    applyInstantResourceGain(effect) {
+      const amount = effect.quantity !== undefined ? effect.quantity : effect.value;
+      if (typeof amount === 'number' && typeof this.increase === 'function') {
+        this.increase(amount);
+      }
+      // Remove the effect immediately to prevent reapplication
+      this.activeEffects = this.activeEffects.filter(e => e !== effect);
     }
   
     // Placeholder for potential future use
@@ -173,7 +185,7 @@ class EffectableEntity {
 
     applySetFundingRate(effect) {
       if (typeof this.fundingRate !== 'undefined' && typeof effect.value === 'number') {
-        this.fundingRate = effect.value;
+        this.fundingRate += effect.value;
       }
     }
 

--- a/funding.js
+++ b/funding.js
@@ -35,7 +35,7 @@ class FundingModule extends EffectableEntity {
 
   applySetFundingRate(effect) {
     if (typeof effect.value === 'number') {
-      this.fundingRate = effect.value;
+      this.fundingRate += effect.value;
     }
   }
 }

--- a/progress-data.js
+++ b/progress-data.js
@@ -722,11 +722,12 @@ progressData = {
         objectives: [],
         reward: [
           {
-            target: 'project',
-            targetId: 'cargo_rocket',
-            type: 'oneTimeStart',
-            oneTimeFlag: true,
-            pendingResourceGains: [{ category: 'colony', resource: 'funding', quantity: 1000000 }]
+            target: 'resource',
+            resourceType: 'colony',
+            targetId: 'funding',
+            type: 'instantResourceGain',
+            quantity: 1000000,
+            oneTimeFlag: true
           }
         ],
         nextChapter: "chapter4.7"

--- a/progress.js
+++ b/progress.js
@@ -265,21 +265,19 @@ class StoryManager {
         let effectiveIndex = 0; // Use separate index for delay timing if filtering rewards
 
         event.reward.forEach((effect) => {
-            // Basic check if effect seems valid
-             if(effect && effect.type && effect.targetId) {
-                 setTimeout(() => {
-                    // Check if storyManager still exists, e.g. during quick save/load/reset
-                     if (!window.storyManager) { // Assuming storyManager is global or accessible
-                          console.warn("StoryManager gone, skipping delayed reward application.");
-                          return;
-                     }
+            if (effect && effect.type) {
+                setTimeout(() => {
+                    if (!window.storyManager) {
+                        console.warn("StoryManager gone, skipping delayed reward application.");
+                        return;
+                    }
                     if (!effect.oneTimeFlag) {
                         this.appliedEffects.push(effect);
                     }
                     addEffect(effect);
-                    console.log(`Applied reward for ${event.id}: ${effect.type} to ${effect.targetId}`);
+                    console.log(`Applied reward for ${event.id}: ${effect.type}`);
                 }, effectiveIndex * delay);
-                 effectiveIndex++;
+                effectiveIndex++;
             } else {
                 console.warn(`Skipping invalid reward object for event ${event.id}:`, effect);
             }


### PR DESCRIPTION
## Summary
- add `instantResourceGain` reward type for story events
- support funding rewards by adding to existing rate instead of overwriting
- allow rewards without `targetId`
- test funding rewards

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68479f7cc6188327ac7b0f6844056cc6