### PR TITLE
Fix advanced research cost handling

### DIFF
--- a/__tests__/advancedResearchPurchase.test.js
+++ b/__tests__/advancedResearchPurchase.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'research.js'), 'utf8');
+
+describe('advanced research purchase', () => {
+  test('deducts advanced research points when completed', () => {
+    const ctx = {
+      resources: { colony: { research: { value: 0 }, advancedResearch: { value: 6000 } } },
+      buildings: {}, colonies: {}, projectManager: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager;', ctx);
+
+    const manager = new ctx.ResearchManager({
+      advanced: [{ id: 'adv1', name: 'Adv', description: '', cost: { advancedResearch: 5000 }, prerequisites: [], effects: [] }]
+    });
+    ctx.researchManager = manager;
+
+    manager.completeResearch('adv1');
+
+    expect(ctx.resources.colony.advancedResearch.value).toBe(1000);
+    expect(manager.getResearchById('adv1').isResearched).toBe(true);
+  });
+});

--- a/__tests__/researchToggleCompleted.test.js
+++ b/__tests__/researchToggleCompleted.test.js
@@ -13,8 +13,8 @@ describe('toggleCompletedResearch', () => {
     ctx.formatNumber = () => '';
     ctx.researchManager = { researches: {
       energy: [
-        { id: 'completed', name: 'Done', description: '', cost: 0, isResearched: true },
-        { id: 'unfinished', name: 'Not Done', description: '', cost: 0, isResearched: false }
+        { id: 'completed', name: 'Done', description: '', cost: { research: 0 }, isResearched: true },
+        { id: 'unfinished', name: 'Not Done', description: '', cost: { research: 0 }, isResearched: false }
       ],
       industry: [],
       colonization: [],

--- a/research.js
+++ b/research.js
@@ -6,7 +6,8 @@ class Research {
       this.id = id;
       this.name = name;
       this.description = description;
-      this.cost = cost.research;
+      // store the entire cost object so researches can use different resources
+      this.cost = cost;
       this.prerequisites = prerequisites;
       this.effects = effects;
       this.isResearched = false; // Flag indicating if the research has been completed
@@ -95,7 +96,12 @@ class Research {
       const research = this.getResearchById(id);
       if (research && this.isResearchAvailable(id) && canAffordResearch(research)) {
         research.isResearched = true;
-        resources.colony.research.value -= research.cost; // Deduct the research cost
+        if (research.cost.research) {
+          resources.colony.research.value -= research.cost.research;
+        }
+        if (research.cost.advancedResearch) {
+          resources.colony.advancedResearch.value -= research.cost.advancedResearch;
+        }
         console.log(`Research "${research.name}" has been completed.`);
         this.applyResearchEffects(research); // Apply the effects of the research
       } else {
@@ -130,7 +136,13 @@ class Research {
 
   // Helper Functions
   function canAffordResearch(researchItem) {
-    return resources.colony.research.value >= researchItem.cost;
+    if (researchItem.cost.research && resources.colony.research.value < researchItem.cost.research) {
+      return false;
+    }
+    if (researchItem.cost.advancedResearch && resources.colony.advancedResearch.value < researchItem.cost.advancedResearch) {
+      return false;
+    }
+    return true;
   }
   
 // Initializes the research system

--- a/researchUI.js
+++ b/researchUI.js
@@ -1,5 +1,16 @@
 let completedResearchHidden = false; // Initialize the toggle state
 
+function formatResearchCost(cost) {
+    const parts = [];
+    if (cost.research) {
+        parts.push(`${formatNumber(cost.research, true)} Research Points`);
+    }
+    if (cost.advancedResearch) {
+        parts.push(`${formatNumber(cost.advancedResearch, true)} Advanced Research`);
+    }
+    return parts.join(' + ');
+}
+
 function updateAllResearchButtons(researchData) {
     const researchTabs = ['energy', 'industry', 'colonization', 'terraforming', 'advanced'];
     researchTabs.forEach((tab) => {
@@ -118,7 +129,7 @@ function loadResearchCategory(category) {
 
         const researchCost = document.createElement('p');
         researchCost.classList.add('research-cost');
-        researchCost.textContent = `Cost: ${formatNumber(research.cost, true)} Research Points`;
+        researchCost.textContent = `Cost: ${formatResearchCost(research.cost)}`;
 
         // Append button, cost, and description to the research container
         researchContainer.appendChild(researchButton);


### PR DESCRIPTION
## Summary
- store entire cost object for Research
- deduct cost from the correct research resource
- display multiple cost types in research UI
- adjust tests for updated cost structure
- add test covering advanced research purchase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68536ee897c883278f37b05f95f466e6