### PR TITLE
Add spaceship project renderUI

### DIFF
--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -1,5 +1,6 @@
 class SpaceExportBaseProject extends SpaceshipProject {
   renderUI(container) {
+    super.renderUI(container);
     if (this.attributes.disposable) {
       this.createResourceDisposalUI(container);
     }

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -1,6 +1,6 @@
 class SpaceMiningProject extends SpaceshipProject {
   renderUI(container) {
-    // Uses default UI elements from projectsUI.js
+    super.renderUI(container);
   }
 
   updateUI() {

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -32,6 +32,18 @@ class SpaceshipProject extends Project {
     return gainPerShip;
   }
 
+  renderUI(container) {
+    if (this.attributes.spaceMining || this.attributes.spaceExport) {
+      createSpaceshipAssignmentUI(this, container);
+      if (this.attributes.costPerShip) {
+        createCostPerShipAndTotalCostUI(this, container);
+      }
+      if (this.attributes.resourceGainPerShip) {
+        createResourceGainPerShipAndTotalGainUI(this, container);
+      }
+    }
+  }
+
   calculateSpaceshipTotalCost() {
     const totalCost = {};
     const costPerShip = this.calculateSpaceshipCost();

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -65,21 +65,6 @@ function createProjectItem(project) {
   descriptionElement.classList.add('project-description');
   projectItem.appendChild(descriptionElement);
 
-  // Spaceship Assignment Section
-  if (project.attributes.spaceMining || project.attributes.spaceExport) {
-    createSpaceshipAssignmentUI(project, projectItem);
-  }
-
-  // Cost Per Ship and Total Cost Display
-  if (project.attributes.costPerShip) {
-    createCostPerShipAndTotalCostUI(project, projectItem);
-  }
-
-
-  // Resource Gain Per Ship and Total Gain Display
-  if (project.attributes.resourceGainPerShip) {
-    createResourceGainPerShipAndTotalGainUI(project, projectItem);
-  }
 
   if (typeof project.renderUI === 'function') {
     project.renderUI(projectItem);


### PR DESCRIPTION
## Summary
- move spaceship UI creation into `SpaceshipProject.renderUI`
- call super.renderUI from mining/export project subclasses
- rely on project render method instead of attribute checks in `createProjectItem`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68617d19569483278d760f28715b2809