### PR TITLE
Add globalPopulationGrowth effect

### DIFF
--- a/__tests__/globalPopulationGrowth.test.js
+++ b/__tests__/globalPopulationGrowth.test.js
@@ -1,0 +1,38 @@
+const EffectableEntity = require('../effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+
+class TestPopulation extends EffectableEntity {
+  constructor(){
+    super({ description: 'pop' });
+  }
+  getEffectiveGrowthMultiplier(){
+    let m = 1;
+    this.activeEffects.forEach(e => {
+      if(e.type === 'growthMultiplier') m *= e.value;
+    });
+    return m;
+  }
+}
+
+describe('globalPopulationGrowth effect', () => {
+  test('applies growth multiplier', () => {
+    const pop = new TestPopulation();
+    pop.addAndReplace({
+      type: 'globalPopulationGrowth',
+      value: 0.1,
+      effectId: 'skill',
+      sourceId: 'skill'
+    });
+    expect(pop.getEffectiveGrowthMultiplier()).toBeCloseTo(1.1);
+  });
+
+  test('replacement updates multiplier', () => {
+    const pop = new TestPopulation();
+    pop.addAndReplace({ type: 'globalPopulationGrowth', value: 0.1, effectId: 'skill', sourceId: 'skill' });
+    pop.addAndReplace({ type: 'globalPopulationGrowth', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+    expect(pop.getEffectiveGrowthMultiplier()).toBeCloseTo(1.2);
+    const count = pop.activeEffects.filter(e => e.type === 'growthMultiplier').length;
+    expect(count).toBe(1);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -133,6 +133,9 @@ class EffectableEntity {
         case 'globalCostReduction':
           this.applyGlobalCostReduction(effect);
           break;
+        case 'globalPopulationGrowth':
+          this.applyGlobalPopulationGrowth(effect);
+          break;
         // Add other effect types here as needed
         default:
           console.log(`Effect type "${effect.type}" is not supported for ${this.name}.`);
@@ -217,6 +220,17 @@ class EffectableEntity {
           }
         }
       }
+    }
+
+    applyGlobalPopulationGrowth(effect) {
+      const multiplier = 1 + effect.value;
+      this.addAndReplace({
+        type: 'growthMultiplier',
+        value: multiplier,
+        effectId: `${effect.effectId}-growthMultiplier`,
+        sourceId: effect.sourceId,
+        onLoad: effect.onLoad
+      });
     }
 
     // Method to apply a boolean flag effect


### PR DESCRIPTION
## Summary
- implement `globalPopulationGrowth` in `EffectableEntity`
- add tests for population growth multiplier effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847ac117edc8327870a6f9343d9975c