### PR TITLE
Fix ore mine worker slider display

### DIFF
--- a/__tests__/colonySliders.test.js
+++ b/__tests__/colonySliders.test.js
@@ -142,7 +142,7 @@ describe('colony sliders', () => {
     expect(foodEffect).toBe('Growth: +0.0%');
     expect(waterEffect).toBe('Growth: +0.0%');
     expect(oreWorkers).toBe('0');
-    expect(oreBoost).toBe('Boost: 100%');
+    expect(oreBoost).toBe('Boost: 0%');
   });
 
   test('initializeColonySlidersUI keeps container hidden', () => {

--- a/colonySlidersUI.js
+++ b/colonySlidersUI.js
@@ -256,7 +256,7 @@ function initializeColonySlidersUI() {
     if (oreValue && oreEffect) {
       const workers = val * 10;
       oreValue.textContent = `${workers}`;
-      const mult = val === 0 ? 1 : val * val;
+      const mult = val === 0 ? 0 : val;
       const percent = (mult * 100).toFixed(0);
       oreEffect.textContent = `Boost: ${percent}%`;
     }


### PR DESCRIPTION
## Summary
- display ore worker boost linearly while adjusting slider
- update tests to match linear ore worker boost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68608070ae8883279d7806041dc2c460