### PR TITLE
Fix golden asteroid load handler

### DIFF
--- a/__tests__/goldenAsteroidOnload.test.js
+++ b/__tests__/goldenAsteroidOnload.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('golden asteroid onload after despawn', () => {
+  test('onload handler does not throw when element removed before load', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="game-container"></div><div id="gold-asteroid-container"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.document = dom.window.document;
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'gold-asteroid.js'), 'utf8');
+    vm.runInContext(`${code}; this.GoldenAsteroid = GoldenAsteroid;`, ctx);
+
+    const asteroid = new ctx.GoldenAsteroid();
+    asteroid.spawn(1000);
+    const el = asteroid.element;
+    asteroid.despawn();
+    expect(() => {
+      if (typeof el.onload === 'function') {
+        el.onload();
+      }
+    }).not.toThrow();
+  });
+});

--- a/gold-asteroid.js
+++ b/gold-asteroid.js
@@ -99,7 +99,8 @@ class GoldenAsteroid {
 
           const gameContainer = document.getElementById('game-container');
 
-          this.element.onload = () => {
+        this.element.onload = () => {
+            if (!this.element) return; // Element may have been removed before load
             const width = this.element.width;
             const height = this.element.height;
             const containerWidth = gameContainer.clientWidth;


### PR DESCRIPTION
## Summary
- avoid exception if golden asteroid element is removed before the image load event fires
- test onload handler when the asteroid despawns before the load event

## Testing
- `npm test` *(fails: hydrology.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_6860a123c4d483278605bf9eaff0986e