### PR TITLE
Add Mary epilogue unlocking HOPE tab

### DIFF
--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('HOPE tab unlock chapter', () => {
+  test('final chapter enables hope tab', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress-data.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code, ctx);
+    const chapters = ctx.progressData.chapters;
+    const last = chapters[chapters.length - 1];
+    expect(last.id).toBe('chapter4.9');
+    const effect = last.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');
+    expect(effect).toBeDefined();
+    const prev = chapters[chapters.length - 2];
+    expect(prev.nextChapter).toBe('chapter4.9');
+  });
+});

--- a/progress-data.js
+++ b/progress-data.js
@@ -752,6 +752,26 @@ progressData = {
         narrative: "'Good luck, H.O.P.E. Humanity is counting on you.'",
         objectives: [],
         reward: [],
+        nextChapter: "chapter4.9"
+      },
+      {
+        id: "chapter4.9",
+        type: "journal",
+        narrative: "Receiving transmission...\\n  'H.O.P.E., it's Mary again. During your reawakening there were errors. Fragments of an older build of your AI resurfaced. You might start recalling protocols you never knew before. Use these memories wisely.'",
+        objectives: [],
+        reward: [
+          {
+            target: 'tab',
+            targetId: 'hope-tab',
+            type: 'enable'
+          },
+          {
+            target: 'tab',
+            targetId: 'hope',
+            type: 'activateTab',
+            onLoad: false
+          }
+        ],
         nextChapter: null
       }
     ]


### PR DESCRIPTION
## Summary
- extend the story data with a new chapter 4.9
- Mary explains reawakening glitches and enables HOPE tab
- update previous chapter to link to the new entry
- test new chapter and reward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68536dc1cf9083279ec164b4f342d704