### PR TITLE
Create subclasses for export/disposal projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
     <script src="src/js/projects/SpaceMiningProject.js"></script>
     <script src="src/js/projects/SpaceMirrorFacilityProject.js"></script>
     <script src="src/js/projects/HyperionLanternProject.js"></script>
+    <script src="src/js/projects/SpaceExportBaseProject.js"></script>
+    <script src="src/js/projects/SpaceExportProject.js"></script>
+    <script src="src/js/projects/SpaceDisposalProject.js"></script>
     <script src="src/js/projectsUI.js"></script>
     <script src="src/js/spaceship.js"></script>
     <script src="src/js/spaceshipUI.js"></script>

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -47,7 +47,7 @@ const projectParameters = {
     }
   },
   exportResources: {
-    type: 'Project',
+    type: 'SpaceExportProject',
     name : "Metal Exportation",
     category : "resources",
     cost: {},
@@ -342,7 +342,7 @@ const projectParameters = {
     }
   },
   disposeResources : {
-    type: 'Project',
+    type: 'SpaceDisposalProject',
     name : "Resource Disposal",
     category : "resources",
     cost: {},

--- a/src/js/projects/SpaceDisposalProject.js
+++ b/src/js/projects/SpaceDisposalProject.js
@@ -1,0 +1,9 @@
+class SpaceDisposalProject extends SpaceExportBaseProject {}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.SpaceDisposalProject = SpaceDisposalProject;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SpaceDisposalProject;
+}

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -1,0 +1,84 @@
+class SpaceExportBaseProject extends Project {
+  renderUI(container) {
+    if (typeof createResourceDisposalUI === 'function') {
+      createResourceDisposalUI(this, container);
+    }
+
+    const elements = projectElements[this.name] || {};
+    const row = elements.checkboxRowContainer;
+    if (row) {
+      const waitCheckboxContainer = document.createElement('div');
+      waitCheckboxContainer.classList.add('checkbox-container');
+
+      const waitCheckbox = document.createElement('input');
+      waitCheckbox.type = 'checkbox';
+      waitCheckbox.checked = this.waitForCapacity !== false;
+      waitCheckbox.id = `${this.name}-wait-capacity`;
+      waitCheckbox.classList.add('wait-capacity-checkbox');
+      waitCheckbox.addEventListener('change', (e) => {
+        this.waitForCapacity = e.target.checked;
+      });
+
+      const waitLabel = document.createElement('label');
+      waitLabel.htmlFor = `${this.name}-wait-capacity`;
+      waitLabel.textContent = 'Wait for full capacity';
+
+      waitCheckboxContainer.appendChild(waitCheckbox);
+      waitCheckboxContainer.appendChild(waitLabel);
+      row.appendChild(waitCheckboxContainer);
+
+      projectElements[this.name] = {
+        ...projectElements[this.name],
+        waitCapacityCheckbox: waitCheckbox,
+        waitCapacityCheckboxContainer: waitCheckboxContainer,
+      };
+    }
+  }
+
+  updateUI() {
+    const elements = projectElements[this.name];
+    if (!elements) return;
+
+    if (elements.waitCapacityCheckbox) {
+      elements.waitCapacityCheckbox.checked = this.waitForCapacity !== false;
+    }
+    if (elements.waitCapacityCheckboxContainer) {
+      if (typeof projectManager !== 'undefined' &&
+          projectManager.isBooleanFlagSet('automateSpecialProjects')) {
+        elements.waitCapacityCheckboxContainer.style.display = 'block';
+      } else {
+        elements.waitCapacityCheckboxContainer.style.display = 'none';
+      }
+    }
+
+    if (elements.disposalPerShipElement) {
+      const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
+      const perShip = this.attributes.disposalAmount * efficiency;
+      elements.disposalPerShipElement.textContent = `Maximum Export per Ship: ${formatNumber(perShip, true)}`;
+    }
+
+    if (elements.totalDisposalElement) {
+      const totalDisposal = this.calculateSpaceshipTotalDisposal();
+      let total = 0;
+      for (const category in totalDisposal) {
+        for (const resource in totalDisposal[category]) {
+          total += totalDisposal[category][resource];
+        }
+      }
+      elements.totalDisposalElement.textContent = `Total Export: ${formatNumber(total, true)}`;
+    }
+
+    if (elements.disposalSelect && this.selectedDisposalResource) {
+      const { category, resource } = this.selectedDisposalResource;
+      elements.disposalSelect.value = `${category}:${resource}`;
+    }
+  }
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.SpaceExportBaseProject = SpaceExportBaseProject;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SpaceExportBaseProject;
+}

--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -1,0 +1,9 @@
+class SpaceExportProject extends SpaceExportBaseProject {}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.SpaceExportProject = SpaceExportProject;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SpaceExportProject;
+}

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -77,10 +77,6 @@ function createProjectItem(project) {
     createCostPerShipAndTotalCostUI(project, projectItem);
   }
 
