### PR TITLE
Add regional life coverage table

### DIFF
--- a/__tests__/lifeCoverageTable.test.js
+++ b/__tests__/lifeCoverageTable.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+// Test that updateLifeBox populates coverage values for each region
+
+describe('life coverage table', () => {
+  test('coverage percentages populate correctly', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div class="row"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.ZONES = ['tropical', 'temperate', 'polar'];
+    ctx.calculateAverageCoverage = () => 0.25;
+    ctx.calculateZonalCoverage = (tf, zone) => {
+      switch(zone){
+        case 'polar': return 0.1;
+        case 'temperate': return 0.2;
+        case 'tropical': return 0.3;
+        default: return 0;
+      }
+    };
+    ctx.terraforming = {
+      life: { target: 0.5 },
+      calculateSolarPanelMultiplier: () => 1,
+      zonalSurface: { tropical:{}, temperate:{}, polar:{} },
+      celestialParameters: { surfaceArea: 1 }
+    };
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const row = dom.window.document.querySelector('.row');
+    ctx.createLifeBox(row);
+    ctx.updateLifeBox();
+
+    expect(dom.window.document.getElementById('life-coverage-overall').textContent).toBe('25.00');
+    expect(dom.window.document.getElementById('life-coverage-polar').textContent).toBe('10.00');
+    expect(dom.window.document.getElementById('life-coverage-temperate').textContent).toBe('20.00');
+    expect(dom.window.document.getElementById('life-coverage-tropical').textContent).toBe('30.00');
+  });
+});

--- a/terraformingUI.js
+++ b/terraformingUI.js
@@ -487,7 +487,20 @@ function createWaterBox(row) {
     // Use static text/placeholders, values will be filled by updateLifeBox
     lifeBox.innerHTML = `
       <h3>Life</h3> <!-- Static name -->
-      <p>Life coverage: <span id="life-current">0.00</span>%</p>
+      <table id="life-coverage-table">
+        <thead>
+          <tr>
+            <th>Region</th>
+            <th>Coverage (%)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Overall</td><td id="life-coverage-overall">0.00</td></tr>
+          <tr><td>Polar</td><td id="life-coverage-polar">0.00</td></tr>
+          <tr><td>Temperate</td><td id="life-coverage-temperate">0.00</td></tr>
+          <tr><td>Tropical</td><td id="life-coverage-tropical">0.00</td></tr>
+        </tbody>
+      </table>
       <p>Photosynthesis multiplier: <span id="life-luminosity-multiplier">${(terraforming.calculateSolarPanelMultiplier()*100).toFixed(2)}</span>%</p>
       `;
 
@@ -528,9 +541,20 @@ function updateLifeBox() {
         lifeBox.style.borderColor = 'red';
     }
 
+    // Calculate zonal coverage percentages
+    const polarCov = calculateZonalCoverage(terraforming, 'polar', 'biomass');
+    const temperateCov = calculateZonalCoverage(terraforming, 'temperate', 'biomass');
+    const tropicalCov = calculateZonalCoverage(terraforming, 'tropical', 'biomass');
+
     // Update life coverage display
-    const lifeCoverageSpan = document.getElementById('life-current');
-    lifeCoverageSpan.textContent = `${(avgBiomassCoverage * 100).toFixed(2)}`; // Display percentage
+    const overallEl = document.getElementById('life-coverage-overall');
+    if (overallEl) overallEl.textContent = (avgBiomassCoverage * 100).toFixed(2);
+    const polarEl = document.getElementById('life-coverage-polar');
+    if (polarEl) polarEl.textContent = (polarCov * 100).toFixed(2);
+    const temperateEl = document.getElementById('life-coverage-temperate');
+    if (temperateEl) temperateEl.textContent = (temperateCov * 100).toFixed(2);
+    const tropicalEl = document.getElementById('life-coverage-tropical');
+    if (tropicalEl) tropicalEl.textContent = (tropicalCov * 100).toFixed(2);
 
     const lifeMultiplierSpan = document.getElementById('life-luminosity-multiplier');
     if (lifeMultiplierSpan) {


### PR DESCRIPTION
## Summary
- show life coverage by region in terraforming summary UI
- update life box UI and logic
- test life coverage table rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686041da3ab083279efbe48ebe24a314