### PR TITLE
Implement advanced research production

### DIFF
--- a/__tests__/advancedResearchProduction.test.js
+++ b/__tests__/advancedResearchProduction.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'research.js'), 'utf8');
+
+describe('advanced research production', () => {
+  test('produces per terraformed planet', () => {
+    const ctx = {
+      resources: {
+        colony: {
+          advancedResearch: {
+            value: 0,
+            unlocked: true,
+            cap: Infinity,
+            increase(amount) { this.value += amount; },
+            modifyRate: jest.fn()
+          }
+        }
+      },
+      spaceManager: {
+        planetStatuses: {
+          mars: { terraformed: true },
+          venus: { terraformed: true },
+          titan: { terraformed: false }
+        }
+      },
+      buildings: {},
+      colonies: {},
+      projectManager: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager;', ctx);
+
+    const manager = new ctx.ResearchManager({});
+    ctx.researchManager = manager;
+
+    manager.update(1000);
+
+    expect(ctx.resources.colony.advancedResearch.value).toBe(2);
+    expect(ctx.resources.colony.advancedResearch.modifyRate).toHaveBeenCalledWith(2, 'Research Manager', 'research');
+  });
+});

--- a/research.js
+++ b/research.js
@@ -37,6 +37,20 @@ class Research {
       }
     }
 
+    update(deltaTime) {
+      if (!resources || !resources.colony || !resources.colony.advancedResearch) return;
+      if (!resources.colony.advancedResearch.unlocked) return;
+      if (typeof spaceManager === 'undefined') return;
+
+      const statuses = spaceManager.planetStatuses || {};
+      const count = Object.values(statuses).filter(s => s.terraformed).length;
+      if (count <= 0) return;
+
+      const rate = count; // 1 per second per terraformed planet
+      resources.colony.advancedResearch.increase(rate * deltaTime / 1000);
+      resources.colony.advancedResearch.modifyRate(rate, 'Research Manager', 'research');
+    }
+
     saveState() {
       const researchState = {};
       for (const category in this.researches) {

--- a/resource.js
+++ b/resource.js
@@ -331,6 +331,10 @@ function produceResources(deltaTime, buildings) {
     lifeManager.updateLife(deltaTime);
   }
 
+  if(researchManager && typeof researchManager.update === 'function'){
+    researchManager.update(deltaTime);
+  }
+
   if(projectManager){
     projectManager.estimateProjects();
   }


### PR DESCRIPTION
## Summary
- add an `update` method to `ResearchManager` that generates advanced research based on terraformed planets
- invoke the new research manager update from `produceResources`
- test that advanced research production occurs and updates the resource rate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685498b65c8883278f0866b5eac16d28