### PR TITLE
Improve play time formatting

### DIFF
--- a/__tests__/numbers.test.js
+++ b/__tests__/numbers.test.js
@@ -1,4 +1,4 @@
-const { formatNumber, formatBigInteger } = require('../numbers.js');
+const { formatNumber, formatBigInteger, formatPlayTime } = require('../numbers.js');
 
 describe('formatNumber', () => {
   test('formats thousands with suffix k', () => {
@@ -13,5 +13,12 @@ describe('formatNumber', () => {
 describe('formatBigInteger', () => {
   test('adds commas', () => {
     expect(formatBigInteger(1234567)).toBe('1,234,567');
+  });
+});
+
+describe('formatPlayTime', () => {
+  test('converts days to years and days string', () => {
+    expect(formatPlayTime(730)).toBe('2 years 0 days');
+    expect(formatPlayTime(40)).toBe('40 days');
   });
 });

--- a/__tests__/playTimeDisplay.test.js
+++ b/__tests__/playTimeDisplay.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../numbers.js');
+
+describe('updatePlayTimeDisplay', () => {
+  test('formats play time as years and days', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="play-time-display"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatPlayTime = numbers.formatPlayTime;
+    ctx.playTimeSeconds = 730;
+    const code = fs.readFileSync(path.join(__dirname, '..', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.updatePlayTimeDisplay();
+    const text = dom.window.document.getElementById('play-time-display').textContent;
+    expect(text).toBe('2 years 0 days');
+  });
+
+  test('handles less than one year', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="play-time-display"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatPlayTime = numbers.formatPlayTime;
+    ctx.playTimeSeconds = 40;
+    const code = fs.readFileSync(path.join(__dirname, '..', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.updatePlayTimeDisplay();
+    const text = dom.window.document.getElementById('play-time-display').textContent;
+    expect(text).toBe('40 days');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -282,7 +282,7 @@
       <div class="terraforming-subtab-content-wrapper">
           <div id = "summary-terraforming" class="terraforming-subtab-content active">
               <h2>Terraforming</h2>
-              <div id="play-time-display">Year 0</div>
+              <div id="play-time-display">0 days</div>
                <!-- Terraforming UI goes here -->
           </div>
           <div id = "life-terraforming" class="terraforming-subtab-content">

--- a/numbers.js
+++ b/numbers.js
@@ -42,8 +42,19 @@ function formatBigInteger(number) {
     return useC ? kelvin - 273.15 : kelvin;
   }
 
-  function getTemperatureUnit() {
+function getTemperatureUnit() {
     return (typeof gameSettings !== 'undefined' && gameSettings.useCelsius) ? '°C' : 'K';
+  }
+
+  function formatPlayTime(days) {
+    const years = Math.floor(days / 365);
+    const remainingDays = Math.floor(days % 365);
+    const parts = [];
+    if (years > 0) {
+      parts.push(`${years} year${years !== 1 ? 's' : ''}`);
+    }
+    parts.push(`${remainingDays} day${remainingDays !== 1 ? 's' : ''}`);
+    return parts.join(' ');
   }
 
   if (typeof module !== 'undefined' && module.exports) {
@@ -52,5 +63,6 @@ function formatBigInteger(number) {
       formatBigInteger,
       toDisplayTemperature,
       getTemperatureUnit,
+      formatPlayTime,
     };
   }

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -99,8 +99,7 @@ function updateTerraformingUI() {
 function updatePlayTimeDisplay() {
     const el = document.getElementById('play-time-display');
     if (!el) return;
-    const years = playTimeSeconds / 365;
-    el.textContent = `Year ${years.toFixed(1)}`;
+    el.textContent = formatPlayTime(playTimeSeconds);
 }
 
 // Functions to create and update each terraforming aspect box


### PR DESCRIPTION
## Summary
- add `formatPlayTime` helper in `numbers.js`
- show play time in years and days in terraforming UI
- initialize play time display text
- test play time formatting and display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f3e9360c88327894e6fafdbc3e961