### PR TITLE
Enable canceling life deployment

### DIFF
--- a/__tests__/lifeCancelDeployment.test.js
+++ b/__tests__/lifeCancelDeployment.test.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+const physics = require('../physics.js');
+const numbers = require('../numbers.js');
+
+describe('LifeDesigner cancelDeployment', () => {
+  test('stops active deployment and retains tentative design', () => {
+    const ctx = { console };
+    vm.createContext(ctx);
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: {
+        research: { value: 0 },
+        funding: { value: 0 },
+        androids: { value: 0 },
+        components: { value: 0 },
+        electronics: { value: 0 }
+      }
+    };
+    ctx.terraforming = {
+      temperature: {
+        zones: {
+          tropical: { day: 200, night: 200 },
+          temperate: { day: 200, night: 200 },
+          polar: { day: 200, night: 200 }
+        }
+      },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,0,0,0,0,0,0,0);
+
+    ctx.lifeDesigner.confirmDesign();
+    expect(ctx.lifeDesigner.isActive).toBe(true);
+
+    ctx.lifeDesigner.cancelDeployment();
+    expect(ctx.lifeDesigner.isActive).toBe(false);
+    expect(ctx.lifeDesigner.tentativeDesign).not.toBeNull();
+    expect(ctx.lifeDesigner.elapsedTime).toBe(0);
+  });
+});

--- a/life.js
+++ b/life.js
@@ -443,6 +443,15 @@ class LifeDesigner extends EffectableEntity {
     }
   }
 
+  cancelDeployment() {
+    if (this.isActive) {
+      this.isActive = false;
+      this.remainingTime = this.getTentativeDuration();
+      this.totalTime = this.getTentativeDuration();
+      this.elapsedTime = 0;
+    }
+  }
+
   discardTentativeDesign() {
     this.tentativeDesign = null;
   }

--- a/lifeUI.js
+++ b/lifeUI.js
@@ -225,9 +225,13 @@ function initializeLifeTerraformingDesignerUI() {
       updateLifeUI();
     });
   
-    // Event listener for the "Revert" button
+    // Event listener for the "Revert"/"Cancel" button
     revertBtn.addEventListener('click', () => {
-      lifeDesigner.discardTentativeDesign();
+      if (lifeDesigner.isActive) {
+        lifeDesigner.cancelDeployment();
+      } else {
+        lifeDesigner.discardTentativeDesign();
+      }
       updateLifeUI();
     });
   
@@ -348,7 +352,7 @@ function updateLifeUI() {
         if (lifeDesigner.isActive) {
             tentativeDesignHeader.style.display = 'table-cell';
             lifePointsRemainingDisplay.style.display = 'inline'; // Keep visible even when deploying
-            revertBtn.style.display = 'none';
+            revertBtn.style.display = 'inline-block';
             createBtn.style.display = 'none';
             showTentativeDesignCells();
             const timeRemaining = Math.max(0, lifeDesigner.remainingTime / 1000).toFixed(2);


### PR DESCRIPTION
## Summary
- implement `cancelDeployment` method for LifeDesigner
- allow Cancel button to stop an active deployment
- show Cancel during deployment
- test cancelling a life deployment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68600b50bda0832786c761f5bdac150e