### PR TITLE
Fix colony slider visibility after reset

### DIFF
--- a/__tests__/colonySliders.test.js
+++ b/__tests__/colonySliders.test.js
@@ -145,6 +145,51 @@ describe('colony sliders', () => {
     expect(oreBoost).toBe('Boost: 100%');
   });
 
+  test('initializeColonySlidersUI keeps container hidden', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+    const { JSDOM } = require(jsdomPath);
+    const vm = require('vm');
+
+    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 };
+    const logicCode = fs.readFileSync(path.join(__dirname, '..', 'colonySliders.js'), 'utf8');
+    vm.runInContext(logicCode, ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'colonySlidersUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+
+    ctx.initializeColonySlidersUI();
+    const container = dom.window.document.getElementById('colony-sliders-container');
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  test('new game reinitializes sliders as hidden', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+    const { JSDOM } = require(jsdomPath);
+    const vm = require('vm');
+
+    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 };
+    const logicCode = fs.readFileSync(path.join(__dirname, '..', 'colonySliders.js'), 'utf8');
+    vm.runInContext(logicCode, ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'colonySlidersUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+
+    // Simulate unlocked state from previous game
+    const container = dom.window.document.getElementById('colony-sliders-container');
+    container.classList.remove('hidden');
+
+    // Starting a new game should hide sliders again
+    ctx.initializeColonySlidersUI();
+
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
   test('slider functions update UI values', () => {
     const fs = require('fs');
     const path = require('path');

--- a/colonySlidersUI.js
+++ b/colonySlidersUI.js
@@ -4,6 +4,8 @@ function initializeColonySlidersUI() {
   const container = document.getElementById('colony-sliders-container');
   if (!container) return;
   container.innerHTML = '';
+  // Ensure sliders start hidden until unlocked via research
+  container.classList.add('hidden');
 
   const box = document.createElement('div');
   box.classList.add('sliders-box');


### PR DESCRIPTION
## Summary
- keep the colony sliders container hidden when the UI initializes
- add test for resetting slider visibility on a new game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a030c616c8327bba309b6ba2a6445