### PR TITLE
Add hydrocarbon generator research

### DIFF
--- a/__tests__/hydrocarbonResearchUnlock.test.js
+++ b/__tests__/hydrocarbonResearchUnlock.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('hydrocarbon advanced research', () => {
+  test('sets unlock flag', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const adv = ctx.researchParameters.advanced;
+    const research = adv.find(r => r.id === 'hydrocarbon_research');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(1000);
+    const flagEffect = research.effects.find(e => e.type === 'booleanFlag' && e.flagId === 'hydrocarbonResearchUnlocked' && e.value === true);
+    expect(flagEffect).toBeDefined();
+  });
+});

--- a/__tests__/hydrocarbonResearchVisibility.test.js
+++ b/__tests__/hydrocarbonResearchVisibility.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'research.js'), 'utf8');
+const uiCode = fs.readFileSync(path.join(__dirname, '..', 'researchUI.js'), 'utf8');
+
+describe('hydrocarbon research visibility', () => {
+  test('hidden when no methane', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="energy-research-buttons"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.canAffordResearch = () => true;
+    ctx.formatNumber = () => '';
+    ctx.resources = { colony: { research: { value: 0 }, advancedResearch: { value: 0 } } };
+    ctx.globalGameIsLoadingFromSave = false;
+    ctx.currentPlanetParameters = { resources: { surface: { liquidMethane: { initialValue: 0 }, hydrocarbonIce: { initialValue: 0 } }, atmospheric: { atmosphericMethane: { initialValue: 0 } } } };
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + uiCode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.loadResearchCategory = loadResearchCategory;', ctx);
+
+    const params = { energy: [ { id: 'hydrocarbon_generator', name: 'Hydro', description: '', cost: { research: 100 }, requiresMethane: true, requiredFlags: [], effects: [] } ], industry: [], colonization: [], terraforming: [], advanced: [] };
+    ctx.researchManager = new ctx.ResearchManager(params);
+    ctx.loadResearchCategory('energy');
+    const ids = Array.from(dom.window.document.querySelectorAll('.research-button')).map(b => b.id);
+    expect(ids.length).toBe(0);
+  });
+
+  test('visible with methane', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="energy-research-buttons"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.canAffordResearch = () => true;
+    ctx.formatNumber = () => '';
+    ctx.resources = { colony: { research: { value: 0 }, advancedResearch: { value: 0 } } };
+    ctx.globalGameIsLoadingFromSave = false;
+    ctx.currentPlanetParameters = { resources: { surface: { liquidMethane: { initialValue: 1 }, hydrocarbonIce: { initialValue: 0 } }, atmospheric: { atmosphericMethane: { initialValue: 0 } } } };
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + uiCode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.loadResearchCategory = loadResearchCategory;', ctx);
+
+    const params = { energy: [ { id: 'hydrocarbon_generator', name: 'Hydro', description: '', cost: { research: 100 }, requiresMethane: true, requiredFlags: [], effects: [] } ], industry: [], colonization: [], terraforming: [], advanced: [] };
+    ctx.researchManager = new ctx.ResearchManager(params);
+    ctx.loadResearchCategory('energy');
+    const ids = Array.from(dom.window.document.querySelectorAll('.research-button')).map(b => b.id);
+    expect(ids).toEqual(['research-hydrocarbon_generator']);
+  });
+});

--- a/buildings-parameters.js
+++ b/buildings-parameters.js
@@ -226,6 +226,24 @@ const buildingsParameters = {
     maintenanceFactor: 0,
     unlocked: false
   },
+  hydrocarbonGenerator: {
+    name: 'Hydrocarbon Generator',
+    category: 'energy',
+    description: 'Burns atmospheric methane and oxygen to generate energy, releasing water vapour and carbon dioxide.',
+    cost: { colony: { metal: 1000, components: 50, electronics: 20 } },
+    consumption: { atmospheric: { atmosphericMethane: 1, oxygen: 4 } },
+    production: {
+      colony: { energy: 50000000 },
+      atmospheric: { carbonDioxide: 2.75, atmosphericWater: 2.25 }
+    },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: true,
+    requiresWorker: 0,
+    maintenanceFactor: 1,
+    unlocked: false
+  },
   nuclearPowerPlant: {
     name: 'Nuclear Power Plant',
     category: 'energy',

--- a/research-parameters.js
+++ b/research-parameters.js
@@ -173,6 +173,22 @@ const researchParameters = {
           }
         ],
       },
+      {
+        id: 'hydrocarbon_generator',
+        name: 'Hydrocarbon Generator',
+        description: 'Allows construction of generators burning methane and oxygen for power.',
+        cost: { research: 10000 },
+        prerequisites: [],
+        requiredFlags: ['hydrocarbonResearchUnlocked'],
+        requiresMethane: true,
+        effects: [
+          {
+            target: 'building',
+            targetId: 'hydrocarbonGenerator',
+            type: 'enable',
+          }
+        ],
+      },
     ],
     industry: [
       {
@@ -1018,6 +1034,21 @@ const researchParameters = {
             target: 'project',
             targetId: 'hyperionLantern',
             type: 'enable'
+          }
+        ]
+      },
+      {
+        id: 'hydrocarbon_research',
+        name: 'Hydrocarbon Combustion Concept',
+        description: 'Opens research into burning methane for power.',
+        cost: { advancedResearch: 1000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'researchManager',
+            type: 'booleanFlag',
+            flagId: 'hydrocarbonResearchUnlocked',
+            value: true
           }
         ]
       }

--- a/research.js
+++ b/research.js
@@ -2,15 +2,15 @@
 
 // Research Class
 class Research {
-    constructor(id, name, description, cost, prerequisites, effects) {
+    constructor(id, name, description, cost, prerequisites, effects, extra = {}) {
       this.id = id;
       this.name = name;
       this.description = description;
-      // store the entire cost object so researches can use different resources
       this.cost = cost;
       this.prerequisites = prerequisites;
       this.effects = effects;
-      this.isResearched = false; // Flag indicating if the research has been completed
+      Object.assign(this, extra);
+      this.isResearched = false;
     }
 }
 
@@ -32,7 +32,8 @@ class Research {
               research.description,
               research.cost,
               research.prerequisites,
-              research.effects
+              research.effects,
+              research
             )
         );
       }

--- a/researchUI.js
+++ b/researchUI.js
@@ -109,7 +109,21 @@ function loadResearchCategory(category) {
         return;
     }
 
+    const planetHasMethane = () => {
+        const surf = currentPlanetParameters.resources.surface;
+        const atm = currentPlanetParameters.resources.atmospheric;
+        return (surf.liquidMethane?.initialValue || 0) > 0 ||
+               (surf.hydrocarbonIce?.initialValue || 0) > 0 ||
+               (atm.atmosphericMethane?.initialValue || 0) > 0;
+    };
+
     researches.forEach((research) => {
+        if (research.requiresMethane && !planetHasMethane()) {
+            return;
+        }
+        if (research.requiredFlags && !research.requiredFlags.every(f => researchManager.isBooleanFlagSet(f))) {
+            return;
+        }
         const researchContainer = document.createElement('div');
         researchContainer.classList.add('research-item');
 


### PR DESCRIPTION
## Summary
- add Hydrocarbon Generator building with methane combustion
- create new regular research to unlock the building
- gate the research behind a new advanced research flag
- show research only when methane exists on the planet
- test new research unlocking and visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685a14e210ac8327a9db49cf5eb4d240