### PR TITLE
Pause story during popups

### DIFF
--- a/pop-up.js
+++ b/pop-up.js
@@ -1,4 +1,5 @@
 function createPopup(title, text, buttonText) {
+  window.popupActive = true; // Flag that a popup is active
   game.scene.pause('mainScene');
   // Create the overlay div
   const overlay = document.createElement('div');
@@ -30,6 +31,7 @@ function createPopup(title, text, buttonText) {
   // Close button event listener
   closeButton.addEventListener('click', () => {
     document.body.removeChild(overlay); // Remove the pop-up
+    window.popupActive = false; // Clear popup flag
     game.scene.resume('mainScene');  // Resume the 'mainScene' scene
   });
 

--- a/progress.js
+++ b/progress.js
@@ -73,6 +73,10 @@ class StoryManager {
     }
 
     update() {
+        // If a pop-up is active, pause story updates until it is closed
+        if (typeof window !== 'undefined' && window.popupActive) {
+            return;
+        }
         // --- Prevent processing completions while waiting for a journal ---
         if (this.waitingForJournalEventId !== null) {
              // console.log(`StoryManager update paused: Waiting for journal event ${this.waitingForJournalEventId}`);


### PR DESCRIPTION
## Summary
- prevent story updates while popup windows are open
- mark popup activity so the StoryManager can check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685aff2c1df4832791a1baa1fb518c7f