### PR TITLE
Improve skill tree UI

### DIFF
--- a/__tests__/skillsUI.test.js
+++ b/__tests__/skillsUI.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('skillsUI createSkillTree', () => {
+  const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+  const { JSDOM } = require(jsdomPath);
+  const vm = require('vm');
+
+  test('buttons include description and locked skills are disabled', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="skill-points-display">Skill Points: <span id="skill-points-value"></span></div><div id="skill-tree"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.addEffect = () => {};
+    const { SkillManager } = require('../skills.js');
+    const skillParams = require('../skills-parameters.js');
+    ctx.skillManager = new SkillManager(skillParams);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'skillsUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+    ctx.initializeSkillsUI();
+
+    const buildBtn = dom.window.document.getElementById('skill-build_cost');
+    const popBtn = dom.window.document.getElementById('skill-pop_growth');
+    expect(buildBtn.innerHTML).toMatch(skillParams.build_cost.description);
+    expect(popBtn.disabled).toBe(true);
+  });
+});

--- a/hopeUI.js
+++ b/hopeUI.js
@@ -1,73 +1,12 @@
 function initializeHopeUI() {
-    updateSkillPointDisplay();
-    createSkillTree();
-}
-
-function updateSkillPointDisplay() {
-    const span = document.getElementById('skill-points-value');
-    if (span) span.textContent = skillManager.skillPoints;
-}
-
-function formatSkillButtonText(skill) {
-    let text = `${skill.name} (Rank ${skill.rank}/${skill.maxRank})`;
-    if (skill.effect) {
-        const value = skill.effect.perRank ? skill.effect.baseValue * skill.rank : skill.effect.baseValue;
-        text += ` - Current: ${value}`;
-    }
-    if (skill.rank < skill.maxRank) {
-        text += ` - Cost: ${skillManager.getUpgradeCost(skill.id)}`;
-    } else {
-        text += ' - Max';
-    }
-    return text;
-}
-
-function updateSkillButton(skill) {
-    const button = document.getElementById(`skill-${skill.id}`);
-    if (!button) return;
-    button.textContent = formatSkillButtonText(skill);
-    button.disabled = skill.rank >= skill.maxRank || skillManager.getUpgradeCost(skill.id) > skillManager.skillPoints;
-}
-
-function createSkillTree() {
-    const container = document.getElementById('skill-tree');
-    if (!container) return;
-    container.innerHTML = '';
-    for (const id in skillManager.skills) {
-        const skill = skillManager.skills[id];
-        const button = document.createElement('button');
-        button.id = `skill-${id}`;
-        button.classList.add('skill-button');
-        button.addEventListener('click', () => purchaseSkill(id));
-        container.appendChild(button);
-        updateSkillButton(skill);
-    }
-}
-
-function purchaseSkill(id) {
-    const cost = skillManager.getUpgradeCost(id);
-    if (skillManager.skillPoints < cost) return;
-    const skill = skillManager.skills[id];
-    if (!skill.unlocked) {
-        skillManager.unlockSkill(id);
-    } else {
-        skillManager.upgradeSkill(id);
-    }
-    skillManager.skillPoints -= cost;
-    updateSkillTreeUI();
-}
-
-function updateSkillTreeUI() {
-    updateSkillPointDisplay();
-    for (const id in skillManager.skills) {
-        updateSkillButton(skillManager.skills[id]);
+    if (typeof initializeSkillsUI === 'function') {
+        initializeSkillsUI();
     }
 }
 
 function updateHopeUI() {
-    updateSkillTreeUI();
+    if (typeof updateSkillTreeUI === 'function') {
+        updateSkillTreeUI();
+    }
 }
 
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { formatSkillButtonText };
-}

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
     <script src="spaceshipUI.js"></script>
     <script src="research.js"></script>
     <script src="skills.js"></script>
+    <script src="skillsUI.js"></script>
     <script src="researchUI.js"></script>
     <script src="funding.js"></script>
     <script src="population.js"></script>

--- a/skillsUI.css
+++ b/skillsUI.css
@@ -5,11 +5,30 @@
 }
 
 .skill-tree {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
+    position: relative;
+    width: 360px;
+    height: 520px;
 }
 
 .skill-button {
-    padding: 8px 12px;
+    width: 100px;
+    height: 100px;
+    position: absolute;
+    text-align: center;
+    padding: 4px;
+}
+
+#skill-lines {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+.skill-connector {
+    stroke: white;
+    stroke-width: 2;
+    fill: none;
 }

