### PR TITLE
Swap positions of two skills

### DIFF
--- a/__tests__/newSkillsParameters.test.js
+++ b/__tests__/newSkillsParameters.test.js
@@ -14,4 +14,14 @@ describe('new skill parameter definitions', () => {
     expect(skill.maxRank).toBe(5);
     expect(skill.requires).toContain('scanning_speed');
   });
+
+  test('pop_growth requires research_boost after swap', () => {
+    const skill = skillParams.pop_growth;
+    expect(skill.requires).toContain('research_boost');
+  });
+
+  test('scanning_speed requires maintenance_reduction after swap', () => {
+    const skill = skillParams.scanning_speed;
+    expect(skill.requires).toContain('maintenance_reduction');
+  });
 });

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -25,7 +25,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    requires: ['maintenance_reduction']
+    requires: ['research_boost']
   },
   worker_reduction: {
     id: 'worker_reduction',
@@ -81,7 +81,7 @@ const skillParameters = {
       baseValue: 2,
       perRank: true
     },
-    requires: ['research_boost']
+    requires: ['maintenance_reduction']
   },
   ship_efficiency: {
     id: 'ship_efficiency',

--- a/skillsUI.js
+++ b/skillsUI.js
@@ -20,8 +20,8 @@ const skillLayout = {
     worker_reduction: { row: 1, col: 2 },
     research_boost: { row: 1, col: 4 },
     maintenance_reduction: { row: 2, col: 2 },
-    scanning_speed: { row: 2, col: 4 },
-    pop_growth: { row: 3, col: 0 },
+    pop_growth: { row: 2, col: 4 },
+    scanning_speed: { row: 3, col: 0 },
     ship_efficiency: { row: 3, col: 2 },
     project_speed: { row: 3, col: 4 },
     life_design_points: { row: 3, col: 6 }


### PR DESCRIPTION
## Summary
- move Population Boom to follow research_boost
- move Rapid Prospecting under maintenance_reduction
- update layout positions for the two skills in the skill tree
- verify new prerequisites in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68486127e7f883279e036e1a229c78c7