### PR TITLE
Implement build count persistence

### DIFF
--- a/__tests__/buildCountPersistence.test.js
+++ b/__tests__/buildCountPersistence.test.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('selected build count save/load', () => {
+  test('selectedBuildCounts persist through save', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = { AUTO: 'AUTO', Game: function(){} };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+    const overrides = `
+      createPopup=()=>{};
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      initializeSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class { activateTab(){} };
+      StoryManager = class { initializeStory(){} update(){} saveState(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('selectedBuildCounts.windTurbine = 25;', ctx);
+    vm.runInContext('var saved = JSON.stringify(getGameState());', ctx);
+    vm.runInContext('selectedBuildCounts.windTurbine = 1;', ctx);
+    vm.runInContext('loadGame(saved);', ctx);
+    const result = vm.runInContext('selectedBuildCounts.windTurbine', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(result).toBe(25);
+  });
+});

--- a/save.js
+++ b/save.js
@@ -19,6 +19,7 @@ function getGameState() {
     milestonesManager: milestonesManager.saveState(),
     skills: skillManager.saveState(),
     spaceManager: spaceManager.saveState(),
+    selectedBuildCounts: selectedBuildCounts,
     settings: gameSettings,
     colonySliderSettings: colonySliderSettings,
     playTimeSeconds: playTimeSeconds
@@ -118,6 +119,18 @@ function loadGame(slotOrCustomString) {
         }
       }
       createColonyButtons(colonies);
+
+      if (gameState.selectedBuildCounts) {
+        for (const key in gameState.selectedBuildCounts) {
+          if (selectedBuildCounts.hasOwnProperty(key)) {
+            selectedBuildCounts[key] = gameState.selectedBuildCounts[key];
+          }
+        }
+        if (typeof updateBuildingDisplay === 'function') {
+          updateBuildingDisplay(buildings);
+          updateBuildingDisplay(colonies);
+        }
+      }
     
       // Restore projects
       if (gameState.projects) {

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -103,6 +103,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
   const buildCountDisplay = document.createElement('span');
   buildCountDisplay.classList.add('build-count-display');
+  buildCountDisplay.id = `${structure.name}-build-count`;
   buildCountDisplay.textContent = formatNumber(selectedBuildCount, true);
   buildCountButtons.appendChild(buildCountDisplay);
 
@@ -460,6 +461,7 @@ function updateDecreaseButtonText(button, buildCount) {
       const structureRow = document.getElementById(`build-${structureName}`).closest('.building-row');
       const countElement = document.getElementById(`${structureName}-count`);
       const countActiveElement = document.getElementById(`${structureName}-count-active`);
+      const buildDisplay = document.getElementById(`${structureName}-build-count`);
   
       // Update visibility based on unlocked state
       if (structure.unlocked && structureRow && !structure.isHidden) {
@@ -472,6 +474,10 @@ function updateDecreaseButtonText(button, buildCount) {
         countElement.textContent = structure.count;
       } else if (countActiveElement) {
         countActiveElement.textContent = `${formatBigInteger(structure.active)}/${formatBigInteger(structure.count)}`;
+      }
+
+      if (buildDisplay) {
+        buildDisplay.textContent = formatNumber(selectedBuildCounts[structureName], true);
       }
 
       // Toggle visibility of the "Hide" button based on conditions


### PR DESCRIPTION
## Summary
- store selected build counts in save data
- restore build count settings when loading a save
- update building UI to display saved count values
- test persistence of selectedBuildCounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686041592e3c832795002c37185d031f