### PR TITLE
Add Hyperion Lantern calculations

### DIFF
--- a/src/js/projects/HyperionLanternProject.js
+++ b/src/js/projects/HyperionLanternProject.js
@@ -7,6 +7,25 @@ class HyperionLanternProject extends Project {
     this.amount = 1;
     this.powerPerInvestment = this.attributes.powerPerInvestment || defaultPower;
   }
+
+  calculateEnergyUsage(){
+    if(!this.isCompleted){
+      return 0;
+    }
+    return this.active * this.powerPerInvestment;
+  }
+
+  calculateFlux(celestialParameters){
+    if(!celestialParameters){
+      return 0;
+    }
+    const power = this.calculateEnergyUsage();
+    if(power <= 0){
+      return 0;
+    }
+    const area = celestialParameters.crossSectionArea || celestialParameters.surfaceArea;
+    return power / area;
+  }
   renderUI(container) {
     const lanternControls = document.createElement('div');
     lanternControls.classList.add('lantern-controls');

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1045,10 +1045,8 @@ class Terraforming extends EffectableEntity{
     calculateLanternFlux(){
       const project = (typeof projectManager !== 'undefined' && projectManager.projects)
         ? projectManager.projects.hyperionLantern : null;
-      if(project && project.isCompleted && project.active > 0){
-        const power = project.active * project.powerPerInvestment;
-        const area = this.celestialParameters.crossSectionArea || this.celestialParameters.surfaceArea;
-        return power / area;
+      if(project && typeof project.calculateFlux === 'function'){
+        return project.calculateFlux(this.celestialParameters);
       }
       return 0;
     }
@@ -1121,9 +1119,11 @@ class Terraforming extends EffectableEntity{
 
       const lantern = (typeof projectManager !== 'undefined' && projectManager.projects)
         ? projectManager.projects.hyperionLantern : null;
-      if(lantern && lantern.isCompleted && lantern.active > 0){
-        const power = lantern.active * lantern.powerPerInvestment;
-        resources.colony.energy.modifyRate(-power, 'Hyperion Lantern', 'terraforming');
+      if(lantern && typeof lantern.calculateEnergyUsage === 'function'){
+        const power = lantern.calculateEnergyUsage();
+        if(power > 0){
+          resources.colony.energy.modifyRate(-power, 'Hyperion Lantern', 'terraforming');
+        }
       }
 
       const lifeLuminosityEffect = {

--- a/tests/hyperionLanternMethods.test.js
+++ b/tests/hyperionLanternMethods.test.js
@@ -1,0 +1,72 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = {};
+
+// Stub Project base class for requiring HyperionLanternProject
+const OriginalProject = global.Project;
+class StubProject extends EffectableEntity {
+  constructor(config, name){
+    super(config);
+    this.name = name;
+    this.attributes = config.attributes || {};
+  }
+}
+
+global.Project = StubProject;
+const HyperionLanternProject = require('../src/js/projects/HyperionLanternProject.js');
+if (OriginalProject === undefined) delete global.Project; else global.Project = OriginalProject;
+
+describe('HyperionLanternProject calculations', () => {
+  test('calculates flux and energy usage', () => {
+    const project = new HyperionLanternProject({ attributes: { powerPerInvestment: 100 } }, 'lantern');
+    project.isCompleted = true;
+    project.active = 2;
+    const area = 50;
+    expect(project.calculateEnergyUsage()).toBe(200);
+    expect(project.calculateFlux({ crossSectionArea: area })).toBeCloseTo(200 / area);
+  });
+});
+
+const Terraforming = require('../src/js/terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+
+describe('Terraforming integration with Hyperion Lantern', () => {
+  test('uses project methods for flux and energy', () => {
+    const OriginalProject2 = global.Project;
+    global.Project = StubProject;
+    const HyperionLanternProject2 = require('../src/js/projects/HyperionLanternProject.js');
+    if (OriginalProject2 === undefined) delete global.Project; else global.Project = OriginalProject2;
+
+    const project = new HyperionLanternProject2({ attributes: { powerPerInvestment: 20 } }, 'hyperionLantern');
+    project.isCompleted = true;
+    project.active = 3;
+    project.calculateEnergyUsage = jest.fn(() => 60);
+    project.calculateFlux = jest.fn(() => 6);
+
+    global.projectManager = { projects: { hyperionLantern: project }, isBooleanFlagSet: () => false };
+    let modifyArgs = null;
+    global.resources = { atmospheric: {}, special: { albedoUpgrades: { value: 0 } }, colony: { energy: { modifyRate: (...args) => { modifyArgs = args; } } } };
+    global.buildings = { spaceMirror: { active: 0 } };
+    global.colonies = {};
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = {};
+    global.oreScanner = {};
+    global.addEffect = () => {};
+
+    const terra = new Terraforming(global.resources, { distanceFromSun: 1, radius: 1, gravity: 1, albedo: 0 });
+    terra.calculateTotalPressure = () => 0;
+
+    terra.applyTerraformingEffects();
+    expect(project.calculateEnergyUsage).toHaveBeenCalled();
+    expect(modifyArgs).toEqual([-60, 'Hyperion Lantern', 'terraforming']);
+
+    const flux = terra.calculateLanternFlux();
+    expect(project.calculateFlux).toHaveBeenCalledWith(terra.celestialParameters);
+    expect(flux).toBe(6);
+  });
+});

--- a/tests/lanternFlux.test.js
+++ b/tests/lanternFlux.test.js
@@ -12,7 +12,17 @@ Terraforming.prototype.updateSurfaceTemperature = function(){};
 describe('Hyperion Lantern flux calculation', () => {
   test('uses cross section area', () => {
     const terra = new Terraforming({}, { radius: 1 });
-    global.projectManager = { projects: { hyperionLantern: { isCompleted: true, active: 1, powerPerInvestment: 100 } } };
+    const project = {
+      isCompleted: true,
+      active: 1,
+      powerPerInvestment: 100,
+      calculateFlux(cp){
+        const power = this.active * this.powerPerInvestment;
+        const area = cp.crossSectionArea || cp.surfaceArea;
+        return power / area;
+      }
+    };
+    global.projectManager = { projects: { hyperionLantern: project } };
     const expected = 100 / (Math.PI * 1000 * 1000);
     expect(terra.calculateLanternFlux()).toBeCloseTo(expected, 5);
   });


### PR DESCRIPTION
## Summary
- add `calculateEnergyUsage` and `calculateFlux` methods to `HyperionLanternProject`
- call these methods from `terraforming.js`
- update lantern flux test for new API and add new integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686189cd3ea48327aa5f5f4f7351d6a1