### PR TITLE
Reorder skills progression

### DIFF
--- a/__tests__/skillsUI.test.js
+++ b/__tests__/skillsUI.test.js
@@ -18,8 +18,8 @@ describe('skillsUI createSkillTree', () => {
     ctx.initializeSkillsUI();
 
     const buildBtn = dom.window.document.getElementById('skill-build_cost');
-    const popBtn = dom.window.document.getElementById('skill-pop_growth');
+    const autoBtn = dom.window.document.getElementById('skill-worker_reduction');
     expect(buildBtn.innerHTML).toMatch(skillParams.build_cost.description);
-    expect(popBtn.disabled).toBe(true);
+    expect(autoBtn.disabled).toBe(true);
   });
 });

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -25,7 +25,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    requires: ['build_cost']
+    requires: ['maintenance_reduction']
   },
   worker_reduction: {
     id: 'worker_reduction',
@@ -39,7 +39,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    requires: ['pop_growth']
+    requires: ['build_cost']
   },
   research_boost: {
     id: 'research_boost',

--- a/skillsUI.js
+++ b/skillsUI.js
@@ -17,11 +17,11 @@ function canUnlockSkill(id) {
 
 const skillLayout = {
     build_cost: { row: 0, col: 1 },
-    pop_growth: { row: 1, col: 0 },
+    worker_reduction: { row: 1, col: 0 },
     research_boost: { row: 1, col: 2 },
-    worker_reduction: { row: 2, col: 0 },
+    maintenance_reduction: { row: 2, col: 0 },
     scanning_speed: { row: 2, col: 2 },
-    maintenance_reduction: { row: 3, col: 0 },
+    pop_growth: { row: 3, col: 0 },
     ship_efficiency: { row: 3, col: 2 }
 };
 


### PR DESCRIPTION
## Summary
- rearrange skill requirements so automation comes before streamlined operations and population boom comes last
- update skill layout mapping to match new order
- adjust skillsUI test to use the new first locked skill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68485c6988ec83278b1b3b15575605ab