### PR TITLE
Add Earth probe special tab and chapter

### DIFF
--- a/__tests__/activateProjectSubtabEffect.test.js
+++ b/__tests__/activateProjectSubtabEffect.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'projects.js'), 'utf8');
+const projectsUICode = fs.readFileSync(path.join(__dirname, '..', 'projectsUI.js'), 'utf8');
+
+describe('activateProjectSubtab effect', () => {
+  test('switches to special projects subtab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab active" data-subtab="resources-projects"></div>
+      <div class="projects-subtab hidden" data-subtab="special-projects"></div>
+      <div id="resources-projects" class="projects-subtab-content active"></div>
+      <div id="special-projects" class="projects-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + projectsUICode + projectsCode + '; this.EffectableEntity = EffectableEntity; this.ProjectManager = ProjectManager; this.activateProjectSubtab = activateProjectSubtab;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.addAndReplace({
+      type: 'activateProjectSubtab',
+      targetId: 'special-projects',
+      effectId: 'test',
+      sourceId: 'test'
+    });
+
+    const subtab = dom.window.document.querySelector('[data-subtab="special-projects"]');
+    const content = dom.window.document.getElementById('special-projects');
+    expect(subtab.classList.contains('active')).toBe(true);
+    expect(content.classList.contains('active')).toBe(true);
+  });
+});

--- a/__tests__/earthProbeProject.test.js
+++ b/__tests__/earthProbeProject.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+
+describe('Earth Recon Probe project', () => {
+  test('parameters include planet restriction and cost doubling', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'project-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.projectParameters = projectParameters;', ctx);
+    const project = ctx.projectParameters.earthProbe;
+    expect(project).toBeDefined();
+    expect(project.repeatable).toBe(true);
+    expect(project.maxRepeatCount).toBe(10);
+    expect(project.attributes.costDoubling).toBe(true);
+    expect(project.attributes.planet).toBe('titan');
+    expect(project.category).toBe('special');
+  });
+
+  test('cost doubles with repeat count', () => {
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'projects.js'), 'utf8');
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const config = {
+      name: 'Probe',
+      category: 'special',
+      cost: { colony: { components: 10 } },
+      duration: 10,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: 10,
+      unlocked: true,
+      attributes: { costDoubling: true }
+    };
+    const p = new ctx.Project(config, 'probe');
+    expect(p.getScaledCost().colony.components).toBe(10);
+    p.repeatCount = 1;
+    expect(p.getScaledCost().colony.components).toBe(20);
+    p.repeatCount = 2;
+    expect(p.getScaledCost().colony.components).toBe(40);
+  });
+});

--- a/__tests__/earthProbeUnlockChapter.test.js
+++ b/__tests__/earthProbeUnlockChapter.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('earth probe unlock chapter', () => {
+  test('chapter4.12 unlocks the earthProbe project at 100 colonists', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress-data.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code, ctx);
+    const chapters = ctx.progressData.chapters;
+    const ch411 = chapters.find(c => c.id === 'chapter4.11');
+    const ch412 = chapters.find(c => c.id === 'chapter4.12');
+    const ch413 = chapters.find(c => c.id === 'chapter4.13');
+    expect(ch411.nextChapter).toBe('chapter4.12');
+    expect(ch412).toBeDefined();
+    const obj = ch412.objectives && ch412.objectives[0];
+    expect(obj).toEqual({
+      type: 'collection',
+      resourceType: 'colony',
+      resource: 'colonists',
+      quantity: 100
+    });
+    const reward = ch412.reward.find(r => r.target === 'project' && r.targetId === 'earthProbe' && r.type === 'enable');
+    const subtabEffect = ch412.reward.find(r => r.target === 'projectManager' && r.type === 'activateProjectSubtab' && r.targetId === 'special-projects');
+    expect(reward).toBeDefined();
+    expect(subtabEffect).toBeDefined();
+    expect(ch412.nextChapter).toBe('chapter4.13');
+    expect(ch413).toBeDefined();
+  });
+});

