### PR TITLE
Fix life UI create button state

### DIFF
--- a/__tests__/lifeUICreateButtonEnabled.test.js
+++ b/__tests__/lifeUICreateButtonEnabled.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+const physics = require('../physics.js');
+const numbers = require('../numbers.js');
+
+describe('lifeUI create button re-enabled', () => {
+  test('create button enabled after deployment completes', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { day: 280, night: 280 }, temperate: { day: 280, night: 280 }, polar: { day: 280, night: 280 } } },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,0,0,0,0,0,0,0);
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    ctx.lifeDesigner.confirmDesign();
+    ctx.lifeDesigner.update(ctx.lifeDesigner.totalTime); // finish instantly
+    ctx.updateLifeUI();
+
+    const createBtn = dom.window.document.getElementById('life-new-design-btn');
+    expect(createBtn.disabled).toBe(false);
+  });
+});

--- a/lifeUI.js
+++ b/lifeUI.js
@@ -355,6 +355,8 @@ function updateLifeUI() {
             lifePointsRemainingDisplay.style.display = 'inline'; // Keep visible even when deploying
             revertBtn.style.display = 'inline-block';
             createBtn.style.display = 'none';
+            createBtn.disabled = true; // Disable create while deploying
+            revertBtn.disabled = true; // Disable revert while deploying
             modifyButtons.forEach(btn => btn.disabled = true);
             showTentativeDesignCells();
             const timeRemaining = Math.max(0, lifeDesigner.remainingTime / 1000).toFixed(2);
@@ -381,6 +383,7 @@ function updateLifeUI() {
       document.getElementById('modify-header').style.display = 'none';
       lifePointsRemainingDisplay.style.display = 'inline'; // Ensure it's visible when no tentative design
       createBtn.style.display = 'inline-block';
+      createBtn.disabled = false; // Re-enable create after deployment
       applyProgressContainer.style.display = 'none';
       applyBtn.style.display = 'none';
       applyBtn.disabled = true;


### PR DESCRIPTION
## Summary
- disable create/revert buttons during life deployment
- enable create button once deployment is finished
- test that create button re-enables when deployment completes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68601055d0c48327912835c3fbfc5d35