### PR TITLE
Add detailed tooltips for terraforming UI

### DIFF
--- a/__tests__/terraformingBoxTooltips.test.js
+++ b/__tests__/terraformingBoxTooltips.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('terraforming box tooltips', () => {
+  test('all terraforming boxes include info tooltips', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="summary-terraforming"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const numbers = require('../numbers.js');
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = { atmospheric: { o2: { displayName: 'O2', value: 0 } } };
+    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.terraformingGasTargets = { o2: { min: 0, max: 100 } };
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    ctx.terraforming = {
+      temperature: { name: 'Temp', value: 0, emissivity: 1, effectiveTempNoAtmosphere: 0,
+        zones: { tropical: { value: 0, day: 0, night: 0, initial: 0 },
+                temperate: { value: 0, day: 0, night: 0, initial: 0 },
+                polar: { value: 0, day: 0, night: 0, initial: 0 } },
+        calculateColonyEnergyPenalty: () => 1,
+        getTemperatureStatus: () => true },
+      atmosphere: { name: 'Atm' },
+      water: { },
+      luminosity: { name: 'Lum', albedo: 0, solarFlux: 0, modifiedSolarFlux: 0 },
+      life: { name: 'Life', target: 0.5 },
+      magnetosphere: { name: 'Mag' },
+      celestialParameters: { albedo: 0, gravity: 1, radius: 1, surfaceArea: 1 },
+      calculateSolarPanelMultiplier: () => 1,
+      calculateWindTurbineMultiplier: () => 1,
+      getAtmosphereStatus: () => true,
+      getLuminosityStatus: () => true,
+      getMagnetosphereStatus: () => true,
+      waterTarget: 0.2,
+      totalEvaporationRate: 0,
+      totalWaterSublimationRate: 0,
+      totalRainfallRate: 0,
+      totalSnowfallRate: 0,
+      totalMeltRate: 0,
+      totalFreezeRate: 0,
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: {}, temperate: {}, polar: {} }
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.createTerraformingSummaryUI();
+
+    const icons = dom.window.document.querySelectorAll('.terraforming-box .info-tooltip-icon');
+    expect(icons.length).toBe(6);
+  });
+});

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -108,6 +108,10 @@ function createTemperatureBox(row) {
     const temperatureBox = document.createElement('div');
     temperatureBox.classList.add('terraforming-box');
     temperatureBox.id = 'temperature-box';
+    const tempInfo = document.createElement('span');
+    tempInfo.classList.add('info-tooltip-icon');
+    tempInfo.title = 'The temperature box displays the planet\'s current average temperatures across all climate zones along with day and night extremes. These values feed into building efficiency calculations, colonist comfort and survival checks, and directly drive the hydrological cycles that determine water and ice coverage.';
+    tempInfo.innerHTML = '&#9432;';
     temperatureBox.innerHTML = `
       <h3>${terraforming.temperature.name}</h3>
       <p>Current average: <span id="temperature-current"></span><span class="temp-unit"></span></p>
@@ -147,6 +151,7 @@ function createTemperatureBox(row) {
         </tbody>
       </table>
     `;
+    temperatureBox.prepend(tempInfo);
 
     const tempPenaltySpan = document.createElement('p');
     tempPenaltySpan.id = 'temperature-energy-penalty';
@@ -223,7 +228,11 @@ function createTemperatureBox(row) {
     const atmosphereBox = document.createElement('div');
     atmosphereBox.classList.add('terraforming-box');
     atmosphereBox.id = 'atmosphere-box';
-  
+    const atmInfo = document.createElement('span');
+    atmInfo.classList.add('info-tooltip-icon');
+    atmInfo.title = 'This box tracks total atmospheric pressure and individual gas composition. Atmospheric density affects optical depth which modifies surface temperature, wind power generation and the sustainability of life support systems.';
+    atmInfo.innerHTML = '&#9432;';
+
     let innerHTML = `
       <h3>${terraforming.atmosphere.name}</h3>
       <p>Current: <span id="atmosphere-current"></span> kPa</p>
@@ -259,6 +268,7 @@ function createTemperatureBox(row) {
     `;
   
     atmosphereBox.innerHTML = innerHTML;
+    atmosphereBox.prepend(atmInfo);
 
     row.appendChild(atmosphereBox);
   }
@@ -322,6 +332,10 @@ function createTemperatureBox(row) {
     const waterBox = document.createElement('div');
     waterBox.classList.add('terraforming-box');
     waterBox.id = 'water-box';
+    const waterInfo = document.createElement('span');
+    waterInfo.classList.add('info-tooltip-icon');
+    waterInfo.title = 'The water box summarizes the planetary hydrological cycle, listing evaporation, sublimation, precipitation and melting rates. Water coverage impacts colonist hydration, certain building requirements and directly contributes to life growth and atmospheric humidity.';
+    waterInfo.innerHTML = '&#9432;';
     // Use static text/placeholders, values will be filled by updateWaterBox
     waterBox.innerHTML = `
       <h3>Water</h3>
@@ -369,6 +383,8 @@ function createTemperatureBox(row) {
       <p class="no-margin">Water coverage: <span id="water-current">0.00</span>%</p>
       <p class="no-margin">Ice coverage: <span id="ice-current">0.00</span>%</p>
     `;
+
+    waterBox.prepend(waterInfo);
 
     const targetSpan = document.createElement('span');
     targetSpan.textContent = "Target : Water coverage > 20%.";
@@ -451,12 +467,18 @@ function createTemperatureBox(row) {
     const lifeBox = document.createElement('div');
     lifeBox.classList.add('terraforming-box');
     lifeBox.id = 'life-box';
+    const lifeInfo = document.createElement('span');
+    lifeInfo.classList.add('info-tooltip-icon');
+    lifeInfo.title = 'Life coverage measures how much biomass has successfully colonised the surface. A higher percentage accelerates terraforming progress, increases available food sources and unlocks advanced biological projects.';
+    lifeInfo.innerHTML = '&#9432;';
     // Use static text/placeholders, values will be filled by updateLifeBox
     lifeBox.innerHTML = `
       <h3>Life</h3> <!-- Static name -->
       <p>Life coverage: <span id="life-current">0.00</span>%</p>
       <p>Photosynthesis multiplier: <span id="life-luminosity-multiplier">${(terraforming.calculateSolarPanelMultiplier()*100).toFixed(2)}</span>%</p>
       `;
+
+    lifeBox.prepend(lifeInfo);
 
     const targetSpan = document.createElement('span');
     targetSpan.textContent = "Target : Life coverage above 50%.";
@@ -505,16 +527,21 @@ function updateLifeBox() {
     const magnetosphereBox = document.createElement('div');
     magnetosphereBox.classList.add('terraforming-box');
     magnetosphereBox.id = 'magnetosphere-box';
+    const magInfo = document.createElement('span');
+    magInfo.classList.add('info-tooltip-icon');
+    magInfo.title = 'The magnetosphere indicator shows whether a planetary magnetic shield is active. A functional shield reduces atmospheric loss and increases life growth rates by protecting organisms from solar radiation.';
+    magInfo.innerHTML = '&#9432;';
 
-    const magnetosphereStatusText = projectManager.isBooleanFlagSet('terraforming', 'magneticShield') 
-      ? 'The planet is sufficiently protected, providing a 50% boost to life growth' 
+    const magnetosphereStatusText = projectManager.isBooleanFlagSet('terraforming', 'magneticShield')
+      ? 'The planet is sufficiently protected, providing a 50% boost to life growth'
       : 'No magnetosphere';
 
     magnetosphereBox.innerHTML = `
       <h3>${terraforming.magnetosphere.name}</h3>
       <p>Status: <span id="magnetosphere-status">${magnetosphereStatusText}</span></p>
     `;
-    
+    magnetosphereBox.prepend(magInfo);
+
     row.appendChild(magnetosphereBox);
   }
 
@@ -542,6 +569,10 @@ function updateLifeBox() {
     const luminosityBox = document.createElement('div');
     luminosityBox.classList.add('terraforming-box');
     luminosityBox.id = 'luminosity-box';
+    const lumInfo = document.createElement('span');
+    lumInfo.classList.add('info-tooltip-icon');
+    lumInfo.title = 'Luminosity represents the stellar energy reaching the surface after accounting for distance and albedo. It dictates solar panel output and interacts with life forms that rely on photosynthesis.';
+    lumInfo.innerHTML = '&#9432;';
     luminosityBox.innerHTML = `
       <h3>${terraforming.luminosity.name}</h3>
       <table>
@@ -567,6 +598,7 @@ function updateLifeBox() {
       </table>
       <p>Solar panel multiplier: <span id="solar-panel-multiplier">${(terraforming.calculateSolarPanelMultiplier()*100).toFixed(2)}</span>%</p>
     `;
+    luminosityBox.prepend(lumInfo);
     row.appendChild(luminosityBox);
 
     const targetSpan = document.createElement('span');


### PR DESCRIPTION
## Summary
- add info tooltip icons to each terraforming summary box
- explain temperatures, atmosphere, water cycle, luminosity, life and magnetosphere effects
- include new unit test verifying tooltip presence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f44c2324c8327b298ff8bd1da5312