### PR TITLE
Scale lantern effect with building productivity

### DIFF
--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1045,7 +1045,8 @@ class Terraforming extends EffectableEntity{
     calculateLanternFlux(){
       const lantern = (typeof buildings !== 'undefined') ? buildings['hyperionLantern'] : null;
       if(lantern && lantern.active > 0){
-        const power = (lantern.powerPerBuilding || 0) * lantern.active;
+        const productivity = typeof lantern.productivity === 'number' ? lantern.productivity : 1;
+        const power = (lantern.powerPerBuilding || 0) * lantern.active * productivity;
         const area = this.celestialParameters.crossSectionArea || this.celestialParameters.surfaceArea;
         return power / area;
       }

--- a/tests/lanternFlux.test.js
+++ b/tests/lanternFlux.test.js
@@ -10,10 +10,17 @@ Terraforming.prototype.updateLuminosity = function(){};
 Terraforming.prototype.updateSurfaceTemperature = function(){};
 
 describe('Hyperion Lantern flux calculation', () => {
-  test('uses cross section area', () => {
+  test('uses cross section area when productivity unspecified', () => {
     const terra = new Terraforming({}, { radius: 1 });
     global.buildings = { hyperionLantern: { active: 1, powerPerBuilding: 100 } };
     const expected = 100 / (Math.PI * 1000 * 1000);
+    expect(terra.calculateLanternFlux()).toBeCloseTo(expected, 5);
+  });
+
+  test('scales with productivity', () => {
+    const terra = new Terraforming({}, { radius: 1 });
+    global.buildings = { hyperionLantern: { active: 2, powerPerBuilding: 100, productivity: 0.5 } };
+    const expected = 100 * 2 * 0.5 / (Math.PI * 1000 * 1000);
     expect(terra.calculateLanternFlux()).toBeCloseTo(expected, 5);
   });
 });


### PR DESCRIPTION
## Summary
- scale Hyperion Lantern luminosity by current productivity in `calculateLanternFlux`
- verify lantern flux multiplier defaults to `1` when productivity isn't specified and scales otherwise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68619961ca608327896f5691b3827df0