### PR TITLE
Add hyperion lantern parameters

### DIFF
--- a/__tests__/hopeTabUnlock.test.js
+++ b/__tests__/hopeTabUnlock.test.js
@@ -10,7 +10,7 @@ describe('HOPE tab unlock chapter', () => {
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
     const last = chapters[chapters.length - 1];
-    expect(last.id).toBe('chapter5.5');
+    expect(last.id).toBe('chapter5.7');
     const hopeChapter = chapters.find(c => c.id === 'chapter4.9');
     expect(hopeChapter).toBeDefined();
     const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');

--- a/__tests__/hyperionLanternProject.test.js
+++ b/__tests__/hyperionLanternProject.test.js
@@ -17,5 +17,8 @@ describe('Hyperion Lantern project', () => {
     expect(project.cost.colony.electronics).toBe(1e9);
     expect(project.cost.colony.metal).toBe(1e9);
     expect(project.cost.colony.glass).toBe(1e9);
+    expect(project.attributes.investmentCost.colony.components).toBe(1e9);
+    expect(project.attributes.investmentCost.colony.electronics).toBe(1e9);
+    expect(project.attributes.powerPerInvestment).toBe(1e15);
   });
 });

--- a/project-parameters.js
+++ b/project-parameters.js
@@ -399,7 +399,16 @@ const projectParameters = {
           flagId: 'hyperionLanternBuilt',
           value: true
         }
-      ]
+      ],
+      // Cost to add additional power modules to the lantern
+      investmentCost: {
+        colony: {
+          components: 1e9,
+          electronics: 1e9
+        }
+      },
+      // Power output provided by each investment (in watts)
+      powerPerInvestment: 1e15
     }
   },
   triangulate_attack: {

--- a/projectsUI.js
+++ b/projectsUI.js
@@ -133,11 +133,24 @@ function createProjectItem(project) {
     });
 
     const investButton = document.createElement('button');
-    investButton.textContent = 'Invest 1B Components & Electronics';
+    const investCost = project.attributes.investmentCost?.colony || {};
+    const investTextParts = [];
+    if (investCost.components) {
+      investTextParts.push(`${formatNumber(investCost.components, true)} Components`);
+    }
+    if (investCost.electronics) {
+      investTextParts.push(`${formatNumber(investCost.electronics, true)} Electronics`);
+    }
+    investButton.textContent = `Invest ${investTextParts.join(' & ')}`;
     investButton.addEventListener('click', () => {
-      if (resources.colony.components.value >= 1e9 && resources.colony.electronics.value >= 1e9) {
-        resources.colony.components.value -= 1e9;
-        resources.colony.electronics.value -= 1e9;
+      if (resources.colony.components.value >= (investCost.components || 0) &&
+          resources.colony.electronics.value >= (investCost.electronics || 0)) {
+        if(investCost.components){
+          resources.colony.components.value -= investCost.components;
+        }
+        if(investCost.electronics){
+          resources.colony.electronics.value -= investCost.electronics;
+        }
         terraforming.hyperionLantern.investments += 1;
         updateProjectUI(project.name);
       }
@@ -728,8 +741,9 @@ function updateProjectUI(projectName) {
       elements.lanternIncrease.disabled = terraforming.hyperionLantern.active >= terraforming.hyperionLantern.investments;
     }
     if(elements.lanternCapacity){
-      const activePower = terraforming.hyperionLantern.active * 1e15;
-      const maxPower = terraforming.hyperionLantern.investments * 1e15;
+      const powerPerInvestment = project.attributes.powerPerInvestment || 0;
+      const activePower = terraforming.hyperionLantern.active * powerPerInvestment;
+      const maxPower = terraforming.hyperionLantern.investments * powerPerInvestment;
       elements.lanternCapacity.textContent = `Active: ${formatNumber(activePower, false, 2)} W / Capacity: ${formatNumber(maxPower, false, 2)} W`;
     }
   }

--- a/terraforming.js
+++ b/terraforming.js
@@ -189,10 +189,16 @@ class Terraforming extends EffectableEntity{
       unlocked: false
     };
 
+    const defaultLanternPower = 1e15;
+    const lanternPower = (typeof projectParameters !== 'undefined' &&
+      projectParameters.hyperionLantern?.attributes?.powerPerInvestment) ?
+      projectParameters.hyperionLantern.attributes.powerPerInvestment : defaultLanternPower;
+
     this.hyperionLantern = {
       built: false,
       investments: 1,
-      active: 0
+      active: 0,
+      powerPerInvestment: lanternPower
     };
 
     this.updateLuminosity();
@@ -1046,7 +1052,7 @@ class Terraforming extends EffectableEntity{
 
     calculateLanternFlux(){
       if(this.hyperionLantern.built && this.hyperionLantern.active > 0){
-        const power = this.hyperionLantern.active * 1e15;
+        const power = this.hyperionLantern.active * this.hyperionLantern.powerPerInvestment;
         return power / this.celestialParameters.surfaceArea;
       }
       return 0;
@@ -1122,7 +1128,7 @@ class Terraforming extends EffectableEntity{
       addEffect(windTurbineEffect);
 
       if(this.hyperionLantern.built && this.hyperionLantern.active > 0){
-        const power = this.hyperionLantern.active * 1e15;
+        const power = this.hyperionLantern.active * this.hyperionLantern.powerPerInvestment;
         resources.colony.energy.modifyRate(-power, 'Hyperion Lantern', 'terraforming');
       }
 


### PR DESCRIPTION
## Summary
- add investmentCost and powerPerInvestment attributes for the Hyperion Lantern
- generate dynamic investment button text and use attribute values in project UI
- let Terraforming read lantern power from project parameters with a default
- update tests for the new attributes and latest chapter IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686164820a2c832799f54476f50ac0e3