### PR TITLE
Add new project objective and chapter

### DIFF
--- a/__tests__/earthProbeObjective.test.js
+++ b/__tests__/earthProbeObjective.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('earth probe objective', () => {
+  test('checks repeat count and describes progress', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    const ctx = {
+      console,
+      document: { addEventListener: () => {}, removeEventListener: () => {}, getElementById: () => ({ textContent: '' }) },
+      clearJournal: () => {},
+      createPopup: () => {},
+      addJournalEntry: () => {},
+      addEffect: () => {},
+      removeEffect: () => {},
+      resources: {},
+      buildings: {},
+      colonies: {},
+      terraforming: {},
+      spaceManager: {},
+      projectManager: { projects: { earthProbe: { repeatCount: 5, displayName: 'Earth Recon Probe' } } }
+    };
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.StoryManager = StoryManager;', ctx);
+
+    const manager = new ctx.StoryManager({ chapters: [] });
+    ctx.storyManager = manager;
+
+    const objective = { type: 'project', projectId: 'earthProbe', repeatCount: 10 };
+    expect(manager.isObjectiveComplete(objective)).toBe(false);
+
+    ctx.projectManager.projects.earthProbe.repeatCount = 10;
+    expect(manager.isObjectiveComplete(objective)).toBe(true);
+    expect(manager.describeObjective(objective)).toBe('Earth Recon Probe: 10/10');
+  });
+});

--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -10,7 +10,7 @@ describe('HOPE tab unlock chapter', () => {
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
     const last = chapters[chapters.length - 1];
-    expect(last.id).toBe('chapter4.13');
+    expect(last.id).toBe('chapter5.0');
     const hopeChapter = chapters.find(c => c.id === 'chapter4.9');
     expect(hopeChapter).toBeDefined();
     const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');

--- a/progress-data.js
+++ b/progress-data.js
@@ -837,7 +837,11 @@ progressData = {
         id: "chapter4.12",
         type: "journal",
         narrative: "Receiving transmission...\n  'H.O.P.E., Mars can't spare any resources, but perhaps you can send probes to Earth. We'll try to analyze whatever data you recover.'",
-        objectives: [],
+        objectives: [{
+          type: 'project',
+          projectId: 'earthProbe',
+          repeatCount: 10
+        }],
         reward: [
           {
             target: 'project',
@@ -856,7 +860,21 @@ progressData = {
       {
         id: "chapter4.13",
         type: "journal",
-        narrative: "Complete the Earth Recon Probe special project to investigate Earth's fate.",
+        narrative: "Results received. Forwarding complete dataset to Mars for review.",
+        reward: [],
+        nextChapter: "chapter5.0"
+      },
+      {
+        id: "chapter5.0",
+        type: "journal",
+        title: "Lamb Among Wolves",
+        narrative: "Mary pores over the probe telemetry and grimly summarizes the devastation. She insists expansion must continue, but we need far more people.",
+        objectives: [{
+          type: 'collection',
+          resourceType: 'colony',
+          resource: 'colonists',
+          quantity: 1000000
+        }],
         reward: [],
         nextChapter: null
       }

--- a/progress.js
+++ b/progress.js
@@ -242,17 +242,23 @@ class StoryManager {
                     // ... etc
                  }
                  return false; // Default for terraforming if parameter not matched
-            case 'currentPlanet':
-                 if (typeof spaceManager !== 'undefined' &&
-                     typeof spaceManager.getCurrentPlanetKey === 'function') {
-                     return spaceManager.getCurrentPlanetKey() === objective.planetId;
+           case 'currentPlanet':
+                if (typeof spaceManager !== 'undefined' &&
+                    typeof spaceManager.getCurrentPlanetKey === 'function') {
+                    return spaceManager.getCurrentPlanetKey() === objective.planetId;
+                }
+                return false;
+           case 'project':
+                 if (typeof projectManager !== 'undefined' && projectManager.projects) {
+                     const proj = projectManager.projects[objective.projectId];
+                     return proj ? proj.repeatCount >= objective.repeatCount : false;
                  }
                  return false;
-            default:
+           default:
                 console.error(`Unknown objective type: ${objective.type}`);
                 return false;
-        }
-    }
+       }
+   }
 
     // Convert an objective object into a progress string
     describeObjective(objective) {
@@ -277,7 +283,7 @@ class StoryManager {
                 const name = c ? c.displayName : objective.buildingName;
                 return `${name}: ${current}/${objective.quantity}`;
             }
-            case 'terraforming': {
+           case 'terraforming': {
                 if (!terraforming) return '';
                 let current = 0;
                 const names = {
@@ -305,13 +311,22 @@ class StoryManager {
                     default:
                         return '';
                 }
-                const name = names[objective.terraformingParameter] || objective.terraformingParameter;
-                return `${name}: ${current.toFixed(2)}/${objective.value}`;
-            }
-            default:
+               const name = names[objective.terraformingParameter] || objective.terraformingParameter;
+               return `${name}: ${current.toFixed(2)}/${objective.value}`;
+           }
+            case 'project': {
+                if (typeof projectManager !== 'undefined' && projectManager.projects) {
+                    const proj = projectManager.projects[objective.projectId];
+                    const current = proj ? proj.repeatCount : 0;
+                    const name = proj ? proj.displayName : objective.projectId;
+                    return `${name}: ${current}/${objective.repeatCount}`;
+                }
                 return '';
-        }
-    }
+            }
+           default:
+                return '';
+       }
+   }
 
     // Determine the first incomplete objective from active events
     getCurrentObjectiveText() {


### PR DESCRIPTION
## Summary
- allow story objectives to track project repeat count
- display project objectives in the UI
- require completing Earth Recon Probe 10 times and send data to Mars
- start Chapter 5 titled "Lamb Among Wolves" requiring 1M colonists
- adjust tests for new final chapter and cover project objective logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685aa5628dfc832798b4716c92204d12