### PR TITLE
Add zonal values to resource tooltip

### DIFF
--- a/__tests__/resourceTooltipZones.test.js
+++ b/__tests__/resourceTooltipZones.test.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../numbers.js');
+
+describe('resource tooltip zonal values', () => {
+  function setupContext() {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.oreScanner = { scanData: {} };
+    ctx.terraforming = {
+      zonalWater: {
+        tropical: { liquid: 10, ice: 5, buriedIce: 15 },
+        temperate: { liquid: 20, ice: 10, buriedIce: 25 },
+        polar: { liquid: 30, ice: 15, buriedIce: 35 }
+      },
+      zonalSurface: {
+        tropical: { dryIce: 1 },
+        temperate: { dryIce: 2 },
+        polar: { dryIce: 3 }
+      },
+      zonalHydrocarbons: { tropical: {}, temperate: {}, polar: {} }
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    return { dom, ctx };
+  }
+
+  test('liquid water tooltip shows zonal amounts', () => {
+    const { dom, ctx } = setupContext();
+    const resource = {
+      name: 'liquidWater', displayName: 'Water', category: 'surface',
+      value: 60, hasCap: false, cap: 0, unlocked: true, reserved: 0,
+      productionRate: 0, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton'
+    };
+    ctx.createResourceDisplay({ surface: { liquidWater: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('liquidWater-tooltip').innerHTML;
+    expect(html).toContain('Tropical: ' + numbers.formatNumber(10, false, 3));
+    expect(html).toContain('Temperate: ' + numbers.formatNumber(20, false, 3));
+    expect(html).toContain('Polar: ' + numbers.formatNumber(30, false, 3));
+  });
+
+  test('ice tooltip sums surface and buried ice', () => {
+    const { dom, ctx } = setupContext();
+    const resource = {
+      name: 'ice', displayName: 'Ice', category: 'surface',
+      value: 0, hasCap: false, cap: 0, unlocked: true, reserved: 0,
+      productionRate: 0, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton'
+    };
+    ctx.createResourceDisplay({ surface: { ice: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('ice-tooltip').innerHTML;
+    const trop = numbers.formatNumber(5 + 15, false, 3);
+    const temp = numbers.formatNumber(10 + 25, false, 3);
+    const pol = numbers.formatNumber(15 + 35, false, 3);
+    expect(html).toContain('Tropical: ' + trop);
+    expect(html).toContain('Temperate: ' + temp);
+    expect(html).toContain('Polar: ' + pol);
+  });
+
+  test('dry ice tooltip shows zonal amounts', () => {
+    const { dom, ctx } = setupContext();
+    const resource = {
+      name: 'dryIce', displayName: 'Dry Ice', category: 'surface',
+      value: 6, hasCap: false, cap: 0, unlocked: true, reserved: 0,
+      productionRate: 0, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton'
+    };
+    ctx.createResourceDisplay({ surface: { dryIce: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('dryIce-tooltip').innerHTML;
+    expect(html).toContain('Tropical: ' + numbers.formatNumber(1, false, 3));
+    expect(html).toContain('Temperate: ' + numbers.formatNumber(2, false, 3));
+    expect(html).toContain('Polar: ' + numbers.formatNumber(3, false, 3));
+  });
+});

--- a/resourceUI.js
+++ b/resourceUI.js
@@ -243,7 +243,49 @@ function updateResourceRateDisplay(resource){
   const tooltipElement = document.getElementById(`${resource.name}-tooltip`);
   if (tooltipElement) {
     let tooltipContent = '';
-    tooltipContent += `<div>Value ${formatNumber(resource.value, false, 3)}${resource.unit ? ' ' + resource.unit : ''}</div>`
+    tooltipContent += `<div>Value ${formatNumber(resource.value, false, 3)}${resource.unit ? ' ' + resource.unit : ''}</div>`;
+
+    // Add zonal breakdown for surface resources if available
+    if (typeof terraforming !== 'undefined') {
+      const zoneValues = {};
+      ['tropical', 'temperate', 'polar'].forEach(zone => {
+        let val;
+        switch (resource.name) {
+          case 'liquidWater':
+            val = terraforming.zonalWater?.[zone]?.liquid;
+            break;
+          case 'ice':
+            const iceObj = terraforming.zonalWater?.[zone];
+            if (iceObj) val = (iceObj.ice || 0) + (iceObj.buriedIce || 0);
+            break;
+          case 'dryIce':
+            val = terraforming.zonalSurface?.[zone]?.dryIce;
+            break;
+          case 'biomass':
+            val = terraforming.zonalSurface?.[zone]?.biomass;
+            break;
+          case 'liquidMethane':
+            val = terraforming.zonalHydrocarbons?.[zone]?.liquid;
+            break;
+          case 'hydrocarbonIce':
+            val = terraforming.zonalHydrocarbons?.[zone]?.ice;
+            break;
+          default:
+            val = undefined;
+        }
+        if (typeof val === 'number') {
+          zoneValues[zone] = val;
+        }
+      });
+      if (Object.keys(zoneValues).length > 0) {
+        tooltipContent += '<br><strong>Zonal Amounts:</strong><br>';
+        ['tropical', 'temperate', 'polar'].forEach(zone => {
+          if (zoneValues[zone] !== undefined) {
+            tooltipContent += `${capitalizeFirstLetter(zone)}: ${formatNumber(zoneValues[zone], false, 3)}${resource.unit ? ' ' + resource.unit : ''}<br>`;
+          }
+        });
+      }
+    }
 
     // Generate the production content
     const productionEntries = Object.entries(resource.productionRateBySource).filter(([source, rate]) => rate !== 0);


### PR DESCRIPTION
## Summary
- include zonal breakdowns for surface resources in resource tooltips
- test tooltip zonal display for water, ice and dry ice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685ffbcab38483279d9325a9c7611021