### PR TITLE
Add biomass albedo to surface model

### DIFF
--- a/__tests__/effectiveAlbedoLife.test.js
+++ b/__tests__/effectiveAlbedoLife.test.js
@@ -1,0 +1,46 @@
+const { getZonePercentage } = require('../zones.js');
+const EffectableEntity = require('../effectable-entity.js');
+const lifeParameters = require('../life-parameters.js');
+const { getPlanetParameters } = require('../planet-parameters.js');
+
+// Globals required by terraforming.js
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+
+const Terraforming = require('../terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+
+function setupGlobals() {
+  global.resources = { atmospheric: {}, special: { albedoUpgrades: { value: 0 } }, surface: { biomass: { value: 0 }, liquidWater: {} } };
+  global.buildings = { spaceMirror: { active: 0 } };
+  global.colonies = {};
+  global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+  global.populationModule = {};
+  global.tabManager = {};
+  global.fundingModule = {};
+  global.lifeDesigner = {};
+  global.lifeManager = {};
+  global.oreScanner = {};
+}
+
+describe('effective albedo with biomass', () => {
+  test('higher biomass coverage lowers albedo', () => {
+    setupGlobals();
+    const params = getPlanetParameters('mars');
+    global.currentPlanetParameters = params;
+    const celestial = { radius: 1, gravity: 1, albedo: 0.5, surfaceArea: 1, distanceFromSun: 1 };
+    const terra = new Terraforming(global.resources, celestial);
+    terra.calculateInitialValues();
+
+    const baseAlbedo = terra.calculateEffectiveAlbedo();
+
+    terra.zonalSurface.tropical.biomass = 10;
+    terra.zonalSurface.temperate.biomass = 10;
+    terra.zonalSurface.polar.biomass = 10;
+
+    const withBiomass = terra.calculateEffectiveAlbedo();
+    expect(withBiomass).toBeLessThan(baseAlbedo);
+  });
+});

--- a/__tests__/initialTemperature.test.js
+++ b/__tests__/initialTemperature.test.js
@@ -60,7 +60,8 @@ function expectedTemperature(terra, params, resources) {
 
   const surfaceFractions = {
     ocean: calculateAverageCoverage(terra, 'liquidWater'),
-    ice: calculateAverageCoverage(terra, 'ice')
+    ice: calculateAverageCoverage(terra, 'ice'),
+    biomass: calculateAverageCoverage(terra, 'biomass')
   };
 
   const temps = physics.dayNightTemperaturesModel({

--- a/physics.js
+++ b/physics.js
@@ -91,7 +91,8 @@ const DEFAULT_SURFACE_ALBEDO = {
   ice: 0.65,
   snow: 0.85,
   co2_ice: 0.50,
-  hydrocarbon: 0.10
+  hydrocarbon: 0.10,
+  biomass: 0.20
 };
 
 function autoSlabHeatCapacity(rotationPeriodH, surfacePressureBar, surfaceFractions, g = 9.81, kappaSoil = 7e-7, rhoCSoil = 1.4e6) {

--- a/terraforming.js
+++ b/terraforming.js
@@ -958,7 +958,8 @@ class Terraforming extends EffectableEntity{
 
         const surfaceFractions = {
           ocean: calculateAverageCoverage(this, 'liquidWater'),
-          ice: calculateAverageCoverage(this, 'ice')
+          ice: calculateAverageCoverage(this, 'ice'),
+          biomass: calculateAverageCoverage(this, 'biomass')
         };
 
       const baseParams = {
@@ -988,17 +989,22 @@ class Terraforming extends EffectableEntity{
         const baseAlbedo = this.celestialParameters.albedo;
         const oceanAlbedo = 0.06;
         const upgradeAlbedo = 0.05;
+        const biomassAlbedo = 0.20;
         const surfaceArea = this.celestialParameters.surfaceArea;
 
-        // Use the new helper function to get water coverage ratio
+        // Use helper functions to get coverage ratios
         const waterRatio = calculateAverageCoverage(this, 'liquidWater');
+        const lifeRatio = calculateAverageCoverage(this, 'biomass');
 
         const albedoUpgrades = resources.special.albedoUpgrades.value;
         // Calculate ratios, ensuring they don't exceed available land area
-        const albedoUpgradeRatio = surfaceArea > 0 ? Math.min(albedoUpgrades / surfaceArea, 1 - waterRatio) : 0;
-        const untouchedRatio = Math.max(1 - waterRatio - albedoUpgradeRatio, 0);
+        const albedoUpgradeRatio = surfaceArea > 0 ? Math.min(albedoUpgrades / surfaceArea, 1 - waterRatio - lifeRatio) : 0;
+        const untouchedRatio = Math.max(1 - waterRatio - albedoUpgradeRatio - lifeRatio, 0);
 
-        const effectiveAlbedo = oceanAlbedo * waterRatio + upgradeAlbedo * albedoUpgradeRatio + untouchedRatio * baseAlbedo;
+        const effectiveAlbedo = oceanAlbedo * waterRatio +
+                               upgradeAlbedo * albedoUpgradeRatio +
+                               lifeRatio * biomassAlbedo +
+                               untouchedRatio * baseAlbedo;
         return effectiveAlbedo;
     }
 


### PR DESCRIPTION
## Summary
- extend default surface albedo table with biomass
- include biomass coverage when calculating effective albedo
- include biomass fraction when calculating temperatures
- adjust temperature tests to include biomass
- add new test verifying biomass reduces albedo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685fd18b23f48327994a0bba705645ee