### PR TITLE
Add project_speed skill effect

### DIFF
--- a/__tests__/projectDurationReduction.test.js
+++ b/__tests__/projectDurationReduction.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../effectable-entity.js');
+
+describe('projectDurationReduction effect', () => {
+  let context;
+  beforeEach(() => {
+    context = {
+      console,
+      EffectableEntity,
+    };
+    vm.createContext(context);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', context);
+
+    context.resources = {
+      colony: { funding: { value: 0, decrease: () => {}, modifyRate: () => {} } },
+      special: { spaceships: { value: 0 } }
+    };
+    context.buildings = {};
+    context.colonies = {};
+    context.populationModule = {};
+    context.tabManager = {};
+    context.fundingModule = {};
+    context.terraforming = {};
+    context.lifeDesigner = {};
+    context.lifeManager = {};
+    context.oreScanner = {};
+
+    global.resources = context.resources;
+    global.buildings = context.buildings;
+    global.colonies = context.colonies;
+    global.populationModule = context.populationModule;
+    global.tabManager = context.tabManager;
+    global.fundingModule = context.fundingModule;
+    global.terraforming = context.terraforming;
+    global.lifeDesigner = context.lifeDesigner;
+    global.lifeManager = context.lifeManager;
+    global.oreScanner = context.oreScanner;
+
+    context.projectManager = new context.ProjectManager();
+    global.projectManager = context.projectManager;
+  });
+
+  test('reduces project starting duration', () => {
+    const params = { test: { name: 'Test', duration: 100, description: '', cost: {}, category: 'resources', unlocked: true } };
+    context.projectManager.initializeProjects(params);
+    context.projectManager.addAndReplace({ type: 'projectDurationReduction', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+    const project = context.projectManager.projects.test;
+    project.start(context.resources);
+    expect(project.startingDuration).toBeCloseTo(80);
+  });
+
+  test('adjusts ongoing project on effect', () => {
+    const params = { test: { name: 'Test', duration: 100, description: '', cost: {}, category: 'resources', unlocked: true } };
+    context.projectManager.initializeProjects(params);
+    const project = context.projectManager.projects.test;
+    project.start(context.resources);
+    project.update(50);
+    expect(project.remainingTime).toBeCloseTo(50);
+    context.projectManager.addAndReplace({ type: 'projectDurationReduction', value: 0.2, effectId: 'skill', sourceId: 'skill' });
+    expect(project.startingDuration).toBeCloseTo(80);
+    expect(project.remainingTime).toBeCloseTo(40);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -151,6 +151,9 @@ class EffectableEntity {
         case 'shipEfficiency':
           this.applyShipEfficiency(effect);
           break;
+        case 'projectDurationReduction':
+          this.applyProjectDurationReduction(effect);
+          break;
         // Add other effect types here as needed
         default:
           console.log(`Effect type "${effect.type}" is not supported for ${this.name}.`);
@@ -320,6 +323,30 @@ class EffectableEntity {
     applyShipEfficiency(effect) {
       if (typeof shipEfficiency !== 'undefined') {
         shipEfficiency = 1 + effect.value;
+      }
+    }
+
+    applyProjectDurationReduction(effect) {
+      if (!this.projects) return;
+
+      if (this.durationMultiplier === undefined) {
+        this.durationMultiplier = 1;
+      }
+
+      const newMultiplier = 1 - effect.value;
+      this.durationMultiplier = newMultiplier;
+
+      for (const name in this.projects) {
+        const project = this.projects[name];
+        if (!project) continue;
+        const base = project.getBaseDuration ? project.getBaseDuration() : project.duration;
+        const newDuration = base * newMultiplier;
+
+        if (project.isActive) {
+          const progressRatio = (project.startingDuration - project.remainingTime) / project.startingDuration;
+          project.startingDuration = newDuration;
+          project.remainingTime = newDuration * (1 - progressRatio);
+        }
       }
     }
 

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -104,7 +104,7 @@ const skillParameters = {
     cost: 1,
     maxRank: 5,
     effect: {
-      target: 'projects',
+      target: 'projectManager',
       type: 'projectDurationReduction',
       baseValue: 0.1,
       perRank: true


### PR DESCRIPTION
## Summary
- target ProjectManager for project_speed skill
- enable projectDurationReduction effect and update effectable entity
- support dynamic duration multipliers for projects
- handle active project progress when duration changes
- test projectDurationReduction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68486266146c83279175c5eaffc5e76f