### PR TITLE
Add units to resource tooltips

### DIFF
--- a/__tests__/resourceTooltipUnits.test.js
+++ b/__tests__/resourceTooltipUnits.test.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../numbers.js');
+
+describe('resource tooltip units', () => {
+  test('tooltip includes unit when provided', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.oreScanner = { scanData: {} };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const resource = {
+      name: 'metal',
+      displayName: 'Metal',
+      category: 'colony',
+      value: 100,
+      cap: 1000,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 1,
+      consumptionRate: 0.5,
+      productionRateBySource: { Mine: 1 },
+      consumptionRateBySource: { Factory: 0.5 },
+      unit: 'ton'
+    };
+
+    ctx.createResourceDisplay({ colony: { metal: resource } });
+    ctx.updateResourceRateDisplay(resource);
+
+    const tooltip = dom.window.document.getElementById('metal-tooltip').innerHTML;
+    expect(tooltip).toContain('ton');
+  });
+
+  test('tooltip omits unit when none provided', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.oreScanner = { scanData: {} };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const resource = {
+      name: 'colonists',
+      displayName: 'Colonists',
+      category: 'colony',
+      value: 10,
+      cap: 100,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      unit: null
+    };
+
+    ctx.createResourceDisplay({ colony: { colonists: resource } });
+    ctx.updateResourceRateDisplay(resource);
+
+    const tooltip = dom.window.document.getElementById('colonists-tooltip').innerHTML;
+    expect(tooltip).not.toContain('ton');
+  });
+});

