### PR TITLE
Move spaceship settings to subclass

### DIFF
--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -13,11 +13,7 @@ class Project extends EffectableEntity {
     this.isActive = false; // Whether the project is currently active
     this.isCompleted = false; // Whether the project has been completed
     this.repeatCount = 0; // Track the current number of times the project has been repeated
-    this.assignedSpaceships = 0;
     this.autoStart = false;
-    this.autoAssignSpaceships = false;
-    this.waitForCapacity = true;
-    this.selectedDisposalResource = null || this.attributes.defaultDisposal;
   }
 
   initializeFromConfig(config, name) {
@@ -357,19 +353,24 @@ class ProjectManager extends EffectableEntity {
     const projectState = {};
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
-      projectState[projectName] = {
+      const state = {
         isActive: project.isActive,
         isCompleted: project.isCompleted,
         remainingTime: project.remainingTime,
         startingDuration: project.startingDuration,
         repeatCount: project.repeatCount,
         pendingResourceGains: project.pendingResourceGains || [],
-        assignedSpaceships: project.assignedSpaceships,
         autoStart : project.autoStart,
-        autoAssignSpaceships : project.autoAssignSpaceships,
-        selectedDisposalResource : project.selectedDisposalResource,
-        waitForCapacity : project.waitForCapacity
       };
+
+      if (typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject) {
+        state.assignedSpaceships = project.assignedSpaceships;
+        state.autoAssignSpaceships = project.autoAssignSpaceships;
+        state.selectedDisposalResource = project.selectedDisposalResource;
+        state.waitForCapacity = project.waitForCapacity;
+      }
+
+      projectState[projectName] = state;
     }
     return projectState;
   }
@@ -395,12 +396,14 @@ class ProjectManager extends EffectableEntity {
           project.oneTimeResourceGainsDisplay = project.pendingResourceGains;
         }
         project.effects = [];
-        project.assignedSpaceships = savedProject.assignedSpaceships;
         project.autoStart = savedProject.autoStart;
-        project.autoAssignSpaceships = savedProject.autoAssignSpaceships;
-        project.selectedDisposalResource = savedProject.selectedDisposalResource || project.attributes.defaultDisposal;
-        if(savedProject.waitForCapacity !== undefined){
-          project.waitForCapacity = savedProject.waitForCapacity;
+        if (typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject) {
+          project.assignedSpaceships = savedProject.assignedSpaceships;
+          project.autoAssignSpaceships = savedProject.autoAssignSpaceships;
+          project.selectedDisposalResource = savedProject.selectedDisposalResource || project.attributes.defaultDisposal;
+          if(savedProject.waitForCapacity !== undefined){
+            project.waitForCapacity = savedProject.waitForCapacity;
+          }
         }
         if(project.attributes.completionEffect && (project.isCompleted || project.repeatCount > 0)){
           project.applyCompletionEffect();

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -1,4 +1,12 @@
 class SpaceshipProject extends Project {
+  constructor(config, name) {
+    super(config, name);
+    this.assignedSpaceships = 0;
+    this.autoAssignSpaceships = false;
+    this.waitForCapacity = true;
+    this.selectedDisposalResource = this.attributes.defaultDisposal;
+  }
+
   calculateSpaceshipCost() {
     const costPerShip = this.attributes.costPerShip;
     const totalCost = {};

--- a/tests/earthProbeProject.test.js
+++ b/tests/earthProbeProject.test.js
@@ -35,6 +35,10 @@ describe('Earth Recon Probe project', () => {
       attributes: { costDoubling: true }
     };
     const p = new ctx.Project(config, 'probe');
+    expect(p.assignedSpaceships).toBeUndefined();
+    expect(p.autoAssignSpaceships).toBeUndefined();
+    expect(p.waitForCapacity).toBeUndefined();
+    expect(p.selectedDisposalResource).toBeUndefined();
     expect(p.getScaledCost().colony.components).toBe(10);
     p.repeatCount = 1;
     expect(p.getScaledCost().colony.components).toBe(20);


### PR DESCRIPTION
## Summary
- move spaceship-related fields from `Project` into `SpaceshipProject`
- guard save/load against missing spaceship fields
- test that `Project` no longer initializes spaceship fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686189bfe0808327bd31e3b082bf9529