### PR TITLE
Add HOPE tab quest alert

### DIFF
--- a/__tests__/hopeAlert.test.js
+++ b/__tests__/hopeAlert.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const { SolisManager } = require('../solis.js');
+
+describe('HOPE tab alert for Solis quests', () => {
+  test('shows and hides alert based on quest availability', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="hope-tab"><span id="hope-alert" class="hope-alert">!</span></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.solisManager = new SolisManager();
+    ctx.solisTabVisible = true;
+    ctx.initializeSkillsUI = () => {};
+    ctx.initializeSolisUI = () => {};
+    ctx.updateSkillTreeUI = () => {};
+    ctx.updateSolisUI = () => {};
+    const code = fs.readFileSync(path.join(__dirname, '..', 'hopeUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.solisManager.currentQuest = { resource: 'metal', quantity: 5 };
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('inline');
+
+    ctx.solisManager.currentQuest = null;
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('none');
+
+    ctx.solisTabVisible = false;
+    ctx.solisManager.currentQuest = { resource: 'metal', quantity: 5 };
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('none');
+  });
+});

--- a/hopeUI.js
+++ b/hopeUI.js
@@ -20,6 +20,16 @@ function initializeHopeUI() {
     }
 }
 
+function updateHopeAlert() {
+    const alertEl = document.getElementById('hope-alert');
+    if (!alertEl) return;
+    if (typeof solisManager !== 'undefined' && solisManager && solisManager.currentQuest && solisTabVisible) {
+        alertEl.style.display = 'inline';
+    } else {
+        alertEl.style.display = 'none';
+    }
+}
+
 function updateHopeUI() {
     if (typeof updateSkillTreeUI === 'function') {
         updateSkillTreeUI();
@@ -27,5 +37,6 @@ function updateHopeUI() {
     if (typeof updateSolisUI === 'function') {
         updateSolisUI();
     }
+    updateHopeAlert();
 }
 

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
     <div class="tab hidden" id="space-tab" data-tab="space">Space</div>
     <!-- *************************** -->
     <!-- *** NEW HOPE TAB BUTTON *** -->
-    <div class="tab hidden" id="hope-tab" data-tab="hope">H.O.P.E.</div>
+    <div class="tab hidden" id="hope-tab" data-tab="hope">H.O.P.E.<span id="hope-alert" class="hope-alert">!</span></div>
     <!-- ***************************** -->
     <div class="tab active" id="settings-tab" data-tab="settings">Save and Settings</div>
   </div>

--- a/style.css
+++ b/style.css
@@ -167,6 +167,13 @@ body {
     display: none;
 }
 
+.hope-alert {
+    color: red;
+    font-weight: bold;
+    display: none;
+    margin-left: 4px;
+}
+
 .journal.collapsed {
     display: none;
 }


### PR DESCRIPTION
## Summary
- show a red exclamation mark on the HOPE tab when Solis quests are ready
- style the alert
- update HOPE UI logic to toggle the alert
- test HOPE alert behavior

## Testing
- `npm test`
- `npm test -- hopeAlert`

------
https://chatgpt.com/codex/tasks/task_b_685ae8a666a0832795130c12477f0b3e