### PR TITLE
Modify skill cost scaling

### DIFF
--- a/__tests__/newSkillsParameters.test.js
+++ b/__tests__/newSkillsParameters.test.js
@@ -5,14 +5,14 @@ describe('new skill parameter definitions', () => {
     const skill = skillParams.project_speed;
     expect(skill).toBeDefined();
     expect(skill.maxRank).toBe(5);
-    expect(skill.requires).toContain('maintenance_reduction');
+    expect(skill.requires).toContain('pop_growth');
   });
 
   test('life_design_points skill exists with correct config', () => {
     const skill = skillParams.life_design_points;
     expect(skill).toBeDefined();
     expect(skill.maxRank).toBe(5);
-    expect(skill.requires).toContain('scanning_speed');
+    expect(skill.requires).toContain('pop_growth');
   });
 
   test('pop_growth requires research_boost after swap', () => {

--- a/__tests__/skills.test.js
+++ b/__tests__/skills.test.js
@@ -43,9 +43,9 @@ describe('SkillManager save/load', () => {
     const manager = new SkillManager(data);
     expect(manager.getUpgradeCost('test')).toBe(1);
     manager.unlockSkill('test');
-    expect(manager.getUpgradeCost('test')).toBe(2);
+    expect(manager.getUpgradeCost('test')).toBe(1);
     manager.upgradeSkill('test');
-    expect(manager.getUpgradeCost('test')).toBe(3);
+    expect(manager.getUpgradeCost('test')).toBe(2);
   });
 
   test('reapplyEffects re-adds effects based on rank', () => {

--- a/skills.js
+++ b/skills.js
@@ -12,7 +12,8 @@ class Skill {
   }
 
   getCostForRank(rank) {
-    return this.baseCost * rank;
+    const factor = Math.max(1, rank - 1);
+    return this.baseCost * factor;
   }
 }
 


### PR DESCRIPTION
## Summary
- implement staggered cost formula in `skills.js`
- adjust skill manager tests for new cost
- fix parameter expectation tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684865127ec88327abdf22db4fb69268