### PR TITLE
Add HOPE skill tree

### DIFF
--- a/__tests__/skillPointsSave.test.js
+++ b/__tests__/skillPointsSave.test.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('skillPoints save/load', () => {
+  test('skillPoints persist through save', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = { AUTO: 'AUTO', Game: function(){} };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+    const overrides = `
+      createPopup=()=>{};
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      initializeSpaceUI=()=>{};
+      TabManager = class { activateTab(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('skillManager.skillPoints = 5;', ctx);
+    vm.runInContext('var saved = JSON.stringify(getGameState());', ctx);
+    vm.runInContext('skillManager.skillPoints = 0;', ctx);
+    vm.runInContext('loadGame(saved);', ctx);
+    const result = vm.runInContext('skillManager.skillPoints', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(result).toBe(5);
+  });
+});

--- a/game.js
+++ b/game.js
@@ -84,6 +84,7 @@ function create() {
   createMilestonesUI();
 
   spaceManager = new SpaceManager(planetParameters);
+  initializeHopeUI();
   initializeSpaceUI(spaceManager);
 
   if(!loadMostRecentSave()){  // Handle initial game state (building counts, etc.)
@@ -140,6 +141,7 @@ function initializeGameState(options = {}) {
   createColonyButtons(colonies);
   initializeColonySlidersUI();
   initializeResearchUI(); // Reinitialize research UI as well
+  initializeHopeUI();
   if (preserveManagers && typeof updateSpaceUI === 'function') {
     updateSpaceUI();
   } else if (!preserveManagers && typeof initializeSpaceUI === 'function') {
@@ -202,6 +204,7 @@ function updateRender() {
   updateTerraformingUI();
   updateWarnings();
   updateMilestonesUI();
+  updateHopeUI();
 }
 
 function update(time, delta) {

--- a/hope.css
+++ b/hope.css
@@ -1,5 +1,0 @@
-/* hope.css - placeholder for HOPE tab styles */
-
-.hope-container {
-    padding: 15px;
-}

--- a/hopeUI.js
+++ b/hopeUI.js
@@ -1,0 +1,73 @@
+function initializeHopeUI() {
+    updateSkillPointDisplay();
+    createSkillTree();
+}
+
+function updateSkillPointDisplay() {
+    const span = document.getElementById('skill-points-value');
+    if (span) span.textContent = skillManager.skillPoints;
+}
+
+function formatSkillButtonText(skill) {
+    let text = `${skill.name} (Rank ${skill.rank}/${skill.maxRank})`;
+    if (skill.effect) {
+        const value = skill.effect.perRank ? skill.effect.baseValue * skill.rank : skill.effect.baseValue;
+        text += ` - Current: ${value}`;
+    }
+    if (skill.rank < skill.maxRank) {
+        text += ` - Cost: ${skillManager.getUpgradeCost(skill.id)}`;
+    } else {
+        text += ' - Max';
+    }
+    return text;
+}
+
+function updateSkillButton(skill) {
+    const button = document.getElementById(`skill-${skill.id}`);
+    if (!button) return;
+    button.textContent = formatSkillButtonText(skill);
+    button.disabled = skill.rank >= skill.maxRank || skillManager.getUpgradeCost(skill.id) > skillManager.skillPoints;
+}
+
+function createSkillTree() {
+    const container = document.getElementById('skill-tree');
+    if (!container) return;
+    container.innerHTML = '';
+    for (const id in skillManager.skills) {
+        const skill = skillManager.skills[id];
+        const button = document.createElement('button');
+        button.id = `skill-${id}`;
+        button.classList.add('skill-button');
+        button.addEventListener('click', () => purchaseSkill(id));
+        container.appendChild(button);
+        updateSkillButton(skill);
+    }
+}
+
+function purchaseSkill(id) {
+    const cost = skillManager.getUpgradeCost(id);
+    if (skillManager.skillPoints < cost) return;
+    const skill = skillManager.skills[id];
+    if (!skill.unlocked) {
+        skillManager.unlockSkill(id);
+    } else {
+        skillManager.upgradeSkill(id);
+    }
+    skillManager.skillPoints -= cost;
+    updateSkillTreeUI();
+}
+
+function updateSkillTreeUI() {
+    updateSkillPointDisplay();
+    for (const id in skillManager.skills) {
+        updateSkillButton(skillManager.skills[id]);
+    }
+}
+
+function updateHopeUI() {
+    updateSkillTreeUI();
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { formatSkillButtonText };
+}

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <!-- Add CSS for the new Space tab if needed -->
     <link rel="stylesheet" href="space.css">
     <!-- Add CSS for the new HOPE tab -->
-    <link rel="stylesheet" href="hope.css">
+    <link rel="stylesheet" href="skillsUI.css">
 
     <!-- Parameter Scripts -->
     <script src="planet-parameters.js"></script>
@@ -78,6 +78,7 @@
     <script src="lifeUI.js"></script>
     <script src="milestones.js"></script>
     <script src="milestonesUI.js"></script>
+    <script src="hopeUI.js"></script>
     <script src="zones.js"></script>
     <script src="globals.js"></script>
     <script src="autobuild.js"></script>
@@ -291,7 +292,15 @@
     <!-- *** NEW HOPE TAB CONTENT *** -->
     <div id="hope" class="tab-content">
         <div class="container hope-container">
-            <!-- Content will be added in future updates -->
+            <div class="hope-subtabs">
+                <div class="hope-subtab active" data-subtab="awakening-hope">Awakening</div>
+            </div>
+            <div class="hope-subtab-content-wrapper">
+                <div id="awakening-hope" class="hope-subtab-content active">
+                    <p id="skill-points-display">Skill Points: <span id="skill-points-value">0</span></p>
+                    <div id="skill-tree" class="skill-tree"></div>
+                </div>
+            </div>
         </div>
     </div>
     <!-- ***************************** -->

--- a/save.js
+++ b/save.js
@@ -156,7 +156,6 @@ function loadGame(slotOrCustomString) {
     if(gameState.milestonesManager){
       milestonesManager.loadState(gameState.milestonesManager);
     }
-
     if(gameState.skills){
       skillManager.loadState(gameState.skills);
     }

--- a/skills.js
+++ b/skills.js
@@ -19,6 +19,7 @@ class Skill {
 class SkillManager {
   constructor(skillData) {
     this.skills = {};
+    this.skillPoints = 0;
     if (skillData) {
       for (const key in skillData) {
         this.skills[key] = new Skill(skillData[key]);
@@ -63,21 +64,23 @@ class SkillManager {
   }
 
   saveState() {
-    const state = {};
+    const state = { skillPoints: this.skillPoints, skills: {} };
     for (const id in this.skills) {
       const skill = this.skills[id];
-      state[id] = { rank: skill.rank, unlocked: skill.unlocked };
+      state.skills[id] = { rank: skill.rank, unlocked: skill.unlocked };
     }
     return state;
   }
 
   loadState(state) {
     if (!state) return;
-    for (const id in state) {
+    this.skillPoints = state.skillPoints || 0;
+    const skillData = state.skills || {};
+    for (const id in skillData) {
       const skill = this.skills[id];
       if (skill) {
-        skill.rank = state[id].rank || 0;
-        skill.unlocked = state[id].unlocked || false;
+        skill.rank = skillData[id].rank || 0;
+        skill.unlocked = skillData[id].unlocked || false;
         if (skill.unlocked && skill.rank > 0) {
           this.applySkillEffect(skill);
         }

--- a/skillsUI.css
+++ b/skillsUI.css
@@ -1,0 +1,15 @@
+/* skillsUI.css - styles for the HOPE skills subtab */
+
+.hope-container {
+    padding: 15px;
+}
+
+.skill-tree {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.skill-button {
+    padding: 8px 12px;
+}

--- a/style.css
+++ b/style.css
@@ -10,7 +10,8 @@ body {
 .buildings-subtabs,
 .research-subtabs,
 .projects-subtabs,
-.terraforming-subtabs
+.terraforming-subtabs,
+.hope-subtabs
  {
     display: flex;
     cursor: pointer;
@@ -24,7 +25,8 @@ body {
 .building-subtab,
 .research-subtab,
 .projects-subtab,
-.terraforming-subtab { /* Added projects-subtab */
+.terraforming-subtab,
+.hope-subtab { /* Added projects-subtab */
     flex: 1;
     padding: 10px;
     text-align: center;
@@ -43,7 +45,8 @@ body {
 .building-subtab.active,
 .research-subtab.active,
 .projects-subtab.active,
-.terraforming-subtab.active { /* Added projects-subtab.active */
+.terraforming-subtab.active,
+.hope-subtab.active { /* Added projects-subtab.active */
     background-color: #666;
     color: #fff; /* Consistent text color for active state */
 }
@@ -88,14 +91,16 @@ body {
 .building-subtab-content,
 .research-subtab-content,
 .projects-subtab-content,
-.terraforming-subtab-content { /* Added projects-subtab-content */
+.terraforming-subtab-content,
+.hope-subtab-content { /* Added projects-subtab-content */
     display: none;
 }
 
 .building-subtab-content.active,
 .research-subtab-content.active,
 .projects-subtab-content.active,
-.terraforming-subtab-content.active { /* Added projects-subtab-content.active */
+.terraforming-subtab-content.active,
+.hope-subtab-content.active { /* Added projects-subtab-content.active */
     display: block;
 }
 


### PR DESCRIPTION
## Summary
- add HOPE skill tree UI and styles
- track skillPoints in globals and save/load logic
- hook HOPE UI into game initialization and rendering
- add tests for skill point persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6847a02065bc83278146e2c75621a340