### PR TITLE
Wind turbine scaling with atmosphere

### DIFF
--- a/__tests__/terraformingSummaryUICreation.test.js
+++ b/__tests__/terraformingSummaryUICreation.test.js
@@ -26,6 +26,7 @@ describe('terraforming summary UI creation', () => {
       life: { name: 'Life' }, magnetosphere: { name: 'Mag' },
       celestialParameters: { albedo: 0, gravity: 1, radius: 1 },
       calculateSolarPanelMultiplier: () => 1,
+      calculateWindTurbineMultiplier: () => 1,
       getAtmosphereStatus: () => true,
       getLuminosityStatus: () => true,
       getMagnetosphereStatus: () => true,

--- a/__tests__/windTurbineMultiplier.test.js
+++ b/__tests__/windTurbineMultiplier.test.js
@@ -1,0 +1,62 @@
+const EffectableEntity = require('../effectable-entity.js');
+// expose class globally before requiring Building
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../building.js');
+
+global.lifeParameters = {};
+const Terraforming = require('../terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+
+function createWindTurbine() {
+  const config = {
+    name: 'Wind',
+    category: 'energy',
+    cost: { colony: { metal: 10 } },
+    consumption: {},
+    production: { colony: { energy: 1 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: true,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new Building(config, 'windTurbine');
+}
+
+describe('wind turbine production effect', () => {
+  test('applyTerraformingEffects adds production multiplier based on pressure', () => {
+    global.resources = { atmospheric: {}, special: { albedoUpgrades: { value: 0 } } };
+    global.maintenanceFraction = 0.1;
+    global.buildings = { windTurbine: createWindTurbine(), spaceMirror: { active: 0 } };
+    global.colonies = {};
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = {};
+    global.oreScanner = {};
+
+    // intercept addEffect to apply to our building
+    global.addEffect = (effect) => {
+      if (effect.target === 'building' && effect.targetId === 'windTurbine') {
+        global.buildings.windTurbine.addAndReplace(effect);
+      }
+    };
+
+    const celestial = { distanceFromSun: 1, radius: 1, gravity: 1, albedo: 0 };
+    const tf = new Terraforming(global.resources, celestial);
+    // stub total pressure to 4.053 kPa (~0.04 atm) so multiplier = 0.2
+    tf.calculateTotalPressure = () => 4.053;
+
+    tf.applyTerraformingEffects();
+
+    const effect = global.buildings.windTurbine.activeEffects.find(e => e.type === 'productionMultiplier');
+    expect(effect).toBeDefined();
+    expect(effect.value).toBeCloseTo(0.2);
+  });
+});

--- a/terraforming.js
+++ b/terraforming.js
@@ -35,6 +35,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
 const SOLAR_PANEL_BASE_LUMINOSITY = 1000;
 const BASE_COMFORTABLE_TEMPERATURE = 295.15;
+const KPA_PER_ATM = 101.325;
 
 const EQUILIBRIUM_WATER_PARAMETER = 0.0007815298782079626;
 const EQUILIBRIUM_METHANE_PARAMETER = 1.465091239311071e-11;
@@ -1111,6 +1112,12 @@ class Terraforming extends EffectableEntity{
       return this.luminosity.modifiedSolarFlux / SOLAR_PANEL_BASE_LUMINOSITY;
     }
 
+    calculateWindTurbineMultiplier(){
+      const pressureKPa = this.calculateTotalPressure();
+      const pressureAtm = pressureKPa / KPA_PER_ATM;
+      return Math.sqrt(pressureAtm);
+    }
+
     calculateColonyEnergyPenalty() {
       const zones = this.temperature.zones;
       const baseTemperature = BASE_COMFORTABLE_TEMPERATURE;
@@ -1147,6 +1154,8 @@ class Terraforming extends EffectableEntity{
     applyTerraformingEffects(){
       const solarPanelMultiplier = this.calculateSolarPanelMultiplier();
 
+      const windTurbineMultiplier = this.calculateWindTurbineMultiplier();
+
       const solarPanelEffect = {
         effectId : 'luminosity',
         target: 'building',
@@ -1155,6 +1164,15 @@ class Terraforming extends EffectableEntity{
         value: solarPanelMultiplier
       }
       addEffect(solarPanelEffect);
+
+      const windTurbineEffect = {
+        effectId: 'atmosphere',
+        target: 'building',
+        targetId: 'windTurbine',
+        type: 'productionMultiplier',
+        value: windTurbineMultiplier
+      }
+      addEffect(windTurbineEffect);
 
       const lifeLuminosityEffect = {
         effectId: 'luminosity',

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -219,6 +219,7 @@ function createTemperatureBox(row) {
       <h3>${terraforming.atmosphere.name}</h3>
       <p>Current: <span id="atmosphere-current"></span> kPa</p>
       <p>Emissivity: <span id="emissivity"></span></p>
+      <p>Wind turbine multiplier: <span id="wind-turbine-multiplier">${(terraforming.calculateWindTurbineMultiplier()*100).toFixed(2)}</span>%</p>
       <table>
         <thead>
           <tr>
@@ -267,6 +268,11 @@ function createTemperatureBox(row) {
 
     const emissivity = document.getElementById('emissivity');
     emissivity.textContent = terraforming.temperature.emissivity.toFixed(2);
+
+    const windMultiplier = document.getElementById('wind-turbine-multiplier');
+    if (windMultiplier) {
+      windMultiplier.textContent = `${(terraforming.calculateWindTurbineMultiplier()*100).toFixed(2)}`;
+    }
   
     // Iterate through gases defined in the global resources (which the UI table expects)
     for (const gas in resources.atmospheric) {


### PR DESCRIPTION
## Summary
- boost wind turbine energy based on atmospheric pressure
- show wind turbine multiplier in the atmosphere UI
- support new multiplier in terraforming summary UI tests
- add regression tests for wind turbine pressure effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6853809eec648327bdc0a3a2959074bb