### PR TITLE
Reduce Hyperion Lantern cost and reorder controls

### DIFF
--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -397,10 +397,10 @@ const projectParameters = {
     category: "infrastructure",
     cost: {
       colony: {
-        metal: 1e9,
-        glass: 1e9,
-        electronics: 1e9,
-        components: 1e9
+        metal: 1e6,
+        glass: 1e6,
+        electronics: 1e6,
+        components: 1e6
       }
     },
     duration: 300000,
@@ -419,9 +419,9 @@ const projectParameters = {
       // Cost to add additional power modules to the lantern
       investmentCost: {
         colony: {
-          components: 1e9,
-          electronics: 1e9,
-          glass: 1e6
+          components: 1e6,
+          electronics: 1e6,
+          glass: 1000
         }
       },
       // Power output provided by each investment (in watts)

--- a/src/js/projects/HyperionLanternProject.js
+++ b/src/js/projects/HyperionLanternProject.js
@@ -82,13 +82,18 @@ class HyperionLanternProject extends Project {
       const amount = this.amount;
       const reqComponents = (investCost.components || 0) * amount;
       const reqElectronics = (investCost.electronics || 0) * amount;
+      const reqGlass = (investCost.glass || 0) * amount;
       if (resources.colony.components.value >= reqComponents &&
-          resources.colony.electronics.value >= reqElectronics) {
+          resources.colony.electronics.value >= reqElectronics &&
+          resources.colony.glass.value >= reqGlass) {
         if(investCost.components){
           resources.colony.components.value -= reqComponents;
         }
         if(investCost.electronics){
           resources.colony.electronics.value -= reqElectronics;
+        }
+        if(investCost.glass){
+          resources.colony.glass.value -= reqGlass;
         }
         this.investments += amount;
         updateProjectUI(this.name);
@@ -102,11 +107,10 @@ class HyperionLanternProject extends Project {
     investmentContainer.appendChild(increaseButton);
     investmentContainer.appendChild(investButton);
 
-    lanternControls.appendChild(investmentContainer);
-
     const capacityDisplay = document.createElement('p');
     capacityDisplay.id = 'lantern-capacity';
     lanternControls.appendChild(capacityDisplay);
+    lanternControls.appendChild(investmentContainer);
 
     const fluxDisplay = document.createElement('p');
     fluxDisplay.id = 'lantern-flux';
@@ -147,7 +151,18 @@ class HyperionLanternProject extends Project {
       if(investCost.electronics){
         parts.push(`${formatNumber(investCost.electronics * amount, true)} Electronics`);
       }
+      if(investCost.glass){
+        parts.push(`${formatNumber(investCost.glass * amount, true)} Glass`);
+      }
       elements.lanternInvest.textContent = `Invest ${parts.join(' & ')}`;
+      const haveComponents = resources.colony.components.value;
+      const haveElectronics = resources.colony.electronics.value;
+      const haveGlass = resources.colony.glass.value;
+      const reqComponents = (investCost.components || 0) * amount;
+      const reqElectronics = (investCost.electronics || 0) * amount;
+      const reqGlass = (investCost.glass || 0) * amount;
+      const canAfford = haveComponents >= reqComponents && haveElectronics >= reqElectronics && haveGlass >= reqGlass;
+      elements.lanternInvest.style.color = canAfford ? 'inherit' : 'red';
     }
     if(elements.lanternAmountDisplay){
       elements.lanternAmountDisplay.textContent = formatNumber(amount, true);

--- a/tests/hyperionLanternAmountButtons.test.js
+++ b/tests/hyperionLanternAmountButtons.test.js
@@ -16,7 +16,7 @@ describe('Hyperion Lantern amount controls', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.formatBigInteger = numbers.formatBigInteger;
     ctx.projectElements = {};
-    ctx.resources = { colony: { components: { value: Infinity }, electronics: { value: Infinity } }, special: { spaceships: { value: 0 } } };
+    ctx.resources = { colony: { components: { value: Infinity }, electronics: { value: Infinity }, glass: { value: Infinity } }, special: { spaceships: { value: 0 } } };
     ctx.buildings = { spaceMirror: { active: 0 } };
     ctx.terraforming = { calculateLanternFlux: () => 0 };
 

--- a/tests/hyperionLanternButtonOrder.test.js
+++ b/tests/hyperionLanternButtonOrder.test.js
@@ -4,8 +4,8 @@ const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_m
 const vm = require('vm');
 const numbers = require('../src/js/numbers.js');
 
-describe('Hyperion Lantern controls disabled before completion', () => {
-  test('buttons disabled until project completed', () => {
+describe('Hyperion Lantern button order', () => {
+  test('increase/decrease below capacity display', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
       <div class="projects-subtab-content-wrapper">
         <div id="infrastructure-projects-list" class="projects-list"></div>
@@ -16,7 +16,7 @@ describe('Hyperion Lantern controls disabled before completion', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.formatBigInteger = numbers.formatBigInteger;
     ctx.projectElements = {};
-    ctx.resources = { colony: { components: { value: 0 }, electronics: { value: 0 }, glass: { value: 0 } }, special: { spaceships: { value: 0 } } };
+    ctx.resources = { colony: { components: { value: Infinity }, electronics: { value: Infinity }, glass: { value: Infinity } }, special: { spaceships: { value: 0 } } };
     ctx.buildings = { spaceMirror: { active: 0 } };
     ctx.terraforming = { calculateLanternFlux: () => 0 };
 
@@ -33,7 +33,7 @@ describe('Hyperion Lantern controls disabled before completion', () => {
 
     ctx.projectManager = new ctx.ProjectManager();
     ctx.projectManager.initializeProjects({ hyperionLantern: ctx.projectParameters.hyperionLantern });
-    ctx.projectManager.projects.hyperionLantern.isCompleted = false;
+    ctx.projectManager.projects.hyperionLantern.isCompleted = true;
     ctx.projectManager.isBooleanFlagSet = () => false;
 
     ctx.initializeProjectsUI();
@@ -42,8 +42,10 @@ describe('Hyperion Lantern controls disabled before completion', () => {
     ctx.projectElements = vm.runInContext('projectElements', ctx);
 
     const elements = ctx.projectElements.hyperionLantern;
-    expect(elements.lanternDecrease.disabled).toBe(true);
-    expect(elements.lanternIncrease.disabled).toBe(true);
-    expect(elements.lanternInvest.disabled).toBe(true);
+    const container = elements.lanternCapacity.parentElement;
+    const children = Array.from(container.children);
+    const capacityIndex = children.indexOf(elements.lanternCapacity);
+    const toggleIndex = children.indexOf(elements.lanternDecrease.parentElement);
+    expect(toggleIndex).toBeGreaterThan(capacityIndex);
   });
 });

--- a/tests/hyperionLanternInvestButton.test.js
+++ b/tests/hyperionLanternInvestButton.test.js
@@ -4,8 +4,8 @@ const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_m
 const vm = require('vm');
 const numbers = require('../src/js/numbers.js');
 
-describe('Hyperion Lantern controls disabled before completion', () => {
-  test('buttons disabled until project completed', () => {
+describe('Hyperion Lantern invest button', () => {
+  test('shows glass cost and color reflects affordability', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
       <div class="projects-subtab-content-wrapper">
         <div id="infrastructure-projects-list" class="projects-list"></div>
@@ -22,6 +22,8 @@ describe('Hyperion Lantern controls disabled before completion', () => {
 
     const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const buildCountCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildCount.js'), 'utf8');
+    vm.runInContext(buildCountCode + '; this.multiplyByTen = multiplyByTen; this.divideByTen = divideByTen;', ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager;', ctx);
     const lanternSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'HyperionLanternProject.js'), 'utf8');
@@ -33,7 +35,7 @@ describe('Hyperion Lantern controls disabled before completion', () => {
 
     ctx.projectManager = new ctx.ProjectManager();
     ctx.projectManager.initializeProjects({ hyperionLantern: ctx.projectParameters.hyperionLantern });
-    ctx.projectManager.projects.hyperionLantern.isCompleted = false;
+    ctx.projectManager.projects.hyperionLantern.isCompleted = true;
     ctx.projectManager.isBooleanFlagSet = () => false;
 
     ctx.initializeProjectsUI();
@@ -41,9 +43,14 @@ describe('Hyperion Lantern controls disabled before completion', () => {
     ctx.createProjectItem(ctx.projectManager.projects.hyperionLantern);
     ctx.projectElements = vm.runInContext('projectElements', ctx);
 
-    const elements = ctx.projectElements.hyperionLantern;
-    expect(elements.lanternDecrease.disabled).toBe(true);
-    expect(elements.lanternIncrease.disabled).toBe(true);
-    expect(elements.lanternInvest.disabled).toBe(true);
+    const investBtn = ctx.projectElements.hyperionLantern.lanternInvest;
+    expect(investBtn.textContent).toMatch(/Glass/);
+    expect(investBtn.style.color).toBe('red');
+
+    ctx.resources.colony.components.value = 2e6;
+    ctx.resources.colony.electronics.value = 2e6;
+    ctx.resources.colony.glass.value = 2000;
+    ctx.updateProjectUI('hyperionLantern');
+    expect(investBtn.style.color).toBe('inherit');
   });
 });

--- a/tests/hyperionLanternProject.test.js
+++ b/tests/hyperionLanternProject.test.js
@@ -13,12 +13,12 @@ describe('Hyperion Lantern project', () => {
     const project = ctx.projectParameters.hyperionLantern;
     expect(project).toBeDefined();
     expect(project.duration).toBe(300000);
-    expect(project.cost.colony.components).toBe(1e9);
-    expect(project.cost.colony.electronics).toBe(1e9);
-    expect(project.cost.colony.metal).toBe(1e9);
-    expect(project.cost.colony.glass).toBe(1e9);
-    expect(project.attributes.investmentCost.colony.components).toBe(1e9);
-    expect(project.attributes.investmentCost.colony.electronics).toBe(1e9);
+    expect(project.cost.colony.components).toBe(1e6);
+    expect(project.cost.colony.electronics).toBe(1e6);
+    expect(project.cost.colony.metal).toBe(1e6);
+    expect(project.cost.colony.glass).toBe(1e6);
+    expect(project.attributes.investmentCost.colony.components).toBe(1e6);
+    expect(project.attributes.investmentCost.colony.electronics).toBe(1e6);
     expect(project.attributes.powerPerInvestment).toBe(1e15);
   });
 });


### PR DESCRIPTION
## Summary
- slash Hyperion Lantern cost and investment cost by 1000x
- reposition its active toggles below the capacity display
- update tests for new pricing
- add UI order test verifying new layout
- show glass investment cost and color button red when unaffordable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68618e6a8d988327bf172789e0db709a