### PR TITLE
Add Androids Efficiency skill

### DIFF
--- a/__tests__/newSkillsParameters.test.js
+++ b/__tests__/newSkillsParameters.test.js
@@ -20,8 +20,8 @@ describe('new skill parameter definitions', () => {
     expect(skill.requires).toContain('research_boost');
   });
 
-  test('scanning_speed requires project_speed after swap', () => {
-    const skill = skillParams.scanning_speed;
+  test('android_efficiency requires project_speed', () => {
+    const skill = skillParams.android_efficiency;
     expect(skill.requires).toContain('project_speed');
   });
 });

--- a/__tests__/skills.test.js
+++ b/__tests__/skills.test.js
@@ -69,25 +69,25 @@ describe('SkillManager save/load', () => {
     );
   });
 
-  test('scanning_speed scales exponentially', () => {
+  test('android_efficiency scales linearly', () => {
     const skillParams = require('../skills-parameters.js');
-    const data = { scanning_speed: skillParams.scanning_speed };
+    const data = { android_efficiency: skillParams.android_efficiency };
     const manager = new SkillManager(data);
-    manager.unlockSkill('scanning_speed');
+    manager.unlockSkill('android_efficiency');
     expect(global.addEffect).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 2, sourceId: 'scanning_speed' })
+      expect.objectContaining({ value: 1.4, sourceId: 'android_efficiency' })
     );
 
     global.addEffect.mockClear();
-    manager.upgradeSkill('scanning_speed');
+    manager.upgradeSkill('android_efficiency');
     expect(global.addEffect).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 4, sourceId: 'scanning_speed' })
+      expect.objectContaining({ value: 1.8, sourceId: 'android_efficiency' })
     );
 
     global.addEffect.mockClear();
-    manager.upgradeSkill('scanning_speed');
+    manager.upgradeSkill('android_efficiency');
     expect(global.addEffect).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 8, sourceId: 'scanning_speed' })
+      expect.objectContaining({ value: 2.2, sourceId: 'android_efficiency' })
     );
   });
 

--- a/skills-parameters.js
+++ b/skills-parameters.js
@@ -69,16 +69,17 @@ const skillParameters = {
     },
     requires: ['pop_growth']
   },
-  scanning_speed: {
-    id: 'scanning_speed',
-    name: 'Rapid Prospecting',
-    description: 'Doubles ore scanning speed each rank',
+  android_efficiency: {
+    id: 'android_efficiency',
+    name: 'Androids Efficiency',
+    description: 'Increases android factory production by 40% per rank',
     cost: 1,
     maxRank: 5,
     effect: {
-      target: 'oreScanner',
-      type: 'scanningSpeedMultiplier',
-      baseValue: 2,
+      target: 'building',
+      targetId: 'androidFactory',
+      type: 'productionMultiplier',
+      baseValue: 0.4,
       perRank: true
     },
     requires: ['project_speed']

--- a/skills.js
+++ b/skills.js
@@ -61,6 +61,8 @@ class SkillManager {
     if (skill.effect.perRank) {
       if (skill.id === 'scanning_speed' && skill.effect.type === 'scanningSpeedMultiplier') {
         effect.value = Math.pow(skill.effect.baseValue, skill.rank);
+      } else if (skill.id === 'android_efficiency' && skill.effect.type === 'productionMultiplier') {
+        effect.value = 1 + skill.effect.baseValue * skill.rank;
       } else {
         effect.value = skill.effect.baseValue * skill.rank;
       }

--- a/skillsUI.js
+++ b/skillsUI.js
@@ -21,7 +21,7 @@ const skillLayout = {
     research_boost: { row: 1, col: 4 },
     maintenance_reduction: { row: 3, col: 4 },
     pop_growth: { row: 2, col: 4 },
-    scanning_speed: { row: 3, col: 0 },
+    android_efficiency: { row: 3, col: 0 },
     ship_efficiency: { row: 3, col: 2 },
     project_speed: { row: 2, col: 2 },
     life_design_points: { row: 3, col: 6 }


### PR DESCRIPTION
## Summary
- add new skill `android_efficiency` in place of Rapid Prospecting
- position skill in UI
- adjust SkillManager to calculate a linear production multiplier
- update tests for new skill behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685d531e48e48327afd21b88cd2810ff