### PR TITLE
Add Solis shop resource upgrades

### DIFF
--- a/__tests__/solisResourceUpgrades.test.js
+++ b/__tests__/solisResourceUpgrades.test.js
@@ -1,0 +1,40 @@
+const { SolisManager } = require('../solis.js');
+
+describe('Solis resource upgrades', () => {
+  const amounts = {
+    metal: 100,
+    components: 100,
+    electronics: 100,
+    glass: 100,
+    water: 1000000,
+    androids: 100
+  };
+
+  for (const key of Object.keys(amounts)) {
+    test(`purchaseUpgrade("${key}") increases resource`, () => {
+      const resource = { value: 0, increase(v) { this.value += v; } };
+      global.resources = { colony: { [key]: resource } };
+      const manager = new SolisManager();
+      manager.solisPoints = 20; // sufficient
+      expect(manager.purchaseUpgrade(key)).toBe(true);
+      expect(resource.value).toBe(amounts[key]);
+    });
+  }
+
+  test('reapplyEffects restores purchased resources', () => {
+    const cols = {};
+    for (const k of Object.keys(amounts)) {
+      cols[k] = { value: 0, increase(v){ this.value += v; } };
+    }
+    global.resources = { colony: cols };
+    const manager = new SolisManager();
+    for (const k of Object.keys(amounts)) {
+      manager.shopUpgrades[k].purchases = k === 'metal' ? 2 : 1;
+    }
+    manager.reapplyEffects();
+    expect(cols.metal.value).toBe(2 * amounts.metal);
+    for (const k of Object.keys(amounts)) {
+      if (k !== 'metal') expect(cols[k].value).toBe(amounts[k]);
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -341,11 +341,7 @@
                         </div>
                         <div class="solis-shop">
                             <h3>Solis Shop</h3>
-                            <div class="solis-shop-item">
-                                <span>Increase funding by 1 (Cost: <span id="solis-shop-funding-cost">1</span>)</span>
-                                <button id="solis-shop-funding-button">Buy</button>
-                                <span>Purchased: <span id="solis-shop-funding-count">0</span></span>
-                            </div>
+                            <div id="solis-shop-items"></div>
                         </div>
                     </div>
                 </div>

--- a/solis.js
+++ b/solis.js
@@ -1,3 +1,12 @@
+const RESOURCE_UPGRADE_AMOUNTS = {
+  metal: 100,
+  components: 100,
+  electronics: 100,
+  glass: 100,
+  water: 1000000,
+  androids: 100
+};
+
 class SolisManager {
   constructor(resourceValues = {}) {
     this.resourceValues = Object.assign({
@@ -116,6 +125,10 @@ class SolisManager {
         effectId: 'solisFunding',
         sourceId: 'solisShop'
       });
+    } else if (resources && resources.colony && resources.colony[key] &&
+               typeof resources.colony[key].increase === 'function') {
+      const amount = RESOURCE_UPGRADE_AMOUNTS[key] || 0;
+      resources.colony[key].increase(amount);
     }
     return true;
   }
@@ -130,6 +143,14 @@ class SolisManager {
         effectId: 'solisFunding',
         sourceId: 'solisShop'
       });
+    }
+
+    for (const key in RESOURCE_UPGRADE_AMOUNTS) {
+      const upgrade = this.shopUpgrades[key];
+      if (upgrade && upgrade.purchases > 0 && resources && resources.colony &&
+          resources.colony[key] && typeof resources.colony[key].increase === 'function') {
+        resources.colony[key].increase(RESOURCE_UPGRADE_AMOUNTS[key] * upgrade.purchases);
+      }
     }
   }
 

--- a/solisUI.js
+++ b/solisUI.js
@@ -1,5 +1,15 @@
 let solisTabVisible = true;
 let solisUIInitialized = false;
+const shopElements = {};
+const shopDescriptions = {
+  funding: 'Increase funding by 1',
+  metal: 'Increase starting metal by 100',
+  components: 'Increase starting components by 100',
+  electronics: 'Increase starting electronics by 100',
+  glass: 'Increase starting glass by 100',
+  water: 'Increase starting water by 1M',
+  androids: 'Increase starting androids by 100'
+};
 
 function showSolisTab() {
   solisTabVisible = true;
@@ -15,6 +25,34 @@ function hideSolisTab() {
   const content = document.getElementById('solis-hope');
   if (tab) tab.classList.add('hidden');
   if (content) content.classList.add('hidden');
+}
+
+function createShopItem(key) {
+  const item = document.createElement('div');
+  item.classList.add('solis-shop-item');
+
+  const label = document.createElement('span');
+  label.innerHTML = `${shopDescriptions[key]} (Cost: <span id="solis-shop-${key}-cost"></span>)`;
+  item.appendChild(label);
+
+  const button = document.createElement('button');
+  button.id = `solis-shop-${key}-button`;
+  button.textContent = 'Buy';
+  button.addEventListener('click', () => {
+    solisManager.purchaseUpgrade(key);
+    updateSolisUI();
+  });
+  item.appendChild(button);
+
+  const purchased = document.createElement('span');
+  purchased.innerHTML = `Purchased: <span id="solis-shop-${key}-count">0</span>`;
+  item.appendChild(purchased);
+
+  const costSpan = label.querySelector(`#solis-shop-${key}-cost`);
+  const countSpan = purchased.querySelector(`#solis-shop-${key}-count`);
+
+  shopElements[key] = { button, cost: costSpan, count: countSpan };
+  return item;
 }
 
 function initializeSolisUI() {
@@ -52,11 +90,10 @@ function initializeSolisUI() {
     });
   }
 
-  const fundingBtn = document.getElementById('solis-shop-funding-button');
-  if (fundingBtn) {
-    fundingBtn.addEventListener('click', () => {
-      solisManager.purchaseUpgrade('funding');
-      updateSolisUI();
+  const container = document.getElementById('solis-shop-items');
+  if (container) {
+    ['funding', 'metal', 'components', 'electronics', 'glass', 'water', 'androids'].forEach(key => {
+      container.appendChild(createShopItem(key));
     });
   }
   
@@ -127,12 +164,13 @@ function updateSolisUI() {
     }
   }
 
-  const fundingCost = document.getElementById('solis-shop-funding-cost');
-  const fundingCount = document.getElementById('solis-shop-funding-count');
-  const fundingBtn = document.getElementById('solis-shop-funding-button');
-  if (fundingCost) fundingCost.textContent = solisManager.getUpgradeCost('funding');
-  if (fundingCount) fundingCount.textContent = solisManager.shopUpgrades.funding.purchases;
-  if (fundingBtn) fundingBtn.disabled = solisManager.solisPoints < solisManager.getUpgradeCost('funding');
+  for (const key in shopElements) {
+    const el = shopElements[key];
+    if (!el) continue;
+    if (el.cost) el.cost.textContent = solisManager.getUpgradeCost(key);
+    if (el.count) el.count.textContent = solisManager.shopUpgrades[key].purchases;
+    if (el.button) el.button.disabled = solisManager.solisPoints < solisManager.getUpgradeCost(key);
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- expand Solis shop with new resource upgrades
- grant purchased resources immediately and on new games
- generate shop UI from JavaScript

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685ae10c55808327bda284612e6f1c30