### PR TITLE
Implement life_design_points skill

### DIFF
--- a/__tests__/lifeDesignPointBonus.test.js
+++ b/__tests__/lifeDesignPointBonus.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+
+describe('lifeDesignPointBonus effect', () => {
+  let context;
+  beforeEach(() => {
+    context = { console, EffectableEntity };
+    vm.createContext(context);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', context);
+
+    context.resources = { surface: { biomass: { value: 0 } }, colony: {}, atmospheric: {} };
+    context.buildings = {};
+    context.colonies = {};
+    context.projectManager = { projects: {} };
+    context.populationModule = {};
+    context.tabManager = {};
+    context.fundingModule = {};
+    context.terraforming = { zonalSurface: { tropical:{}, temperate:{}, polar:{} }, zonalWater:{}, celestialParameters:{surfaceArea:1,gravity:1,radius:1}, zonalTemperature:{}, getMagnetosphereStatus:()=>true };
+    context.lifeManager = {};
+    context.oreScanner = {};
+
+    global.resources = context.resources;
+    global.buildings = context.buildings;
+    global.colonies = context.colonies;
+    global.projectManager = context.projectManager;
+    global.populationModule = context.populationModule;
+    global.tabManager = context.tabManager;
+    global.fundingModule = context.fundingModule;
+    global.terraforming = context.terraforming;
+    global.lifeManager = context.lifeManager;
+    global.oreScanner = context.oreScanner;
+
+    context.lifeDesigner = new context.LifeDesigner();
+    global.lifeDesigner = context.lifeDesigner;
+  });
+
+  test('adds bonus points to maxLifeDesignPoints', () => {
+    const designer = context.lifeDesigner;
+    expect(designer.maxLifeDesignPoints()).toBe(50);
+    designer.addAndReplace({ type: 'lifeDesignPointBonus', value: 10, effectId: 'skill', sourceId: 'skill' });
+    expect(designer.maxLifeDesignPoints()).toBe(60);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -154,6 +154,9 @@ class EffectableEntity {
         case 'projectDurationReduction':
           this.applyProjectDurationReduction(effect);
           break;
+        case 'lifeDesignPointBonus':
+          this.applyLifeDesignPointBonus(effect);
+          break;
         // Add other effect types here as needed
         default:
           console.log(`Effect type "${effect.type}" is not supported for ${this.name}.`);
@@ -347,6 +350,12 @@ class EffectableEntity {
           project.startingDuration = newDuration;
           project.remainingTime = newDuration * (1 - progressRatio);
         }
+      }
+    }
+
+    applyLifeDesignPointBonus(effect) {
+      if (typeof this.designPointBonus !== 'undefined') {
+        this.designPointBonus += effect.value;
       }
     }
 

--- a/life.js
+++ b/life.js
@@ -335,6 +335,9 @@ class LifeDesigner extends EffectableEntity {
     this.currentDesign = new LifeDesign(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); // Added spaceEfficiency and geologicalBurial default
     this.tentativeDesign = null;
 
+    this.baseMaxPoints = lifeDesignerConfig.maxPoints;
+    this.designPointBonus = 0;
+
     this.isActive = false;
     this.remainingTime = this.getTentativeDuration();
     this.totalTime = this.getTentativeDuration();
@@ -356,6 +359,15 @@ class LifeDesigner extends EffectableEntity {
 
   enable(){
     this.enabled = true;
+  }
+
+  applyActiveEffects(firstTime = true){
+    this.designPointBonus = 0;
+    super.applyActiveEffects(firstTime);
+  }
+
+  applyLifeDesignPointBonus(effect){
+    this.designPointBonus += effect.value;
   }
 
   createNewDesign(
@@ -455,7 +467,7 @@ class LifeDesigner extends EffectableEntity {
   maxLifeDesignPoints() {
     const totalPurchases = Object.values(this.purchaseCounts)
       .reduce((acc, val) => acc + val, 0);
-    return lifeDesignerConfig.maxPoints + totalPurchases;
+    return this.baseMaxPoints + this.designPointBonus + totalPurchases;
   }
 
   saveState() {

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -109,7 +109,7 @@ const skillParameters = {
       baseValue: 0.1,
       perRank: true
     },
-    requires: ['pop_growth']
+    requires: ['maintenance_reduction']
   },
   life_design_points: {
     id: 'life_design_points',
@@ -123,7 +123,7 @@ const skillParameters = {
       baseValue: 10,
       perRank: true
     },
-    requires: ['pop_growth']
+    requires: ['scanning_speed']
   }
 };
 


### PR DESCRIPTION
## Summary
- add skill parameter for life_design_points and fix prerequisites
- extend LifeDesigner with design point bonus support
- implement lifeDesignPointBonus effect handling
- test lifeDesignPointBonus effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68486588a6288327b4fa7d45d29da754