### PR TITLE
Disable deploy button when life can’t survive

### DIFF
--- a/__tests__/lifeUIDeployButton.test.js
+++ b/__tests__/lifeUIDeployButton.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+const physics = require('../physics.js');
+const numbers = require('../numbers.js');
+
+describe('lifeUI deploy button', () => {
+  test('disabled when life cannot survive anywhere', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    // Minimal globals
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { day: 200, night: 200 }, temperate: { day: 200, night: 200 }, polar: { day: 200, night: 200 } } },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    // Load dependencies
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,0,0,0,0,0,0,0);
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    let applyBtn = dom.window.document.getElementById('life-apply-btn');
+    expect(applyBtn.disabled).toBe(true);
+
+    // Make environment survivable
+    ctx.terraforming.temperature.zones.tropical.day = 280;
+    ctx.terraforming.temperature.zones.tropical.night = 280;
+    ctx.terraforming.temperature.zones.temperate.day = 280;
+    ctx.terraforming.temperature.zones.temperate.night = 280;
+    ctx.terraforming.temperature.zones.polar.day = 280;
+    ctx.terraforming.temperature.zones.polar.night = 280;
+
+    ctx.updateLifeUI();
+    applyBtn = dom.window.document.getElementById('life-apply-btn');
+    expect(applyBtn.disabled).toBe(false);
+  });
+});

--- a/lifeUI.js
+++ b/lifeUI.js
@@ -355,7 +355,9 @@ function updateLifeUI() {
             showTentativeDesignCells();
             applyBtn.textContent = `Deploy: Duration ${(lifeDesigner.getTentativeDuration() / 1000).toFixed(2)} seconds`;
             applyProgressBar.style.width = '0%';
-            applyBtn.disabled = false; // Ensure button is enabled when not active
+            const survivable = lifeDesigner.tentativeDesign && lifeDesigner.tentativeDesign.canSurviveAnywhere();
+            applyBtn.disabled = !survivable; // Disable if design cannot survive
+            applyBtn.title = survivable ? '' : 'Life cannot survive anywhere';
             applyBtn.style.background = ''; // Reset background
         }
     }


### PR DESCRIPTION
## Summary
- prevent deployment if designed life can't survive anywhere
- test that life UI disables deploy until conditions allow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a2aaf5bdc8327b90c6ec56bee1c8f