### PR TITLE
Implement lifeGrowthMultiplier effect

### DIFF
--- a/__tests__/lifeGrowthMultiplierEffect.test.js
+++ b/__tests__/lifeGrowthMultiplierEffect.test.js
@@ -13,18 +13,20 @@ describe('lifeGrowthMultiplier effect', () => {
     ctx.lifeManager = new ctx.LifeManager();
   });
 
-  test('adds multiplier to life growth', () => {
+  test('stacks multipliers from different sources', () => {
     const manager = ctx.lifeManager;
     expect(manager.getEffectiveLifeGrowthMultiplier()).toBe(1);
-    manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 1.5, effectId: 'test', sourceId: 'test' });
-    expect(manager.getEffectiveLifeGrowthMultiplier()).toBeCloseTo(1.5);
+    manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 2, effectId: 'a', sourceId: 'a' });
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBeCloseTo(2);
+    manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 1.5, effectId: 'b', sourceId: 'b' });
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBeCloseTo(3);
   });
 
   test('replacing multiplier effect does not stack', () => {
     const manager = ctx.lifeManager;
     manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 2, effectId: 'skill', sourceId: 'skill' });
-    expect(manager.getEffectiveLifeGrowthMultiplier()).toBe(2);
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBeCloseTo(2);
     manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 3, effectId: 'skill', sourceId: 'skill' });
-    expect(manager.getEffectiveLifeGrowthMultiplier()).toBe(3);
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBeCloseTo(3);
   });
 });

--- a/__tests__/lifeGrowthMultiplierEffect.test.js
+++ b/__tests__/lifeGrowthMultiplierEffect.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../effectable-entity.js');
+
+describe('lifeGrowthMultiplier effect', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'life.js'), 'utf8');
+    vm.runInContext(code + '; this.LifeManager = LifeManager;', ctx);
+    ctx.lifeManager = new ctx.LifeManager();
+  });
+
+  test('adds multiplier to life growth', () => {
+    const manager = ctx.lifeManager;
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBe(1);
+    manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 1.5, effectId: 'test', sourceId: 'test' });
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBeCloseTo(1.5);
+  });
+
+  test('replacing multiplier effect does not stack', () => {
+    const manager = ctx.lifeManager;
+    manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 2, effectId: 'skill', sourceId: 'skill' });
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBe(2);
+    manager.addAndReplace({ type: 'lifeGrowthMultiplier', value: 3, effectId: 'skill', sourceId: 'skill' });
+    expect(manager.getEffectiveLifeGrowthMultiplier()).toBe(3);
+  });
+});

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -420,9 +420,7 @@ class EffectableEntity {
       }
 
       applyLifeGrowthMultiplier(effect) {
-        if (typeof this.lifeGrowthMultiplier !== 'undefined') {
-          this.lifeGrowthMultiplier *= effect.value;
-        }
+        // multiplier effects are computed on demand in LifeManager
       }
 
 

--- a/effectable-entity.js
+++ b/effectable-entity.js
@@ -179,6 +179,9 @@ class EffectableEntity {
         case 'lifeDesignPointBonus':
           this.applyLifeDesignPointBonus(effect);
           break;
+        case 'lifeGrowthMultiplier':
+          this.applyLifeGrowthMultiplier(effect);
+          break;
         // Add other effect types here as needed
         default:
           console.log(`Effect type "${effect.type}" is not supported for ${this.name}.`);
@@ -410,11 +413,17 @@ class EffectableEntity {
       }
     }
 
-    applyLifeDesignPointBonus(effect) {
-      if (typeof this.designPointBonus !== 'undefined') {
-        this.designPointBonus += effect.value;
+      applyLifeDesignPointBonus(effect) {
+        if (typeof this.designPointBonus !== 'undefined') {
+          this.designPointBonus += effect.value;
+        }
       }
-    }
+
+      applyLifeGrowthMultiplier(effect) {
+        if (typeof this.lifeGrowthMultiplier !== 'undefined') {
+          this.lifeGrowthMultiplier *= effect.value;
+        }
+      }
 
 
     // Method to apply a boolean flag effect

--- a/life.js
+++ b/life.js
@@ -525,16 +525,30 @@ function initializeLifeUI() {
 class LifeManager extends EffectableEntity {
   constructor() {
     super({description : 'Life Manager'})
+    this.lifeGrowthMultiplier = 1;
+  }
+
+  replaceEffect(effect){
+    const index = this.activeEffects.findIndex(e => e.effectId === effect.effectId);
+    if(index !== -1){
+      this.activeEffects[index] = effect;
+      this.applyActiveEffects(false);
+    }else{
+      super.replaceEffect(effect);
+    }
+  }
+
+  applyActiveEffects(firstTime = true){
+    this.lifeGrowthMultiplier = 1;
+    super.applyActiveEffects(firstTime);
+  }
+
+  applyLifeGrowthMultiplier(effect){
+    this.lifeGrowthMultiplier *= effect.value;
   }
 
   getEffectiveLifeGrowthMultiplier(){
-    let multiplier = 1; // Start with default multiplier
-    this.activeEffects.forEach(effect => {
-      if (effect.type === 'lifeGrowthMultiplier') {
-        multiplier *= effect.value;
-      }
-    });
-    return multiplier;
+    return this.lifeGrowthMultiplier;
   }
 
   // Method to update life growth/decay based on zonal environmental conditions

--- a/life.js
+++ b/life.js
@@ -525,30 +525,16 @@ function initializeLifeUI() {
 class LifeManager extends EffectableEntity {
   constructor() {
     super({description : 'Life Manager'})
-    this.lifeGrowthMultiplier = 1;
-  }
-
-  replaceEffect(effect){
-    const index = this.activeEffects.findIndex(e => e.effectId === effect.effectId);
-    if(index !== -1){
-      this.activeEffects[index] = effect;
-      this.applyActiveEffects(false);
-    }else{
-      super.replaceEffect(effect);
-    }
-  }
-
-  applyActiveEffects(firstTime = true){
-    this.lifeGrowthMultiplier = 1;
-    super.applyActiveEffects(firstTime);
-  }
-
-  applyLifeGrowthMultiplier(effect){
-    this.lifeGrowthMultiplier *= effect.value;
   }
 
   getEffectiveLifeGrowthMultiplier(){
-    return this.lifeGrowthMultiplier;
+    let multiplier = 1; // Start with default multiplier
+    this.activeEffects.forEach(effect => {
+      if (effect.type === 'lifeGrowthMultiplier') {
+        multiplier *= effect.value;
+      }
+    });
+    return multiplier;
   }
 
   // Method to update life growth/decay based on zonal environmental conditions


### PR DESCRIPTION
## Summary
- add effect handling for `lifeGrowthMultiplier`
- track life growth multiplier in `LifeManager`
- test `lifeGrowthMultiplier` effect behavior

## Testing
- `npm test` *(fails: hydrology.test.js - flow calculations, see log; all other tests pass)*

------
https://chatgpt.com/codex/tasks/task_b_6860a05db97c8327b636f6f49251aa4b