### PR TITLE
Align tooltips with terraforming box titles

### DIFF
--- a/__tests__/terraformingBoxTooltips.test.js
+++ b/__tests__/terraformingBoxTooltips.test.js
@@ -5,7 +5,7 @@ const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 
 describe('terraforming box tooltips', () => {
-  test('all terraforming boxes include info tooltips', () => {
+  test('all terraforming boxes include info tooltips in headings', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="summary-terraforming"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     const numbers = require('../numbers.js');
@@ -52,7 +52,12 @@ describe('terraforming box tooltips', () => {
 
     ctx.createTerraformingSummaryUI();
 
-    const icons = dom.window.document.querySelectorAll('.terraforming-box .info-tooltip-icon');
-    expect(icons.length).toBe(6);
+    const boxes = dom.window.document.querySelectorAll('.terraforming-box');
+    expect(boxes.length).toBe(6);
+    boxes.forEach(box => {
+      const heading = box.querySelector('h3');
+      const icon = heading && heading.querySelector('.info-tooltip-icon');
+      expect(icon).not.toBeNull();
+    });
   });
 });

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -151,7 +151,10 @@ function createTemperatureBox(row) {
         </tbody>
       </table>
     `;
-    temperatureBox.prepend(tempInfo);
+    const temperatureHeading = temperatureBox.querySelector('h3');
+    if (temperatureHeading) {
+      temperatureHeading.appendChild(tempInfo);
+    }
 
     const tempPenaltySpan = document.createElement('p');
     tempPenaltySpan.id = 'temperature-energy-penalty';
@@ -268,7 +271,10 @@ function createTemperatureBox(row) {
     `;
   
     atmosphereBox.innerHTML = innerHTML;
-    atmosphereBox.prepend(atmInfo);
+    const atmosphereHeading = atmosphereBox.querySelector('h3');
+    if (atmosphereHeading) {
+      atmosphereHeading.appendChild(atmInfo);
+    }
 
     row.appendChild(atmosphereBox);
   }
@@ -384,7 +390,10 @@ function createTemperatureBox(row) {
       <p class="no-margin">Ice coverage: <span id="ice-current">0.00</span>%</p>
     `;
 
-    waterBox.prepend(waterInfo);
+    const waterHeading = waterBox.querySelector('h3');
+    if (waterHeading) {
+      waterHeading.appendChild(waterInfo);
+    }
 
     const targetSpan = document.createElement('span');
     targetSpan.textContent = "Target : Water coverage > 20%.";
@@ -478,7 +487,10 @@ function createTemperatureBox(row) {
       <p>Photosynthesis multiplier: <span id="life-luminosity-multiplier">${(terraforming.calculateSolarPanelMultiplier()*100).toFixed(2)}</span>%</p>
       `;
 
-    lifeBox.prepend(lifeInfo);
+    const lifeHeading = lifeBox.querySelector('h3');
+    if (lifeHeading) {
+      lifeHeading.appendChild(lifeInfo);
+    }
 
     const targetSpan = document.createElement('span');
     targetSpan.textContent = "Target : Life coverage above 50%.";
@@ -540,7 +552,10 @@ function updateLifeBox() {
       <h3>${terraforming.magnetosphere.name}</h3>
       <p>Status: <span id="magnetosphere-status">${magnetosphereStatusText}</span></p>
     `;
-    magnetosphereBox.prepend(magInfo);
+    const magnetosphereHeading = magnetosphereBox.querySelector('h3');
+    if (magnetosphereHeading) {
+      magnetosphereHeading.appendChild(magInfo);
+    }
 
     row.appendChild(magnetosphereBox);
   }
@@ -598,7 +613,10 @@ function updateLifeBox() {
       </table>
       <p>Solar panel multiplier: <span id="solar-panel-multiplier">${(terraforming.calculateSolarPanelMultiplier()*100).toFixed(2)}</span>%</p>
     `;
-    luminosityBox.prepend(lumInfo);
+    const luminosityHeading = luminosityBox.querySelector('h3');
+    if (luminosityHeading) {
+      luminosityHeading.appendChild(lumInfo);
+    }
     row.appendChild(luminosityBox);
 
     const targetSpan = document.createElement('span');


### PR DESCRIPTION
## Summary
- insert tooltip icons inside each terraforming box heading
- update tooltip tests to verify icons are within the title headings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f47735edc8327a013b9d5351b3a61