### PR TITLE
Add Solis quest system under HOPE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ scripts implement the tabs, pop-ups and other interface elements.
 - **gold-asteroid.js** spawns a temporary event that awards large production multipliers when clicked.
 - **autobuild.js** automatically constructs buildings based on population ratios when auto-build is enabled.
 - **milestones.js** and **milestonesUI.js** track long term objectives and unlock rewards.
+- **solis.js** and **solisUI.js** manage the Solis shop and quest system which grants Solis points for completing delivery quests.
 - **save.js** manages localStorage save slots and autosaving of resources, structures, research and story progress.
 
 # Effectable Entities Design

--- a/__tests__/solisQuestGeneration.test.js
+++ b/__tests__/solisQuestGeneration.test.js
@@ -1,0 +1,30 @@
+const { SolisManager } = require('../solis.js');
+
+describe('SolisManager quest generation', () => {
+  test('generates quests only for unlocked resources', () => {
+    global.resources = {
+      colony: {
+        metal: { unlocked: true },
+        components: { unlocked: false }
+      }
+    };
+    const manager = new SolisManager({ metal: 1, components: 10 });
+    const quest = manager.generateQuest();
+    expect(quest.resource).toBe('metal');
+    expect(quest.quantity).toBeGreaterThanOrEqual(1000);
+    expect(quest.quantity).toBeLessThanOrEqual(9999);
+  });
+
+  test('scales quantity by resource value', () => {
+    global.resources = { colony: { metal: { unlocked: true }, components: { unlocked: true } } };
+    const manager = new SolisManager({ metal: 1, components: 10 });
+    jest.spyOn(global.Math, 'random').mockReturnValue(0); // ensures value = 1000
+    const quest = manager.generateQuest();
+    Math.random.mockRestore();
+    if (quest.resource === 'components') {
+      expect(quest.quantity).toBe(100);
+    } else {
+      expect(quest.quantity).toBe(1000);
+    }
+  });
+});

