### PR TITLE
Introduce phase-change helpers and refactor cycles

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
     <script src="src/js/progress.js"></script>
     <script src="src/js/physics.js"></script>
     <script src="src/js/hydrology.js"></script>
+    <script src="src/js/phase-change-utils.js"></script>
     <script src="src/js/water-cycle.js"></script>
     <script src="src/js/dry-ice-cycle.js"></script>
     <script src="src/js/hydrocarbon-cycle.js"></script>

--- a/src/js/phase-change-utils.js
+++ b/src/js/phase-change-utils.js
@@ -1,0 +1,34 @@
+// Utility functions for phase change calculations
+
+const isNodePCU = (typeof module !== 'undefined' && module.exports);
+var airDensityFn;
+if (isNodePCU) {
+  airDensityFn = require('./physics.js').airDensity;
+} else {
+  airDensityFn = globalThis.airDensity;
+}
+
+function psychrometricConstant(atmPressure, latentHeat) {
+  return (C_P_AIR * atmPressure) / (EPSILON * latentHeat);
+}
+
+function penmanRate({ T, solarFlux, atmPressure, e_a, latentHeat, albedo = 0.6, r_a = 100, Delta_s, e_s }) {
+  if (typeof Delta_s !== 'number' || typeof e_s !== 'number') {
+    throw new Error('penmanRate requires Delta_s and e_s');
+  }
+  const R_n = (1 - albedo) * solarFlux;
+  const gamma_s = psychrometricConstant(atmPressure, latentHeat);
+  const rho_a_val = airDensityFn(atmPressure, T);
+
+  const numerator = (Delta_s * R_n) + (rho_a_val * C_P_AIR * (e_s - e_a) / r_a);
+  const denominator = (Delta_s + gamma_s) * latentHeat;
+  const rate = numerator / denominator;
+  return Math.max(0, rate);
+}
+
+if (isNodePCU) {
+  module.exports = { psychrometricConstant, penmanRate };
+} else {
+  globalThis.psychrometricConstant = psychrometricConstant;
+  globalThis.penmanRate = penmanRate;
+}

--- a/tests/equilibriumConstants.test.js
+++ b/tests/equilibriumConstants.test.js
@@ -19,6 +19,9 @@ global.airDensity = physics.airDensity;
 global.C_P_AIR = 1004;
 global.EPSILON = 0.622;
 global.R_AIR = 287;
+const phaseUtils = require('../src/js/phase-change-utils.js');
+global.penmanRate = phaseUtils.penmanRate;
+global.psychrometricConstant = phaseUtils.psychrometricConstant;
 // water-cycle functions
 const fs = require('fs');
 eval(fs.readFileSync(require.resolve('../src/js/water-cycle.js'), 'utf8'));

--- a/tests/phaseChangeUtils.test.js
+++ b/tests/phaseChangeUtils.test.js
@@ -1,0 +1,62 @@
+const physics = require('../src/js/physics.js');
+const water = require('../src/js/water-cycle.js');
+const utils = require('../src/js/phase-change-utils.js');
+
+global.airDensity = physics.airDensity;
+// constants used by utility
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+
+describe('phase-change utility helpers', () => {
+  test('psychrometricConstant computes expected value', () => {
+    const res = utils.psychrometricConstant(101325, 2.45e6);
+    const expected = (1004 * 101325) / (0.622 * 2.45e6);
+    expect(res).toBeCloseTo(expected);
+  });
+
+  test('penmanRate matches manual formula', () => {
+    const params = {
+      T: 300,
+      solarFlux: 500,
+      atmPressure: 101325,
+      e_a: 1000,
+      latentHeat: 2.45e6,
+      albedo: 0.3,
+      r_a: 100,
+      Delta_s: water.slopeSaturationVaporPressureWater(300),
+      e_s: water.saturationVaporPressureBuck(300)
+    };
+    const gamma_s = utils.psychrometricConstant(params.atmPressure, params.latentHeat);
+    const rho_a_val = physics.airDensity(params.atmPressure, params.T);
+    const R_n = (1 - params.albedo) * params.solarFlux;
+    const expected = ((params.Delta_s * R_n) +
+                      (rho_a_val * 1004 * (params.e_s - params.e_a) / params.r_a)) /
+                     ((params.Delta_s + gamma_s) * params.latentHeat);
+    const res = utils.penmanRate(params);
+    expect(res).toBeCloseTo(expected);
+  });
+});
+
+// verify cycle modules still compute rates using helpers
+
+describe('cycle modules via utils', () => {
+  test('evaporationRateWater uses penmanRate', () => {
+    const T = 300;
+    const solarFlux = 500;
+    const atmPressure = 101325;
+    const e_a = 1000;
+    const expected = utils.penmanRate({
+      T,
+      solarFlux,
+      atmPressure,
+      e_a,
+      latentHeat: 2.45e6,
+      albedo: 0.3,
+      r_a: 100,
+      Delta_s: water.slopeSaturationVaporPressureWater(T),
+      e_s: water.saturationVaporPressureBuck(T)
+    });
+    const res = water.evaporationRateWater(T, solarFlux, atmPressure, e_a, 100);
+    expect(res).toBeCloseTo(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- create `phase-change-utils.js` with shared psychrometric and Penman helpers
- refactor dry-ice, water and hydrocarbon cycle modules to use new helpers
- load helper before cycle scripts in `index.html`
- add unit tests for the utilities and update existing tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686181abefb48327afe152dc4f4bd154