### PR TITLE
Add hideWhenSmall resource flag

### DIFF
--- a/__tests__/hydrology.test.js
+++ b/__tests__/hydrology.test.js
@@ -38,8 +38,8 @@ describe('hydrology melting with buried ice', () => {
     const temps = { polar: 250, temperate: 274, tropical: 260 };
     const melt = simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1000, temps, zoneElevations);
     const slopeFactor = 1 + (zoneElevations.polar - zoneElevations.temperate);
-    // Melt coefficient updated in hydrology to 0.0001
-    const expectedMelt = (100 + 50) * 0.0001 * slopeFactor;
+    // Melt coefficient updated in hydrology to 0.001
+    const expectedMelt = (100 + 50) * 0.001 * slopeFactor;
     const surfaceFraction = 100 / (100 + 50);
     const meltFromIce = expectedMelt * surfaceFraction;
     const meltFromBuried = expectedMelt - meltFromIce;

--- a/__tests__/resourceHideWhenSmall.test.js
+++ b/__tests__/resourceHideWhenSmall.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../numbers.js');
+
+describe('resource hideWhenSmall display', () => {
+  function setup(value) {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.oreScanner = { scanData: {} };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const res = {
+      name: 'dryIce',
+      displayName: 'Dry Ice',
+      category: 'surface',
+      value: value,
+      cap: 0,
+      hasCap: false,
+      reserved: 0,
+      unlocked: true,
+      hideWhenSmall: true,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      isBooleanFlagSet: () => false
+    };
+    ctx.createResourceDisplay({ surface: { dryIce: res } });
+    ctx.updateResourceDisplay({ surface: { dryIce: res } });
+    return { dom, res, ctx };
+  }
+
+  test('hidden when below threshold', () => {
+    const { dom } = setup(5e-5);
+    const el = dom.window.document.getElementById('dryIce-container');
+    expect(el.style.display).toBe('none');
+  });
+
+  test('shown when above threshold', () => {
+    const { dom } = setup(1e-3);
+    const el = dom.window.document.getElementById('dryIce-container');
+    expect(el.style.display).toBe('block');
+  });
+});

--- a/planet-parameters.js
+++ b/planet-parameters.js
@@ -52,11 +52,11 @@ const defaultPlanetParameters = {
       land: {name : 'Land', initialValue : 14400000000, hasCap: true, unlocked: false, land:true}, // Default (Mars)
       ice: { name: 'Ice', initialValue: 0, unlocked:false , unit: 'ton' }, // Default (Mars)
       liquidWater: { name: 'Water', initialValue: 0, unlocked:false , unit: 'ton' },
-      dryIce : {name : 'Dry Ice', initialValue: 0, unlocked: false, unit: 'ton' }, // Default (Mars)
+      dryIce : {name : 'Dry Ice', initialValue: 0, unlocked: false, unit: 'ton', hideWhenSmall: true }, // Default (Mars)
       scrapMetal : {name : 'Scrap Metal', initialValue : 0, unlocked: false, unit: 'ton' },
       biomass: {name : 'Biomass', hasCap : false, initialValue: 0, unlocked: false, unit: 'ton' },
-      liquidMethane: { name: 'Liquid Methane', initialValue: 0, unlocked: false , unit: 'ton' },
-      hydrocarbonIce: { name: 'Methane Ice', initialValue: 0, unlocked: false , unit: 'ton' },
+      liquidMethane: { name: 'Liquid Methane', initialValue: 0, unlocked: false , unit: 'ton', hideWhenSmall: true },
+      hydrocarbonIce: { name: 'Methane Ice', initialValue: 0, unlocked: false , unit: 'ton', hideWhenSmall: true },
     },
     underground: {
       ore: { name: 'Ore deposits', initialValue: 5, maxDeposits: 14400, hasCap: true, areaTotal: 144000, unlocked:false }, // Default (Mars)
@@ -67,8 +67,8 @@ const defaultPlanetParameters = {
       inertGas: { name: 'Inert Gas', initialValue: 1.075e12, unlocked:false , unit: 'ton' }, // Default (Mars) - Adjusted based on review
       oxygen: { name: 'Oxygen', initialValue: 3.25e10, unlocked:false , unit: 'ton' }, // Default (Mars) - Adjusted based on review
       atmosphericWater: { name: 'Water Vap.', initialValue: 10192599116.52503, unlocked:false , unit: 'ton' }, // Default (Mars) - Adjusted based on review
-      greenhouseGas: {name: 'Safe GHG', initialValue : 0, unlocked: false, unit: 'ton' }, // Default (Mars)
-      atmosphericMethane: { name: 'Methane', initialValue: 0, unlocked: false, unit: 'ton' }
+      greenhouseGas: {name: 'Safe GHG', initialValue : 0, unlocked: false, unit: 'ton', hideWhenSmall: true }, // Default (Mars)
+      atmosphericMethane: { name: 'Methane', initialValue: 0, unlocked: false, unit: 'ton', hideWhenSmall: true }
     },
     special: {
       albedoUpgrades: {name : 'Albedo upgrades', hasCap: true, baseCap: 144800000000000,initialValue: 0, unlocked: false}, // Default (Mars)

--- a/resource.js
+++ b/resource.js
@@ -22,6 +22,7 @@ class Resource extends EffectableEntity {
     this.unlocked = resourceData.unlocked;
     this.maintenanceConversion = resourceData.maintenanceConversion || {}; // Stores any maintenance conversion mapping
     this.conversionValue = resourceData.conversionValue || 1; // Default to 1 if not provided
+    this.hideWhenSmall = resourceData.hideWhenSmall || false; // Flag to hide when value is very small
   }
 
   // Method to initialize configurable properties
@@ -49,6 +50,9 @@ class Resource extends EffectableEntity {
     }
     if (config.conversionValue !== undefined) {
       this.conversionValue = config.conversionValue || 1;
+    }
+    if (config.hideWhenSmall !== undefined) {
+      this.hideWhenSmall = config.hideWhenSmall;
     }
 
     if (this.name === 'land' && config.initialValue !== undefined) {

--- a/resourceUI.js
+++ b/resourceUI.js
@@ -130,8 +130,9 @@ function updateResourceDisplay(resources) {
       const resourceElement = document.getElementById(`${resourceName}-container`);
       const resourceNameElement = document.getElementById(`${resourceName}-name`);
 
-      // Reveal resource if unlocked
-      if (resourceObj.unlocked) {
+      const showResource = resourceObj.unlocked && (!resourceObj.hideWhenSmall || resourceObj.value >= 1e-4);
+
+      if (showResource) {
         hasUnlockedResources = true;
         if (resourceElement) resourceElement.style.display = 'block';
       } else {


### PR DESCRIPTION
## Summary
- allow resources to specify a `hideWhenSmall` flag
- default dry ice, safe GHG and methane resources to hide when tiny
- hide resources in UI if `hideWhenSmall` and value < 1e-4
- add tests for the new display rule
- update hydrology test for new melt coefficient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68612ea9af94832794c8eda193abf495