### PR TITLE
Remove units from resource tooltip table

### DIFF
--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -297,7 +297,7 @@ function updateResourceRateDisplay(resource){
         tooltipContent += `
           <div style="display: table-row;">
             <div style="display: table-cell; text-align: left; padding-right: 10px;">${source}</div>
-            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s</div>
+            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}/s</div>
           </div>`;
       });
       tooltipContent += '</div>';
@@ -312,7 +312,7 @@ function updateResourceRateDisplay(resource){
         tooltipContent += `
           <div style="display: table-row;">
             <div style="display: table-cell; text-align: left; padding-right: 10px;">${source}</div>
-            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s</div>
+            <div style="display: table-cell; text-align: right;">${formatNumber(rate, false, 2)}/s</div>
           </div>`;
       });
       tooltipContent += '</div>';

--- a/tests/resourceTooltipUnits.test.js
+++ b/tests/resourceTooltipUnits.test.js
@@ -70,4 +70,38 @@ describe('resource tooltip units', () => {
     const tooltip = dom.window.document.getElementById('colonists-tooltip').innerHTML;
     expect(tooltip).not.toContain('ton');
   });
+
+  test('table rows omit unit but top value retains it', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.oreScanner = { scanData: {} };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const resource = {
+      name: 'metal',
+      displayName: 'Metal',
+      category: 'colony',
+      value: 100,
+      cap: 1000,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 1,
+      consumptionRate: 0.5,
+      productionRateBySource: { Mine: 1 },
+      consumptionRateBySource: { Factory: 0.5 },
+      unit: 'ton'
+    };
+
+    ctx.createResourceDisplay({ colony: { metal: resource } });
+    ctx.updateResourceRateDisplay(resource);
+
+    const tooltip = dom.window.document.getElementById('metal-tooltip').innerHTML;
+    expect(tooltip).toContain('Value');
+    expect(tooltip).toContain('ton');
+    expect(tooltip).not.toContain(' ton/s');
+  });
 });


### PR DESCRIPTION
## Summary
- drop units from production/consumption table entries in resource tooltip
- ensure tests cover missing units in the table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68618f195e948327806b0381bbc224ff