### PR TITLE
Disable life design controls during deployment

### DIFF
--- a/__tests__/lifeUIDisableControls.test.js
+++ b/__tests__/lifeUIDisableControls.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+const physics = require('../physics.js');
+const numbers = require('../numbers.js');
+
+describe('lifeUI controls disable during deployment', () => {
+  test('modify buttons are disabled when deploying', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = {
+      surface: { biomass: { value: 10 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 10 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 10 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { day: 300, night: 300 }, temperate: { day: 300, night: 300 }, polar: { day: 300, night: 300 } } },
+      zonalSurface: { tropical: { biomass: 10 }, temperate: { biomass: 10 }, polar: { biomass: 10 } },
+      zonalWater: { tropical: { liquid: 1 }, temperate: { liquid: 1 }, polar: { liquid: 1 } },
+      getMagnetosphereStatus: () => true,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,0,0,0,0,0,0,0);
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    let modifyBtn = dom.window.document.querySelector('.life-tentative-btn');
+    expect(modifyBtn.disabled).toBe(false);
+
+    ctx.lifeDesigner.confirmDesign();
+    ctx.updateLifeUI();
+
+    modifyBtn = dom.window.document.querySelector('.life-tentative-btn');
+    const createBtn = dom.window.document.getElementById('life-new-design-btn');
+    const revertBtn = dom.window.document.getElementById('life-revert-btn');
+    expect(modifyBtn.disabled).toBe(true);
+    expect(createBtn.disabled).toBe(true);
+    expect(revertBtn.disabled).toBe(true);
+  });
+});

--- a/lifeUI.js
+++ b/lifeUI.js
@@ -336,7 +336,8 @@ function updateLifeUI() {
     const revertBtn = document.getElementById('life-revert-btn');
     const applyProgressContainer = document.getElementById('life-apply-progress-container');
     const applyProgressBar = document.getElementById('life-apply-progress');
-  
+    const modifyButtons = document.querySelectorAll('.life-tentative-btn');
+
     if (lifeDesigner.tentativeDesign) {
         tentativeDesignHeader.style.display = 'table-cell';
         document.getElementById('modify-header').style.display = 'table-cell';
@@ -348,8 +349,9 @@ function updateLifeUI() {
         if (lifeDesigner.isActive) {
             tentativeDesignHeader.style.display = 'table-cell';
             lifePointsRemainingDisplay.style.display = 'inline'; // Keep visible even when deploying
-            revertBtn.style.display = 'none';
-            createBtn.style.display = 'none';
+            revertBtn.disabled = true;
+            createBtn.disabled = true;
+            modifyButtons.forEach(btn => btn.disabled = true);
             showTentativeDesignCells();
             const timeRemaining = Math.max(0, lifeDesigner.remainingTime / 1000).toFixed(2);
             const progressPercent = lifeDesigner.getProgress();
@@ -365,6 +367,9 @@ function updateLifeUI() {
             applyBtn.disabled = !survivable; // Disable if design cannot survive
             applyBtn.title = survivable ? '' : 'Life cannot survive anywhere';
             applyBtn.style.background = ''; // Reset background
+            revertBtn.disabled = false;
+            createBtn.disabled = false;
+            modifyButtons.forEach(btn => btn.disabled = false);
         }
     }
     else {


### PR DESCRIPTION
## Summary
- disable Life Designer buttons during deployment
- test that Life Designer buttons get disabled when a design is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68600a1c655883278a6335c7780da320