### PR TITLE
Move spaceship start logic to subclass

### DIFF
--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -147,18 +147,6 @@ class Project extends EffectableEntity {
       this.remainingTime = this.getEffectiveDuration(); // Default duration for other projects
       this.startingDuration = this.remainingTime;
   
-      // If the project involves space mining, calculate spaceship resource gains
-      if (this.attributes.spaceMining) {
-        const spaceshipResourceGain = this.calculateSpaceshipTotalResourceGain();
-        this.pendingResourceGains = this.pendingResourceGains || []; // Initialize if undefined
-  
-        for (const category in spaceshipResourceGain) {
-          for (const resource in spaceshipResourceGain[category]) {
-            const quantity = spaceshipResourceGain[category][resource];
-            this.pendingResourceGains.push({ category, resource, quantity });
-          }
-        }
-      }
   
       console.log(`Project ${this.name} started.`);
       return true;

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -148,6 +148,26 @@ class SpaceshipProject extends Project {
     }
   }
 
+  start(resources) {
+    const started = super.start(resources);
+    if (!started) return false;
+
+    if (this.attributes.spaceMining) {
+      const gain = this.calculateSpaceshipTotalResourceGain();
+      this.pendingResourceGains = this.pendingResourceGains || [];
+      for (const category in gain) {
+        for (const resource in gain[category]) {
+          this.pendingResourceGains.push({
+            category,
+            resource,
+            quantity: gain[category][resource]
+          });
+        }
+      }
+    }
+    return true;
+  }
+
   complete() {
     super.complete();
     if (this.pendingResourceGains && (this.attributes.spaceMining || this.attributes.spaceExport)) {

--- a/tests/spaceMiningRate.test.js
+++ b/tests/spaceMiningRate.test.js
@@ -72,10 +72,9 @@ describe('space mining rate scaling', () => {
     };
     const project = new SpaceshipProject(config, 'test');
     project.assignedSpaceships = 1;
-    project.pendingResourceGains = [{ category: 'colony', resource: 'metal', quantity: 10 }];
-    project.autoStart = true;
-    project.isActive = true;
     project.getEffectiveDuration = () => 500;
+    project.start(context.resources);
+    project.autoStart = true;
 
     project.estimateProjectCostAndGain();
 


### PR DESCRIPTION
## Summary
- move spaceship-specific initialization from Project.start to SpaceshipProject.start
- compute mining gains when starting a SpaceshipProject
- update spaceMiningRate test for new start flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861805a5cc88327888a5d9b4cc1c11d