### PR TITLE
Fix worker cost coloring

### DIFF
--- a/__tests__/workerRequirementColor.test.js
+++ b/__tests__/workerRequirementColor.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../numbers.js');
+
+describe('updateStructureCostDisplay worker color', () => {
+  test('uses net worker requirement for orange color', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="cost"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+
+    ctx.resources = { colony: { workers: { value: 15 } } };
+
+    const structure = {
+      getTotalWorkerNeed: () => 10,
+      getEffectiveWorkerMultiplier: () => 2,
+      getEffectiveCost: () => ({}),
+      requiresLand: false,
+      canAffordLand: () => true,
+      requiresDeposit: false,
+      canAffordDeposit: () => true,
+      displayName: 'Test',
+      name: 'test'
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'structuresUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const costElement = dom.window.document.getElementById('cost');
+    ctx.updateStructureCostDisplay(costElement, structure, 1);
+
+    expect(costElement.innerHTML).toMatch(/color:\s*orange/);
+  });
+});

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -391,10 +391,10 @@ function updateDecreaseButtonText(button, buildCount) {
       const workerText = `Workers: ${formatNumber(requiredWorkers, true)}`;
       let formattedWorkerText;
   
-      if (availableWorkers >= structure.getTotalWorkerNeed()) {
+      if (availableWorkers >= requiredWorkers) {
         formattedWorkerText = workerText;
       } else {
-        // Use yellow color if not enough workers are available
+        // Use orange color if not enough workers are available
         formattedWorkerText = `<span style="color: orange;">${workerText}</span>`;
       }
   


### PR DESCRIPTION
## Summary
- check available workers against net requirement for current build
- test orange cost color uses adjusted worker need
- clarify comment about orange color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a0d730bb88327b127553770107230