### PR TITLE
Fix funding upgrade after story effect

### DIFF
--- a/__tests__/solisFundingUpgrade.test.js
+++ b/__tests__/solisFundingUpgrade.test.js
@@ -28,4 +28,19 @@ describe('Solis funding upgrade', () => {
     manager.purchaseUpgrade('funding');
     expect(fundingModule.fundingRate).toBe(7);
   });
+
+  test('setFundingRate effect persists when purchasing upgrades', () => {
+    const fundingModule = new FundingModule({}, 0);
+    global.fundingModule = fundingModule;
+    global.addEffect = (effect) => fundingModule.addAndReplace(effect);
+
+    // Apply story effect that sets funding rate to 3
+    addEffect({ target: 'fundingModule', type: 'setFundingRate', value: 3 });
+
+    const manager = new SolisManager();
+    manager.solisPoints = 1;
+
+    manager.purchaseUpgrade('funding');
+    expect(fundingModule.fundingRate).toBe(4);
+  });
 });

--- a/funding.js
+++ b/funding.js
@@ -37,7 +37,8 @@ class FundingModule extends EffectableEntity {
 
   applySetFundingRate(effect) {
     if (typeof effect.value === 'number') {
-      this.fundingRate = effect.value;
+      this.baseFundingRate = effect.value;
+      this.fundingRate = this.baseFundingRate + this.fundingBonus;
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure `setFundingRate` effects update the base rate in `FundingModule`
- test that buying Solis funding upgrades stacks with story-set funding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685ae0e6bfb88327a5c8a6d269e34f32