--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -10,7 +10,7 @@ describe('HOPE tab unlock chapter', () => {
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
     const last = chapters[chapters.length - 1];
-    expect(last.id).toBe('chapter4.11');
+    expect(last.id).toBe('chapter4.13');
     const hopeChapter = chapters.find(c => c.id === 'chapter4.9');
     expect(hopeChapter).toBeDefined();
     const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');

--- a/__tests__/projectLoadStateUI.test.js
+++ b/__tests__/projectLoadStateUI.test.js
@@ -6,7 +6,7 @@ const vm = require('vm');
 
 describe('ProjectManager loadState', () => {
   test('clears and rerenders project UI', () => {
-    const dom = new JSDOM(`<!DOCTYPE html><div id="resources-projects-list" class="projects-list"></div><div id="infrastructure-projects-list" class="projects-list"></div>`, { runScripts: 'outside-only' });
+    const dom = new JSDOM(`<!DOCTYPE html><div id="resources-projects-list" class="projects-list"></div><div id="infrastructure-projects-list" class="projects-list"></div><div id="special-projects-list" class="projects-list"></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
 
     ctx.initializeProjectsUI = function() {

--- a/__tests__/projectsUIInitialization.test.js
+++ b/__tests__/projectsUIInitialization.test.js
@@ -8,7 +8,8 @@ describe('initializeProjectsUI', () => {
   test('clears existing project elements', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
       <div class="projects-list" id="resources-projects-list"><div class="dummy"></div></div>
-      <div class="projects-list" id="infrastructure-projects-list"><div></div></div>`, { runScripts: 'outside-only' });
+      <div class="projects-list" id="infrastructure-projects-list"><div></div></div>
+      <div class="projects-list" id="special-projects-list"></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.projectElements = { dummy: {} };
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'projectsUI.js'), 'utf8');
@@ -18,8 +19,10 @@ describe('initializeProjectsUI', () => {
 
     const resList = dom.window.document.getElementById('resources-projects-list');
     const infraList = dom.window.document.getElementById('infrastructure-projects-list');
+    const specialList = dom.window.document.getElementById('special-projects-list');
     expect(resList.children.length).toBe(0);
     expect(infraList.children.length).toBe(0);
     expect(Object.keys(ctx.projectElements).length).toBe(0);
+    expect(specialList.children.length).toBe(0);
   });
 });

--- a/__tests__/specialProjectsVisibility.test.js
+++ b/__tests__/specialProjectsVisibility.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const uiCode = fs.readFileSync(path.join(__dirname, '..', 'projectsUI.js'), 'utf8');
+
+describe('updateSpecialProjectsVisibility', () => {
+  test('shows or hides the special subtab based on unlocked projects', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab hidden" data-subtab="special-projects"></div>
+      <div id="special-projects" class="projects-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectManager = { projects: { probe: { category: 'special', unlocked: false, attributes: { planet: 'titan' } } } };
+    ctx.spaceManager = { getCurrentPlanetKey: () => 'titan' };
+    vm.createContext(ctx);
+    vm.runInContext(uiCode + '; this.updateSpecialProjectsVisibility = updateSpecialProjectsVisibility;', ctx);
+
+    ctx.updateSpecialProjectsVisibility();
+    const subtab = dom.window.document.querySelector('[data-subtab="special-projects"]');
+    const content = dom.window.document.getElementById('special-projects');
+    expect(subtab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+
+    ctx.projectManager.projects.probe.unlocked = true;
+    ctx.updateSpecialProjectsVisibility();
+    expect(subtab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -126,6 +126,11 @@ class EffectableEntity {
             activateResearchSubtab(effect.targetId);
           }
           break;
+        case 'activateProjectSubtab':
+          if (typeof activateProjectSubtab === 'function') {
+            activateProjectSubtab(effect.targetId);
+          }
+          break;
         case 'booleanFlag':  // New effect type to handle boolean flags
           this.applyBooleanFlag(effect);
           break;

--- a/index.html
+++ b/index.html
@@ -179,6 +179,7 @@
           <div class="projects-subtabs">
             <div id="resources-projects-tab" class="projects-subtab active" data-subtab="resources-projects">Resources</div>
             <div id="infrastructure-projects-tab" class="projects-subtab" data-subtab="infrastructure-projects">Infrastructure</div>
+            <div id="special-projects-tab" class="projects-subtab hidden" data-subtab="special-projects">Special</div>
           </div>
           <div class="projects-subtab-content-wrapper">
             <div id="resources-projects" class="projects-subtab-content active">
@@ -186,6 +187,9 @@
             </div>
             <div id="infrastructure-projects" class="projects-subtab-content">
               <div class="projects-list" id="infrastructure-projects-list"></div>
+            </div>
+            <div id="special-projects" class="projects-subtab-content hidden">
+              <div class="projects-list" id="special-projects-list"></div>
             </div>
           </div>
         </div>

--- a/progress-data.js
+++ b/progress-data.js
@@ -828,6 +828,38 @@ progressData = {
             onLoad: false
           }
         ],
+        nextChapter: "chapter4.12"
+      },
+      {
+        id: "chapter4.12",
+        type: "journal",
+        narrative: "Receiving transmission...\\n  'H.O.P.E., Mars can't spare any resources, but perhaps you can send probes to Earth. We'll try to analyze whatever data you recover.'",
+        objectives: [{
+          type: 'collection',
+          resourceType: 'colony',
+          resource: 'colonists',
+          quantity: 100
+        }],
+        reward: [
+          {
+            target: 'project',
+            targetId: 'earthProbe',
+            type: 'enable'
+          },
+          {
+            target: 'projectManager',
+            type: 'activateProjectSubtab',
+            targetId: 'special-projects',
+            onLoad: false
+          }
+        ],
+        nextChapter: "chapter4.13"
+      },
+      {
+        id: "chapter4.13",
+        type: "journal",
+        narrative: "Launch the Earth Recon Probe special project to continue investigating Earth's fate.",
+        reward: [],
         nextChapter: null
       }
     ]

--- a/project-parameters.js
+++ b/project-parameters.js
@@ -344,6 +344,38 @@ const projectParameters = {
     disposalAmount : 1000000
     }
   },
+  earthProbe : {
+    name : "Earth Recon Probe",
+    category : "special",
+    cost : {
+      colony : {
+        components : 10,
+        electronics : 10,
+        energy : 10000
+      }
+    },
+    duration : 72000,
+    description : "Send an automated probe back to Earth to search for clues.",
+    repeatable : true,
+    maxRepeatCount : 10,
+    unlocked : false,
+    attributes : {
+      planet : 'titan',
+      costDoubling : true,
+      storySteps : [
+        'Probe launched. Earth is shattered into enormous fragments.',
+        'Vast seas of molten rock glow across the debris.',
+        'No continents remain—only swirling magma clouds.',
+        'Radiation saturates the wreckage of former cities.',
+        'Scorched fragments show traces of precision energy beams.',
+        'Spectral data hints at positron annihilation on a planetary scale.',
+        'Cratered pieces reveal an impact from a colossal asteroid.',
+        'All signs indicate these cataclysms struck within minutes.',
+        'The debris now spreads out like a newborn asteroid belt.',
+        'There is no surface left to land on—only scattered remnants.'
+      ]
+    }
+  },
   hyperionLantern: {
     name: "Hyperion Lantern",
     category: "infrastructure",

--- a/projects.js
+++ b/projects.js
@@ -81,6 +81,17 @@ class Project extends EffectableEntity {
   // Method to calculate scaled cost if costScaling is enabled
   getScaledCost() {
     const cost = this.getEffectiveCost();
+    if (this.attributes.costDoubling) {
+      const multiplier = Math.pow(2, this.repeatCount);
+      const scaledCost = {};
+      for (const resourceCategory in cost) {
+        scaledCost[resourceCategory] = {};
+        for (const resource in cost[resourceCategory]) {
+          scaledCost[resourceCategory][resource] = cost[resourceCategory][resource] * multiplier;
+        }
+      }
+      return scaledCost;
+    }
     if (this.attributes.costScaling) {
       const multiplier = this.repeatCount + 1;
       const scaledCost = {};
@@ -253,6 +264,13 @@ class Project extends EffectableEntity {
     // Apply completion effect if applicable
     if (this.attributes && this.attributes.completionEffect) {
       this.applyCompletionEffect();
+    }
+
+    if (this.attributes && Array.isArray(this.attributes.storySteps)) {
+      const step = this.attributes.storySteps[this.repeatCount - 1];
+      if (step && typeof addJournalEntry === 'function') {
+        addJournalEntry(step);
+      }
     }
 
   }

--- a/projectsUI.js
+++ b/projectsUI.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById(category).classList.add('active');
     });
   });
+  updateSpecialProjectsVisibility();
 });
 
 function renderProjects() {
@@ -38,6 +39,7 @@ function renderProjects() {
   });
 
   updateEmptyProjectMessages();
+  updateSpecialProjectsVisibility();
 }
 
 function initializeProjectsUI() {
@@ -456,7 +458,10 @@ function updateProjectUI(projectName) {
   // Update the project item's visibility based on the unlocked state
   const projectItem = elements.projectItem;
   if (projectItem) {
-    if (project.unlocked) {
+    const planetOk = !project.attributes.planet ||
+      (typeof spaceManager !== 'undefined' && spaceManager.getCurrentPlanetKey &&
+       spaceManager.getCurrentPlanetKey() === project.attributes.planet);
+    if (project.unlocked && planetOk) {
       projectItem.style.display = 'block';
     } else {
       projectItem.style.display = 'none';
@@ -762,4 +767,42 @@ function updateEmptyProjectMessages() {
       message.remove();
     }
   });
+}
+
+function updateSpecialProjectsVisibility() {
+  const subtab = document.querySelector('.projects-subtab[data-subtab="special-projects"]');
+  const content = document.getElementById('special-projects');
+  if (!subtab || !content) return;
+
+  let visible = false;
+  if (projectManager && projectManager.projects) {
+    visible = Object.values(projectManager.projects).some(p => {
+      const planetOk = !p.attributes.planet ||
+        (typeof spaceManager !== 'undefined' && spaceManager.getCurrentPlanetKey &&
+         spaceManager.getCurrentPlanetKey() === p.attributes.planet);
+      return p.category === 'special' && p.unlocked && planetOk;
+    });
+  }
+
+  if (visible) {
+    subtab.classList.remove('hidden');
+    content.classList.remove('hidden');
+  } else {
+    subtab.classList.add('hidden');
+    content.classList.add('hidden');
+  }
+}
+
+function activateProjectSubtab(subtabId) {
+  document.querySelectorAll('.projects-subtab').forEach(t => t.classList.remove('active'));
+  document.querySelectorAll('.projects-subtab-content').forEach(c => c.classList.remove('active'));
+
+  const subtab = document.querySelector(`.projects-subtab[data-subtab="${subtabId}"]`);
+  const content = document.getElementById(subtabId);
+  if (subtab && content) {
+    subtab.classList.remove('hidden');
+    content.classList.remove('hidden');
+    subtab.classList.add('active');
+    content.classList.add('active');
+  }
 }


### PR DESCRIPTION
## Summary
- add new "Special" subtab for projects and show it only when a special project is unlocked
- implement `activateProjectSubtab` effect and visibility logic
- create repeatable `earthProbe` project in new category with catastrophic story steps
- unlock earth probe via new chapters and automatically open the special subtab
- update and extend tests for the new tab, project, and chapters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685889a5eb00832790ead4b290b39542