--- a/planet-parameters.js
+++ b/planet-parameters.js
@@ -35,40 +35,40 @@ const defaultPlanetParameters = {
       funding: { name: 'Funding', initialValue: 0, unlocked: false },
       colonists: { name: 'Colonists', initialValue: 0, hasCap: true, baseCap: 0, unlocked:false },
       workers: { name: 'Workers', initialValue: 0, hasCap: true, baseCap: 0, unlocked:false },
-      energy: { name: 'Energy', initialValue: 0, hasCap: true, baseCap: 50000000, unlocked:false },
-      metal: { name: 'Metal', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'}},
-      silicon: { name: 'Silicon', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false },
-      glass: { name: 'Glass', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false },
-      water: { name: 'Water', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false, maintenanceConversion : {atmospheric : 'atmosphericWater'}}, // Default (Mars)
-      food: { name: 'Food', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false },
-      components: { name: 'Components', initialValue: 0, hasCap: true, baseCap: 500, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'}  },
-      electronics: { name: 'Electronics', initialValue: 0, hasCap: true, baseCap: 200, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'}, conversionValue : 0.2},
-      superconductors: { name: 'Superconductors', initialValue: 0, hasCap: true, baseCap: 200, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'} },
+      energy: { name: 'Energy', initialValue: 0, hasCap: true, baseCap: 50000000, unlocked:false , unit: 'Watt-day' },
+      metal: { name: 'Metal', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'}, unit: 'ton'},
+      silicon: { name: 'Silicon', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false , unit: 'ton' },
+      glass: { name: 'Glass', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false , unit: 'ton' },
+      water: { name: 'Water', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false, maintenanceConversion : {atmospheric : 'atmosphericWater'}, unit: 'ton'}, // Default (Mars)
+      food: { name: 'Food', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false , unit: 'ton' },
+      components: { name: 'Components', initialValue: 0, hasCap: true, baseCap: 500, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'}, unit: 'ton' },
+      electronics: { name: 'Electronics', initialValue: 0, hasCap: true, baseCap: 200, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'}, unit: 'ton', conversionValue : 0.2},
+      superconductors: { name: 'Superconductors', initialValue: 0, hasCap: true, baseCap: 200, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'} , unit: 'ton' },
       androids: {name: 'Android', initialValue: 0, hasCap: true, baseCap: 1000, unlocked: false, maintenanceConversion : {surface : 'scrapMetal'}},
       research: { name: 'Research', initialValue: 0, hasCap: false, unlocked:false },
       advancedResearch: { name: 'Adv. Research', initialValue: 0, hasCap: false, unlocked:false },
     },
     surface: {
       land: {name : 'Land', initialValue : 14400000000, hasCap: true, unlocked: false, land:true}, // Default (Mars)
-      ice: { name: 'Ice', initialValue: 0, unlocked:false }, // Default (Mars)
-      liquidWater: { name: 'Water', initialValue: 0, unlocked:false },
-      dryIce : {name : 'Dry Ice', initialValue: 30010169900060.594, unlocked: false}, // Default (Mars)
-      scrapMetal : {name : 'Scrap Metal', initialValue : 0, unlocked: false},
-      biomass: {name : 'Biomass', hasCap : false, initialValue: 0, unlocked: false},
-      liquidMethane: { name: 'Liquid Methane', initialValue: 0, unlocked: false },
-      hydrocarbonIce: { name: 'Methane Ice', initialValue: 0, unlocked: false },
+      ice: { name: 'Ice', initialValue: 0, unlocked:false , unit: 'ton' }, // Default (Mars)
+      liquidWater: { name: 'Water', initialValue: 0, unlocked:false , unit: 'ton' },
+      dryIce : {name : 'Dry Ice', initialValue: 30010169900060.594, unlocked: false, unit: 'ton' }, // Default (Mars)
+      scrapMetal : {name : 'Scrap Metal', initialValue : 0, unlocked: false, unit: 'ton' },
+      biomass: {name : 'Biomass', hasCap : false, initialValue: 0, unlocked: false, unit: 'ton' },
+      liquidMethane: { name: 'Liquid Methane', initialValue: 0, unlocked: false , unit: 'ton' },
+      hydrocarbonIce: { name: 'Methane Ice', initialValue: 0, unlocked: false , unit: 'ton' },
     },
     underground: {
       ore: { name: 'Ore deposits', initialValue: 5, maxDeposits: 14400, hasCap: true, areaTotal: 144000, unlocked:false }, // Default (Mars)
       geothermal: { name: 'Geo. vent', initialValue: 3, maxDeposits: 144, hasCap: true, areaTotal: 144000, unlocked: false } // Default (Mars)
     },
     atmospheric: {
-      carbonDioxide: { name: 'Carbon Dioxide', initialValue: 23157704873578.164, unlocked:false }, // Default (Mars)
-      inertGas: { name: 'Inert Gas', initialValue: 1.075e12, unlocked:false }, // Default (Mars) - Adjusted based on review
-      oxygen: { name: 'Oxygen', initialValue: 3.25e10, unlocked:false }, // Default (Mars) - Adjusted based on review
-      atmosphericWater: { name: 'Water Vap.', initialValue: 10192599116.52503, unlocked:false }, // Default (Mars) - Adjusted based on review
-      greenhouseGas: {name: 'Safe GHG', initialValue : 0, unlocked: false}, // Default (Mars)
-      atmosphericMethane: { name: 'Methane', initialValue: 0, unlocked: false }
+      carbonDioxide: { name: 'Carbon Dioxide', initialValue: 23157704873578.164, unlocked:false , unit: 'ton' }, // Default (Mars)
+      inertGas: { name: 'Inert Gas', initialValue: 1.075e12, unlocked:false , unit: 'ton' }, // Default (Mars) - Adjusted based on review
+      oxygen: { name: 'Oxygen', initialValue: 3.25e10, unlocked:false , unit: 'ton' }, // Default (Mars) - Adjusted based on review
+      atmosphericWater: { name: 'Water Vap.', initialValue: 10192599116.52503, unlocked:false , unit: 'ton' }, // Default (Mars) - Adjusted based on review
+      greenhouseGas: {name: 'Safe GHG', initialValue : 0, unlocked: false, unit: 'ton' }, // Default (Mars)
+      atmosphericMethane: { name: 'Methane', initialValue: 0, unlocked: false, unit: 'ton' }
     },
     special: {
       albedoUpgrades: {name : 'Albedo upgrades', hasCap: true, baseCap: 144800000000000,initialValue: 0, unlocked: false}, // Default (Mars)

--- a/resource.js
+++ b/resource.js
@@ -6,6 +6,7 @@ class Resource extends EffectableEntity {
     this.name = resourceData.name || '';
     this.category = resourceData.category;
     this.displayName = resourceData.displayName || resourceData.name || '';
+    this.unit = resourceData.unit || null;
     this.value = resourceData.initialValue || 0;
     this.hasCap = resourceData.hasCap || false;
     this.baseCap = resourceData.baseCap || 0; // Store the base capacity of the resource
@@ -39,6 +40,9 @@ class Resource extends EffectableEntity {
     }
     if (config.unlocked !== undefined) {
       this.unlocked = config.unlocked;
+    }
+    if (config.unit !== undefined) {
+      this.unit = config.unit;
     }
     if (config.maintenanceConversion !== undefined) {
       this.maintenanceConversion = config.maintenanceConversion || {};

--- a/resourceUI.js
+++ b/resourceUI.js
@@ -243,7 +243,7 @@ function updateResourceRateDisplay(resource){
   const tooltipElement = document.getElementById(`${resource.name}-tooltip`);
   if (tooltipElement) {
     let tooltipContent = '';
-    tooltipContent += `<div>Value ${formatNumber(resource.value, false, 3)}</div>`
+    tooltipContent += `<div>Value ${formatNumber(resource.value, false, 3)}${resource.unit ? ' ' + resource.unit : ''}</div>`
 
     // Generate the production content
     const productionEntries = Object.entries(resource.productionRateBySource).filter(([source, rate]) => rate !== 0);
@@ -254,7 +254,7 @@ function updateResourceRateDisplay(resource){
         tooltipContent += `
           <div style="display: table-row;">
             <div style="display: table-cell; text-align: left; padding-right: 10px;">${source}</div>
-            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}/s</div>
+            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s</div>
           </div>`;
       });
       tooltipContent += '</div>';
@@ -269,7 +269,7 @@ function updateResourceRateDisplay(resource){
         tooltipContent += `
           <div style="display: table-row;">
             <div style="display: table-cell; text-align: left; padding-right: 10px;">${source}</div>
-            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}/s</div>
+            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s</div>
           </div>`;
       });
       tooltipContent += '</div>';


### PR DESCRIPTION
## Summary
- support units in resource data and initialization
- include resource units in tooltip formatting
- specify ton or Watt-day units in planet parameters
- test tooltip unit rendering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685f3d89a5c48327abf9abc48dac81a1