### PR TITLE
Apply shipEfficiency to exports

### DIFF
--- a/__tests__/shipEfficiency.test.js
+++ b/__tests__/shipEfficiency.test.js
@@ -83,4 +83,34 @@ describe('shipEfficiency effect', () => {
     gain = project.calculateSpaceshipGainPerShip();
     expect(gain.colony.metal).toBeCloseTo(12);
   });
+
+  test('multiplies export amount', () => {
+    const exportConfig = {
+      name: 'ExportTest',
+      category: 'resources',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        costPerShip: { colony: { metal: 1 } },
+        disposable: { colony: ['metal'] },
+        disposalAmount: 20,
+        fundingGainAmount: 1
+      }
+    };
+    const exportProject = new Project(exportConfig, 'exportTest');
+    exportProject.assignedSpaceships = 1;
+    exportProject.selectedDisposalResource = { category: 'colony', resource: 'metal' };
+
+    let disposal = exportProject.calculateSpaceshipTotalDisposal();
+    expect(disposal.colony.metal).toBeCloseTo(20);
+    global.globalEffects.addAndReplace({ type: 'shipEfficiency', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+    context.shipEfficiency = global.shipEfficiency;
+    disposal = exportProject.calculateSpaceshipTotalDisposal();
+    expect(disposal.colony.metal).toBeCloseTo(24);
+  });
 });

--- a/projectsUI.js
+++ b/projectsUI.js
@@ -446,12 +446,21 @@ function updateProjectUI(projectName) {
 
   if (project.attributes.spaceExport) {
     const elements = projectElements[project.name];
+    const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
 
-    // Calculate the total disposal amount with scaling factor
-    const scalingFactor = project.assignedSpaceships > 100 ? project.assignedSpaceships / 100 : 1;
-    const totalDisposalAmount = project.attributes.disposalAmount * scalingFactor;
+    if (elements.disposalPerShipElement) {
+      const perShip = project.attributes.disposalAmount * efficiency;
+      elements.disposalPerShipElement.textContent = `Maximum Export per Ship: ${formatNumber(perShip, true)}`;
+    }
 
-    elements.totalDisposalElement.textContent = `Total Export: ${formatNumber(totalDisposalAmount, true)}`;
+    const totalDisposal = project.calculateSpaceshipTotalDisposal();
+    let totalAmount = 0;
+    for (const category in totalDisposal) {
+      for (const resource in totalDisposal[category]) {
+        totalAmount += totalDisposal[category][resource];
+      }
+    }
+    elements.totalDisposalElement.textContent = `Total Export: ${formatNumber(totalAmount, true)}`;
   }
 
   // Update Repeat Count if applicable

--- a/spaceshipUI.js
+++ b/spaceshipUI.js
@@ -264,7 +264,9 @@ function updateSpaceshipProjectCostAndGains(project, elements) {
     const disposalPerShipElement = document.createElement('p');
     disposalPerShipElement.id = `${project.name}-disposal-per-ship`;
     disposalPerShipElement.classList.add('project-disposal-per-ship');
-    disposalPerShipElement.textContent = `Maximum Export per Ship: ${formatNumber(project.attributes.disposalAmount, true)}`;
+    const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
+    const disposalPerShipAmount = project.attributes.disposalAmount * efficiency;
+    disposalPerShipElement.textContent = `Maximum Export per Ship: ${formatNumber(disposalPerShipAmount, true)}`;
     disposalContainer.appendChild(disposalPerShipElement);
 
     //Gain Amount


### PR DESCRIPTION
## Summary
- show shipEfficiency effect in export displays
- compute total export using ship efficiency
- test export scaling with shipEfficiency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847bfe379d48327b37c37db7196d87a