### PR TITLE
Add missing skill effects

### DIFF
--- a/__tests__/globalMaintenanceReduction.test.js
+++ b/__tests__/globalMaintenanceReduction.test.js
@@ -1,0 +1,67 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../building.js');
+
+function createBuilding(id) {
+  const config = {
+    name: 'Test',
+    category: 'test',
+    cost: { colony: { metal: 100 } },
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: false,
+    requiresMaintenance: true,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new Building(config, id);
+}
+
+describe('globalMaintenanceReduction effect', () => {
+  let b1, b2;
+  beforeEach(() => {
+    global.buildings = {};
+    global.colonies = {};
+    global.projectManager = { projects: {} };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.terraforming = {};
+    global.lifeDesigner = {};
+    global.lifeManager = {};
+    global.oreScanner = {};
+    global.resources = { colony: { metal: { updateStorageCap: () => {} } } };
+    global.globalEffects = new EffectableEntity({ description: 'global' });
+    global.maintenanceFraction = 0.1;
+
+    b1 = createBuilding('b1');
+    b2 = createBuilding('b2');
+    global.buildings.b1 = b1;
+    global.buildings.b2 = b2;
+  });
+
+  test('applies maintenance multiplier to all entities', () => {
+    global.globalEffects.addAndReplace({
+      type: 'globalMaintenanceReduction',
+      value: 0.1,
+      effectId: 'skill',
+      sourceId: 'skill'
+    });
+
+    expect(b1.getEffectiveMaintenanceCostMultiplier('colony','metal')).toBeCloseTo(0.9);
+    expect(b2.getEffectiveMaintenanceCostMultiplier('colony','metal')).toBeCloseTo(0.9);
+  });
+
+  test('replacement updates multiplier', () => {
+    global.globalEffects.addAndReplace({ type: 'globalMaintenanceReduction', value: 0.1, effectId: 'skill', sourceId: 'skill' });
+    global.globalEffects.addAndReplace({ type: 'globalMaintenanceReduction', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+
+    expect(b1.getEffectiveMaintenanceCostMultiplier('colony','metal')).toBeCloseTo(0.8);
+    const count = b1.activeEffects.filter(e => e.type === 'maintenanceCostMultiplier').length;
+    expect(count).toBe(1);
+  });
+});

--- a/__tests__/scanningSpeedMultiplier.test.js
+++ b/__tests__/scanningSpeedMultiplier.test.js
@@ -1,0 +1,22 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const OreScanning = require('../ore-scanning.js');
+
+describe('scanningSpeedMultiplier effect', () => {
+  const params = {
+    resources: { underground: { ore: { initialValue: 0, maxDeposits: 1, areaTotal: 100 } } }
+  };
+
+  test('doubles scanning progress', () => {
+    global.resources = { underground: { ore: { addDeposit: jest.fn() } } };
+    const scanner = new OreScanning(params);
+    scanner.scanData.ore.currentScanningStrength = 1;
+    scanner.startScan('ore');
+    scanner.updateScan(50);
+    expect(scanner.scanData.ore.D_current).toBe(0);
+
+    scanner.addAndReplace({ type: 'scanningSpeedMultiplier', value: 2, effectId: 'skill', sourceId: 'skill' });
+    scanner.updateScan(50);
+    expect(scanner.scanData.ore.D_current).toBe(1);
+  });
+});

--- a/__tests__/shipEfficiency.test.js
+++ b/__tests__/shipEfficiency.test.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+let Project;
+let context;
+
+describe('shipEfficiency effect', () => {
+  let project;
+  beforeEach(() => {
+    context = {
+      console,
+      EffectableEntity,
+      shipEfficiency: 1,
+      resources: {},
+      buildings: {},
+      colonies: {},
+      projectManager: { projects: {} },
+      populationModule: {},
+      tabManager: {},
+      fundingModule: {},
+      terraforming: {},
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {},
+      globalEffects: new EffectableEntity({ description: 'global' })
+    };
+    vm.createContext(context);
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'projects.js'), 'utf8');
+    vm.runInContext(projectCode + '; this.Project = Project;', context);
+    Project = context.Project;
+
+    global.buildings = {};
+    global.colonies = {};
+    global.projectManager = { projects: {} };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.terraforming = {};
+    global.lifeDesigner = {};
+    global.lifeManager = {};
+    global.oreScanner = {};
+    global.resources = { colony: { metal: { updateStorageCap: () => {} } }, special:{ spaceships:{ value:0 } } };
+    global.globalEffects = context.globalEffects;
+    global.shipEfficiency = context.shipEfficiency;
+
+    const config = {
+      name: 'Test',
+      category: 'resources',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { metal: 1 } },
+        resourceGainPerShip: { colony: { metal: 10 } }
+      }
+    };
+    project = new Project(config, 'test');
+    project.assignedSpaceships = 1;
+  });
+
+  test('multiplies spaceship resource gain', () => {
+    let gain = project.calculateSpaceshipTotalResourceGain();
+    expect(gain.colony.metal).toBeCloseTo(10);
+    global.globalEffects.addAndReplace({ type: 'shipEfficiency', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+    context.shipEfficiency = global.shipEfficiency;
+    gain = project.calculateSpaceshipTotalResourceGain();
+    expect(gain.colony.metal).toBeCloseTo(12);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -142,6 +142,15 @@ class EffectableEntity {
         case 'globalResearchBoost':
           this.applyGlobalResearchBoost(effect);
           break;
+        case 'globalMaintenanceReduction':
+          this.applyGlobalMaintenanceReduction(effect);
+          break;
+        case 'scanningSpeedMultiplier':
+          this.applyScanningSpeedMultiplier(effect);
+          break;
+        case 'shipEfficiency':
+          this.applyShipEfficiency(effect);
+          break;
         // Add other effect types here as needed
         default:
           console.log(`Effect type "${effect.type}" is not supported for ${this.name}.`);
@@ -274,6 +283,43 @@ class EffectableEntity {
             sourceId: effect.sourceId
           });
         }
+      }
+    }
+
+    applyGlobalMaintenanceReduction(effect) {
+      const multiplier = 1 - effect.value;
+      const targets = { building: buildings, colony: colonies };
+      for (const groupName in targets) {
+        const group = targets[groupName];
+        for (const id in group) {
+          const entity = group[id];
+          if (!entity || !entity.cost) continue;
+          for (const category in entity.cost) {
+            for (const resource in entity.cost[category]) {
+              const effectId = `${effect.effectId}-${id}-${category}-${resource}`;
+              group[id].addAndReplace({
+                type: 'maintenanceCostMultiplier',
+                resourceCategory: category,
+                resourceId: resource,
+                value: multiplier,
+                effectId,
+                sourceId: effect.sourceId
+              });
+            }
+          }
+        }
+      }
+    }
+
+    applyScanningSpeedMultiplier(effect) {
+      if (this.scanningSpeedMultiplier !== undefined) {
+        this.scanningSpeedMultiplier = effect.value;
+      }
+    }
+
+    applyShipEfficiency(effect) {
+      if (typeof shipEfficiency !== 'undefined') {
+        shipEfficiency = 1 + effect.value;
       }
     }
 

--- a/globals.js
+++ b/globals.js
@@ -4,6 +4,7 @@ let tabManager;
 let currentPlanetParameters = planetParameters[defaultPlanet];
 let resources = {};
 let maintenanceFraction = currentPlanetParameters.buildingParameters.maintenanceFraction;
+let shipEfficiency = 1;
 let dayNightCycle;
 let buildings = {};
 let colonies = {};

--- a/ore-scanning.js
+++ b/ore-scanning.js
@@ -16,6 +16,12 @@ class OreScanning extends EffectableEntity {
       }
   
       this.loadFromConfig(planetParameters);
+      this.scanningSpeedMultiplier = 1;
+    }
+
+    applyActiveEffects(firstTime = true) {
+      this.scanningSpeedMultiplier = 1;
+      super.applyActiveEffects(firstTime);
     }
 
     // Method to save the current state of ore scanning
@@ -108,7 +114,7 @@ class OreScanning extends EffectableEntity {
         }
 
         // Update progress
-        const progressIncrement = deltaTime / scanData.remainingTime;
+        const progressIncrement = (deltaTime * this.scanningSpeedMultiplier) / scanData.remainingTime;
         scanData.currentScanProgress += progressIncrement;
 
         if (scanData.currentScanProgress >= 1) {

--- a/projects.js
+++ b/projects.js
@@ -428,11 +428,12 @@ class Project extends EffectableEntity {
     const totalResourceGain = {};
     const resourceGainPerShip = this.attributes.resourceGainPerShip;
     const scalingFactor = this.assignedSpaceships > 100 ? this.assignedSpaceships / 100 : 1;
+    const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
 
     for (const category in resourceGainPerShip) {
       totalResourceGain[category] = {};
       for (const resource in resourceGainPerShip[category]) {
-        totalResourceGain[category][resource] = resourceGainPerShip[category][resource] * scalingFactor;
+        totalResourceGain[category][resource] = resourceGainPerShip[category][resource] * scalingFactor * efficiency;
       }
     }
 
@@ -444,7 +445,8 @@ class Project extends EffectableEntity {
     const totalDisposal = {};
     const disposalAmount = this.attributes.disposalAmount;
     const scalingFactor = this.assignedSpaceships > 100 ? this.assignedSpaceships / 100 : 1;
-    const scaledDisposalAmount = disposalAmount * scalingFactor;
+    const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
+    const scaledDisposalAmount = disposalAmount * scalingFactor * efficiency;
 
     if (this.selectedDisposalResource) {
         const { category, resource } = this.selectedDisposalResource;


### PR DESCRIPTION
## Summary
- add globalMaintenanceReduction, scanningSpeedMultiplier and shipEfficiency effect handling
- support scanning speed multiplier in OreScanning
- apply ship efficiency to spaceship resource calculations
- expose new shipEfficiency global variable
- test new effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847af830cf88327967bc6dedc1be1cd