### PR TITLE
Implement ScannerProject subclass

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
     <script src="src/js/colonySlidersUI.js"></script>
     <script src="src/js/projects.js"></script>
     <script src="src/js/projects/SpaceshipProject.js"></script>
+    <script src="src/js/projects/ScannerProject.js"></script>
     <script src="src/js/projects/SpaceMiningProject.js"></script>
     <script src="src/js/projects/SpaceMirrorFacilityProject.js"></script>
     <script src="src/js/projects/HyperionLanternProject.js"></script>

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -66,7 +66,7 @@ const projectParameters = {
     }
   },
   satellite: {
-    type: 'Project',
+    type: 'ScannerProject',
     name: "Ore satellite",
     category :"infrastructure",
     cost: {
@@ -90,7 +90,7 @@ const projectParameters = {
     }
   },
   geo_satellite: {
-    type: 'Project',
+    type: 'ScannerProject',
     name: "Geothermal satellite",
     category :"infrastructure",
     cost: {

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -260,9 +260,6 @@ class Project extends EffectableEntity {
       this.applyResourceGain();
     }
 
-    if (this.attributes && this.attributes.scanner && this.attributes.scanner.canSearchForDeposits) {
-      this.applyScannerEffect();
-    }
 
     // Apply spaceship resource gains
     if (this.pendingResourceGains && this.attributes.spaceMining) {
@@ -359,18 +356,6 @@ class Project extends EffectableEntity {
     this.pendingResourceGains = []; // Clear pending gains after applying them
   }
 
-  applyScannerEffect() {
-    if (this.attributes.scanner && this.attributes.scanner.searchValue && this.attributes.scanner.depositType) {
-      const depositType = this.attributes.scanner.depositType;
-      const additionalStrength = this.attributes.scanner.searchValue;
-
-      oreScanner.adjustScanningStrength(depositType, oreScanner.scanData[depositType].currentScanningStrength + additionalStrength);
-
-      console.log(`Scanner strength for ${depositType} increased by ${additionalStrength}. New scanning strength: ${oreScanner.scanData[depositType].currentScanningStrength}`);
-      oreScanner.startScan(depositType);
-      console.log(`Scanning for ${depositType} started after applying scanner effect from ${this.name}`);
-    }
-  }
 
   applyCompletionEffect() {
     this.attributes.completionEffect.forEach((effect) => {

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -1,0 +1,42 @@
+class ScannerProject extends Project {
+  applyScannerEffect() {
+    if (
+      this.attributes.scanner &&
+      this.attributes.scanner.searchValue &&
+      this.attributes.scanner.depositType
+    ) {
+      const depositType = this.attributes.scanner.depositType;
+      const additionalStrength = this.attributes.scanner.searchValue;
+      oreScanner.adjustScanningStrength(
+        depositType,
+        oreScanner.scanData[depositType].currentScanningStrength + additionalStrength
+      );
+      console.log(
+        `Scanner strength for ${depositType} increased by ${additionalStrength}. New scanning strength: ${oreScanner.scanData[depositType].currentScanningStrength}`
+      );
+      oreScanner.startScan(depositType);
+      console.log(
+        `Scanning for ${depositType} started after applying scanner effect from ${this.name}`
+      );
+    }
+  }
+
+  complete() {
+    super.complete();
+    if (
+      this.attributes &&
+      this.attributes.scanner &&
+      this.attributes.scanner.canSearchForDeposits
+    ) {
+      this.applyScannerEffect();
+    }
+  }
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.ScannerProject = ScannerProject;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ScannerProject;
+}

--- a/tests/scannerProject.test.js
+++ b/tests/scannerProject.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('ScannerProject scanning effect', () => {
+  test('satellite projects use ScannerProject type', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.projectParameters = projectParameters;', ctx);
+    expect(ctx.projectParameters.satellite.type).toBe('ScannerProject');
+    expect(ctx.projectParameters.geo_satellite.type).toBe('ScannerProject');
+  });
+
+  test('applyScannerEffect increases strength and starts scan', () => {
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
+
+    ctx.oreScanner = {
+      scanData: { ore: { currentScanningStrength: 0 } },
+      adjustScanningStrength: jest.fn((type, val) => {
+        ctx.oreScanner.scanData[type].currentScanningStrength = val;
+      }),
+      startScan: jest.fn()
+    };
+
+    const config = {
+      name: 'scan',
+      category: 'infra',
+      cost: {},
+      duration: 1,
+      description: '',
+      repeatable: false,
+      unlocked: true,
+      attributes: { scanner: { canSearchForDeposits: true, searchValue: 0.5, depositType: 'ore' } }
+    };
+
+    const project = new ctx.ScannerProject(config, 'scan');
+    project.complete();
+
+    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledWith('ore', 0.5);
+    expect(ctx.oreScanner.startScan).toHaveBeenCalledWith('ore');
+  });
+});


### PR DESCRIPTION
## Summary
- create `ScannerProject` subclass that handles deposit scanning
- move scanner logic out of `Project`
- wire satellite projects to use `ScannerProject`
- include new file in `index.html`
- test scanner project behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68617d4350a08327927e34c34aa30433