### PR TITLE
Increase Hyperion Lantern research cost

### DIFF
--- a/__tests__/hyperionLanternResearch.test.js
+++ b/__tests__/hyperionLanternResearch.test.js
@@ -13,7 +13,7 @@ describe('Hyperion Lantern research', () => {
     const advanced = ctx.researchParameters.advanced;
     const research = advanced.find(r => r.id === 'hyperion_lantern');
     expect(research).toBeDefined();
-    expect(research.cost.advancedResearch).toBe(5000);
+    expect(research.cost.advancedResearch).toBe(10000);
     const enable = research.effects.find(e => e.target === 'project' && e.targetId === 'hyperionLantern');
     expect(enable).toBeDefined();
   });

--- a/research-parameters.js
+++ b/research-parameters.js
@@ -1027,7 +1027,7 @@ const researchParameters = {
         id: 'hyperion_lantern',
         name: 'Hyperion Lantern',
         description: 'Research the construction of a large orbital facility that increases planetary luminosity.',
-        cost: { advancedResearch: 5000 },
+        cost: { advancedResearch: 10000 },
         prerequisites: [],
         effects: [
           {


### PR DESCRIPTION
## Summary
- raise cost of Hyperion Lantern research to 10000
- update unit test expectation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685a18a70ca883279174c178ac1948d4