--- a/game.js
+++ b/game.js
@@ -76,6 +76,8 @@ function create() {
 
   goldenAsteroid = new GoldenAsteroid();
 
+  solisManager = new SolisManager();
+
   lifeDesigner = new LifeDesigner();
   lifeManager = new LifeManager();
   initializeLifeUI();
@@ -130,6 +132,8 @@ function initializeGameState(options = {}) {
   terraforming.initializeTerraforming();
 
   goldenAsteroid = new GoldenAsteroid();
+
+  solisManager = new SolisManager();
 
   lifeDesigner = new LifeDesigner();
   lifeManager = new LifeManager();
@@ -189,6 +193,10 @@ function updateLogic(delta) {
   oreScanner.updateScan(delta);  // Update ore scanning progress
 
   goldenAsteroid.update(delta);
+
+  if (solisManager) {
+    solisManager.update(delta);
+  }
 
   lifeDesigner.update(delta);
 

--- a/globals.js
+++ b/globals.js
@@ -32,3 +32,4 @@ let colonySliderSettings = {
 
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
 let skillManager;
+let solisManager;

--- a/hopeUI.js
+++ b/hopeUI.js
@@ -1,12 +1,31 @@
+function initializeHopeTabs() {
+    document.querySelectorAll('.hope-subtab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            document.querySelectorAll('.hope-subtab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.hope-subtab-content').forEach(c => c.classList.remove('active'));
+            tab.classList.add('active');
+            const id = tab.dataset.subtab;
+            document.getElementById(id).classList.add('active');
+        });
+    });
+}
+
 function initializeHopeUI() {
+    initializeHopeTabs();
     if (typeof initializeSkillsUI === 'function') {
         initializeSkillsUI();
+    }
+    if (typeof initializeSolisUI === 'function') {
+        initializeSolisUI();
     }
 }
 
 function updateHopeUI() {
     if (typeof updateSkillTreeUI === 'function') {
         updateSkillTreeUI();
+    }
+    if (typeof updateSolisUI === 'function') {
+        updateSolisUI();
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -80,6 +80,8 @@
     <script src="milestones.js"></script>
     <script src="milestonesUI.js"></script>
     <script src="hopeUI.js"></script>
+    <script src="solis.js"></script>
+    <script src="solisUI.js"></script>
     <script src="zones.js"></script>
     <script src="globals.js"></script>
     <script src="autobuild.js"></script>
@@ -308,11 +310,21 @@
         <div class="container hope-container">
             <div class="hope-subtabs">
                 <div class="hope-subtab active" data-subtab="awakening-hope">Awakening</div>
+                <div class="hope-subtab" data-subtab="solis-hope">Solis</div>
             </div>
             <div class="hope-subtab-content-wrapper">
                 <div id="awakening-hope" class="hope-subtab-content active">
                     <div id="skill-points-display">Skill Points: <span id="skill-points-value">0</span></div>
                     <div id="skill-tree" class="skill-tree"></div>
+                </div>
+                <div id="solis-hope" class="hope-subtab-content">
+                    <div id="solis-points-display">Solis Points: <span id="solis-points-value">0</span></div>
+                    <div id="solis-quest-text">No quest available</div>
+                    <div>Reward: <span id="solis-reward">1</span> point(s)</div>
+                    <button id="solis-complete-button">Complete Quest</button>
+                    <button id="solis-refresh-button">Refresh</button>
+                    <button id="solis-multiply-button">x10</button>
+                    <button id="solis-divide-button">/10</button>
                 </div>
             </div>
         </div>

--- a/save.js
+++ b/save.js
@@ -14,6 +14,7 @@ function getGameState() {
     journalEntries: journalEntriesData,
     journalHistory: journalHistoryData,
     goldenAsteroid: goldenAsteroid.saveState(),
+    solisManager: solisManager.saveState(),
     lifeDesigner: lifeDesigner.saveState(),
     milestonesManager: milestonesManager.saveState(),
     skills: skillManager.saveState(),
@@ -149,6 +150,10 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.goldenAsteroid){
       goldenAsteroid.loadState(gameState.goldenAsteroid);
+    }
+
+    if(gameState.solisManager){
+      solisManager.loadState(gameState.solisManager);
     }
 
     if(gameState.lifeDesigner){

--- a/solis.js
+++ b/solis.js
@@ -1,0 +1,97 @@
+class SolisManager {
+  constructor(resourceValues = {}) {
+    this.resourceValues = Object.assign({
+      metal: 1,
+      components: 10,
+      electronics: 20,
+      androids: 50,
+      superconductors: 100,
+    }, resourceValues);
+    this.solisPoints = 0;
+    this.rewardMultiplier = 1;
+    this.currentQuest = null;
+    this.lastQuestTime = 0;
+    this.lastRefreshTime = 0;
+    this.questInterval = 15 * 60 * 1000; // 15 minutes
+    this.refreshCooldown = 5 * 60 * 1000; // 5 minutes
+  }
+
+  availableResources() {
+    const list = [];
+    for (const name in this.resourceValues) {
+      if (resources.colony && resources.colony[name] && resources.colony[name].unlocked) {
+        list.push(name);
+      }
+    }
+    return list;
+  }
+
+  generateQuest() {
+    const options = this.availableResources();
+    if (options.length === 0) {
+      this.currentQuest = null;
+      return null;
+    }
+    const resource = options[Math.floor(Math.random() * options.length)];
+    const value = Math.floor(Math.random() * 9000) + 1000; // metal value
+    const quantity = Math.round(value / this.resourceValues[resource]);
+    this.currentQuest = { resource, quantity, value };
+    this.lastQuestTime = Date.now();
+    return this.currentQuest;
+  }
+
+  refreshQuest() {
+    const now = Date.now();
+    if (now - this.lastRefreshTime >= this.refreshCooldown) {
+      this.generateQuest();
+      this.lastRefreshTime = now;
+    }
+  }
+
+  completeQuest() {
+    if (!this.currentQuest) return false;
+    const res = resources.colony[this.currentQuest.resource];
+    if (!res || res.value < this.currentQuest.quantity) return false;
+    res.decrease(this.currentQuest.quantity);
+    this.solisPoints += this.rewardMultiplier;
+    this.currentQuest = null;
+    return true;
+  }
+
+  multiplyReward() {
+    this.rewardMultiplier += 1;
+  }
+
+  divideReward() {
+    this.rewardMultiplier = Math.max(1, this.rewardMultiplier - 1);
+  }
+
+  update(delta) {
+    const now = Date.now();
+    if (!this.currentQuest && now - this.lastQuestTime >= this.questInterval) {
+      this.generateQuest();
+    }
+  }
+
+  saveState() {
+    return {
+      solisPoints: this.solisPoints,
+      rewardMultiplier: this.rewardMultiplier,
+      currentQuest: this.currentQuest,
+      lastQuestTime: this.lastQuestTime,
+      lastRefreshTime: this.lastRefreshTime
+    };
+  }
+
+  loadState(data) {
+    this.solisPoints = data.solisPoints || 0;
+    this.rewardMultiplier = data.rewardMultiplier || 1;
+    this.currentQuest = data.currentQuest;
+    this.lastQuestTime = data.lastQuestTime || 0;
+    this.lastRefreshTime = data.lastRefreshTime || 0;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { SolisManager };
+}

--- a/solisUI.js
+++ b/solisUI.js
@@ -1,0 +1,95 @@
+let solisTabVisible = true;
+
+function showSolisTab() {
+  solisTabVisible = true;
+  const tab = document.querySelector('.hope-subtab[data-subtab="solis-hope"]');
+  const content = document.getElementById('solis-hope');
+  if (tab) tab.classList.remove('hidden');
+  if (content) content.classList.remove('hidden');
+}
+
+function hideSolisTab() {
+  solisTabVisible = false;
+  const tab = document.querySelector('.hope-subtab[data-subtab="solis-hope"]');
+  const content = document.getElementById('solis-hope');
+  if (tab) tab.classList.add('hidden');
+  if (content) content.classList.add('hidden');
+}
+
+function initializeSolisUI() {
+  const refreshBtn = document.getElementById('solis-refresh-button');
+  const completeBtn = document.getElementById('solis-complete-button');
+  const multBtn = document.getElementById('solis-multiply-button');
+  const divBtn = document.getElementById('solis-divide-button');
+
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => {
+      solisManager.refreshQuest();
+      updateSolisUI();
+    });
+  }
+  if (completeBtn) {
+    completeBtn.addEventListener('click', () => {
+      if (solisManager.completeQuest()) {
+        updateSolisUI();
+      }
+    });
+  }
+  if (multBtn) {
+    multBtn.addEventListener('click', () => {
+      solisManager.multiplyReward();
+      updateSolisUI();
+    });
+  }
+  if (divBtn) {
+    divBtn.addEventListener('click', () => {
+      solisManager.divideReward();
+      updateSolisUI();
+    });
+  }
+}
+
+function updateSolisUI() {
+  const questText = document.getElementById('solis-quest-text');
+  const refreshBtn = document.getElementById('solis-refresh-button');
+  const completeBtn = document.getElementById('solis-complete-button');
+  const pointsSpan = document.getElementById('solis-points-value');
+  const rewardSpan = document.getElementById('solis-reward');
+
+  if (pointsSpan) {
+    pointsSpan.textContent = solisManager.solisPoints;
+  }
+  if (rewardSpan) {
+    rewardSpan.textContent = solisManager.rewardMultiplier;
+  }
+  const quest = solisManager.currentQuest;
+  if (questText) {
+    if (quest) {
+      questText.textContent = `Deliver ${quest.quantity} ${quest.resource}`;
+    } else {
+      questText.textContent = 'No quest available';
+    }
+  }
+  const now = Date.now();
+  if (refreshBtn) {
+    const remaining = solisManager.refreshCooldown - (now - solisManager.lastRefreshTime);
+    if (remaining > 0) {
+      refreshBtn.disabled = true;
+      refreshBtn.textContent = `Refresh (${Math.ceil(remaining / 1000)}s)`;
+    } else {
+      refreshBtn.disabled = false;
+      refreshBtn.textContent = 'Refresh';
+    }
+  }
+  if (completeBtn) {
+    if (quest && resources.colony[quest.resource] && resources.colony[quest.resource].value >= quest.quantity) {
+      completeBtn.disabled = false;
+    } else {
+      completeBtn.disabled = true;
+    }
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { hideSolisTab, showSolisTab };
+}


### PR DESCRIPTION
## Summary
- introduce SolisManager for quests and Solis points
- add solisUI for quest interaction
- show new "Solis" subtab in HOPE and wire up UI
- integrate Solis scripts with initialization, saving/loading and updates
- document shop module in AGENTS.md
- add tests for quest generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685acc57aedc8327a0e3aa0a3cab8c34