### PR TITLE
Move growth rate display left of colony sliders

### DIFF
--- a/__tests__/colonyGrowthDisplay.test.js
+++ b/__tests__/colonyGrowthDisplay.test.js
@@ -11,8 +11,10 @@ describe('colony growth rate display', () => {
     const html = `<!DOCTYPE html>
       <div class="container colonies-container">
         <div class="header-container"></div>
-        <div id="colony-controls-container"></div>
-        <div id="right-controls-container"></div>
+        <div id="colony-controls-container">
+          <div id="colony-sliders-container"></div>
+          <div id="right-controls-container"></div>
+        </div>
       </div>
       <button id="unhide-obsolete-button"></button>`;
     const dom = new JSDOM(html, { runScripts: 'outside-only' });

--- a/colonies.css
+++ b/colonies.css
@@ -22,6 +22,9 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    grid-column: 1;
+    justify-self: end;
+    margin-right: 50px;
   }
 
   .growth-rate-line {

--- a/colonyUI.js
+++ b/colonyUI.js
@@ -52,8 +52,13 @@ function createGrowthRateDisplay(){
   growthLine.appendChild(growthInfo);
   container.appendChild(growthLine);
 
-  const rightControlsContainer = document.getElementById('right-controls-container');
-  rightControlsContainer.appendChild(container);
+  // Insert to the left of the sliders
+  const firstChild = controlsContainer.firstChild;
+  if(firstChild){
+    controlsContainer.insertBefore(container, firstChild);
+  } else {
+    controlsContainer.appendChild(container);
+  }
 }
 
 function updateGrowthRateDisplay(){


### PR DESCRIPTION
## Summary
- show colony growth rate details before the slider section
- align the growth rate box on the left side
- update growth rate test DOM

## Testing
- `npm test` *(fails: buildCountPersistence, completedResearchSave, loadGamePlanet, playTimeSave, hydrology, skillPointsSave)*

------
https://chatgpt.com/codex/tasks/task_b_686052a997708327a8547b56a8980233