### PR TITLE
Display lock message for Life tab

### DIFF
--- a/__tests__/lifeUILockedMessage.test.js
+++ b/__tests__/lifeUILockedMessage.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+
+const EffectableEntity = require('../effectable-entity.js');
+const physics = require('../physics.js');
+const numbers = require('../numbers.js');
+
+describe('lifeUI locked message', () => {
+  test('shows message when life designer locked', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { day: 200, night: 200 }, temperate: { day: 200, night: 200 }, polar: { day: 200, night: 200 } } },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    // lifeDesigner.enabled is false by default
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    const lockedMessage = dom.window.document.getElementById('life-designer-locked-message');
+    const lifeContent = dom.window.document.getElementById('life-terraforming-content');
+    expect(lockedMessage.style.display).toBe('block');
+    expect(lifeContent.style.display).toBe('none');
+  });
+});

--- a/lifeUI.js
+++ b/lifeUI.js
@@ -39,9 +39,12 @@ function getConvertedDisplay(attributeName, attribute) {
 // Function to initialize the life terraforming designer UI
 function initializeLifeTerraformingDesignerUI() {
     const lifeTerraformingDiv = document.getElementById('life-terraforming');
-  
+
     // Generate the HTML content
     lifeTerraformingDiv.innerHTML = `
+      <p id="life-designer-locked-message" class="empty-message" style="display:none;">
+        Complete the "Life Designing and Production" research to unlock the Life Designer.
+      </p>
       <div id="life-terraforming-content">
         <h2>Life Designer</h2>
         <div id="life-designer-main-area" style="display: flex; gap: 20px; align-items: stretch;">
@@ -312,10 +315,13 @@ function initializeLifeTerraformingDesignerUI() {
 function updateLifeUI() {
   // Toggle the visibility of the life-terraforming div
   const lifeTerraformingDiv = document.getElementById('life-terraforming-content');
+  const lockedMessage = document.getElementById('life-designer-locked-message');
   if (lifeDesigner.enabled) {
     lifeTerraformingDiv.style.display = 'block';
+    if (lockedMessage) lockedMessage.style.display = 'none';
   } else {
     lifeTerraformingDiv.style.display = 'none';
+    if (lockedMessage) lockedMessage.style.display = 'block';
   }
 
     updateDesignValues();


### PR DESCRIPTION
## Summary
- show a message in the Life terraforming tab when the Life Designer isn't unlocked
- hide the message once Life Designer is enabled
- test Life tab locked message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685ab75c6ef88327bb302db6cc704cba