--- a/skillsUI.js
+++ b/skillsUI.js
@@ -1,0 +1,147 @@
+// Skills tree display and interactions
+let skillPrereqs = {};
+
+function buildSkillPrereqs() {
+    skillPrereqs = {};
+    for (const id in skillManager.skills) {
+        skillPrereqs[id] = [];
+    }
+    for (const id in skillManager.skills) {
+        const skill = skillManager.skills[id];
+        if (Array.isArray(skill.unlocks)) {
+            skill.unlocks.forEach(u => {
+                if (!skillPrereqs[u]) skillPrereqs[u] = [];
+                skillPrereqs[u].push(id);
+            });
+        }
+    }
+}
+
+function canUnlockSkill(id) {
+    const prereqs = skillPrereqs[id];
+    if (!prereqs || prereqs.length === 0) return true;
+    return prereqs.some(p => skillManager.skills[p] && skillManager.skills[p].unlocked);
+}
+
+const skillLayout = {
+    build_cost: { row: 0, col: 1 },
+    pop_growth: { row: 1, col: 0 },
+    research_boost: { row: 1, col: 2 },
+    worker_reduction: { row: 2, col: 0 },
+    scanning_speed: { row: 2, col: 2 },
+    maintenance_reduction: { row: 3, col: 0 },
+    ship_efficiency: { row: 3, col: 1 }
+};
+
+function updateSkillPointDisplay() {
+    const span = document.getElementById('skill-points-value');
+    if (span) span.textContent = skillManager.skillPoints;
+}
+
+function formatSkillButtonText(skill) {
+    let text = `<strong>${skill.name}</strong><br>${skill.description}<br>`;
+    text += `Rank ${skill.rank}/${skill.maxRank}`;
+    if (skill.rank < skill.maxRank) {
+        text += `<br>Cost: ${skillManager.getUpgradeCost(skill.id)}`;
+    } else {
+        text += '<br>Max';
+    }
+    return text;
+}
+
+function updateSkillButton(skill) {
+    const button = document.getElementById(`skill-${skill.id}`);
+    if (!button) return;
+    button.innerHTML = formatSkillButtonText(skill);
+    const locked = !skill.unlocked && !canUnlockSkill(skill.id);
+    button.disabled = locked || skill.rank >= skill.maxRank || skillManager.getUpgradeCost(skill.id) > skillManager.skillPoints;
+}
+
+function createSkillTree() {
+    buildSkillPrereqs();
+    const container = document.getElementById('skill-tree');
+    if (!container) return;
+    container.innerHTML = '';
+    container.style.position = 'relative';
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.id = 'skill-lines';
+    svg.style.position = 'absolute';
+    svg.style.left = '0';
+    svg.style.top = '0';
+    svg.style.width = '100%';
+    svg.style.height = '100%';
+    svg.style.pointerEvents = 'none';
+    container.appendChild(svg);
+
+    for (const id in skillManager.skills) {
+        const skill = skillManager.skills[id];
+        const button = document.createElement('button');
+        button.id = `skill-${id}`;
+        button.classList.add('skill-button');
+        const pos = skillLayout[id] || { row: 0, col: 0 };
+        button.style.position = 'absolute';
+        button.style.left = `${pos.col * 120 + 10}px`;
+        button.style.top = `${pos.row * 120 + 10}px`;
+        button.addEventListener('click', () => purchaseSkill(id));
+        container.appendChild(button);
+        updateSkillButton(skill);
+    }
+    drawSkillConnections();
+}
+
+function drawSkillConnections() {
+    const svg = document.getElementById('skill-lines');
+    if (!svg) return;
+    svg.innerHTML = '';
+    const cell = 120;
+    const margin = 10;
+    for (const id in skillManager.skills) {
+        const skill = skillManager.skills[id];
+        const fromPos = skillLayout[id];
+        if (!fromPos) continue;
+        const startX = fromPos.col * cell + margin + 50;
+        const startY = fromPos.row * cell + margin + 100;
+        for (const unlock of skill.unlocks || []) {
+            const toPos = skillLayout[unlock];
+            if (!toPos) continue;
+            const endX = toPos.col * cell + margin + 50;
+            const endY = toPos.row * cell + margin;
+            const midY = (startY + endY) / 2;
+            const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+            poly.setAttribute('points', `${startX},${startY} ${startX},${midY} ${endX},${midY} ${endX},${endY}`);
+            poly.setAttribute('class', 'skill-connector');
+            svg.appendChild(poly);
+        }
+    }
+}
+
+function purchaseSkill(id) {
+    const cost = skillManager.getUpgradeCost(id);
+    if (skillManager.skillPoints < cost) return;
+    const skill = skillManager.skills[id];
+    if (!skill.unlocked) {
+        if (!canUnlockSkill(id)) return;
+        skillManager.unlockSkill(id);
+    } else {
+        skillManager.upgradeSkill(id);
+    }
+    skillManager.skillPoints -= cost;
+    updateSkillTreeUI();
+}
+
+function updateSkillTreeUI() {
+    updateSkillPointDisplay();
+    for (const id in skillManager.skills) {
+        updateSkillButton(skillManager.skills[id]);
+    }
+    drawSkillConnections();
+}
+
+function initializeSkillsUI() {
+    updateSkillPointDisplay();
+    createSkillTree();
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { formatSkillButtonText, canUnlockSkill };
+}


### PR DESCRIPTION
## Summary
- add new `skillsUI.js` module for skill tree rendering
- display skill descriptions and connect skills with right-angle lines
- disable skill buttons until prerequisites unlocked
- make skill buttons square via CSS
- load the new skills UI in `index.html`
- adjust `hopeUI.js` to rely on new skills UI
- add tests for the skills UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847a61be764832781b9e89e515776dc