### PR TITLE
Fix story rewards processed on load

### DIFF
--- a/__tests__/storyLoadRewards.test.js
+++ b/__tests__/storyLoadRewards.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('StoryManager loads waiting event rewards immediately', () => {
+  test('waiting journal event completion applies rewards on load', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    const context = {
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      document: { addEventListener: () => {}, removeEventListener: () => {} },
+      clearJournal: () => {},
+      createPopup: () => {},
+      addJournalEntry: () => {},
+      addEffect: jest.fn(),
+      removeEffect: () => {},
+      buildings: {},
+      colonies: {},
+      resources: {},
+      terraforming: {},
+      progressData: {
+        chapters: [
+          { id: 'c1', type: 'journal', narrative: 'n', reward: [{ target: 'global', type: 'dummy' }], rewardDelay: 0 }
+        ]
+      }
+    };
+    vm.createContext(context);
+    vm.runInContext(`${code}; this.StoryManager = StoryManager;`, context);
+
+    const manager = new context.StoryManager(context.progressData);
+    context.window = { storyManager: manager };
+
+    const state = {
+      activeEventIds: ['c1'],
+      completedEventIds: [],
+      appliedEffects: [],
+      waitingForJournalEventId: 'c1'
+    };
+
+    manager.loadState(state);
+
+    expect(context.addEffect).toHaveBeenCalledWith({ target: 'global', type: 'dummy' });
+    expect(manager.completedEventIds.has('c1')).toBe(true);
+    expect(manager.activeEventIds.has('c1')).toBe(false);
+  });
+});

--- a/progress.js
+++ b/progress.js
@@ -382,12 +382,19 @@ class StoryManager {
 
         console.log(`StoryManager state loaded. Active: [${Array.from(this.activeEventIds).join(', ')}], Completed: [${Array.from(this.completedEventIds).join(', ')}], Waiting: ${this.waitingForJournalEventId}`);
 
-        // If loading while waiting, the journal animation likely won't restart,
-        // so the 'storyJournalFinishedTyping' event won't fire.
-        // We might need to immediately process completion if we load into a waiting state.
+        // If loading while waiting for a journal event, the typing animation
+        // will not resume. Immediately finalize the event so any rewards are
+        // applied without delay.
         if (this.waitingForJournalEventId !== null) {
-             console.warn(`Loaded game while waiting for journal event ${this.waitingForJournalEventId}. Assuming journal is finished and processing completion immediately.`);
-             this.handleJournalFinished(); // Manually trigger the handler
+            const pendingId = this.waitingForJournalEventId;
+            this.waitingForJournalEventId = null;
+
+            if (this.activeEventIds.has(pendingId)) {
+                console.warn(`Loaded game while waiting for journal event ${pendingId}. Completing it immediately.`);
+                this.processEventCompletion(pendingId);
+            } else {
+                console.warn(`Loaded waiting event ${pendingId}, but it is no longer active.`);
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
- apply pending story rewards immediately on load
- add regression test for loading waiting story events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68549372ad648327a5dba5cac120d964