### PR TITLE
Fix journal queue clearing on load

### DIFF
--- a/__tests__/journalLoadEntries.test.js
+++ b/__tests__/journalLoadEntries.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('loadJournalEntries resets queue and typing', () => {
+  test('loading clears pending queue and stops typing', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    // Queue an entry so typing is active
+    ctx.addJournalEntry('queued');
+    jest.useFakeTimers();
+    jest.advanceTimersByTime(50);
+
+    // Load new entries which should interrupt current typing
+    ctx.loadJournalEntries(['loaded']);
+
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    const entries = dom.window.document.querySelectorAll('#journal-entries p');
+    expect(entries.length).toBe(1);
+    expect(entries[0].textContent).toBe('loaded');
+  });
+});

--- a/journal.js
+++ b/journal.js
@@ -63,6 +63,8 @@ function processNextJournalEntry() {
 function loadJournalEntries(entries) {
   const journalEntries = document.getElementById('journal-entries');
   journalEntries.innerHTML = ''; // Clear existing journal entries
+  journalQueue = [];
+  journalTyping = false;
 
   // Iterate over the saved entries and append them
   entries.forEach(entryText => {
@@ -88,6 +90,8 @@ function clearJournal() {
   const journalEntries = document.getElementById('journal-entries');
   journalEntries.innerHTML = ''; // Remove all entries from the display
   journalEntriesData = []; // Clear the stored data array
+  journalQueue = [];
+  journalTyping = false;
 }
 
 function updateJournalAlert() {


### PR DESCRIPTION
## Summary
- clear queued journal entries when loading or clearing journal
- add test verifying `loadJournalEntries` interrupts queued typing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68548909e66c8327b6770835924a1ecc