### PR TITLE
Add advanced research tab

### DIFF
--- a/__tests__/advancedResearchReveal.test.js
+++ b/__tests__/advancedResearchReveal.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'research.js'), 'utf8');
+const researchUICode = fs.readFileSync(path.join(__dirname, '..', 'researchUI.js'), 'utf8');
+
+describe('booleanFlag advancedResearchUnlocked', () => {
+  test('reveals the advanced research subtab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="research-subtab hidden" data-subtab="advanced-research"></div><div id="advanced-research" class="research-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.globalGameIsLoadingFromSave = false;
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + researchUICode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.updateAdvancedResearchVisibility = updateAdvancedResearchVisibility;', ctx);
+
+    ctx.researchManager = new ctx.ResearchManager({ advanced: [] });
+    ctx.researchManager.addAndReplace({
+      type: 'booleanFlag',
+      flagId: 'advancedResearchUnlocked',
+      value: true,
+      effectId: 'test',
+      sourceId: 'test'
+    });
+
+    ctx.updateAdvancedResearchVisibility();
+
+    const subtab = dom.window.document.querySelector('.research-subtab');
+    const content = dom.window.document.getElementById('advanced-research');
+    expect(subtab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+  });
+});

--- a/__tests__/researchToggleCompleted.test.js
+++ b/__tests__/researchToggleCompleted.test.js
@@ -18,7 +18,8 @@ describe('toggleCompletedResearch', () => {
       ],
       industry: [],
       colonization: [],
-      terraforming: []
+      terraforming: [],
+      advanced: []
     } };
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'researchUI.js'), 'utf8');

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -45,6 +45,9 @@ class EffectableEntity {
         effectsToRemove.forEach(effect => {
           if (effect.type === 'booleanFlag') {
             this.booleanFlags.delete(effect.flagId);
+            if (typeof this[effect.flagId] === 'boolean') {
+              this[effect.flagId] = false;
+            }
           }
         });
     
@@ -359,16 +362,22 @@ class EffectableEntity {
       }
     }
 
+
     // Method to apply a boolean flag effect
     applyBooleanFlag(effect) {
       const { flagId, value } = effect;
       if (value) {
-        this.booleanFlags.add(flagId); // Add the flag to the Set
-        console.log(`Boolean flag "${flagId}" set to true for ${this.name}.`);
+        this.booleanFlags.add(flagId);
       } else {
-        this.booleanFlags.delete(flagId); // Remove the flag from the Set
-        console.log(`Boolean flag "${flagId}" set to false for ${this.name}.`);
+        this.booleanFlags.delete(flagId);
       }
+
+      if (typeof this[flagId] === 'boolean') {
+        this[flagId] = value;
+      }
+
+
+      console.log(`Boolean flag "${flagId}" set to ${value} for ${this.name}.`);
     }
 
     // Method to check if a boolean flag is set

--- a/index.html
+++ b/index.html
@@ -215,6 +215,7 @@
                 <div class="research-subtab" data-subtab="industry-research">Industry</div>
                 <div class="research-subtab" data-subtab="colonization-research">Colonization</div>
                 <div class="research-subtab" data-subtab="terraforming-research">Terraforming</div>
+                <div class="research-subtab hidden" data-subtab="advanced-research">Advanced</div>
             </div>
             <div class="subtab-content-wrapper">
                 <div id="energy-research" class="research-subtab-content active">
@@ -244,6 +245,13 @@
                     <button class="toggle-completed-button">Toggle Completed</button>
                   </div>
                   <div class="research-list" id="terraforming-research-buttons"></div>
+                </div>
+                <div id="advanced-research" class="research-subtab-content hidden">
+                  <div class="research-header">
+                    <span class="research-title">Advanced Research</span>
+                    <button class="toggle-completed-button">Toggle Completed</button>
+                  </div>
+                  <div class="research-list" id="advanced-research-buttons"></div>
                 </div>
               </div>
         </div>

--- a/research-parameters.js
+++ b/research-parameters.js
@@ -951,5 +951,8 @@ const researchParameters = {
         ],
       },   
     ],
+    advanced: [
+      // researches unlocking late game technology will be added here
+    ]
   };
   

--- a/research.js
+++ b/research.js
@@ -11,12 +11,14 @@ class Research {
       this.effects = effects;
       this.isResearched = false; // Flag indicating if the research has been completed
     }
-  }
-  
+}
+
   // Research Manager Class to manage all researches
-  class ResearchManager {
+  class ResearchManager extends EffectableEntity {
     constructor(researchData) {
+      super({ description: 'Manages all research' });
       this.researches = {};
+      this.advancedResearchUnlocked = false;
   
       // Load research data and create Research instances
       for (const category in researchData) {
@@ -135,4 +137,8 @@ class Research {
 function initializeResearchUI() {
     // Initializes the UI tabs for research
     initializeResearchTabs(); // Delegates the sub-tab event listeners and initial UI load to research-ui.js
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { ResearchManager, Research };
 }

--- a/researchUI.js
+++ b/researchUI.js
@@ -1,7 +1,7 @@
 let completedResearchHidden = false; // Initialize the toggle state
 
 function updateAllResearchButtons(researchData) {
-    const researchTabs = ['energy', 'industry', 'colonization', 'terraforming'];
+    const researchTabs = ['energy', 'industry', 'colonization', 'terraforming', 'advanced'];
     researchTabs.forEach((tab) => {
         researchData[tab].forEach((researchItem) => {
             const button = document.getElementById(`research-${researchItem.id}`);
@@ -59,8 +59,10 @@ function initializeResearchTabs() {
         button.onclick = toggleCompletedResearch;
     });
 
+    updateAdvancedResearchVisibility();
+
     // Load all research categories
-    const researchCategories = ['energy', 'industry', 'colonization', 'terraforming'];
+    const researchCategories = ['energy', 'industry', 'colonization', 'terraforming', 'advanced'];
     researchCategories.forEach(category => {
         loadResearchCategory(category);
     });
@@ -150,7 +152,23 @@ function updateCompletedResearchVisibility() {
     });
 }
 
+function updateAdvancedResearchVisibility() {
+    const visible = researchManager && researchManager.advancedResearchUnlocked;
+    const subtab = document.querySelector('.research-subtab[data-subtab="advanced-research"]');
+    const content = document.getElementById('advanced-research');
+    if (subtab && content) {
+        if (visible) {
+            subtab.classList.remove('hidden');
+            content.classList.remove('hidden');
+        } else {
+            subtab.classList.add('hidden');
+            content.classList.add('hidden');
+        }
+    }
+}
+
 function updateResearchUI() {
     updateAllResearchButtons(researchManager.researches); // Update research buttons display
     updateCompletedResearchVisibility();
+    updateAdvancedResearchVisibility();
 }


### PR DESCRIPTION
## Summary
- introduce ResearchManager as `EffectableEntity` with `advancedResearchUnlocked`
- track advanced research visibility on ResearchManager instead of global flags
- update UI visibility checks
- adjust test to use ResearchManager when unlocking advanced research
- use boolean flag effect instead of new effect
- remove DOM-specific logic from `EffectableEntity`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68535e444200832796900f8f502891ff