### PR TITLE
Implement persistent Solis shop

### DIFF
--- a/__tests__/solisTravelPersistence.test.js
+++ b/__tests__/solisTravelPersistence.test.js
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Solis state persists across planet travel', () => {
+  test('traveling does not reset solis manager', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) { this.config = config; },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+
+    vm.runInContext('solisManager.solisPoints = 5; solisManager.currentQuest = {resource:"metal", quantity:10};', ctx);
+    const before = vm.runInContext('solisManager', ctx);
+
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const after = vm.runInContext('solisManager', ctx);
+    const points = vm.runInContext('solisManager.solisPoints', ctx);
+    const quantity = vm.runInContext('solisManager.currentQuest.quantity', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(after).toBe(before);
+    expect(points).toBe(5);
+    expect(quantity).toBe(10);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -143,6 +143,9 @@ class EffectableEntity {
         case 'setFundingRate':
           this.applySetFundingRate(effect);
           break;
+        case 'fundingBonus':
+          this.applyFundingBonus(effect);
+          break;
         case 'globalCostReduction':
           this.applyGlobalCostReduction(effect);
           break;
@@ -232,6 +235,12 @@ class EffectableEntity {
     applySetFundingRate(effect) {
       if (typeof this.fundingRate !== 'undefined' && typeof effect.value === 'number') {
         this.fundingRate += effect.value;
+      }
+    }
+
+    applyFundingBonus(effect) {
+      if (typeof this.fundingRate !== 'undefined' && typeof this.baseFundingRate !== 'undefined') {
+        this.fundingRate = this.baseFundingRate + effect.value;
       }
     }
 

--- a/funding.js
+++ b/funding.js
@@ -4,7 +4,9 @@ class FundingModule extends EffectableEntity {
     super({config : 'Funding Module'});
 
     this.resources = resources;
-    this.fundingRate = fundingRate; // Set the funding rate from planet parameters
+    this.baseFundingRate = fundingRate; // store the starting funding rate
+    this.fundingBonus = 0; // additional funding from effects
+    this.fundingRate = fundingRate; // effective funding rate
   }
 
   // Method to get the effective production multiplier
@@ -36,6 +38,14 @@ class FundingModule extends EffectableEntity {
   applySetFundingRate(effect) {
     if (typeof effect.value === 'number') {
       this.fundingRate = effect.value;
+    }
+  }
+
+  // New effect handler for additive funding bonuses
+  applyFundingBonus(effect) {
+    if (typeof effect.value === 'number') {
+      this.fundingBonus = effect.value;
+      this.fundingRate = this.baseFundingRate + this.fundingBonus;
     }
   }
 }

--- a/game.js
+++ b/game.js
@@ -76,7 +76,9 @@ function create() {
 
   goldenAsteroid = new GoldenAsteroid();
 
-  solisManager = new SolisManager();
+  if (!preserveManagers || !solisManager) {
+    solisManager = new SolisManager();
+  }
 
   lifeDesigner = new LifeDesigner();
   lifeManager = new LifeManager();
@@ -133,7 +135,9 @@ function initializeGameState(options = {}) {
 
   goldenAsteroid = new GoldenAsteroid();
 
-  solisManager = new SolisManager();
+  if (!preserveManagers || !solisManager) {
+    solisManager = new SolisManager();
+  }
 
   lifeDesigner = new LifeDesigner();
   lifeManager = new LifeManager();
@@ -167,6 +171,9 @@ function initializeGameState(options = {}) {
   }
   if (preserveManagers && skillManager && typeof skillManager.reapplyEffects === 'function') {
     skillManager.reapplyEffects();
+  }
+  if (preserveManagers && solisManager && typeof solisManager.reapplyEffects === 'function') {
+    solisManager.reapplyEffects();
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -339,6 +339,14 @@
                                 <button id="solis-complete-button">Complete Quest</button>
                             </div>
                         </div>
+                        <div class="solis-shop">
+                            <h3>Solis Shop</h3>
+                            <div class="solis-shop-item">
+                                <span>Increase funding by 1 (Cost: <span id="solis-shop-funding-cost">1</span>)</span>
+                                <button id="solis-shop-funding-button">Buy</button>
+                                <span>Purchased: <span id="solis-shop-funding-count">0</span></span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/save.js
+++ b/save.js
@@ -154,6 +154,9 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.solisManager){
       solisManager.loadState(gameState.solisManager);
+      if (typeof solisManager.reapplyEffects === 'function') {
+        solisManager.reapplyEffects();
+      }
     }
 
     if(gameState.lifeDesigner){

--- a/skillsUI.js
+++ b/skillsUI.js
@@ -65,7 +65,7 @@ function updateSkillButton(skill) {
 function createSkillTree() {
     buildSkillPrereqs();
     const container = document.getElementById('skill-tree');
-    if (!container) return;
+    if (!container || container.nodeType !== 1) return;
 
     container.innerHTML = ''; // Clear previous content
 
@@ -90,13 +90,17 @@ function createSkillTree() {
     }
 
     // Defer drawing connections to ensure buttons are in the DOM and have dimensions
-    requestAnimationFrame(drawSkillConnections);
+    if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(drawSkillConnections);
+    } else {
+        drawSkillConnections();
+    }
 }
 
 function drawSkillConnections() {
     const svg = document.getElementById('skill-lines');
     const container = document.getElementById('skill-tree');
-    if (!svg || !container) return;
+    if (!svg || !container || container.nodeType !== 1) return;
 
     svg.innerHTML = ''; // Clear existing lines
 
@@ -155,7 +159,11 @@ function updateSkillTreeUI() {
     for (const id in skillManager.skills) {
         updateSkillButton(skillManager.skills[id]);
     }
-    drawSkillConnections();
+    if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(drawSkillConnections);
+    } else {
+        drawSkillConnections();
+    }
 }
 
 function initializeSkillsUI() {

--- a/solis.css
+++ b/solis.css
@@ -133,3 +133,14 @@
     opacity: 0.7;
     cursor: not-allowed;
 }
+
+.solis-shop-item {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-top: 10px;
+}
+
+.solis-shop-item button {
+    padding: 5px 10px;
+}

--- a/solisUI.js
+++ b/solisUI.js
@@ -51,6 +51,14 @@ function initializeSolisUI() {
       updateSolisUI();
     });
   }
+
+  const fundingBtn = document.getElementById('solis-shop-funding-button');
+  if (fundingBtn) {
+    fundingBtn.addEventListener('click', () => {
+      solisManager.purchaseUpgrade('funding');
+      updateSolisUI();
+    });
+  }
   
   // New: Set initial button text
   if (multBtn) multBtn.textContent = '+';
@@ -118,6 +126,13 @@ function updateSolisUI() {
       cooldownDiv.innerHTML = '';
     }
   }
+
+  const fundingCost = document.getElementById('solis-shop-funding-cost');
+  const fundingCount = document.getElementById('solis-shop-funding-count');
+  const fundingBtn = document.getElementById('solis-shop-funding-button');
+  if (fundingCost) fundingCost.textContent = solisManager.getUpgradeCost('funding');
+  if (fundingCount) fundingCount.textContent = solisManager.shopUpgrades.funding.purchases;
+  if (fundingBtn) fundingBtn.disabled = solisManager.solisPoints < solisManager.getUpgradeCost('funding');
 }
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- keep SolisManager when travelling to another planet
- add a simple Solis shop with funding upgrade
- show purchase count and cost in the Solis tab
- persist Solis upgrades in saves
- reapply Solis effects when loading or changing planets
- adjust skills UI to avoid errors in tests
- test that Solis state survives planet travel
- fix funding upgrade effect to use additive bonus
- test funding upgrade increases funding rate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685adaf443e48327b51d94a4aa5a6740