### PR TITLE
Refactor project update hooks

### DIFF
--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -312,13 +312,8 @@ class ProjectManager extends EffectableEntity {
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
   
-      // Auto-assign spaceships if the project has autoAssignSpaceships set to true and is a space mining project
-      if ((project.attributes.spaceMining  || project.attributes.spaceExport) && project.autoAssignSpaceships) {
-        const availableSpaceships = Math.floor(resources.special.spaceships.value);
-        if (availableSpaceships > 0) {
-          // Use the existing function to assign all available spaceships to this project
-          assignSpaceshipsToProject(project, availableSpaceships, document.getElementById(`${project.name}-assigned-spaceships`));
-        }
+      if (typeof project.autoAssign === 'function') {
+        project.autoAssign();
       }
   
       // Update each project if it is active
@@ -335,8 +330,8 @@ class ProjectManager extends EffectableEntity {
   estimateProjects() {
     for (const projectName in this.projects){
       const project = this.projects[projectName];
-      if(project.attributes.spaceMining || project.attributes.spaceExport || project.attributes.resourceChoiceGainCost){
-        project.estimateProjectCostAndGain();
+      if (typeof project.estimateCostAndGain === 'function') {
+        project.estimateCostAndGain();
       }
     }
   }

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -219,6 +219,10 @@ class CargoRocketProject extends Project {
       );
     }
   }
+
+  estimateCostAndGain() {
+    this.estimateProjectCostAndGain();
+  }
 }
 
 if (typeof globalThis !== 'undefined') {

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -58,6 +58,18 @@ class SpaceshipProject extends Project {
     updateSpaceshipProjectCostAndGains(this, elements);
   }
 
+  autoAssign() {
+    if (!this.autoAssignSpaceships) return;
+    const availableSpaceships = Math.floor(resources.special.spaceships.value);
+    if (availableSpaceships > 0) {
+      assignSpaceshipsToProject(
+        this,
+        availableSpaceships,
+        document.getElementById(`${this.name}-assigned-spaceships`)
+      );
+    }
+  }
+
   calculateSpaceshipTotalCost() {
     const totalCost = {};
     const costPerShip = this.calculateSpaceshipCost();
@@ -235,6 +247,10 @@ class SpaceshipProject extends Project {
         });
       }
     }
+  }
+
+  estimateCostAndGain() {
+    this.estimateProjectCostAndGain();
   }
 }
 

--- a/tests/projectAutoAssign.test.js
+++ b/tests/projectAutoAssign.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('ProjectManager autoAssign uses method', () => {
+  let context;
+  beforeEach(() => {
+    context = {
+      console,
+      EffectableEntity,
+      resources: {
+        colony: { metal: { value: 0, updateStorageCap: () => {} } },
+        special: { spaceships: { value: 3 } }
+      },
+      buildings: {},
+      colonies: {},
+      populationModule: {},
+      tabManager: {},
+      fundingModule: {},
+      terraforming: {},
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {},
+      globalEffects: new EffectableEntity({ description: 'global' })
+    };
+    context.document = { getElementById: () => null };
+    vm.createContext(context);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', context);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', context);
+    const shipUtils = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'spaceship.js'), 'utf8');
+    vm.runInContext(shipUtils + '; this.assignSpaceshipsToProject = assignSpaceshipsToProject;', context);
+    context.projectManager = new context.ProjectManager();
+    global.resources = context.resources;
+  });
+
+  test('updateProjects calls autoAssign', () => {
+    const config = {
+      name: 'Test',
+      category: 'resources',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { spaceMining: true }
+    };
+    const project = new context.SpaceshipProject(config, 'test');
+    project.autoAssignSpaceships = true;
+    context.projectManager.projects.test = project;
+    const spy = jest.spyOn(project, 'autoAssign');
+    context.projectManager.updateProjects(0);
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/spaceMiningRate.test.js
+++ b/tests/spaceMiningRate.test.js
@@ -76,7 +76,7 @@ describe('space mining rate scaling', () => {
     project.start(context.resources);
     project.autoStart = true;
 
-    project.estimateProjectCostAndGain();
+    project.estimateCostAndGain();
 
     expect(global.resources.colony.metal.modifyRate).toHaveBeenCalledWith(
       20,


### PR DESCRIPTION
## Summary
- add `autoAssign` and `estimateCostAndGain` helpers on `SpaceshipProject`
- expose similar estimation helper on `CargoRocketProject`
- use these methods from `ProjectManager` instead of checking attributes
- update space mining test for new helper
- add unit test covering automatic spaceship assignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861841cb2bc832791a1ff9ab0838f41