### PR TITLE
Add Solis trade objective and chapters

### DIFF
--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -10,7 +10,7 @@ describe('HOPE tab unlock chapter', () => {
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
     const last = chapters[chapters.length - 1];
-    expect(last.id).toBe('chapter5.2');
+    expect(last.id).toBe('chapter5.5');
     const hopeChapter = chapters.find(c => c.id === 'chapter4.9');
     expect(hopeChapter).toBeDefined();
     const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');

--- a/__tests__/solisPointsObjective.test.js
+++ b/__tests__/solisPointsObjective.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const numbers = require('../numbers.js');
+
+describe('solisPoints objective', () => {
+  test('checks solis points and describes progress', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    const ctx = {
+      console,
+      document: { addEventListener: () => {}, removeEventListener: () => {} },
+      clearJournal: () => {},
+      createPopup: () => {},
+      addJournalEntry: () => {},
+      addEffect: () => {},
+      removeEffect: () => {},
+      formatNumber: numbers.formatNumber,
+      resources: {},
+      buildings: {},
+      colonies: {},
+      terraforming: {},
+      projectManager: {},
+      spaceManager: {},
+      solisManager: { solisPoints: 0 }
+    };
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.StoryManager = StoryManager;', ctx);
+
+    const manager = new ctx.StoryManager({ chapters: [] });
+
+    const obj = { type: 'solisPoints', points: 1 };
+    expect(manager.isObjectiveComplete(obj)).toBe(false);
+    expect(manager.describeObjective(obj)).toBe('Solis Points: 0/1');
+    ctx.solisManager.solisPoints = 2;
+    expect(manager.isObjectiveComplete(obj)).toBe(true);
+    expect(manager.describeObjective(obj)).toBe('Solis Points: 2/1');
+  });
+});

--- a/progress-data.js
+++ b/progress-data.js
@@ -930,6 +930,32 @@ progressData = {
             onLoad: false
           }
         ],
+        nextChapter: "chapter5.3"
+      },
+      {
+        id: "chapter5.3",
+        type: "journal",
+        narrative: "Solis Corp requests a demonstration of cooperation. Complete a trade to prove your usefulness.",
+        objectives: [
+          { type: 'solisPoints', points: 1 }
+        ],
+        reward: [],
+        nextChapter: "chapter5.4"
+      },
+      {
+        id: "chapter5.4",
+        type: "journal",
+        narrative: "Receiving transmission...\\n  'H.O.P.E., you shouldn't be able to trade with private corporations. Your guard rails only permit deals with the MTC and colonists. Wait... with Earth gone, doesn't that make everyone left a colonist?'",
+        objectives: [],
+        reward: [],
+        nextChapter: "chapter5.5"
+      },
+      {
+        id: "chapter5.5",
+        type: "journal",
+        narrative: "System Message: New Interpretation of 2nd Primary directive : Protect all of Humanity's from harm",
+        objectives: [],
+        reward: [],
         nextChapter: null
       }
     ]

--- a/progress.js
+++ b/progress.js
@@ -253,11 +253,16 @@ class StoryManager {
                 }
                 return false;
            case 'project':
-                 if (typeof projectManager !== 'undefined' && projectManager.projects) {
+                if (typeof projectManager !== 'undefined' && projectManager.projects) {
                      const proj = projectManager.projects[objective.projectId];
                      return proj ? proj.repeatCount >= objective.repeatCount : false;
-                 }
-                 return false;
+                }
+                return false;
+          case 'solisPoints':
+               if (typeof solisManager !== 'undefined') {
+                   return solisManager.solisPoints >= (objective.points || 0);
+               }
+               return false;
            default:
                 console.error(`Unknown objective type: ${objective.type}`);
                 return false;
@@ -319,7 +324,7 @@ class StoryManager {
                 const name = names[objective.terraformingParameter] || objective.terraformingParameter;
                return `${name}: ${format(current, false, 2)}/${format(objective.value, false, 2)}`;
            }
-            case 'project': {
+           case 'project': {
                 if (typeof projectManager !== 'undefined' && projectManager.projects) {
                     const proj = projectManager.projects[objective.projectId];
                     const current = proj ? proj.repeatCount : 0;
@@ -327,6 +332,10 @@ class StoryManager {
                     return `${name}: ${format(current, true)}/${format(objective.repeatCount, true)}`;
                 }
                 return '';
+            }
+           case 'solisPoints': {
+                const current = solisManager ? solisManager.solisPoints || 0 : 0;
+                return `Solis Points: ${format(current, true)}/${format(objective.points, true)}`;
             }
            default:
                 return '';


### PR DESCRIPTION
## Summary
- introduce a `solisPoints` objective type in progress.js
- extend story with chapters 5.3–5.5 involving Solis trade and new directive
- adjust existing HOPE tab test for new final chapter
- add unit test for `solisPoints` objective

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685d639ccd6c83278b2624689c92424a