### PR TITLE
Handle Celsius setting in objective display

### DIFF
--- a/__tests__/currentObjectiveUI.test.js
+++ b/__tests__/currentObjectiveUI.test.js
@@ -15,6 +15,14 @@ describe('current objective UI', () => {
     ctx.console = console;
     ctx.document = dom.window.document;
     ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
     ctx.addJournalEntry = () => {};
     ctx.createPopup = () => {};
     ctx.clearJournal = () => {};
@@ -51,6 +59,12 @@ describe('current objective UI', () => {
     ctx.console = console;
     ctx.document = dom.window.document;
     ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
     ctx.addJournalEntry = () => {};
     ctx.createPopup = () => {};
     ctx.clearJournal = () => {};
@@ -87,6 +101,8 @@ describe('current objective UI', () => {
     ctx.console = console;
     ctx.document = dom.window.document;
     ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
     ctx.addJournalEntry = () => {};
     ctx.createPopup = () => {};
     ctx.clearJournal = () => {};
@@ -101,6 +117,8 @@ describe('current objective UI', () => {
       calculateTotalPressure: () => 15
     };
     ctx.spaceManager = {};
+    ctx.gameSettings = { useCelsius: false };
+    global.gameSettings = ctx.gameSettings;
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
     vm.runInContext(`${code}; this.StoryManager = StoryManager;`, ctx);
@@ -114,6 +132,49 @@ describe('current objective UI', () => {
     manager.update();
 
     const text = dom.window.document.getElementById('current-objective').textContent;
-    expect(text).toBe('Objective: Equatorial Temp: 220.00/238.00');
+    expect(text).toBe('Objective: Equatorial Temp: 220.00K/238.00K');
+  });
+
+  test('describes terraforming objective using Celsius when enabled', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="current-objective"></div>`, {
+      runScripts: 'outside-only'
+    });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.console = console;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.document = dom.window.document;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.addJournalEntry = () => {};
+    ctx.createPopup = () => {};
+    ctx.clearJournal = () => {};
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+
+    ctx.resources = { colony: {} };
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { value: 220, night: 210, day: 230 } } },
+      calculateTotalPressure: () => 15
+    };
+    ctx.spaceManager = {};
+    ctx.gameSettings = { useCelsius: true };
+    global.gameSettings = ctx.gameSettings;
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'progress.js'), 'utf8');
+    vm.runInContext(`${code}; this.StoryManager = StoryManager;`, ctx);
+
+    const progressData = { chapters: [ { id: 'c1', type: 'journal', narrative: '', objectives: [ { type: 'terraforming', terraformingParameter: 'tropicalTemperature', value: 238 } ] } ] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.storyManager = manager;
+
+    const event = manager.findEventById('c1');
+    manager.activateEvent(event);
+    manager.update();
+
+    const text = dom.window.document.getElementById('current-objective').textContent;
+    expect(text).toBe('Objective: Equatorial Temp: -53.15°C/-35.15°C');
   });
 });

--- a/progress.js
+++ b/progress.js
@@ -322,7 +322,14 @@ class StoryManager {
                         return '';
                 }
                 const name = names[objective.terraformingParameter] || objective.terraformingParameter;
-               return `${name}: ${format(current, false, 2)}/${format(objective.value, false, 2)}`;
+                const isTemp = ['tropicalTemperature','tropicalNightTemperature','tropicalDayTemperature'].includes(objective.terraformingParameter);
+                if (isTemp && typeof toDisplayTemperature === 'function' && typeof getTemperatureUnit === 'function') {
+                    const unit = getTemperatureUnit();
+                    const currentDisp = format(toDisplayTemperature(current), false, 2);
+                    const targetDisp = format(toDisplayTemperature(objective.value), false, 2);
+                    return `${name}: ${currentDisp}${unit}/${targetDisp}${unit}`;
+                }
+                return `${name}: ${format(current, false, 2)}/${format(objective.value, false, 2)}`;
            }
            case 'project': {
                 if (typeof projectManager !== 'undefined' && projectManager.projects) {


### PR DESCRIPTION
## Summary
- show terraforming temperature objectives in Celsius/Kelvin based on settings
- update objective UI tests for both Kelvin and Celsius modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f3dccff3c8327ad11f8f678b258e0