### PR TITLE
Add play time tracker

### DIFF
--- a/__tests__/playTimeSave.test.js
+++ b/__tests__/playTimeSave.test.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('play time persistence', () => {
+  test('playTimeSeconds persists through save/load', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = { AUTO: 'AUTO', Game: function(){} };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+    const overrides = `
+      createPopup=()=>{};
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      initializeSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class { activateTab(){} };
+      StoryManager = class { initializeStory(){} update(){} saveState(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('playTimeSeconds = 730;', ctx);
+    vm.runInContext('var saved = JSON.stringify(getGameState());', ctx);
+    vm.runInContext('playTimeSeconds = 0;', ctx);
+    vm.runInContext('loadGame(saved);', ctx);
+    const result = vm.runInContext('playTimeSeconds', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(result).toBe(730);
+  });
+});

--- a/game.js
+++ b/game.js
@@ -104,6 +104,8 @@ function initializeGameState(options = {}) {
   
   globalEffects = new EffectableEntity({description : 'Manages global effects'});
 
+  playTimeSeconds = 0;
+
   dayNightCycle = new DayNightCycle(120000); // Day duration of 2 minutes (120000 milliseconds)
   resources = {};
   resources = createResources(currentPlanetParameters.resources);
@@ -176,6 +178,7 @@ function initializeGameState(options = {}) {
 }
 
 function updateLogic(delta) {
+  playTimeSeconds += delta / 1000;
   dayNightCycle.update(delta);
 
   const allStructures = {...buildings, ...colonies};

--- a/globals.js
+++ b/globals.js
@@ -34,3 +34,4 @@ let colonySliderSettings = {
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
 let skillManager;
 let solisManager;
+let playTimeSeconds = 0;

--- a/index.html
+++ b/index.html
@@ -282,6 +282,7 @@
       <div class="terraforming-subtab-content-wrapper">
           <div id = "summary-terraforming" class="terraforming-subtab-content active">
               <h2>Terraforming</h2>
+              <div id="play-time-display">Year 0</div>
                <!-- Terraforming UI goes here -->
           </div>
           <div id = "life-terraforming" class="terraforming-subtab-content">

--- a/save.js
+++ b/save.js
@@ -20,7 +20,8 @@ function getGameState() {
     skills: skillManager.saveState(),
     spaceManager: spaceManager.saveState(),
     settings: gameSettings,
-    colonySliderSettings: colonySliderSettings
+    colonySliderSettings: colonySliderSettings,
+    playTimeSeconds: playTimeSeconds
   };
 }
 
@@ -195,6 +196,10 @@ function loadGame(slotOrCustomString) {
       setFoodConsumptionMultiplier(colonySliderSettings.foodConsumption);
       setLuxuryWaterMultiplier(colonySliderSettings.luxuryWater);
       setOreMineWorkerAssist(colonySliderSettings.oreMineWorkers);
+    }
+
+    if(gameState.playTimeSeconds !== undefined){
+      playTimeSeconds = gameState.playTimeSeconds;
     }
 
     tabManager.activateTab('buildings');

--- a/terraforming.css
+++ b/terraforming.css
@@ -51,3 +51,9 @@
   .no-margin {
     margin: 0;
   }
+
+  #play-time-display {
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 10px;
+  }

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -53,6 +53,8 @@ function createTerraformingSummaryUI() {
 
     const terraformingContainer = document.getElementById('summary-terraforming');
 
+
+
     // Create the first row of boxes
     const row1 = document.createElement('div');
     row1.classList.add('terraforming-row');
@@ -81,6 +83,7 @@ function createTerraformingSummaryUI() {
 
 // Function to update the terraforming UI elements
 function updateTerraformingUI() {
+    updatePlayTimeDisplay();
     updateTemperatureBox();
     updateAtmosphereBox();
     updateWaterBox();
@@ -92,6 +95,13 @@ function updateTerraformingUI() {
     // Update the button state
     updateCompleteTerraformingButton();
   }
+
+function updatePlayTimeDisplay() {
+    const el = document.getElementById('play-time-display');
+    if (!el) return;
+    const years = playTimeSeconds / 365;
+    el.textContent = `Year ${years.toFixed(1)}`;
+}
 
 // Functions to create and update each terraforming aspect box
 


### PR DESCRIPTION
## Summary
- show elapsed play time in years on terraforming summary page
- persist play time between saves
- test play time save/load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f3ba2376c8327a5084cb919fdd225