### PR TITLE
Add modular nuclear reactor cost reduction

### DIFF
--- a/__tests__/modularNuclearReactorResearch.test.js
+++ b/__tests__/modularNuclearReactorResearch.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Modular Nuclear Reactor research', () => {
+  test('exists in advanced research with correct cost and effects', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const advanced = ctx.researchParameters.advanced;
+    const research = advanced.find(r => r.id === 'modular_nuclear_reactor');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(1000);
+    const costEffect = research.effects.find(e => e.target === 'researchManager' && e.type === 'researchCostMultiplier');
+    expect(costEffect).toBeDefined();
+    const prodEffect = research.effects.find(e => e.target === 'building' && e.targetId === 'nuclearPowerPlant' && e.type === 'productionMultiplier');
+    expect(prodEffect).toBeDefined();
+    const consEffect = research.effects.find(e => e.target === 'building' && e.targetId === 'nuclearPowerPlant' && e.type === 'consumptionMultiplier');
+    expect(consEffect).toBeDefined();
+    const costEffects = research.effects.filter(e => e.target === 'building' && e.targetId === 'nuclearPowerPlant' && e.type === 'resourceCostMultiplier');
+    expect(costEffects).toHaveLength(3);
+  });
+});

--- a/__tests__/researchCostMultiplierEffect.test.js
+++ b/__tests__/researchCostMultiplierEffect.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../effectable-entity.js');
+
+describe('researchCostMultiplier effect', () => {
+  let context;
+  beforeEach(() => {
+    context = {
+      EffectableEntity,
+      buildings: {},
+      colonies: {},
+      projectManager: {},
+      populationModule: {},
+      tabManager: {},
+      fundingModule: {},
+      terraforming: {},
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {},
+      resources: { colony: { research: { value: 0 } } },
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(context);
+    const researchCode = fs.readFileSync(path.join(__dirname, '..', 'research.js'), 'utf8');
+    vm.runInContext(researchCode + '; this.ResearchManager = ResearchManager;', context);
+  });
+
+  test('multiplies research cost', () => {
+    const params = {
+      energy: [
+        { id: 'fission_plant1', name: 'Fission', description: '', cost: { research: 10000 }, prerequisites: [], effects: [] }
+      ],
+      advanced: []
+    };
+    context.researchManager = new context.ResearchManager(params);
+    context.addEffect = () => {};
+
+    context.researchManager.addAndReplace({
+      target: 'researchManager',
+      targetId: 'fission_plant1',
+      type: 'researchCostMultiplier',
+      value: 0.5,
+      effectId: 'test',
+      sourceId: 'test'
+    });
+
+    const research = context.researchManager.getResearchById('fission_plant1');
+    expect(research.cost.research).toBeCloseTo(5000);
+  });
+});

--- a/__tests__/resourceCostMultiplierEffect.test.js
+++ b/__tests__/resourceCostMultiplierEffect.test.js
@@ -1,0 +1,38 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../building.js');
+
+describe('resourceCostMultiplier effect', () => {
+  test('applies multiplier to building cost', () => {
+    global.maintenanceFraction = 0;
+    const building = new Building({
+      name: 'Test',
+      category: 'test',
+      cost: { colony: { metal: 100 } },
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: false,
+      requiresMaintenance: false,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true
+    }, 'testBuilding');
+
+    building.addEffect({
+      type: 'resourceCostMultiplier',
+      resourceCategory: 'colony',
+      resourceId: 'metal',
+      value: 0.5
+    });
+
+    const multiplier = building.getEffectiveCostMultiplier('colony', 'metal');
+    expect(multiplier).toBeCloseTo(0.5);
+
+    const cost = building.getEffectiveCost(1);
+    expect(cost.colony.metal).toBeCloseTo(50);
+  });
+});
+

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -157,6 +157,9 @@ class EffectableEntity {
         case 'projectDurationReduction':
           this.applyProjectDurationReduction(effect);
           break;
+        case 'researchCostMultiplier':
+          this.applyResearchCostMultiplier(effect);
+          break;
         case 'lifeDesignPointBonus':
           this.applyLifeDesignPointBonus(effect);
           break;
@@ -352,6 +355,25 @@ class EffectableEntity {
           const progressRatio = (project.startingDuration - project.remainingTime) / project.startingDuration;
           project.startingDuration = newDuration;
           project.remainingTime = newDuration * (1 - progressRatio);
+        }
+      }
+    }
+
+    applyResearchCostMultiplier(effect) {
+      if (!this.researches) return;
+
+      for (const category in this.researches) {
+        const research = this.researches[category].find(r => r.id === effect.targetId);
+        if (!research) continue;
+
+        if (!research.originalCost) {
+          research.originalCost = JSON.parse(JSON.stringify(research.cost));
+        } else {
+          research.cost = JSON.parse(JSON.stringify(research.originalCost));
+        }
+
+        for (const key in research.cost) {
+          research.cost[key] *= effect.value;
         }
       }
     }

--- a/research-parameters.js
+++ b/research-parameters.js
@@ -953,6 +953,57 @@ const researchParameters = {
     ],
     advanced: [
       {
+        id: 'modular_nuclear_reactor',
+        name: 'Modular Nuclear Reactor',
+        description: 'Miniaturizes fission reactors and makes their research affordable.',
+        cost: { advancedResearch: 1000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'researchManager',
+            targetId: 'fission_plant1',
+            type: 'researchCostMultiplier',
+            value: 0.01
+          },
+          {
+            target: 'building',
+            targetId: 'nuclearPowerPlant',
+            type: 'productionMultiplier',
+            value: 0.01
+          },
+          {
+            target: 'building',
+            targetId: 'nuclearPowerPlant',
+            type: 'consumptionMultiplier',
+            value: 0.01
+          },
+          {
+            target: 'building',
+            targetId: 'nuclearPowerPlant',
+            type: 'resourceCostMultiplier',
+            resourceCategory: 'colony',
+            resourceId: 'metal',
+            value: 0.01
+          },
+          {
+            target: 'building',
+            targetId: 'nuclearPowerPlant',
+            type: 'resourceCostMultiplier',
+            resourceCategory: 'colony',
+            resourceId: 'components',
+            value: 0.01
+          },
+          {
+            target: 'building',
+            targetId: 'nuclearPowerPlant',
+            type: 'resourceCostMultiplier',
+            resourceCategory: 'colony',
+            resourceId: 'electronics',
+            value: 0.01
+          }
+        ]
+      },
+      {
         id: 'hyperion_lantern',
         name: 'Hyperion Lantern',
         description: 'Research the construction of a large orbital facility that increases planetary luminosity.',


### PR DESCRIPTION
## Summary
- make modular nuclear reactor research also lower the cost of nuclear power plants
- test that the research defines all new effects
- add unit test for `resourceCostMultiplier` effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6858801a83308327ad9561ea74197f54