### PR TITLE
Sort research list by cost

### DIFF
--- a/__tests__/researchCostOrderUpdate.test.js
+++ b/__tests__/researchCostOrderUpdate.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'research.js'), 'utf8');
+const researchUICode = fs.readFileSync(path.join(__dirname, '..', 'researchUI.js'), 'utf8');
+
+describe('research order updates with cost', () => {
+  test('researches are sorted by cost', () => {
+    const ctx = { EffectableEntity: require('../effectable-entity.js') };
+    vm.createContext(ctx);
+    vm.runInContext(researchCode + '; this.ResearchManager = ResearchManager;', ctx);
+
+    const params = {
+      energy: [
+        { id: 'a', name: 'A', description: '', cost: { research: 200 }, prerequisites: [], effects: [] },
+        { id: 'b', name: 'B', description: '', cost: { research: 100 }, prerequisites: [], effects: [] }
+      ],
+      industry: [],
+      colonization: [],
+      terraforming: [],
+      advanced: []
+    };
+
+    const manager = new ctx.ResearchManager(params);
+    const order = manager.getResearchesByCategory('energy').map(r => r.id);
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  test('ui reorders when cost changes', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="energy-research-buttons"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.canAffordResearch = () => true;
+    ctx.formatNumber = () => '';
+    ctx.resources = { colony: { research: { value: 0 }, advancedResearch: { value: 0 } } };
+    ctx.globalGameIsLoadingFromSave = false;
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + researchUICode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.loadResearchCategory = loadResearchCategory; this.updateResearchUI = updateResearchUI;', ctx);
+
+    const params = {
+      energy: [
+        { id: 'a', name: 'A', description: '', cost: { research: 100 }, prerequisites: [], effects: [] },
+        { id: 'b', name: 'B', description: '', cost: { research: 200 }, prerequisites: [], effects: [] }
+      ],
+      industry: [],
+      colonization: [],
+      terraforming: [],
+      advanced: []
+    };
+
+    ctx.researchManager = new ctx.ResearchManager(params);
+    ctx.loadResearchCategory('energy');
+
+    let ids = Array.from(dom.window.document.querySelectorAll('.research-button')).map(b => b.id);
+    expect(ids).toEqual(['research-a', 'research-b']);
+
+    ctx.researchManager.addAndReplace({
+      target: 'researchManager',
+      targetId: 'b',
+      type: 'researchCostMultiplier',
+      value: 0.1,
+      effectId: 'e',
+      sourceId: 'e'
+    });
+
+    ctx.updateResearchUI();
+    ids = Array.from(dom.window.document.querySelectorAll('.research-button')).map(b => b.id);
+    expect(ids[0]).toBe('research-b');
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -376,6 +376,10 @@ class EffectableEntity {
           research.cost[key] *= effect.value;
         }
       }
+
+      if (typeof this.sortAllResearches === 'function') {
+        this.sortAllResearches();
+      }
     }
 
     applyLifeDesignPointBonus(effect) {

--- a/research.js
+++ b/research.js
@@ -20,6 +20,7 @@ class Research {
       super({ description: 'Manages all research' });
       this.researches = {};
       this.advancedResearchUnlocked = false;
+      this.orderDirty = false;
   
       // Load research data and create Research instances
       for (const category in researchData) {
@@ -35,6 +36,9 @@ class Research {
             )
         );
       }
+
+      this.sortAllResearches();
+      this.orderDirty = false;
     }
 
     update(deltaTime) {
@@ -75,6 +79,7 @@ class Research {
           }
         });
       }
+      this.sortAllResearches();
     }
   
     // Get a specific research by its ID
@@ -91,6 +96,19 @@ class Research {
     // Get all researches within a category
     getResearchesByCategory(category) {
       return this.researches[category] || [];
+    }
+
+    calculateResearchTotalCost(research) {
+      return Object.values(research.cost || {}).reduce((sum, val) => sum + val, 0);
+    }
+
+    sortAllResearches() {
+      for (const category in this.researches) {
+        this.researches[category].sort((a, b) =>
+          this.calculateResearchTotalCost(a) - this.calculateResearchTotalCost(b)
+        );
+      }
+      this.orderDirty = true;
     }
   
     // Check if a research is available (i.e., prerequisites are met)

--- a/researchUI.js
+++ b/researchUI.js
@@ -179,6 +179,11 @@ function updateAdvancedResearchVisibility() {
 }
 
 function updateResearchUI() {
+    if (researchManager.orderDirty) {
+        const categories = ['energy', 'industry', 'colonization', 'terraforming', 'advanced'];
+        categories.forEach(category => loadResearchCategory(category));
+        researchManager.orderDirty = false;
+    }
     updateAllResearchButtons(researchManager.researches); // Update research buttons display
     updateCompletedResearchVisibility();
     updateAdvancedResearchVisibility();


### PR DESCRIPTION
## Summary
- track a dirty flag for research order and provide methods to sort by total cost
- resort researches whenever research costs change
- refresh research UI when order is dirty
- test that researches are ordered by cost and the UI updates when costs change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6858834ef35c8327b8bf1e723c5c5e67