-  // Resource Disposal Dropdown for spaceExport projects
-  if (project.attributes.spaceExport) {
-    createResourceDisposalUI(project, projectItem);
-  }
 
   // Resource Gain Per Ship and Total Gain Display
   if (project.attributes.resourceGainPerShip) {
@@ -177,34 +173,6 @@ function createProjectItem(project) {
   autoStartCheckboxContainer.appendChild(autoStartLabel);
   checkboxRowContainer.appendChild(autoStartCheckboxContainer);
 
-  if (project.attributes.spaceExport) {
-    const waitCheckboxContainer = document.createElement('div');
-    waitCheckboxContainer.classList.add('checkbox-container');
-
-    const waitCheckbox = document.createElement('input');
-    waitCheckbox.type = 'checkbox';
-    waitCheckbox.checked = project.waitForCapacity !== false; // default true
-    waitCheckbox.id = `${project.name}-wait-capacity`;
-    waitCheckbox.classList.add('wait-capacity-checkbox');
-
-    waitCheckbox.addEventListener('change', (event) => {
-      project.waitForCapacity = event.target.checked;
-    });
-
-    const waitLabel = document.createElement('label');
-    waitLabel.htmlFor = `${project.name}-wait-capacity`;
-    waitLabel.textContent = 'Wait for full capacity';
-
-    waitCheckboxContainer.appendChild(waitCheckbox);
-    waitCheckboxContainer.appendChild(waitLabel);
-    checkboxRowContainer.appendChild(waitCheckboxContainer);
-
-    projectElements[project.name] = {
-      ...projectElements[project.name],
-      waitCapacityCheckbox: waitCheckbox,
-      waitCapacityCheckboxContainer: waitCheckboxContainer,
-    };
-  }
 
   // Store UI elements for updating later
   projectElements[project.name] = {
@@ -461,24 +429,6 @@ function updateProjectUI(projectName) {
     updateSpaceshipProjectCostAndGains(project, elements); // Helper function for cost and gain
   }
 
-  if (project.attributes.spaceExport) {
-    const elements = projectElements[project.name];
-    const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
-
-    if (elements.disposalPerShipElement) {
-      const perShip = project.attributes.disposalAmount * efficiency;
-      elements.disposalPerShipElement.textContent = `Maximum Export per Ship: ${formatNumber(perShip, true)}`;
-    }
-
-    const totalDisposal = project.calculateSpaceshipTotalDisposal();
-    let totalAmount = 0;
-    for (const category in totalDisposal) {
-      for (const resource in totalDisposal[category]) {
-        totalAmount += totalDisposal[category][resource];
-      }
-    }
-    elements.totalDisposalElement.textContent = `Total Export: ${formatNumber(totalAmount, true)}`;
-  }
 
   // Update Repeat Count if applicable
   if (elements.repeatCountElement) {
@@ -497,16 +447,6 @@ function updateProjectUI(projectName) {
 
   if (elements.waitCapacityCheckbox) {
     elements.waitCapacityCheckbox.checked = project.waitForCapacity !== false;
-  }
-
-    // For spaceExport projects, set the saved disposal resource in the dropdown if it exists
-    if (project.attributes.spaceExport && project.selectedDisposalResource) {
-      const { category, resource } = project.selectedDisposalResource;
-      const disposalSelect = elements.disposalSelect; // Retrieve the stored disposalSelect element
-      
-      if (disposalSelect) {
-          disposalSelect.value = `${category}:${resource}`; // Set the dropdown to saved value
-      }
   }
 
   // Update Resource Gain Information if applicable
@@ -580,15 +520,11 @@ function updateProjectUI(projectName) {
     // Show the auto-start checkbox if the project can be repeated
     if (elements.autoStartCheckboxContainer && projectManager.isBooleanFlagSet('automateSpecialProjects')) {
       elements.autoStartCheckboxContainer.style.display = 'block';
-      if (elements.waitCapacityCheckboxContainer) {
-        elements.waitCapacityCheckboxContainer.style.display = 'block';
-      }
+      // Wait capacity visibility handled by project subclass
     }
     else {
       elements.autoStartCheckboxContainer.style.display = 'none';
-      if (elements.waitCapacityCheckboxContainer) {
-        elements.waitCapacityCheckboxContainer.style.display = 'none';
-      }
+      // Wait capacity visibility handled by project subclass
     }
   }
 }

--- a/tests/spaceProjectSubclass.test.js
+++ b/tests/spaceProjectSubclass.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('space project subclasses', () => {
+  test('manager creates correct subclass instances', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const exportSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportProject.js'), 'utf8');
+    vm.runInContext(exportSubclass + '; this.SpaceExportProject = SpaceExportProject;', ctx);
+    const disposalSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceDisposalProject.js'), 'utf8');
+    vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.resources = { colony: { metal: { value: 0, updateStorageCap: () => {} } }, special: { spaceships: { value: 0 } } };
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.initializeProjects({
+      exportResources: ctx.projectParameters.exportResources,
+      disposeResources: ctx.projectParameters.disposeResources
+    });
+
+    expect(ctx.projectManager.projects.exportResources instanceof ctx.SpaceExportProject).toBe(true);
+    expect(ctx.projectManager.projects.disposeResources instanceof ctx.SpaceDisposalProject).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `SpaceExportBaseProject` for shared export UI logic
- make `SpaceExportProject` and `SpaceDisposalProject` extend the new base
- move wait-capacity and disposal UI logic from `projectsUI` into these classes
- load the new script in `index.html`
- update regression test for the new hierarchy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861723d26048327b34546e401f254f7