### PR TITLE
Add option to silence Solis alert

### DIFF
--- a/__tests__/solisSilenceAlert.test.js
+++ b/__tests__/solisSilenceAlert.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../solis.js');
+
+describe('silence Solis alert setting', () => {
+  test('alert hidden when silenced', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="hope-tab"><span id="hope-alert" class="hope-alert">!</span></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.solisManager = new SolisManager();
+    ctx.solisTabVisible = true;
+    ctx.gameSettings = { silenceSolisAlert: true };
+    ctx.initializeSkillsUI = () => {};
+    ctx.initializeSolisUI = () => {};
+    ctx.updateSkillTreeUI = () => {};
+    ctx.updateSolisUI = () => {};
+    const code = fs.readFileSync(path.join(__dirname, '..', 'hopeUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.solisManager.currentQuest = { resource: 'metal', quantity: 5 };
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('none');
+
+    ctx.gameSettings.silenceSolisAlert = false;
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('inline');
+  });
+});

--- a/globals.js
+++ b/globals.js
@@ -21,6 +21,7 @@ let fundingModule;
 let gameSettings = {
   useCelsius: false,
   hideCompletedResearch: false,
+  silenceSolisAlert: false,
 };
 
 let colonySliderSettings = {

--- a/hopeUI.js
+++ b/hopeUI.js
@@ -27,6 +27,10 @@ function initializeHopeUI() {
 function updateHopeAlert() {
     const alertEl = document.getElementById('hope-alert');
     if (!alertEl) return;
+    if (typeof gameSettings !== 'undefined' && gameSettings.silenceSolisAlert) {
+        alertEl.style.display = 'none';
+        return;
+    }
     if (typeof solisManager !== 'undefined' && solisManager && solisManager.currentQuest && solisTabVisible) {
         alertEl.style.display = 'inline';
     } else {

--- a/index.html
+++ b/index.html
@@ -344,6 +344,11 @@
                                 <button id="solis-complete-button">Complete Quest</button>
                             </div>
                         </div>
+                        <div class="solis-options">
+                            <label>
+                                <input type="checkbox" id="solis-silence-toggle"> Silence quest alert
+                            </label>
+                        </div>
                         <div class="solis-shop">
                             <div id="solis-shop-items"></div>
                         </div>
@@ -529,6 +534,15 @@
         celsiusToggle.addEventListener('change', () => {
             gameSettings.useCelsius = celsiusToggle.checked;
             updateTerraformingUI();
+        });
+    }
+
+    const silenceToggle = document.getElementById('solis-silence-toggle');
+    if (silenceToggle) {
+        silenceToggle.checked = gameSettings.silenceSolisAlert;
+        silenceToggle.addEventListener('change', () => {
+            gameSettings.silenceSolisAlert = silenceToggle.checked;
+            updateHopeAlert();
         });
     }
 

--- a/save.js
+++ b/save.js
@@ -176,6 +176,10 @@ function loadGame(slotOrCustomString) {
       if(toggle){
         toggle.checked = gameSettings.useCelsius;
       }
+      const silenceToggle = document.getElementById('solis-silence-toggle');
+      if(silenceToggle){
+        silenceToggle.checked = gameSettings.silenceSolisAlert;
+      }
       if (typeof completedResearchHidden !== 'undefined') {
         completedResearchHidden = gameSettings.hideCompletedResearch || false;
         if (typeof updateAllResearchButtons === 'function') {

--- a/solisUI.js
+++ b/solisUI.js
@@ -71,6 +71,7 @@ function initializeSolisUI() {
   const completeBtn = document.getElementById('solis-complete-button');
   const multBtn = document.getElementById('solis-multiply-button');
   const divBtn = document.getElementById('solis-divide-button');
+  const silenceToggle = document.getElementById('solis-silence-toggle');
 
   if (refreshBtn) {
     refreshBtn.addEventListener('click', () => {
@@ -95,6 +96,20 @@ function initializeSolisUI() {
     divBtn.addEventListener('click', () => {
       solisManager.divideReward();
       updateSolisUI();
+    });
+  }
+
+  if (silenceToggle) {
+    if (typeof gameSettings !== 'undefined') {
+      silenceToggle.checked = gameSettings.silenceSolisAlert || false;
+    }
+    silenceToggle.addEventListener('change', () => {
+      if (typeof gameSettings !== 'undefined') {
+        gameSettings.silenceSolisAlert = silenceToggle.checked;
+      }
+      if (typeof updateHopeAlert === 'function') {
+        updateHopeAlert();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- add `silenceSolisAlert` setting
- expose checkbox in Solis tab to control alert
- persist the setting in save/load logic
- update HOPE alert logic to honour the setting
- test alert suppression

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685d559648ac8327b3fdf34fb3beed66