### PR TITLE
Reset sliders on new game start

### DIFF
--- a/__tests__/gameUpdateTick.test.js
+++ b/__tests__/gameUpdateTick.test.js
@@ -76,6 +76,8 @@ describe('game update tick', () => {
       createMilestonesUI=()=>{};
       initializeSpaceUI=()=>{};
       updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
       TabManager = class {};
       StoryManager = class { initializeStory(){} update(){} };
     `;

--- a/__tests__/initializeGameStateSliders.test.js
+++ b/__tests__/initializeGameStateSliders.test.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+test('initializeGameState resets colony sliders to defaults', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const htmlPath = path.join(__dirname, '..', 'index.html');
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    runScripts: 'outside-only',
+    url: 'file://' + htmlPath,
+  });
+
+  function createNullElement() {
+    return new Proxy(function () {}, {
+      get: () => createNullElement(),
+      apply: () => createNullElement(),
+      set: () => true,
+    });
+  }
+  const nullElement = createNullElement();
+  const doc = dom.window.document;
+  doc.createElement = () => nullElement;
+  doc.getElementById = () => nullElement;
+  doc.querySelector = () => nullElement;
+  doc.querySelectorAll = () => [];
+  doc.getElementsByClassName = () => [];
+  doc.addEventListener = () => {};
+  doc.removeEventListener = () => {};
+
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalPhaser = global.Phaser;
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+  dom.window.Phaser = {
+    AUTO: 'AUTO',
+    Game: function(config){ this.config = config; },
+  };
+  global.Phaser = dom.window.Phaser;
+
+  const srcRegex = /<script\s+[^>]*src=['"]([^'"#]+)['"][^>]*>/gi;
+  const sources = [];
+  let match;
+  while ((match = srcRegex.exec(html)) !== null) {
+    if (!/^https?:\/\//.test(match[1])) {
+      sources.push(match[1]);
+    }
+  }
+
+  const ctx = dom.getInternalVMContext();
+  ctx.structuredClone = structuredClone;
+  ctx.colonySliderSettings = { workerRatio: 0.7, foodConsumption: 2, luxuryWater: 3, oreMineWorkers: 5 };
+
+  const errors = [];
+  for (const src of sources) {
+    const file = path.join(__dirname, '..', src);
+    const code = fs.readFileSync(file, 'utf8');
+    try {
+      vm.runInContext(code, ctx);
+    } catch (err) {
+      errors.push({ script: src, message: err.message });
+    }
+  }
+
+  const overrides = `
+    createResourceDisplay=()=>{};
+    createBuildingButtons=()=>{};
+    createColonyButtons=()=>{};
+    initializeResearchUI=()=>{};
+    initializeLifeUI=()=>{};
+    createMilestonesUI=()=>{};
+    initializeSpaceUI=()=>{};
+    updateDayNightDisplay=()=>{};
+    addEffect=()=>{};
+    removeEffect=()=>{};
+    TabManager = class {};
+    StoryManager = class { initializeStory(){} update(){} };
+  `;
+  vm.runInContext(overrides, ctx);
+
+  vm.runInContext('initializeGameState();', ctx);
+
+  const settings = vm.runInContext('colonySliderSettings', ctx);
+
+  global.window = originalWindow;
+  global.document = originalDocument;
+  global.Phaser = originalPhaser;
+
+  if (errors.length) {
+    throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+  }
+
+  expect(settings).toEqual({ workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 });
+});

--- a/__tests__/loadGamePlanet.test.js
+++ b/__tests__/loadGamePlanet.test.js
@@ -76,6 +76,8 @@ describe('load game planet initialization', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
       TabManager = class { activateTab(){} };
       StoryManager = class { initializeStory(){} update(){} saveState(){} };
     `;

--- a/__tests__/planetSelection.test.js
+++ b/__tests__/planetSelection.test.js
@@ -75,6 +75,8 @@ describe('planet selection', () => {
       initializeLifeUI=()=>{};
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
       TabManager = class {};
       StoryManager = class { initializeStory(){} update(){} };
     `;

--- a/__tests__/planetSelectionBlocked.test.js
+++ b/__tests__/planetSelectionBlocked.test.js
@@ -75,6 +75,8 @@ describe('planet selection blocked when not terraformed', () => {
       initializeLifeUI=()=>{};
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
       TabManager = class {};
       StoryManager = class { initializeStory(){} update(){} };
     `;

--- a/__tests__/skillPointsSave.test.js
+++ b/__tests__/skillPointsSave.test.js
@@ -71,6 +71,8 @@ describe('skillPoints save/load', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
       TabManager = class { activateTab(){} };
     `;
     vm.runInContext(overrides, ctx);

--- a/__tests__/travelSkillPoint.test.js
+++ b/__tests__/travelSkillPoint.test.js
@@ -75,6 +75,8 @@ describe('skill point gained on first planet visit', () => {
       initializeLifeUI=()=>{};
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
       TabManager = class {};
       StoryManager = class { initializeStory(){} update(){} };
     `;

--- a/game.js
+++ b/game.js
@@ -115,6 +115,12 @@ function initializeGameState(options = {}) {
   if (!preserveManagers || !skillManager) {
     skillManager = new SkillManager(skillParameters);
   }
+  // Reset colony management sliders to their default values
+  // so a fresh game always starts from a clean state. Saved games
+  // will overwrite these values after loading.
+  if (typeof resetColonySliders === 'function') {
+    resetColonySliders();
+  }
   const fundingRate = currentPlanetParameters.fundingRate || 0;
   fundingModule = new FundingModule(resources, fundingRate);
   populationModule = new PopulationModule(resources, currentPlanetParameters.populationParameters);


### PR DESCRIPTION
## Summary
- reset colony slider values inside `initializeGameState`
- update tests to stub `addEffect` and `removeEffect`
- add regression test covering slider reset on game init

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a058153a88327aac26483fac30d0d