### PR TITLE
Organize Celsius setting under new Settings header

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,11 +363,8 @@
     <!-- Settings Tab Content -->
     <div id="settings" class="tab-content active">
       <!-- ... existing settings content ... -->
-       <div class="container settings-container">
+      <div class="container settings-container">
           <h2>Save</h2>
-          <label style="display:block;margin-bottom:8px;">
-            <input type="checkbox" id="celsius-toggle"> Display temperature in Celsius
-          </label>
           <div class="save-slots">
               <!-- ... table ... -->
               <table>
@@ -450,6 +447,10 @@
                   </tbody>
               </table>
           </div>
+          <h2>Settings</h2>
+          <label style="display:block;margin-bottom:8px;">
+            <input type="checkbox" id="celsius-toggle"> Display temperature in Celsius
+          </label>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- restructure Save and Settings tab to add a dedicated Settings section
- keep the Celsius/Kelvin toggle within the new Settings header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6860894fa07c83279e6ac71ab682a2e3