### PR TITLE
Fix rewards after journal typing

### DIFF
--- a/__tests__/chapter4ColonistObjective.test.js
+++ b/__tests__/chapter4ColonistObjective.test.js
@@ -9,7 +9,7 @@ describe('chapter4 colonist milestone', () => {
     vm.createContext(ctx);
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
-    const prev = chapters.find(c => c.id === 'chapter4.9');
+    const prev = chapters.find(c => c.id === 'chapter4.9b');
     const chapter = chapters.find(c => c.id === 'chapter4.10');
     expect(prev).toBeDefined();
     expect(chapter).toBeDefined();

--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -15,6 +15,6 @@ describe('HOPE tab unlock chapter', () => {
     expect(hopeChapter).toBeDefined();
     const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');
     expect(effect).toBeDefined();
-    expect(hopeChapter.nextChapter).toBe('chapter4.10');
+    expect(hopeChapter.nextChapter).toBe('chapter4.9b');
   });
 });

--- a/__tests__/jumpToChapter.test.js
+++ b/__tests__/jumpToChapter.test.js
@@ -35,7 +35,7 @@ describe('StoryManager jumpToChapter', () => {
 
     expect(Array.from(manager.completedEventIds)).toEqual(['c1']);
     expect(manager.activeEventIds.has('c2')).toBe(true);
-    expect(context.addJournalEntry).toHaveBeenCalledWith('two');
+    expect(context.addJournalEntry).toHaveBeenCalledWith('two', 'c2');
     expect(context.addEffect).toHaveBeenCalledWith({ target: 'global', type: 'dummy' });
   });
 });


### PR DESCRIPTION
## Summary
- include event ids with journal entries so StoryManager can wait for typing
- wait for text completion before applying StoryManager rewards
- adjust tests for new jumpToChapter call and updated progress data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68549042cef88327831a06da0fd6519c