### PR TITLE
Add Solis tab unlock and new chapters

### DIFF
--- a/__tests__/enableSolisTabEffect.test.js
+++ b/__tests__/enableSolisTabEffect.test.js
@@ -6,9 +6,10 @@ const vm = require('vm');
 
 const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
 const solisUICode = fs.readFileSync(path.join(__dirname, '..', 'solisUI.js'), 'utf8');
+const solisCode = fs.readFileSync(path.join(__dirname, '..', 'solis.js'), 'utf8');
 const hopeUICode = fs.readFileSync(path.join(__dirname, '..', 'hopeUI.js'), 'utf8');
 
-describe('showSolisTab and activateHopeSubtab effects', () => {
+describe('enable effect with SolisManager and activateHopeSubtab', () => {
   test('reveals and activates the Solis tab', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
       <div class="hope-subtab" data-subtab="awakening-hope"></div>
@@ -19,11 +20,12 @@ describe('showSolisTab and activateHopeSubtab effects', () => {
     ctx.document = dom.window.document;
     ctx.console = console;
     vm.createContext(ctx);
-    vm.runInContext(`${solisUICode}\n${hopeUICode}\n${effectCode}; this.EffectableEntity = EffectableEntity;`, ctx);
+    vm.runInContext(`${effectCode}\n${solisUICode}\n${solisCode}\n${hopeUICode}; this.EffectableEntity = EffectableEntity; this.SolisManager = SolisManager;`, ctx);
     ctx.globalEffects = new ctx.EffectableEntity({ description: 'global' });
-    ctx.globalEffects.addAndReplace({
-      target: 'global',
-      type: 'showSolisTab',
+    ctx.solisManager = new ctx.SolisManager();
+    ctx.solisManager.addAndReplace({
+      target: 'solisManager',
+      type: 'enable',
       effectId: 't1',
       sourceId: 't1'
     });

--- a/__tests__/hopeAlert.test.js
+++ b/__tests__/hopeAlert.test.js
@@ -3,6 +3,8 @@ const path = require('path');
 const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
 const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('HOPE tab alert for Solis quests', () => {

--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -10,7 +10,7 @@ describe('HOPE tab unlock chapter', () => {
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
     const last = chapters[chapters.length - 1];
-    expect(last.id).toBe('chapter5.0');
+    expect(last.id).toBe('chapter5.2');
     const hopeChapter = chapters.find(c => c.id === 'chapter4.9');
     expect(hopeChapter).toBeDefined();
     const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');

--- a/__tests__/showSolisTabEffect.test.js
+++ b/__tests__/showSolisTabEffect.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+const solisUICode = fs.readFileSync(path.join(__dirname, '..', 'solisUI.js'), 'utf8');
+const hopeUICode = fs.readFileSync(path.join(__dirname, '..', 'hopeUI.js'), 'utf8');
+
+describe('showSolisTab and activateHopeSubtab effects', () => {
+  test('reveals and activates the Solis tab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="hope-subtab" data-subtab="awakening-hope"></div>
+      <div class="hope-subtab hidden" data-subtab="solis-hope"></div>
+      <div id="awakening-hope" class="hope-subtab-content active"></div>
+      <div id="solis-hope" class="hope-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    vm.runInContext(`${solisUICode}\n${hopeUICode}\n${effectCode}; this.EffectableEntity = EffectableEntity;`, ctx);
+    ctx.globalEffects = new ctx.EffectableEntity({ description: 'global' });
+    ctx.globalEffects.addAndReplace({
+      target: 'global',
+      type: 'showSolisTab',
+      effectId: 't1',
+      sourceId: 't1'
+    });
+    ctx.globalEffects.addAndReplace({
+      target: 'global',
+      type: 'activateHopeSubtab',
+      targetId: 'solis-hope',
+      effectId: 't2',
+      sourceId: 't2'
+    });
+    const tab = dom.window.document.querySelector('[data-subtab="solis-hope"]');
+    const content = dom.window.document.getElementById('solis-hope');
+    const visible = vm.runInContext('solisTabVisible', ctx);
+    expect(visible).toBe(true);
+    expect(tab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+    expect(tab.classList.contains('active')).toBe(true);
+    expect(content.classList.contains('active')).toBe(true);
+  });
+});

--- a/__tests__/solisAutoGenerate.test.js
+++ b/__tests__/solisAutoGenerate.test.js
@@ -1,3 +1,5 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('SolisManager auto generation after completion', () => {

--- a/__tests__/solisCompletionCooldown.test.js
+++ b/__tests__/solisCompletionCooldown.test.js
@@ -1,3 +1,5 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('SolisManager completion cooldown', () => {

--- a/__tests__/solisFundingUpgrade.test.js
+++ b/__tests__/solisFundingUpgrade.test.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
-const { SolisManager } = require('../solis.js');
 const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../solis.js');
 
 describe('Solis funding upgrade', () => {
   let FundingModule;

--- a/__tests__/solisInitialQuest.test.js
+++ b/__tests__/solisInitialQuest.test.js
@@ -1,3 +1,5 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('SolisManager initial quest', () => {

--- a/__tests__/solisMultiply.test.js
+++ b/__tests__/solisMultiply.test.js
@@ -5,6 +5,8 @@ const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules',
 const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('Solis UI multiply button', () => {

--- a/__tests__/solisQuestGeneration.test.js
+++ b/__tests__/solisQuestGeneration.test.js
@@ -1,3 +1,5 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('SolisManager quest generation', () => {

--- a/__tests__/solisResourceUpgrades.test.js
+++ b/__tests__/solisResourceUpgrades.test.js
@@ -1,3 +1,5 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('Solis resource upgrades', () => {

--- a/__tests__/solisTabHiddenByDefault.test.js
+++ b/__tests__/solisTabHiddenByDefault.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Solis tab hidden by default', () => {
+  test('initializeSolisUI hides tab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="hope-subtab" data-subtab="solis-hope"></div>
+      <div id="solis-hope"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'solisUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+    ctx.initializeSolisUI();
+    const tab = dom.window.document.querySelector('[data-subtab="solis-hope"]');
+    const content = dom.window.document.getElementById('solis-hope');
+    const visible = vm.runInContext('solisTabVisible', ctx);
+    expect(visible).toBe(false);
+    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/__tests__/solisTierPersistence.test.js
+++ b/__tests__/solisTierPersistence.test.js
@@ -1,3 +1,5 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
 const { SolisManager } = require('../solis.js');
 
 describe('SolisManager tier persistence', () => {

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -131,6 +131,16 @@ class EffectableEntity {
             activateProjectSubtab(effect.targetId);
           }
           break;
+        case 'activateHopeSubtab':
+          if (typeof activateHopeSubtab === 'function') {
+            activateHopeSubtab(effect.targetId);
+          }
+          break;
+        case 'showSolisTab':
+          if (typeof showSolisTab === 'function') {
+            showSolisTab();
+          }
+          break;
         case 'booleanFlag':  // New effect type to handle boolean flags
           this.applyBooleanFlag(effect);
           break;

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -136,11 +136,6 @@ class EffectableEntity {
             activateHopeSubtab(effect.targetId);
           }
           break;
-        case 'showSolisTab':
-          if (typeof showSolisTab === 'function') {
-            showSolisTab();
-          }
-          break;
         case 'booleanFlag':  // New effect type to handle boolean flags
           this.applyBooleanFlag(effect);
           break;
@@ -501,7 +496,8 @@ function addOrRemoveEffect(effect, action) {
     'lifeDesigner': lifeDesigner,
     'lifeManager': lifeManager,
     'oreScanner': oreScanner,
-    'researchManager' : researchManager
+    'researchManager' : researchManager,
+    'solisManager' : solisManager
   };
 
   if (effect.target in targetHandlers) {

--- a/hopeUI.js
+++ b/hopeUI.js
@@ -10,6 +10,19 @@ function initializeHopeTabs() {
     });
 }
 
+function activateHopeSubtab(subtabId) {
+    document.querySelectorAll('.hope-subtab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.hope-subtab-content').forEach(c => c.classList.remove('active'));
+    const tab = document.querySelector(`.hope-subtab[data-subtab="${subtabId}"]`);
+    const content = document.getElementById(subtabId);
+    if (tab && content) {
+        tab.classList.remove('hidden');
+        content.classList.remove('hidden');
+        tab.classList.add('active');
+        content.classList.add('active');
+    }
+}
+
 function initializeHopeUI() {
     initializeHopeTabs();
     if (typeof initializeSkillsUI === 'function') {

--- a/progress-data.js
+++ b/progress-data.js
@@ -902,7 +902,7 @@ progressData = {
         narrative: "Adrian Solis appears once more. 'H.O.P.E., I'm proud to back this mission. If you can assist me as well, Solis Corp can offer even greater aid.'",
         objectives: [],
         reward: [
-          { target: 'global', type: 'showSolisTab' },
+          { target: 'solisManager', type: 'enable' },
           { target: 'global', type: 'activateHopeSubtab', targetId: 'solis-hope', onLoad: false }
         ],
         nextChapter: null

--- a/progress-data.js
+++ b/progress-data.js
@@ -886,6 +886,25 @@ progressData = {
         }],
         reward: [],
         special : 'clearJournal',
+        nextChapter: "chapter5.1"
+      },
+      {
+        id: "chapter5.1",
+        type: "journal",
+        narrative: "The news spreads quickly across the colonies. Shock turns to anger and grief as humanity realizes Earth was destroyed in a deliberate attack.",
+        objectives: [],
+        reward: [],
+        nextChapter: "chapter5.2"
+      },
+      {
+        id: "chapter5.2",
+        type: "journal",
+        narrative: "Adrian Solis appears once more. 'H.O.P.E., I'm proud to back this mission. If you can assist me as well, Solis Corp can offer even greater aid.'",
+        objectives: [],
+        reward: [
+          { target: 'global', type: 'showSolisTab' },
+          { target: 'global', type: 'activateHopeSubtab', targetId: 'solis-hope', onLoad: false }
+        ],
         nextChapter: null
       }
     ]

--- a/solis.js
+++ b/solis.js
@@ -7,8 +7,9 @@ const RESOURCE_UPGRADE_AMOUNTS = {
   androids: 100
 };
 
-class SolisManager {
+class SolisManager extends EffectableEntity {
   constructor(resourceValues = {}) {
+    super({ description: 'Solis Manager' });
     this.resourceValues = Object.assign({
       metal: 1,
       components: 10,
@@ -196,6 +197,12 @@ class SolisManager {
           this.shopUpgrades[k].purchases = data.upgrades[k];
         }
       }
+    }
+  }
+
+  enable() {
+    if (typeof showSolisTab === 'function') {
+      showSolisTab();
     }
   }
 }

--- a/solisUI.js
+++ b/solisUI.js
@@ -1,4 +1,4 @@
-let solisTabVisible = true;
+let solisTabVisible = false;
 let solisUIInitialized = false;
 const shopElements = {};
 const shopDescriptions = {
@@ -66,6 +66,7 @@ function initializeSolisUI() {
   if (solisUIInitialized) {
     return;
   }
+  hideSolisTab();
   const refreshBtn = document.getElementById('solis-refresh-button');
   const completeBtn = document.getElementById('solis-complete-button');
   const multBtn = document.getElementById('solis-multiply-button');


### PR DESCRIPTION
## Summary
- hide Solis tab until it is unlocked
- add helper to activate HOPE subtabs
- support `showSolisTab` and `activateHopeSubtab` effects
- extend story with chapters 5.1 and 5.2
- update HOPE unlock test and add tests for Solis tab behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685aebddf7188327a80d766d619a8477