### PR TITLE
Implement global worker & research effects

### DIFF
--- a/__tests__/globalResearchBoost.test.js
+++ b/__tests__/globalResearchBoost.test.js
@@ -1,0 +1,67 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../building.js');
+
+function createColony(id) {
+  const config = {
+    name: 'Colony',
+    category: 'colony',
+    cost: { colony: { metal: 100 } },
+    consumption: {},
+    production: { colony: { research: 10 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: false,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new Building(config, id);
+}
+
+describe('globalResearchBoost effect', () => {
+  let c1, c2;
+  beforeEach(() => {
+    global.buildings = {};
+    global.colonies = {};
+    global.projectManager = { projects: {} };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.terraforming = {};
+    global.lifeDesigner = {};
+    global.lifeManager = {};
+    global.oreScanner = {};
+    global.resources = { colony: { metal: { updateStorageCap: () => {} }, research: { updateStorageCap: () => {} } } };
+    global.globalEffects = new EffectableEntity({ description: 'global' });
+    global.maintenanceFraction = 0.1;
+
+    c1 = createColony('c1');
+    c2 = createColony('c2');
+    global.colonies.c1 = c1;
+    global.colonies.c2 = c2;
+  });
+
+  test('applies research production multiplier to colonies', () => {
+    global.globalEffects.addAndReplace({
+      type: 'globalResearchBoost',
+      value: 0.2,
+      effectId: 'skill',
+      sourceId: 'skill'
+    });
+
+    expect(c1.getEffectiveResourceProductionMultiplier('colony','research')).toBeCloseTo(1.2);
+    expect(c2.getEffectiveResourceProductionMultiplier('colony','research')).toBeCloseTo(1.2);
+  });
+
+  test('replacement updates multiplier', () => {
+    global.globalEffects.addAndReplace({ type: 'globalResearchBoost', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+    global.globalEffects.addAndReplace({ type: 'globalResearchBoost', value: 0.4, effectId: 'skill', sourceId: 'skill' });
+
+    expect(c1.getEffectiveResourceProductionMultiplier('colony','research')).toBeCloseTo(1.4);
+    const count = c1.activeEffects.filter(e => e.type === 'resourceProductionMultiplier').length;
+    expect(count).toBe(1);
+  });
+});

--- a/__tests__/globalWorkerReduction.test.js
+++ b/__tests__/globalWorkerReduction.test.js
@@ -1,0 +1,66 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../building.js');
+function createBuilding(id) {
+  const config = {
+    name: 'Test',
+    category: 'test',
+    cost: { colony: { metal: 100 } },
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: false,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 10,
+    unlocked: true
+  };
+  return new Building(config, id);
+}
+
+describe('globalWorkerReduction effect', () => {
+  let b1, b2;
+  beforeEach(() => {
+    global.buildings = {};
+    global.colonies = {};
+    global.projectManager = { projects: {} };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.terraforming = {};
+    global.lifeDesigner = {};
+    global.lifeManager = {};
+    global.oreScanner = {};
+    global.resources = { colony: { metal: { updateStorageCap: () => {} } } };
+    global.globalEffects = new EffectableEntity({ description: 'global' });
+    global.maintenanceFraction = 0.1;
+
+    b1 = createBuilding('b1');
+    b2 = createBuilding('b2');
+    global.buildings.b1 = b1;
+    global.buildings.b2 = b2;
+  });
+
+  test('applies worker multiplier to all buildings', () => {
+    global.globalEffects.addAndReplace({
+      type: 'globalWorkerReduction',
+      value: 0.1,
+      effectId: 'skill',
+      sourceId: 'skill'
+    });
+
+    expect(b1.getEffectiveWorkerMultiplier()).toBeCloseTo(0.9);
+    expect(b2.getEffectiveWorkerMultiplier()).toBeCloseTo(0.9);
+  });
+
+  test('replacement updates multiplier', () => {
+    global.globalEffects.addAndReplace({ type: 'globalWorkerReduction', value: 0.1, effectId: 'skill', sourceId: 'skill' });
+    global.globalEffects.addAndReplace({ type: 'globalWorkerReduction', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+
+    expect(b1.getEffectiveWorkerMultiplier()).toBeCloseTo(0.8);
+    const count = b1.activeEffects.filter(e => e.type === 'workerMultiplier').length;
+    expect(count).toBe(1);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -136,6 +136,12 @@ class EffectableEntity {
         case 'globalPopulationGrowth':
           this.applyGlobalPopulationGrowth(effect);
           break;
+        case 'globalWorkerReduction':
+          this.applyGlobalWorkerReduction(effect);
+          break;
+        case 'globalResearchBoost':
+          this.applyGlobalResearchBoost(effect);
+          break;
         // Add other effect types here as needed
         default:
           console.log(`Effect type "${effect.type}" is not supported for ${this.name}.`);
@@ -231,6 +237,44 @@ class EffectableEntity {
         sourceId: effect.sourceId,
         onLoad: effect.onLoad
       });
+    }
+
+    applyGlobalWorkerReduction(effect) {
+      const multiplier = 1 - effect.value;
+      for (const id in buildings) {
+        const building = buildings[id];
+        if (!building) continue;
+        const effectId = `${effect.effectId}-${id}`;
+        building.addAndReplace({
+          type: 'workerMultiplier',
+          value: multiplier,
+          effectId,
+          sourceId: effect.sourceId
+        });
+      }
+    }
+
+    applyGlobalResearchBoost(effect) {
+      const multiplier = 1 + effect.value;
+      for (const id in colonies) {
+        const colony = colonies[id];
+        if (
+          colony &&
+          colony.production &&
+          colony.production.colony &&
+          colony.production.colony.research !== undefined
+        ) {
+          const effectId = `${effect.effectId}-${id}`;
+          colony.addAndReplace({
+            type: 'resourceProductionMultiplier',
+            resourceCategory: 'colony',
+            resourceTarget: 'research',
+            value: multiplier,
+            effectId,
+            sourceId: effect.sourceId
+          });
+        }
+      }
     }
 
     // Method to apply a boolean flag effect


### PR DESCRIPTION
## Summary
- support new globalWorkerReduction and globalResearchBoost effect types
- test worker requirement reduction
- test research production boost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847adae07a4832780dffa7593470fed