### PR TITLE
Exponential scanning speed skill

### DIFF
--- a/__tests__/skills.test.js
+++ b/__tests__/skills.test.js
@@ -68,4 +68,26 @@ describe('SkillManager save/load', () => {
       expect.objectContaining({ value: 2, sourceId: 'test' })
     );
   });
+
+  test('scanning_speed scales exponentially', () => {
+    const skillParams = require('../skills-parameters.js');
+    const data = { scanning_speed: skillParams.scanning_speed };
+    const manager = new SkillManager(data);
+    manager.unlockSkill('scanning_speed');
+    expect(global.addEffect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ value: 2, sourceId: 'scanning_speed' })
+    );
+
+    global.addEffect.mockClear();
+    manager.upgradeSkill('scanning_speed');
+    expect(global.addEffect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ value: 4, sourceId: 'scanning_speed' })
+    );
+
+    global.addEffect.mockClear();
+    manager.upgradeSkill('scanning_speed');
+    expect(global.addEffect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ value: 8, sourceId: 'scanning_speed' })
+    );
+  });
 });

--- a/skills.js
+++ b/skills.js
@@ -59,7 +59,11 @@ class SkillManager {
       effectId: skill.id,
     });
     if (skill.effect.perRank) {
-      effect.value = skill.effect.baseValue * skill.rank;
+      if (skill.id === 'scanning_speed' && skill.effect.type === 'scanningSpeedMultiplier') {
+        effect.value = Math.pow(skill.effect.baseValue, skill.rank);
+      } else {
+        effect.value = skill.effect.baseValue * skill.rank;
+      }
     }
     addEffect(effect);
   }


### PR DESCRIPTION
## Summary
- make `scanning_speed` scale exponentially instead of linearly
- test that scanning_speed multiplies per rank

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a0dce602c83278e33976e9b0ae531