### PR TITLE
Switch skills to requirements

### DIFF
--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -11,7 +11,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    unlocks: ['pop_growth', 'research_boost']
+    requires: []
   },
   pop_growth: {
     id: 'pop_growth',
@@ -25,7 +25,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    unlocks: ['worker_reduction']
+    requires: ['build_cost']
   },
   worker_reduction: {
     id: 'worker_reduction',
@@ -39,7 +39,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    unlocks: ['maintenance_reduction']
+    requires: ['pop_growth']
   },
   research_boost: {
     id: 'research_boost',
@@ -53,7 +53,7 @@ const skillParameters = {
       baseValue: 0.2,
       perRank: true
     },
-    unlocks: ['scanning_speed']
+    requires: ['build_cost']
   },
   maintenance_reduction: {
     id: 'maintenance_reduction',
@@ -67,6 +67,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
+    requires: ['worker_reduction']
   },
   scanning_speed: {
     id: 'scanning_speed',
@@ -80,7 +81,7 @@ const skillParameters = {
       baseValue: 2,
       perRank: true
     },
-    unlocks: ['ship_efficiency']
+    requires: ['research_boost']
   },
   ship_efficiency: {
     id: 'ship_efficiency',
@@ -93,7 +94,8 @@ const skillParameters = {
       type: 'shipEfficiency',
       baseValue: 0.2,
       perRank: true
-    }
+    },
+    requires: ['scanning_speed']
   }
 };
 

--- a/skills.js
+++ b/skills.js
@@ -6,7 +6,7 @@ class Skill {
     this.baseCost = config.cost; // base cost for rank 1
     this.maxRank = config.maxRank || 1;
     this.effect = config.effect || null;
-    this.unlocks = config.unlocks || [];
+    this.requires = config.requires || [];
     this.rank = 0;
     this.unlocked = false;
   }

--- a/skillsUI.js
+++ b/skillsUI.js
@@ -4,23 +4,15 @@ let skillPrereqs = {};
 function buildSkillPrereqs() {
     skillPrereqs = {};
     for (const id in skillManager.skills) {
-        skillPrereqs[id] = [];
-    }
-    for (const id in skillManager.skills) {
         const skill = skillManager.skills[id];
-        if (Array.isArray(skill.unlocks)) {
-            skill.unlocks.forEach(u => {
-                if (!skillPrereqs[u]) skillPrereqs[u] = [];
-                skillPrereqs[u].push(id);
-            });
-        }
+        skillPrereqs[id] = Array.isArray(skill.requires) ? skill.requires.slice() : [];
     }
 }
 
 function canUnlockSkill(id) {
     const prereqs = skillPrereqs[id];
     if (!prereqs || prereqs.length === 0) return true;
-    return prereqs.some(p => skillManager.skills[p] && skillManager.skills[p].unlocked);
+    return prereqs.every(p => skillManager.skills[p] && skillManager.skills[p].unlocked);
 }
 
 const skillLayout = {
@@ -97,15 +89,15 @@ function drawSkillConnections() {
     const margin = 10;
     for (const id in skillManager.skills) {
         const skill = skillManager.skills[id];
-        const fromPos = skillLayout[id];
-        if (!fromPos) continue;
-        const startX = fromPos.col * cell + margin + 100;
-        const startY = fromPos.row * cell + margin + 100;
-        for (const unlock of skill.unlocks || []) {
-            const toPos = skillLayout[unlock];
-            if (!toPos) continue;
-            const endX = toPos.col * cell + margin + 100;
-            const endY = toPos.row * cell + margin;
+        const toPos = skillLayout[id];
+        if (!toPos) continue;
+        const endX = toPos.col * cell + margin + 100;
+        const endY = toPos.row * cell + margin;
+        for (const prereq of skill.requires || []) {
+            const fromPos = skillLayout[prereq];
+            if (!fromPos) continue;
+            const startX = fromPos.col * cell + margin + 100;
+            const startY = fromPos.row * cell + margin + 100;
             const midY = (startY + endY) / 2;
             const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
             poly.setAttribute('points', `${startX},${startY} ${startX},${midY} ${endX},${midY} ${endX},${endY}`);


### PR DESCRIPTION
## Summary
- refactor skills to use `requires` dependencies instead of `unlocks`
- update UI logic to draw connections from prerequisites
- adjust skill parameter data accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684859ee10a483279bc0aa4009a07a8b