### PR TITLE
Add colony growth rate display

### DIFF
--- a/__tests__/colonyGrowthDisplay.test.js
+++ b/__tests__/colonyGrowthDisplay.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const numbers = require('../numbers.js');
+
+describe('colony growth rate display', () => {
+  test('creates growth rate element with tooltip', () => {
+    const html = `<!DOCTYPE html><div class="container colonies-container"><div class="header-container"></div></div><button id="unhide-obsolete-button"></button>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.populationModule = { getCurrentGrowthPercent: () => 0.5 };
+    ctx.colonies = {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'colonyUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    ctx.updateGrowthRateDisplay();
+
+    const value = dom.window.document.getElementById('growth-rate-value');
+    expect(value.textContent).toBe('+0.50%/s');
+    const icon = dom.window.document.querySelector('#growth-rate-container .info-tooltip-icon');
+    expect(icon).not.toBeNull();
+  });
+});

--- a/colonies.css
+++ b/colonies.css
@@ -19,6 +19,15 @@
     background-color: #45a049;
   }
 
+  /* Growth rate display */
+  #growth-rate-container {
+    margin-left: 10px;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
 /* Style the need boxes */
 .need-box {
   width: 120px;

--- a/colonyUI.js
+++ b/colonyUI.js
@@ -1,5 +1,38 @@
 let showObsoleteBuildings = false;
 
+function createGrowthRateDisplay(){
+  const header = document.querySelector('.colonies-container .header-container');
+  if(!header || document.getElementById('growth-rate-container')) return;
+
+  const container = document.createElement('div');
+  container.id = 'growth-rate-container';
+  container.classList.add('growth-rate');
+
+  const label = document.createElement('span');
+  label.textContent = 'Growth:';
+  container.appendChild(label);
+
+  const value = document.createElement('span');
+  value.id = 'growth-rate-value';
+  value.textContent = '0%/s';
+  container.appendChild(value);
+
+  const info = document.createElement('span');
+  info.classList.add('info-tooltip-icon');
+  info.title = 'Population growth uses logistic growth: rate \u00d7 population \u00d7 (1 - population / capacity). The rate is (happiness - 50%) / 300. Food and energy each provide up to 50 happiness when satisfied. Comfort adds 20 times its rating. Each luxury good can add 10 happiness if food and energy are met. Milestones provide additional happiness. Happiness above 50% increases growth, while below 50% causes decay.';
+  info.innerHTML = '\u9432';
+  container.appendChild(info);
+
+  header.appendChild(container);
+}
+
+function updateGrowthRateDisplay(){
+  const el = document.getElementById('growth-rate-value');
+  if(!el || typeof populationModule === 'undefined') return;
+  const rate = populationModule.getCurrentGrowthPercent();
+  el.textContent = `${rate >= 0 ? '+' : ''}${formatNumber(rate, false, 2)}%/s`;
+}
+
 // Create the colony-specific details display
 function createColonyDetails(structure) {
   const colonyDetails = document.createElement('div');
@@ -127,4 +160,6 @@ document.addEventListener('DOMContentLoaded', () => {
       updateColonyDisplay(colonies); // Re-render to show the unhidden buildings
     });
   }
+
+  createGrowthRateDisplay();
 });

--- a/game.js
+++ b/game.js
@@ -220,6 +220,9 @@ function updateRender() {
   updateResourceDisplay(resources);
   updateBuildingDisplay(buildings);  // Render building information
   updateColonyDisplay(colonies);     // Render colony information
+  if (typeof updateGrowthRateDisplay === 'function') {
+    updateGrowthRateDisplay();
+  }
   renderProjects();                  // Render project information (handled in projects.js)
   updateResearchUI();
   updateTerraformingUI();


### PR DESCRIPTION
## Summary
- show population growth per second on the colony tab
- track per-second growth in `PopulationModule`
- update the colony UI with tooltip explanation
- style the growth rate container
- add Jest test covering the UI element


------
https://chatgpt.com/codex/tasks/task_b_685bee5857bc8327b66495cb160ad2dc