### PR TITLE
Fix ship efficiency gain display

### DIFF
--- a/__tests__/shipEfficiency.test.js
+++ b/__tests__/shipEfficiency.test.js
@@ -74,4 +74,13 @@ describe('shipEfficiency effect', () => {
     gain = project.calculateSpaceshipTotalResourceGain();
     expect(gain.colony.metal).toBeCloseTo(12);
   });
+
+  test('calculates gain per ship with efficiency', () => {
+    let gain = project.calculateSpaceshipGainPerShip();
+    expect(gain.colony.metal).toBeCloseTo(10);
+    global.globalEffects.addAndReplace({ type: 'shipEfficiency', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+    context.shipEfficiency = global.shipEfficiency;
+    gain = project.calculateSpaceshipGainPerShip();
+    expect(gain.colony.metal).toBeCloseTo(12);
+  });
 });

--- a/projects.js
+++ b/projects.js
@@ -407,6 +407,21 @@ class Project extends EffectableEntity {
     return totalCost;
   }
 
+  calculateSpaceshipGainPerShip() {
+    const resourceGainPerShip = this.attributes.resourceGainPerShip;
+    const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
+    const gainPerShip = {};
+
+    for (const category in resourceGainPerShip) {
+      gainPerShip[category] = {};
+      for (const resource in resourceGainPerShip[category]) {
+        gainPerShip[category][resource] = resourceGainPerShip[category][resource] * efficiency;
+      }
+    }
+
+    return gainPerShip;
+  }
+
     // Calculates adjusted total cost based on assigned spaceships, scaling if assignedSpaceships > 100
     calculateSpaceshipTotalCost() {
     const totalCost = {};

--- a/spaceshipUI.js
+++ b/spaceshipUI.js
@@ -27,8 +27,9 @@ function updateSpaceshipProjectCostAndGains(project, elements) {
   
     // Update Resource Gain per Ship display
     if (elements.resourceGainPerShipElement && project.attributes.resourceGainPerShip) {
-      const gainPerShipText = Object.entries(project.attributes.resourceGainPerShip)
-        .flatMap(([category, resourcesList]) => 
+      const gainPerShip = project.calculateSpaceshipGainPerShip();
+      const gainPerShipText = Object.entries(gainPerShip)
+        .flatMap(([category, resourcesList]) =>
           Object.entries(resourcesList)
             .filter(([, amount]) => amount > 0) // Only include non-zero gains
             .map(([resource, amount]) => {
@@ -144,7 +145,18 @@ function updateSpaceshipProjectCostAndGains(project, elements) {
     const resourceGainPerShipElement = document.createElement('p');
     resourceGainPerShipElement.id = `${project.name}-resource-gain-per-ship`;
     resourceGainPerShipElement.classList.add('project-resource-gain-per-ship');
-    resourceGainPerShipElement.textContent = `Gain per Ship: ...`; // Initial text
+    const initialGain = project.calculateSpaceshipGainPerShip();
+    const initialGainText = Object.entries(initialGain)
+      .flatMap(([category, resourcesList]) =>
+        Object.entries(resourcesList)
+          .filter(([, amount]) => amount > 0)
+          .map(([resource, amount]) => {
+            const resourceDisplayName = resources[category][resource].displayName ||
+              resource.charAt(0).toUpperCase() + resource.slice(1);
+            return `${resourceDisplayName}: ${formatNumber(amount, true)}`;
+          })
+      ).join(', ');
+    resourceGainPerShipElement.textContent = `Gain per Ship: ${initialGainText}`;
   
     const totalGainElement = document.createElement('span');
     totalGainElement.id = `${project.name}-total-resource-gain`;


### PR DESCRIPTION
## Summary
- calculate gain per ship with efficiency via new `calculateSpaceshipGainPerShip`
- show the calculated gain in spaceship UI
- test `calculateSpaceshipGainPerShip` with ship efficiency effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847bdde26648327afa3b20e1945a6a7