### PR TITLE
Add Terraforming Bureau research and GHG factory temperature control

### DIFF
--- a/__tests__/ghgFactoryTempDisable.test.js
+++ b/__tests__/ghgFactoryTempDisable.test.js
@@ -1,0 +1,56 @@
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../building.js');
+
+global.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 283.15 };
+
+function createFactory() {
+  const config = {
+    name: 'Greenhouse Gas factory',
+    category: 'terraforming',
+    cost: {},
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new Building(config, 'ghgFactory');
+}
+
+describe('GHG factory temperature disabling', () => {
+  beforeEach(() => {
+    global.resources = { colony:{}, atmospheric:{}, surface:{}, underground:{} };
+    global.populationModule = { getWorkerAvailabilityRatio: () => 1 };
+    global.terraforming = { temperature: { value: 0 } };
+    ghgFactorySettings.autoDisableAboveTemp = false;
+    ghgFactorySettings.disableTempThreshold = 283.15;
+  });
+
+  test('disables production above threshold', () => {
+    const fac = createFactory();
+    fac.active = 1;
+    fac.addEffect({ type: 'booleanFlag', flagId: 'terraformingBureauFeature', value: true });
+    ghgFactorySettings.autoDisableAboveTemp = true;
+    ghgFactorySettings.disableTempThreshold = 280;
+    terraforming.temperature.value = 285;
+    fac.updateProductivity(global.resources, 1000);
+    expect(fac.productivity).toBe(0);
+  });
+
+  test('produces when below threshold', () => {
+    const fac = createFactory();
+    fac.active = 1;
+    fac.addEffect({ type: 'booleanFlag', flagId: 'terraformingBureauFeature', value: true });
+    ghgFactorySettings.autoDisableAboveTemp = true;
+    ghgFactorySettings.disableTempThreshold = 285;
+    terraforming.temperature.value = 280;
+    fac.updateProductivity(global.resources, 1000);
+    expect(fac.productivity).toBeGreaterThan(0);
+  });
+});

--- a/building.js
+++ b/building.js
@@ -396,7 +396,20 @@ class Building extends EffectableEntity {
     if(this.active === 0){
       this.productivity = 0;
     } else{
-      const targetProductivity = Math.max(0, Math.min(1, this.calculateBaseMinRatio(resources, deltaTime)));
+      let targetProductivity = Math.max(0, Math.min(1, this.calculateBaseMinRatio(resources, deltaTime)));
+
+      // Automatically disable GHG factory if temperature exceeds threshold
+      if(
+        this.name === 'ghgFactory' &&
+        this.isBooleanFlagSet('terraformingBureauFeature') &&
+        ghgFactorySettings.autoDisableAboveTemp &&
+        terraforming && terraforming.temperature
+      ){
+        if(terraforming.temperature.value > ghgFactorySettings.disableTempThreshold){
+          targetProductivity = 0;
+        }
+      }
+
       if(Math.abs(targetProductivity - this.productivity) < 0.001){
         this.productivity = targetProductivity;
       }

--- a/globals.js
+++ b/globals.js
@@ -31,6 +31,11 @@ let colonySliderSettings = {
   oreMineWorkers: 0
 };
 
+let ghgFactorySettings = {
+  autoDisableAboveTemp: false,
+  disableTempThreshold: 283.15 // Kelvin
+};
+
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
 let skillManager;
 let solisManager;

--- a/index.html
+++ b/index.html
@@ -535,6 +535,9 @@
         celsiusToggle.addEventListener('change', () => {
             gameSettings.useCelsius = celsiusToggle.checked;
             updateTerraformingUI();
+            if (typeof updateBuildingDisplay === 'function') {
+                updateBuildingDisplay(buildings);
+            }
         });
     }
 

--- a/research-parameters.js
+++ b/research-parameters.js
@@ -689,7 +689,23 @@ const researchParameters = {
             type: 'enable',
           },
         ],
-      },   
+      },
+      {
+        id: 'terraforming_bureau',
+        name: 'Terraforming Bureau',
+        description: 'Establishes oversight to automatically halt GHG factories at a chosen temperature.',
+        cost: { research: 10000000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'building',
+            targetId: 'ghgFactory',
+            type: 'booleanFlag',
+            flagId: 'terraformingBureauFeature',
+            value: true
+          }
+        ],
+      },
     ],
     terraforming: [
       {

--- a/save.js
+++ b/save.js
@@ -21,6 +21,7 @@ function getGameState() {
     spaceManager: spaceManager.saveState(),
     settings: gameSettings,
     colonySliderSettings: colonySliderSettings,
+    ghgFactorySettings: ghgFactorySettings,
     playTimeSeconds: playTimeSeconds
   };
 }
@@ -196,6 +197,10 @@ function loadGame(slotOrCustomString) {
       setFoodConsumptionMultiplier(colonySliderSettings.foodConsumption);
       setLuxuryWaterMultiplier(colonySliderSettings.luxuryWater);
       setOreMineWorkerAssist(colonySliderSettings.oreMineWorkers);
+    }
+
+    if(gameState.ghgFactorySettings){
+      Object.assign(ghgFactorySettings, gameState.ghgFactorySettings);
     }
 
     if(gameState.playTimeSeconds !== undefined){

--- a/structuresUI.js
+++ b/structuresUI.js
@@ -287,6 +287,44 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   autoBuildPriorityLabel.prepend(autoBuildPriority);
   autoBuildTargetContainer.appendChild(autoBuildPriorityLabel);
 
+  if(structure.name === 'ghgFactory') {
+    const tempControl = document.createElement('div');
+    tempControl.id = `${structure.name}-temp-control`;
+    tempControl.classList.add('ghg-temp-control');
+    tempControl.style.display = structure.isBooleanFlagSet('terraformingBureauFeature') ? 'flex' : 'none';
+
+    const tempCheckbox = document.createElement('input');
+    tempCheckbox.type = 'checkbox';
+    tempCheckbox.classList.add('ghg-temp-checkbox');
+    tempCheckbox.checked = ghgFactorySettings.autoDisableAboveTemp;
+    tempCheckbox.addEventListener('change', () => {
+      ghgFactorySettings.autoDisableAboveTemp = tempCheckbox.checked;
+    });
+    tempControl.appendChild(tempCheckbox);
+
+    const tempLabel = document.createElement('span');
+    tempLabel.textContent = 'Disable if avg T > ';
+    tempControl.appendChild(tempLabel);
+
+    const tempInput = document.createElement('input');
+    tempInput.type = 'number';
+    tempInput.step = 1;
+    tempInput.classList.add('ghg-temp-input');
+    tempInput.value = toDisplayTemperature(ghgFactorySettings.disableTempThreshold);
+    tempInput.addEventListener('input', () => {
+      const val = parseFloat(tempInput.value);
+      ghgFactorySettings.disableTempThreshold = gameSettings.useCelsius ? val + 273.15 : val;
+    });
+    tempControl.appendChild(tempInput);
+
+    const unitSpan = document.createElement('span');
+    unitSpan.classList.add('ghg-temp-unit');
+    unitSpan.textContent = getTemperatureUnit();
+    tempControl.appendChild(unitSpan);
+
+    autoBuildTargetContainer.appendChild(tempControl);
+  }
+
   autoBuildContainer.appendChild(autoBuildTargetContainer);
 
   combinedStructureRow.append(autoBuildContainer);
@@ -505,6 +543,24 @@ function updateDecreaseButtonText(button, buildCount) {
         const targetCount = Math.ceil((structure.autoBuildPercent * population) / 100);
         const autoBuildTarget = document.getElementById(`${structure.name}-auto-build-target`);
         autoBuildTarget.textContent = `Target : ${formatBigInteger(targetCount)}`;
+
+        const tempControl = autoBuildContainer.querySelector('.ghg-temp-control');
+        if(tempControl){
+          const enabled = structure.isBooleanFlagSet('terraformingBureauFeature');
+          tempControl.style.display = enabled ? 'flex' : 'none';
+          const tempCheckbox = tempControl.querySelector('.ghg-temp-checkbox');
+          if(tempCheckbox){
+            tempCheckbox.checked = ghgFactorySettings.autoDisableAboveTemp;
+          }
+          const tempInput = tempControl.querySelector('.ghg-temp-input');
+          if(tempInput){
+            tempInput.value = toDisplayTemperature(ghgFactorySettings.disableTempThreshold);
+          }
+          const unitSpan = tempControl.querySelector('.ghg-temp-unit');
+          if(unitSpan){
+            unitSpan.textContent = getTemperatureUnit();
+          }
+        }
       }
   
       const productivityElement = document.getElementById(`${structureName}-productivity`);


### PR DESCRIPTION
## Summary
- add Terraforming Bureau research to enable an auto-disable option for greenhouse gas factories
- store factory temperature settings in a new global `ghgFactorySettings` object
- use booleanFlag effect and global settings to shut down GHG factories when too hot
- refresh greenhouse gas factory controls with the new settings
- adjust related unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686040eff9a88327875505f87fa20dc2