### PR TITLE
Add wait-for-capacity option to export projects

### DIFF
--- a/__tests__/waitForCapacity.test.js
+++ b/__tests__/waitForCapacity.test.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+
+describe('waitForCapacity flag', () => {
+  let Project;
+  let context;
+  beforeEach(() => {
+    context = {
+      console,
+      EffectableEntity,
+      shipEfficiency: 1,
+      resources: {},
+      buildings: {},
+      colonies: {},
+      projectManager: { projects: {} },
+      populationModule: {},
+      tabManager: {},
+      fundingModule: {},
+      terraforming: {},
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {},
+      globalEffects: new EffectableEntity({ description: 'global' })
+    };
+    vm.createContext(context);
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'projects.js'), 'utf8');
+    vm.runInContext(projectCode + '; this.Project = Project;', context);
+    Project = context.Project;
+
+    global.buildings = {};
+    global.colonies = {};
+    global.projectManager = context.projectManager;
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.terraforming = {};
+    global.lifeDesigner = {};
+    global.lifeManager = {};
+    global.oreScanner = {};
+    global.globalEffects = context.globalEffects;
+    global.shipEfficiency = context.shipEfficiency;
+
+    global.resources = {
+      colony: {
+        metal: { value: 0 },
+        energy: { value: 0 }
+      },
+      special: { spaceships: { value: 0 } }
+    };
+    context.resources = global.resources;
+  });
+
+  function createExportProject() {
+    const config = {
+      name: 'Export',
+      category: 'resources',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        costPerShip: { colony: { metal: 10 } },
+        disposable: { colony: ['metal'] },
+        disposalAmount: 100,
+        fundingGainAmount: 1
+      }
+    };
+    const project = new Project(config, 'export');
+    project.assignedSpaceships = 1;
+    project.selectedDisposalResource = { category: 'colony', resource: 'metal' };
+    return project;
+  }
+
+  test('requires full disposal amount when enabled', () => {
+    const project = createExportProject();
+    project.waitForCapacity = true;
+    global.resources.colony.metal.value = 100; // cost only (10) plus partial disposal
+    global.resources.special.spaceships.value = 1;
+    expect(project.canStart()).toBe(false);
+    global.resources.colony.metal.value = 110; // cost + disposal
+    expect(project.canStart()).toBe(true);
+  });
+
+  test('ignores disposal amount when disabled', () => {
+    const project = createExportProject();
+    project.waitForCapacity = false;
+    global.resources.colony.metal.value = 10; // only cost
+    global.resources.special.spaceships.value = 1;
+    expect(project.canStart()).toBe(true);
+  });
+});

--- a/projectsUI.js
+++ b/projectsUI.js
@@ -246,6 +246,35 @@ function createProjectItem(project) {
   autoStartCheckboxContainer.appendChild(autoStartLabel);
   checkboxRowContainer.appendChild(autoStartCheckboxContainer);
 
+  if (project.attributes.spaceExport) {
+    const waitCheckboxContainer = document.createElement('div');
+    waitCheckboxContainer.classList.add('checkbox-container');
+
+    const waitCheckbox = document.createElement('input');
+    waitCheckbox.type = 'checkbox';
+    waitCheckbox.checked = project.waitForCapacity !== false; // default true
+    waitCheckbox.id = `${project.name}-wait-capacity`;
+    waitCheckbox.classList.add('wait-capacity-checkbox');
+
+    waitCheckbox.addEventListener('change', (event) => {
+      project.waitForCapacity = event.target.checked;
+    });
+
+    const waitLabel = document.createElement('label');
+    waitLabel.htmlFor = `${project.name}-wait-capacity`;
+    waitLabel.textContent = 'Wait for full capacity';
+
+    waitCheckboxContainer.appendChild(waitCheckbox);
+    waitCheckboxContainer.appendChild(waitLabel);
+    checkboxRowContainer.appendChild(waitCheckboxContainer);
+
+    projectElements[project.name] = {
+      ...projectElements[project.name],
+      waitCapacityCheckbox: waitCheckbox,
+      waitCapacityCheckboxContainer: waitCheckboxContainer,
+    };
+  }
+
   // Store UI elements for updating later
   projectElements[project.name] = {
     ...projectElements[project.name],
@@ -535,6 +564,10 @@ function updateProjectUI(projectName) {
     elements.autoAssignCheckbox.checked = project.autoAssignSpaceships || false;
   }
 
+  if (elements.waitCapacityCheckbox) {
+    elements.waitCapacityCheckbox.checked = project.waitForCapacity !== false;
+  }
+
     // For spaceExport projects, set the saved disposal resource in the dropdown if it exists
     if (project.attributes.spaceExport && project.selectedDisposalResource) {
       const { category, resource } = project.selectedDisposalResource;
@@ -616,9 +649,15 @@ function updateProjectUI(projectName) {
     // Show the auto-start checkbox if the project can be repeated
     if (elements.autoStartCheckboxContainer && projectManager.isBooleanFlagSet('automateSpecialProjects')) {
       elements.autoStartCheckboxContainer.style.display = 'block';
+      if (elements.waitCapacityCheckboxContainer) {
+        elements.waitCapacityCheckboxContainer.style.display = 'block';
+      }
     }
     else {
-      elements.autoStartCheckboxContainer.style.display = 'none';      
+      elements.autoStartCheckboxContainer.style.display = 'none';
+      if (elements.waitCapacityCheckboxContainer) {
+        elements.waitCapacityCheckboxContainer.style.display = 'none';
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `waitForCapacity` flag in `Project` class with persistence
- block auto-start of export projects until enough resources are available when flag set
- add UI checkbox next to auto-start for export projects
- hide/show checkbox with automation toggle
- test that projects respect the new flag before starting
- ensure disposal checks include project costs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685f418c10088327b57c45e401444ff9