### PR TITLE
Move one-time rocket start logic

### DIFF
--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -135,7 +135,9 @@ class EffectableEntity {
           this.applyBooleanFlag(effect);
           break;
         case 'oneTimeStart':
-          this.applyOneTimeStart(effect);
+          if (typeof CargoRocketProject !== 'undefined' && this instanceof CargoRocketProject) {
+            this.applyOneTimeStart(effect);
+          }
           break;
         case 'instantResourceGain':
           this.applyInstantResourceGain(effect);

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -405,23 +405,6 @@ class Project extends EffectableEntity {
     this.unlocked = true;
   }
 
-  applyOneTimeStart(effect) {
-    console.log('Getting one time cargo rocket');
-    this.pendingResourceGains = effect.pendingResourceGains;
-    this.isActive = true;
-    this.remainingTime = 30000;
-  
-    // Update the visible entered amount in the resource selection UI
-    this.pendingResourceGains.forEach(({ resource, quantity }) => {
-      const inputElement = document.querySelector(`.resource-selection-${this.name}[data-resource="${resource}"]`);
-      if (inputElement) {
-        inputElement.value = quantity;
-      }
-    });
-  
-    // Update the total cost display
-    updateTotalCostDisplay(this);
-  }
 
   calculateSpaceshipCost() {
     const costPerShip = this.attributes.costPerShip;

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -47,6 +47,24 @@ class CargoRocketProject extends Project {
       this.selectedResources = selectedResources;
     }
   }
+
+  applyOneTimeStart(effect) {
+    console.log('Getting one time cargo rocket');
+    this.pendingResourceGains = effect.pendingResourceGains;
+    this.isActive = true;
+    this.remainingTime = 30000;
+
+    // Update the visible entered amount in the resource selection UI
+    this.pendingResourceGains.forEach(({ resource, quantity }) => {
+      const inputElement = document.querySelector(`.resource-selection-${this.name}[data-resource="${resource}"]`);
+      if (inputElement) {
+        inputElement.value = quantity;
+      }
+    });
+
+    // Update the total cost display
+    updateTotalCostDisplay(this);
+  }
 }
 
 if (typeof globalThis !== 'undefined') {


### PR DESCRIPTION
## Summary
- drop `applyOneTimeStart` from generic `Project`
- implement `applyOneTimeStart` in `CargoRocketProject`
- only call this method when the project is a `CargoRocketProject`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861797d99908327a8d34356347c7353