### PR TITLE
Add journal history overlay

### DIFF
--- a/__tests__/showJournalHistory.test.js
+++ b/__tests__/showJournalHistory.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('showJournalHistory overlay', () => {
+  test('creates and removes history overlay', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.loadJournalEntries(['first', 'second']);
+    ctx.showJournalHistory();
+
+    const overlay = dom.window.document.querySelector('.history-overlay');
+    expect(overlay).not.toBeNull();
+    const entries = overlay.querySelectorAll('.history-entries p');
+    expect(entries.length).toBe(2);
+    expect(entries[0].textContent).toBe('first');
+    expect(entries[1].textContent).toBe('second');
+
+    const close = overlay.querySelector('.history-close-button');
+    close.dispatchEvent(new dom.window.Event('click'));
+    expect(dom.window.document.querySelector('.history-overlay')).toBeNull();
+  });
+
+  test('history persists after clearing current entries', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.addJournalEntry('one');
+    jest.useFakeTimers();
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    ctx.clearJournal();
+    ctx.showJournalHistory();
+
+    const entries = dom.window.document.querySelectorAll('.history-entries p');
+    expect(entries.length).toBe(1);
+    expect(entries[0].textContent).toBe('one');
+  });
+
+  test('custom history loaded via loadJournalEntries', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.loadJournalEntries(['current'], ['old', 'older']);
+    ctx.showJournalHistory();
+
+    const entries = dom.window.document.querySelectorAll('.history-entries p');
+    expect(entries.length).toBe(2);
+    expect(entries[0].textContent).toBe('old');
+    expect(entries[1].textContent).toBe('older');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
       <div id="day-night-progress-bar" class="day-night-progress-bar"></div>
     </div>
     <button id="toggle-journal-button" class="journal-toggle">Hide Journal</button>
+    <button id="show-history-button" class="journal-history">Show History</button>
     <span id="journal-alert" class="journal-alert">!</span>
   </div>
 

--- a/journal.js
+++ b/journal.js
@@ -1,4 +1,5 @@
-let journalEntriesData = []; // Array to store journal entries
+let journalEntriesData = []; // Array to store entries currently shown
+let journalHistoryData = []; // Array to store all journal history
 let journalCollapsed = false;
 let journalUnread = false;
 
@@ -28,6 +29,7 @@ function processNextJournalEntry() {
   journalEntries.appendChild(entry); // Append the empty paragraph first
 
   journalEntriesData.push(text); // Store the journal entry in the array
+  journalHistoryData.push(text); // Also keep it in the full history
 
   let index = 0;
 
@@ -62,7 +64,7 @@ function processNextJournalEntry() {
   }
 }
 
-function loadJournalEntries(entries) {
+function loadJournalEntries(entries, history = null) {
   const journalEntries = document.getElementById('journal-entries');
   journalEntries.innerHTML = ''; // Clear existing journal entries
   journalQueue = [];
@@ -84,6 +86,11 @@ function loadJournalEntries(entries) {
 
   journalEntries.scrollTop = journalEntries.scrollHeight; // Scroll to the latest entry
   journalEntriesData = entries; // Restore the journalEntriesData array
+  if (history) {
+    journalHistoryData = history.slice();
+  } else {
+    journalHistoryData = entries.slice();
+  }
 }
 
 /**
@@ -92,7 +99,7 @@ function loadJournalEntries(entries) {
 function clearJournal() {
   const journalEntries = document.getElementById('journal-entries');
   journalEntries.innerHTML = ''; // Remove all entries from the display
-  journalEntriesData = []; // Clear the stored data array
+  journalEntriesData = []; // Clear the stored data array but keep history
   journalQueue = [];
   journalTyping = false;
   journalCurrentEventId = null;
@@ -120,9 +127,52 @@ function toggleJournal() {
   }
 }
 
+function showJournalHistory() {
+  const overlay = document.createElement('div');
+  overlay.classList.add('history-overlay');
+
+  const windowDiv = document.createElement('div');
+  windowDiv.classList.add('history-window');
+
+  const title = document.createElement('h2');
+  title.textContent = 'Journal History';
+
+  const entriesContainer = document.createElement('div');
+  entriesContainer.classList.add('history-entries');
+  journalHistoryData.forEach(text => {
+    const entry = document.createElement('p');
+    const lines = text.split('\n');
+    lines.forEach((line, idx) => {
+      entry.appendChild(document.createTextNode(line));
+      if (idx < lines.length - 1) {
+        entry.appendChild(document.createElement('br'));
+      }
+    });
+    entriesContainer.appendChild(entry);
+  });
+
+  const closeBtn = document.createElement('button');
+  closeBtn.classList.add('history-close-button');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => {
+    document.body.removeChild(overlay);
+  });
+
+  windowDiv.appendChild(title);
+  windowDiv.appendChild(entriesContainer);
+  windowDiv.appendChild(closeBtn);
+
+  overlay.appendChild(windowDiv);
+  document.body.appendChild(overlay);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const toggleButton = document.getElementById('toggle-journal-button');
   if (toggleButton) {
     toggleButton.addEventListener('click', toggleJournal);
+  }
+  const historyButton = document.getElementById('show-history-button');
+  if (historyButton) {
+    historyButton.addEventListener('click', showJournalHistory);
   }
 });

--- a/save.js
+++ b/save.js
@@ -12,6 +12,7 @@ function getGameState() {
     terraforming: terraforming.saveState(),
     story: storyManager.saveState(),
     journalEntries: journalEntriesData,
+    journalHistory: journalHistoryData,
     goldenAsteroid: goldenAsteroid.saveState(),
     lifeDesigner: lifeDesigner.saveState(),
     milestonesManager: milestonesManager.saveState(),
@@ -131,7 +132,8 @@ function loadGame(slotOrCustomString) {
     }
 
       if (gameState.journalEntries) {
-        loadJournalEntries(gameState.journalEntries); // Restore journal entries
+        const history = gameState.journalHistory || gameState.journalEntries;
+        loadJournalEntries(gameState.journalEntries, history); // Restore journal
       }
 
       // Restore research progress

--- a/style.css
+++ b/style.css
@@ -158,6 +158,10 @@ body {
     padding: 5px 10px;
 }
 
+.journal-history {
+    padding: 5px 10px;
+}
+
 .journal-alert {
     color: red;
     font-weight: bold;
@@ -172,4 +176,36 @@ body {
     color: gray;
     font-style: italic;
     margin: 10px 0;
+}
+
+/* Journal history overlay */
+.history-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.history-window {
+    width: 60%;
+    max-height: 80%;
+    background-color: #f4f4f4;
+    padding: 20px;
+    border-radius: 10px;
+    overflow-y: auto;
+}
+
+.history-window h2 {
+    margin-top: 0;
+}
+
+.history-close-button {
+    margin-top: 10px;
+    padding: 5px 15px;
 }


### PR DESCRIPTION
## Summary
- add a Show History button in the top bar
- style and implement the new journal history overlay window
- hook the new button to display all journal entries
- persist journal history across clears and loads
- test the showJournalHistory function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685a9f9497888327a2f6dbbbf232b88c