### PR TITLE
Add new project speed & life design point skills

### DIFF
--- a/__tests__/newSkillsParameters.test.js
+++ b/__tests__/newSkillsParameters.test.js
@@ -1,0 +1,17 @@
+const skillParams = require('../skills-parameters.js');
+
+describe('new skill parameter definitions', () => {
+  test('project_speed skill exists with correct config', () => {
+    const skill = skillParams.project_speed;
+    expect(skill).toBeDefined();
+    expect(skill.maxRank).toBe(5);
+    expect(skill.requires).toContain('maintenance_reduction');
+  });
+
+  test('life_design_points skill exists with correct config', () => {
+    const skill = skillParams.life_design_points;
+    expect(skill).toBeDefined();
+    expect(skill.maxRank).toBe(5);
+    expect(skill.requires).toContain('scanning_speed');
+  });
+});

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -96,6 +96,34 @@ const skillParameters = {
       perRank: true
     },
     requires: ['scanning_speed']
+  },
+  project_speed: {
+    id: 'project_speed',
+    name: 'Faster Projects',
+    description: 'Reduces project durations by 10% per rank',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'projects',
+      type: 'projectDurationReduction',
+      baseValue: 0.1,
+      perRank: true
+    },
+    requires: ['maintenance_reduction']
+  },
+  life_design_points: {
+    id: 'life_design_points',
+    name: 'More Life Design Points',
+    description: 'Grants 10 life design points per rank',
+    cost: 1,
+    maxRank: 5,
+    effect: {
+      target: 'lifeDesigner',
+      type: 'lifeDesignPointBonus',
+      baseValue: 10,
+      perRank: true
+    },
+    requires: ['scanning_speed']
   }
 };
 

--- a/skillsUI.js
+++ b/skillsUI.js
@@ -22,7 +22,9 @@ const skillLayout = {
     maintenance_reduction: { row: 2, col: 0 },
     scanning_speed: { row: 2, col: 2 },
     pop_growth: { row: 3, col: 0 },
-    ship_efficiency: { row: 3, col: 2 }
+    ship_efficiency: { row: 3, col: 2 },
+    project_speed: { row: 4, col: 0 },
+    life_design_points: { row: 4, col: 2 }
 };
 
 function updateSkillPointDisplay() {


### PR DESCRIPTION
## Summary
- add `project_speed` and `life_design_points` skill definitions
- position the new skills in the skill tree
- test presence of the new skill parameters

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68485e4e16c48327bff6a5fce4317276