### PR TITLE
Adjust milestone happiness bonus

### DIFF
--- a/__tests__/milestoneHappinessReady.test.js
+++ b/__tests__/milestoneHappinessReady.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Milestones ready to claim contribute to happiness bonus', () => {
+  test('getHappinessBonus counts ready milestones', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+    const code = fs.readFileSync(path.join(__dirname, '..', 'milestones.js'), 'utf8');
+    vm.runInContext(`${code}; this.MilestonesManager = MilestonesManager;`, ctx);
+
+    const manager = new ctx.MilestonesManager();
+    const total = manager.milestones.length;
+
+    expect(manager.getHappinessBonus()).toBe(0);
+
+    manager.milestones[0].canBeCompleted = true;
+    expect(manager.getHappinessBonus()).toBeCloseTo(10 / total);
+
+    manager.milestones[0].isCompleted = true;
+    manager.milestones[0].canBeCompleted = false;
+    expect(manager.getHappinessBonus()).toBeCloseTo(10 / total);
+  });
+});

--- a/colonyUI.js
+++ b/colonyUI.js
@@ -19,7 +19,7 @@ function createGrowthRateDisplay(){
 
   const info = document.createElement('span');
   info.classList.add('info-tooltip-icon');
-  info.title = 'Population growth uses logistic growth: rate \u00d7 population \u00d7 (1 - population / capacity). The rate is (happiness - 50%) / 300. Food and energy each provide up to 25 happiness when satisfied, for a total of 50. Comfort adds 20 times its rating. Each luxury good can add 10 happiness if food and energy are met. Milestones provide an additional 10 happiness. Happiness above 50% increases growth, while below 50% causes decay.  There are other sources of growth rate, such as colony sliders, and they act as multipliers.';
+  info.title = 'Population growth uses logistic growth: rate \u00d7 population \u00d7 (1 - population / capacity). The rate is (happiness - 50%) / 300. Food and energy each provide up to 25 happiness when satisfied, for a total of 50. Comfort adds 20 times its rating. Each luxury good can add 10 happiness if food and energy are met. Milestones that are ready to claim or claimed provide an additional 10 happiness. Happiness above 50% increases growth, while below 50% causes decay.  There are other sources of growth rate, such as colony sliders, and they act as multipliers.';
   info.innerHTML = '&#9432';
   container.appendChild(info);
 

--- a/milestones.js
+++ b/milestones.js
@@ -289,7 +289,7 @@ class MilestonesManager {
 
     getHappinessBonus() {
         const totalMilestones = this.milestones.length;
-        const completedMilestones = this.milestones.filter(milestone => milestone.isCompleted).length;
+        const completedMilestones = this.milestones.filter(milestone => milestone.isCompleted || milestone.canBeCompleted).length;
     
         // Calculate happiness bonus
         const happinessBonus = totalMilestones > 0 


### PR DESCRIPTION
## Summary
- update milestone happiness bonus to count ready-to-claim milestones
- clarify colony tooltip about milestone happiness
- test happiness bonus for ready milestones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f3e45bb2883278bf18fb71dc040de