### PR TITLE
Fix Life design point stacking

### DIFF
--- a/__tests__/lifeDesignPointBonus.test.js
+++ b/__tests__/lifeDesignPointBonus.test.js
@@ -43,4 +43,12 @@ describe('lifeDesignPointBonus effect', () => {
     designer.addAndReplace({ type: 'lifeDesignPointBonus', value: 10, effectId: 'skill', sourceId: 'skill' });
     expect(designer.maxLifeDesignPoints()).toBe(60);
   });
+
+  test('replacing bonus effect does not stack previous values', () => {
+    const designer = context.lifeDesigner;
+    designer.addAndReplace({ type: 'lifeDesignPointBonus', value: 10, effectId: 'skill', sourceId: 'skill' });
+    expect(designer.maxLifeDesignPoints()).toBe(60);
+    designer.addAndReplace({ type: 'lifeDesignPointBonus', value: 20, effectId: 'skill', sourceId: 'skill' });
+    expect(designer.maxLifeDesignPoints()).toBe(70);
+  });
 });

--- a/life.js
+++ b/life.js
@@ -357,6 +357,18 @@ class LifeDesigner extends EffectableEntity {
     this.enabled = false;
   }
 
+  replaceEffect(effect) {
+    const existingEffectIndex = this.activeEffects.findIndex(
+      (activeEffect) => activeEffect.effectId === effect.effectId
+    );
+    if (existingEffectIndex !== -1) {
+      this.activeEffects[existingEffectIndex] = effect;
+      this.applyActiveEffects(false);
+    } else {
+      super.replaceEffect(effect);
+    }
+  }
+
   enable(){
     this.enabled = true;
   }


### PR DESCRIPTION
## Summary
- ensure replacing effects on LifeDesigner re-applies all active effects
- test that life_design_points bonus doesn't stack with upgrades

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684868b8f6688327a4d31e1eeafe3ed3