### PR TITLE
Move resource choice helpers into CargoRocketProject

### DIFF
--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -239,29 +239,6 @@ class Project extends EffectableEntity {
     return effectiveResourceGain;
   }
 
-  getResourceChoiceGainCost() {
-    // Deduct funding for selected resources if applicable
-    if (this.selectedResources && this.selectedResources.length > 0) {
-      let totalFundingCost = 0;
-      this.pendingResourceGains = [];  // Track resources that will be gained later
-      this.selectedResources.forEach(({ category, resource, quantity }) => {
-        const pricePerUnit = this.attributes.resourceChoiceGainCost[category][resource];
-        totalFundingCost += pricePerUnit * quantity;
-        this.pendingResourceGains.push({ category, resource, quantity });
-        });
-      return totalFundingCost;
-    }
-      return 0;
-  }
-
-  applyResourceChoiceGain() {
-    // Apply resource gain based on the selected resources and their quantities
-    this.pendingResourceGains.forEach(({ category, resource, quantity }) => {
-      resources[category][resource].increase(quantity);
-      console.log(`Increased ${resource} by ${quantity}`);
-    });
-    this.pendingResourceGains = false;
-  }
 
   // New method to handle spaceship resource gain application
   applySpaceshipResourceGain() {

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -167,6 +167,30 @@ class CargoRocketProject extends Project {
     resources.colony.funding.decrease(this.getResourceChoiceGainCost());
   }
 
+  getResourceChoiceGainCost() {
+    // Deduct funding for selected resources if applicable
+    if (this.selectedResources && this.selectedResources.length > 0) {
+      let totalFundingCost = 0;
+      this.pendingResourceGains = []; // Track resources that will be gained later
+      this.selectedResources.forEach(({ category, resource, quantity }) => {
+        const pricePerUnit = this.attributes.resourceChoiceGainCost[category][resource];
+        totalFundingCost += pricePerUnit * quantity;
+        this.pendingResourceGains.push({ category, resource, quantity });
+      });
+      return totalFundingCost;
+    }
+    return 0;
+  }
+
+  applyResourceChoiceGain() {
+    // Apply resource gain based on the selected resources and their quantities
+    this.pendingResourceGains.forEach(({ category, resource, quantity }) => {
+      resources[category][resource].increase(quantity);
+      console.log(`Increased ${resource} by ${quantity}`);
+    });
+    this.pendingResourceGains = false;
+  }
+
   complete() {
     super.complete();
     if (this.pendingResourceGains && this.attributes.resourceChoiceGainCost) {

--- a/tests/cargoRocketProject.test.js
+++ b/tests/cargoRocketProject.test.js
@@ -14,4 +14,19 @@ describe('Cargo Rocket project', () => {
     expect(project.repeatable).toBe(true);
     expect(project.attributes.resourceChoiceGainCost).toBeDefined();
   });
+
+  test('CargoRocketProject defines resource choice methods', () => {
+    const ctx = { console };
+    vm.createContext(ctx);
+
+    const effCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const subclassCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(subclassCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+
+    expect(typeof ctx.CargoRocketProject.prototype.getResourceChoiceGainCost).toBe('function');
+    expect(typeof ctx.CargoRocketProject.prototype.applyResourceChoiceGain).toBe('function');
+  });
 });


### PR DESCRIPTION
## Summary
- migrate getResourceChoiceGainCost and applyResourceChoiceGain from Project
- implement these helpers directly in CargoRocketProject
- remove unused helpers from the base Project class
- test that CargoRocketProject exposes these helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861805382e483279baa4460e1f6b24b