### PR TITLE
Add chapter 4.11 unlocking advanced research

### DIFF
--- a/__tests__/advancedResearchUnlockChapter.test.js
+++ b/__tests__/advancedResearchUnlockChapter.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('advanced research unlock chapter', () => {
+  test('chapter4.11 unlocks advanced research resource and tab', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress-data.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code, ctx);
+    const chapters = ctx.progressData.chapters;
+    const ch4_10 = chapters.find(c => c.id === 'chapter4.10');
+    const ch4_11 = chapters.find(c => c.id === 'chapter4.11');
+    expect(ch4_10.nextChapter).toBe('chapter4.11');
+    expect(ch4_11).toBeDefined();
+    const resEffect = ch4_11.reward.find(r => r.target === 'resource' && r.resourceType === 'colony' && r.targetId === 'advancedResearch' && r.type === 'enable');
+    const flagEffect = ch4_11.reward.find(r => r.target === 'researchManager' && r.type === 'booleanFlag' && r.flagId === 'advancedResearchUnlocked' && r.value === true);
+    expect(resEffect).toBeDefined();
+    expect(flagEffect).toBeDefined();
+  });
+});

--- a/__tests__/chapter4ColonistObjective.test.js
+++ b/__tests__/chapter4ColonistObjective.test.js
@@ -21,5 +21,6 @@ describe('chapter4 colonist milestone', () => {
       quantity: 100
     });
     expect(chapter.narrative).toMatch(/two beams of light.*giant asteroid/);
+    expect(chapter.nextChapter).toBe('chapter4.11');
   });
 });

--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -3,18 +3,18 @@ const path = require('path');
 const vm = require('vm');
 
 describe('HOPE tab unlock chapter', () => {
-  test('HOPE tab unlock occurs before last chapter', () => {
+  test('HOPE tab unlock occurs before final chapters', () => {
     const code = fs.readFileSync(path.join(__dirname, '..', 'progress-data.js'), 'utf8');
     const ctx = {};
     vm.createContext(ctx);
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
     const last = chapters[chapters.length - 1];
-    expect(last.id).toBe('chapter4.10');
-    const prev = chapters[chapters.length - 2];
-    expect(prev.id).toBe('chapter4.9');
-    const effect = prev.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');
+    expect(last.id).toBe('chapter4.11');
+    const hopeChapter = chapters.find(c => c.id === 'chapter4.9');
+    expect(hopeChapter).toBeDefined();
+    const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');
     expect(effect).toBeDefined();
-    expect(prev.nextChapter).toBe('chapter4.10');
+    expect(hopeChapter.nextChapter).toBe('chapter4.10');
   });
 });

--- a/progress-data.js
+++ b/progress-data.js
@@ -787,6 +787,28 @@ progressData = {
         reward: [
         ],
         special : 'clearJournal',
+        nextChapter: "chapter4.11"
+      },
+      {
+        id: "chapter4.11",
+        type: "journal",
+        narrative: "Receiving transmission...\\n  'H.O.P.E., people on Mars are torn. Some blame you for abandoning Earth, others want to help however they can. The Mars Terraforming Committee has voted to support your mission with their best minds. Advanced research facilities are at your disposal.'",
+        objectives: [],
+        reward: [
+          {
+            target: 'resource',
+            resourceType: 'colony',
+            targetId: 'advancedResearch',
+            type: 'enable'
+          },
+          {
+            target: 'researchManager',
+            type: 'booleanFlag',
+            flagId: 'advancedResearchUnlocked',
+            value: true
+          }
+        ],
+        special : 'clearJournal',
         nextChapter: null
       }
     ]


### PR DESCRIPTION
## Summary
- continue the story with new chapter 4.11
- enable advanced research resource and tab via new chapter
- update tests for chapter ordering
- add a test ensuring chapter 4.11 unlocks advanced research

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68548d241bfc832780812bf6ccf95ca1