### PR TITLE
Add empty-state messages for buildings and projects

### DIFF
--- a/projectsUI.js
+++ b/projectsUI.js
@@ -36,6 +36,8 @@ function renderProjects() {
   projectsArray.forEach(project => {
     updateProjectUI(project.name);
   });
+
+  updateEmptyProjectMessages();
 }
 
 function initializeProjectsUI() {
@@ -668,10 +670,32 @@ function formatTotalResourceGainDisplay(totalResourceGain) {
   const gainArray = [];
   for (const category in totalResourceGain) {
     for (const resource in totalResourceGain[category]) {
-      const resourceDisplayName = resources[category][resource].displayName || 
+      const resourceDisplayName = resources[category][resource].displayName ||
         resource.charAt(0).toUpperCase() + resource.slice(1);
       gainArray.push(`${resourceDisplayName}: ${formatNumber(totalResourceGain[category][resource], true)}`);
     }
   }
   return `Total Gain: ${gainArray.join(', ')}`;
+}
+
+function updateEmptyProjectMessages() {
+  document.querySelectorAll('.projects-list').forEach(container => {
+    const messageId = `${container.id}-empty-message`;
+    let message = document.getElementById(messageId);
+
+    const hasVisible = Array.from(container.getElementsByClassName('special-projects-item'))
+      .some(item => item.style.display !== 'none');
+
+    if (!hasVisible) {
+      if (!message) {
+        message = document.createElement('p');
+        message.id = messageId;
+        message.classList.add('empty-message');
+        message.textContent = 'Nothing available for now.';
+        container.appendChild(message);
+      }
+    } else if (message) {
+      message.remove();
+    }
+  });
 }

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -353,6 +353,7 @@ function updateDecreaseButtonText(button, buildCount) {
   
   function updateBuildingDisplay(buildings) {
     updateStructureDisplay(buildings);
+    updateEmptyBuildingMessages();
   }
   
   function updateStructureButtonText(button, structure, buildCount = 1) {
@@ -612,4 +613,36 @@ function formatStorageDetails(storageObject) {
     }
   }
   return storageDetails.slice(0, -2); // Remove trailing comma and space
+}
+
+function updateEmptyBuildingMessages() {
+  const containerIds = [
+    'resource-buildings-buttons',
+    'production-buildings-buttons',
+    'energy-buildings-buttons',
+    'storage-buildings-buttons',
+    'terraforming-buildings-buttons'
+  ];
+
+  containerIds.forEach(id => {
+    const container = document.getElementById(id);
+    if (!container) return;
+    const messageId = `${id}-empty-message`;
+    let message = document.getElementById(messageId);
+
+    const hasVisible = Array.from(container.getElementsByClassName('combined-building-row'))
+      .some(row => row.style.display !== 'none');
+
+    if (!hasVisible) {
+      if (!message) {
+        message = document.createElement('p');
+        message.id = messageId;
+        message.classList.add('empty-message');
+        message.textContent = 'Nothing available for now.';
+        container.appendChild(message);
+      }
+    } else if (message) {
+      message.remove();
+    }
+  });
 }

--- a/style.css
+++ b/style.css
@@ -162,3 +162,9 @@ body {
 .journal.collapsed {
     display: none;
 }
+
+.empty-message {
+    color: gray;
+    font-style: italic;
+    margin: 10px 0;
+}


### PR DESCRIPTION
## Summary
- show "Nothing available for now" when a buildings or projects subtab has no unlocked items
- add helper functions to update empty state messages
- style empty-state messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685372a24db883278a6c49666cde6979