### PR TITLE
Persist 'Hide Completed' preference

### DIFF
--- a/__tests__/completedResearchSave.test.js
+++ b/__tests__/completedResearchSave.test.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('hide completed research save/load', () => {
+  test('completed research visibility state persists', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = { AUTO: 'AUTO', Game: function(){} };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+    const overrides = `
+      createPopup=()=>{};
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      initializeSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class { activateTab(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('completedResearchHidden = true; gameSettings.hideCompletedResearch = true;', ctx);
+    vm.runInContext('var saved = JSON.stringify(getGameState());', ctx);
+    vm.runInContext('completedResearchHidden = false; gameSettings.hideCompletedResearch = false;', ctx);
+    vm.runInContext('loadGame(saved);', ctx);
+    const result = vm.runInContext('completedResearchHidden', ctx);
+    const setting = vm.runInContext('gameSettings.hideCompletedResearch', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(result).toBe(true);
+    expect(setting).toBe(true);
+  });
+});

--- a/globals.js
+++ b/globals.js
@@ -18,7 +18,10 @@ let lifeDesigner;
 let lifeManager;
 let fundingModule;
 
-let gameSettings = { useCelsius: false };
+let gameSettings = {
+  useCelsius: false,
+  hideCompletedResearch: false,
+};
 
 let colonySliderSettings = {
   workerRatio: 0.5,

--- a/researchUI.js
+++ b/researchUI.js
@@ -1,4 +1,6 @@
-let completedResearchHidden = false; // Initialize the toggle state
+let completedResearchHidden =
+    (typeof gameSettings !== 'undefined' && gameSettings.hideCompletedResearch) ||
+    false; // Initialize the toggle state
 
 function formatResearchCost(cost) {
     const parts = [];
@@ -57,6 +59,9 @@ function updateResearchButtonText(button, researchItem) {
 }
 
 function initializeResearchTabs() {
+    if (typeof gameSettings !== 'undefined') {
+        completedResearchHidden = gameSettings.hideCompletedResearch || false;
+    }
     // Set up event listeners for research sub-tabs
     document.querySelectorAll('.research-subtab').forEach(subtab => {
         subtab.onclick = () => {
@@ -77,6 +82,9 @@ function initializeResearchTabs() {
     researchCategories.forEach(category => {
         loadResearchCategory(category);
     });
+
+    updateAllResearchButtons(researchManager.researches);
+    updateCompletedResearchVisibility();
 
     // Activate the 'energy' category
     activateResearchSubtab('energy-research');
@@ -157,6 +165,9 @@ function loadResearchCategory(category) {
 
 function toggleCompletedResearch() {
     completedResearchHidden = !completedResearchHidden; // Toggle the state
+    if (typeof gameSettings !== 'undefined') {
+        gameSettings.hideCompletedResearch = completedResearchHidden;
+    }
     updateAllResearchButtons(researchManager.researches); // Apply visibility changes
     updateCompletedResearchVisibility();
 }

--- a/save.js
+++ b/save.js
@@ -168,6 +168,13 @@ function loadGame(slotOrCustomString) {
       if(toggle){
         toggle.checked = gameSettings.useCelsius;
       }
+      if (typeof completedResearchHidden !== 'undefined') {
+        completedResearchHidden = gameSettings.hideCompletedResearch || false;
+        if (typeof updateAllResearchButtons === 'function') {
+          updateAllResearchButtons(researchManager.researches);
+          updateCompletedResearchVisibility();
+        }
+      }
     }
 
     if(gameState.colonySliderSettings){


### PR DESCRIPTION
## Summary
- track completed research toggle in global settings
- apply hidden state when loading and toggling
- save/load preference in save.js
- test save/load of completed research visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685aa8ad86b08327b8655187d68aa38b