### PR TITLE
Fix Titan starting resources locked

### DIFF
--- a/__tests__/newGameResetsPlanet.test.js
+++ b/__tests__/newGameResetsPlanet.test.js
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('new game resets to Mars', () => {
+  test('starting new game from Titan returns to Mars with resources locked', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) {
+        this.config = config;
+      },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      initializeSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class { activateTab(){} };
+      StoryManager = class { initializeStory(){} update(){} saveState(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    vm.runInContext('startNewGame();', ctx);
+
+    const planetName = vm.runInContext('currentPlanetParameters.name', ctx);
+    const methaneUnlocked = vm.runInContext('resources.surface.liquidMethane.unlocked', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(planetName).toBe('Mars');
+    expect(methaneUnlocked).toBe(false);
+  });
+});

--- a/game.js
+++ b/game.js
@@ -222,3 +222,9 @@ function update(time, delta) {
 
   autosave(delta);      // Call the autosave function
 }
+
+function startNewGame() {
+  defaultPlanet = 'mars';
+  currentPlanetParameters = planetParameters.mars;
+  initializeGameState();
+}

--- a/index.html
+++ b/index.html
@@ -461,10 +461,13 @@
 
     // Event listener for "New Game" button
     document.getElementById('new-game-button').addEventListener('click', () => {
-        // Add a confirmation dialog
         if (confirm("Are you sure you want to start a new game? Any unsaved progress will be lost.")) {
-            initializeGameState(); // Call your existing function
-             activateTab('settings'); // Switch back to settings tab after reset
+            if (typeof startNewGame === 'function') {
+                startNewGame();
+            } else {
+                initializeGameState();
+            }
+            activateTab('settings');
         }
     });
 

--- a/planet-parameters.js
+++ b/planet-parameters.js
@@ -157,10 +157,12 @@ const titanOverrides = {
       ice: {initialValue: 15000000000010070 },
       dryIce : { initialValue: 32083.440978549916 },
       "liquidMethane": {
-        "initialValue": 4499999731588.555, unlocked : true
+        "initialValue": 4499999731588.555,
+        "unlocked": false
       },
       "hydrocarbonIce": {
-        "initialValue": 268411.0742637397, unlocked : true
+        "initialValue": 268411.0742637397,
+        "unlocked": false
       }
     },
     underground: {
@@ -173,7 +175,8 @@ const titanOverrides = {
       oxygen: { initialValue: 1e9 },
       atmosphericWater: { initialValue: 0 },
       "atmosphericMethane": {
-        "initialValue": 130000000000000, unlocked : true
+        "initialValue": 130000000000000,
+        "unlocked": false
       }
     },
     special: {


### PR DESCRIPTION
## Summary
- add `startNewGame` utility in game.js
- reset planet to Mars when clicking New Game
- test new-game resets Titan to Mars

## Testing
- `npm test --silent -- -i`


------
https://chatgpt.com/codex/tasks/task_b_6854a5221cc08327801c750be456af49