### PR TITLE
Add objective display to journal

### DIFF
--- a/__tests__/currentObjectiveUI.test.js
+++ b/__tests__/currentObjectiveUI.test.js
@@ -1,0 +1,115 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('current objective UI', () => {
+  test('updates element with progress text', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="current-objective"></div>`, {
+      runScripts: 'outside-only'
+    });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.console = console;
+    ctx.document = dom.window.document;
+    ctx.addJournalEntry = () => {};
+    ctx.createPopup = () => {};
+    ctx.clearJournal = () => {};
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+
+    ctx.resources = { colony: { metal: { value: 50, displayName: 'Metal' } } };
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.terraforming = {};
+    ctx.spaceManager = {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    vm.runInContext(`${code}; this.StoryManager = StoryManager;`, ctx);
+
+    const progressData = { chapters: [ { id: 'c1', type: 'journal', narrative: '', objectives: [ { type: 'collection', resourceType: 'colony', resource: 'metal', quantity: 100 } ] } ] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.storyManager = manager;
+
+    const event = manager.findEventById('c1');
+    manager.activateEvent(event);
+    manager.update();
+
+    const text = dom.window.document.getElementById('current-objective').textContent;
+    expect(text).toBe('Objective: Metal: 50/100');
+  });
+
+  test('uses building display name', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="current-objective"></div>`, {
+      runScripts: 'outside-only'
+    });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.console = console;
+    ctx.document = dom.window.document;
+    ctx.addJournalEntry = () => {};
+    ctx.createPopup = () => {};
+    ctx.clearJournal = () => {};
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+
+    ctx.resources = { colony: {} };
+    ctx.buildings = { oreMine: { count: 1, displayName: 'Ore Mine' } };
+    ctx.colonies = {};
+    ctx.terraforming = {};
+    ctx.spaceManager = {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    vm.runInContext(`${code}; this.StoryManager = StoryManager;`, ctx);
+
+    const progressData = { chapters: [ { id: 'c1', type: 'journal', narrative: '', objectives: [ { type: 'building', buildingName: 'oreMine', quantity: 2 } ] } ] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.storyManager = manager;
+
+    const event = manager.findEventById('c1');
+    manager.activateEvent(event);
+    manager.update();
+
+    const text = dom.window.document.getElementById('current-objective').textContent;
+    expect(text).toBe('Objective: Ore Mine: 1/2');
+  });
+
+  test('describes terraforming objective with friendly text', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="current-objective"></div>`, {
+      runScripts: 'outside-only'
+    });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.console = console;
+    ctx.document = dom.window.document;
+    ctx.addJournalEntry = () => {};
+    ctx.createPopup = () => {};
+    ctx.clearJournal = () => {};
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+
+    ctx.resources = { colony: {} };
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { value: 220, night: 210, day: 230 } } },
+      calculateTotalPressure: () => 15
+    };
+    ctx.spaceManager = {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    vm.runInContext(`${code}; this.StoryManager = StoryManager;`, ctx);
+
+    const progressData = { chapters: [ { id: 'c1', type: 'journal', narrative: '', objectives: [ { type: 'terraforming', terraformingParameter: 'tropicalTemperature', value: 238 } ] } ] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.storyManager = manager;
+
+    const event = manager.findEventById('c1');
+    manager.activateEvent(event);
+    manager.update();
+
+    const text = dom.window.document.getElementById('current-objective').textContent;
+    expect(text).toBe('Objective: Equatorial Temp: 220.00/238');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -414,6 +414,7 @@
     <!-- Journal Section -->
     <div id="journal" class="journal">
         <h3>Journal</h3>
+        <div id="current-objective" class="current-objective"></div>
         <div id="journal-entries">
             <!-- Journal entries will be dynamically inserted here -->
         </div>

--- a/style.css
+++ b/style.css
@@ -133,6 +133,11 @@ body {
     color: #333;
 }
 
+#current-objective {
+    margin: 5px 0;
+    font-weight: bold;
+}
+
 #special-messages {
     min-height: 65px;
 }


### PR DESCRIPTION
## Summary
- show current objective in Journal UI
- style current objective text
- compute objective progress in StoryManager
- expose progress via new test
- use display names when describing objectives
- include friendly text for terraforming goals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6859cc2811bc8327a7b4aed578682184