### PR TITLE
Add skill tree reset

### DIFF
--- a/__tests__/skills.test.js
+++ b/__tests__/skills.test.js
@@ -90,4 +90,31 @@ describe('SkillManager save/load', () => {
       expect.objectContaining({ value: 8, sourceId: 'scanning_speed' })
     );
   });
+
+  test('resetSkillTree clears ranks and effects', () => {
+    global.removeEffect = jest.fn();
+    const data = {
+      test: {
+        id: 'test',
+        name: 'Test Skill',
+        description: 'desc',
+        cost: 1,
+        maxRank: 2,
+        effect: { target: 'global', type: 'dummy', baseValue: 1, perRank: true }
+      }
+    };
+    const manager = new SkillManager(data);
+    manager.skillPoints = 5;
+    manager.unlockSkill('test');
+    manager.upgradeSkill('test');
+
+    manager.resetSkillTree();
+
+    expect(manager.skillPoints).toBe(0);
+    expect(manager.skills.test.rank).toBe(0);
+    expect(manager.skills.test.unlocked).toBe(false);
+    expect(global.removeEffect).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'test', target: 'global' })
+    );
+  });
 });

--- a/skills.js
+++ b/skills.js
@@ -101,6 +101,22 @@ class SkillManager {
       }
     }
   }
+
+  resetSkillTree() {
+    for (const id in this.skills) {
+      const skill = this.skills[id];
+      if (skill.unlocked && skill.effect) {
+        const effect = { target: skill.effect.target, sourceId: skill.id };
+        if (skill.effect.targetId) effect.targetId = skill.effect.targetId;
+        if (typeof removeEffect === 'function') {
+          removeEffect(effect);
+        }
+      }
+      skill.rank = 0;
+      skill.unlocked = false;
+    }
+    this.skillPoints = 0;
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- add `resetSkillTree` method to `SkillManager`
- test skill tree reset functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68536f86a38c83278ecad3fbdfdfc18f