### PR TITLE
Improve Hyperion lantern controls

### DIFF
--- a/__tests__/hyperionLanternAmountButtons.test.js
+++ b/__tests__/hyperionLanternAmountButtons.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../numbers.js');
+
+describe('Hyperion Lantern amount controls', () => {
+  test('x10 and /10 update button texts', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper">
+        <div id="infrastructure-projects-list" class="projects-list"></div>
+      </div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatBigInteger = numbers.formatBigInteger;
+    ctx.projectElements = {};
+    ctx.resources = { colony: { components: { value: Infinity }, electronics: { value: Infinity } }, special: { spaceships: { value: 0 } } };
+    ctx.buildings = { spaceMirror: { active: 0 } };
+    ctx.terraforming = { hyperionLantern: { built: true, investments: 10, active: 0 } };
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const buildCountCode = fs.readFileSync(path.join(__dirname, '..', 'buildCount.js'), 'utf8');
+    vm.runInContext(buildCountCode + '; this.multiplyByTen = multiplyByTen; this.divideByTen = divideByTen;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.initializeProjects({ hyperionLantern: ctx.projectParameters.hyperionLantern });
+    ctx.projectManager.projects.hyperionLantern.isCompleted = true;
+    ctx.projectManager.isBooleanFlagSet = () => false;
+
+    ctx.initializeProjectsUI();
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    ctx.createProjectItem(ctx.projectManager.projects.hyperionLantern);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    const elements = ctx.projectElements.hyperionLantern;
+    expect(elements.lanternIncrease.textContent).toBe('+1');
+
+    elements.lanternMultiply.click();
+    expect(elements.lanternIncrease.textContent).toBe('+10');
+    expect(elements.lanternAmountDisplay.textContent).toBe('10');
+
+    elements.lanternDivide.click();
+    expect(elements.lanternIncrease.textContent).toBe('+1');
+    expect(elements.lanternAmountDisplay.textContent).toBe('1');
+  });
+});

--- a/__tests__/lanternFlux.test.js
+++ b/__tests__/lanternFlux.test.js
@@ -1,0 +1,21 @@
+const { getZonePercentage } = require('../zones.js');
+global.getZonePercentage = getZonePercentage;
+const EffectableEntity = require('../effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const lifeParameters = require('../life-parameters.js');
+global.lifeParameters = lifeParameters;
+const Terraforming = require('../terraforming.js');
+
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+
+describe('Hyperion Lantern flux calculation', () => {
+  test('uses cross section area', () => {
+    const terra = new Terraforming({}, { radius: 1 });
+    terra.hyperionLantern.built = true;
+    terra.hyperionLantern.active = 1;
+    terra.hyperionLantern.powerPerInvestment = 100;
+    const expected = 100 / (Math.PI * 1000 * 1000);
+    expect(terra.calculateLanternFlux()).toBeCloseTo(expected, 5);
+  });
+});

--- a/terraforming.js
+++ b/terraforming.js
@@ -61,7 +61,9 @@ class Terraforming extends EffectableEntity{
 
     this.resources = resources;
     this.celestialParameters = celestialParameters;
-    this.celestialParameters.surfaceArea = 4 * Math.PI * Math.pow(this.celestialParameters.radius * 1000, 2);
+    const radiusMeters = this.celestialParameters.radius * 1000;
+    this.celestialParameters.surfaceArea = 4 * Math.PI * Math.pow(radiusMeters, 2);
+    this.celestialParameters.crossSectionArea = Math.PI * Math.pow(radiusMeters, 2);
 
     this.lifeParameters = lifeParameters; // Load external life parameters
 
@@ -1053,7 +1055,8 @@ class Terraforming extends EffectableEntity{
     calculateLanternFlux(){
       if(this.hyperionLantern.built && this.hyperionLantern.active > 0){
         const power = this.hyperionLantern.active * this.hyperionLantern.powerPerInvestment;
-        return power / this.celestialParameters.surfaceArea;
+        const area = this.celestialParameters.crossSectionArea || this.celestialParameters.surfaceArea;
+        return power / area;
       }
       return 0;
     }


### PR DESCRIPTION
## Summary
- compute cross-section area for celestial bodies
- base lantern flux on the disk area
- add x10 and /10 buttons for Hyperion Lantern controls
- show lantern flux and selected amount in project UI
- test lantern flux computation and multiplier buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68616676db5c8327be0230ea22af702d