### PR TITLE
Enable stacking festival bonuses

### DIFF
--- a/__tests__/festivalStacking.test.js
+++ b/__tests__/festivalStacking.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('MilestonesManager festival stacking', () => {
+  test('additional festivals extend countdown duration', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'milestones.js'), 'utf8');
+    vm.runInContext(`${code}; this.MilestonesManager = MilestonesManager;`, ctx);
+
+    const manager = new ctx.MilestonesManager();
+    manager.startCountdown(1000);
+    expect(manager.countdownRemainingTime).toBe(1000);
+    manager.startCountdown(500);
+    expect(manager.countdownRemainingTime).toBe(1500);
+    expect(manager.countdownActive).toBe(true);
+  });
+});

--- a/milestones.js
+++ b/milestones.js
@@ -2,30 +2,30 @@ const festivalEffects = [
     {
         target: 'fundingModule',
         type: 'productionMultiplier',
-        value : 2
+        value : 3
     },
     {
         target: 'building',
         targetId: 'oreMine',
         type: 'productionMultiplier',
-        value: 2
+        value: 3
     },
     {
         target: 'building',
         targetId: 'componentFactory',
         type: 'productionMultiplier',
-        value: 2
+        value: 3
     },
     {
         target: 'building',
         targetId: 'electronicsFactory',
         type: 'productionMultiplier',
-        value: 2
+        value: 3
     },
     {
       target: 'population',
       type: 'growthMultiplier',
-      value: 2
+      value: 3
   },
     {
         type: 'booleanFlag',
@@ -274,7 +274,7 @@ class MilestonesManager {
             milestone.canBeCompleted = false;
         }
         this.addEffects();
-        this.startCountdown(10000);
+        this.startCountdown(30000);
     }
 
     // Get milestones that can be completed
@@ -300,9 +300,11 @@ class MilestonesManager {
     }
 
     startCountdown(duration) {
-        this.countdownRemainingTime = duration;
-        if(!this.countdownActive){
-          this.countdownActive = true;
+        if (this.countdownActive) {
+            this.countdownRemainingTime += duration;
+        } else {
+            this.countdownRemainingTime = duration;
+            this.countdownActive = true;
         }
     }
 

--- a/milestonesUI.js
+++ b/milestonesUI.js
@@ -97,7 +97,7 @@ function updateMilestonesUI() {
             document.getElementById('festival-container').appendChild(milestonesManager.countdownElement);
         }
         const seconds = Math.ceil(milestonesManager.countdownRemainingTime / 1000);
-        milestonesManager.countdownElement.textContent = `Festival 2x multiplier! ${seconds}s`;
+        milestonesManager.countdownElement.textContent = `Festival 3x multiplier! ${seconds}s`;
     } else {
         if(milestonesManager.countdownElement){
             milestonesManager.countdownElement.remove();


### PR DESCRIPTION
## Summary
- make festival production multipliers 3x
- extend festival duration to 30s and stack additional celebrations
- update UI string for new 3x buff
- test festival countdown stacking logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f3c178c40832781cb51d04a348877