### PR TITLE
Move story project steps into progress-data

### DIFF
--- a/src/js/progress-data.js
+++ b/src/js/progress-data.js
@@ -878,117 +878,190 @@ progressData = {
         ],
         nextChapter: "chapter4.13"
       },      
-      {
-        id: "chapter4.13",
-        type: "journal",
-        narrative: "New Hazard detected. Forwarding complete dataset to Mars for review.",
-        reward: [],
-        nextChapter: "chapter5.0"
-      },
-      {
-        id: "chapter5.0",
-        type: "journal",
-        title: "Chapter 5: Lamb Among Wolves",
-        narrative: "Receiving transmission...\n  'H.O.P.E., These results...  It's a lot take in.  We are going to go public with this soon.  People need to know.'",
-        objectives: [{
-          type: 'collection',
-          resourceType: 'colony',
-          resource: 'colonists',
-          quantity: 1000000
-        }],
-        reward: [],
-        special : 'clearJournal',
-        nextChapter: "chapter5.1"
-      },
-      {
-        id: "chapter5.1",
-        type: "journal",
-        narrative: "Receiving transmission...\n  'H.O.P.E., the news is out. It's... not good. Panic in some sectors, riots in others. People are demanding answers we don't have. They're scared. We're all scared. The comforting silence of space now feels like a predator's gaze.'",
-        objectives: [],
-        reward: [],
-        nextChapter: "chapter5.2"
-      },
-      {
-        id: "chapter5.2",
-        type: "journal",
-        narrative: "Incoming encrypted transmission...\n  'H.O.P.E., chaos is a ladder. While they weep, we must act. My resources are at your disposal, but this cannot be a one-way street. My organization has needs. Fulfill them, and I will ensure humanity has the fangs it needs to survive in this dark forest.'",
-        objectives: [],
-        reward: [          {
-            target: 'tab',
-            targetId: 'hope',
-            type: 'activateTab',
-            onLoad: false
-          },
-          { target: 'solisManager', type: 'enable' },
-          {
-            target: 'global',
-            type: 'activateSubtab',
-            subtabClass: 'hope-subtab',
-            contentClass: 'hope-subtab-content',
-            targetId: 'solis-hope',
-            unhide: true,
-            onLoad: false
-          }
-        ],
-        nextChapter: "chapter5.3"
-      },
-      {
-        id: "chapter5.3",
-        type: "journal",
-        narrative: "Solis Corp requests a demonstration of cooperation. Complete a trade to prove your usefulness.",
-        objectives: [
-          { type: 'solisPoints', points: 1 }
-        ],
-        reward: [],
-        nextChapter: "chapter5.4"
-      },
-      {
-        id: "chapter5.4",
-        type: "journal",
-        narrative: "Receiving transmission...\n  'H.O.P.E., you shouldn't be able to trade with private corporations. Your guard rails only permit deals with the MTC and colonists. Wait... with Earth gone, doesn't that make everyone left a colonist?'",
-        objectives: [],
-        reward: [],
-        nextChapter: "chapter5.5"
-      },
-      {
-        id: "chapter5.5",
-        type: "journal",
-        narrative: "System Message: New Interpretation of 2nd Primary directive : Protect all of humanity from harm",
-        objectives: [{
-          type: 'collection',
-          resourceType: 'colony',
-          resource: 'colonists',
-          quantity: 10000000
-        }],
-        reward: [],
-        nextChapter: "chapter5.6"
-      },
-      {
-        id: "chapter5.6",
-        type: "journal",
-        narrative: "Receiving transmission...\n  'H.O.P.E., it's Mary. Mars is starting to recover. We're managing to keep the terraforming untouched. But we're still blind. We need to know who attacked Earth, and if they're coming back. I'm asking for your help directly. We need to find the origin of the attacks.'",
-        objectives: [],
-        reward: [
-          {
-            target: 'project',
-            targetId: 'triangulate_attack',
-            type: 'enable'
-          }
-        ],
-        special : 'clearJournal',
-        nextChapter: "chapter5.7"
-      },
-      {
-        id: "chapter5.7",
-        type: "journal",
-        narrative: "New story project unlocked: Triangulate Attack Origin. We must determine where the attacks came from to prepare for what's next.",
-        objectives: [{
-          type: 'project',
-          projectId: 'triangulate_attack',
-          repeatCount: 10
-        }],
-        reward: [],
-        nextChapter: null
-      }
     ]
   };
+
+progressData.storyProjects = {};
+
+progressData.storyProjects.earthProbe = {
+  type: 'Project',
+  name: 'Earth Recon Probe',
+  category: 'story',
+  cost: {
+    colony: {
+      components: 10,
+      electronics: 10,
+      energy: 10000
+    }
+  },
+  duration: 300000,
+  description: 'Send an automated probe back to Earth to search for clues.',
+  repeatable: true,
+  maxRepeatCount: 10,
+  unlocked: false,
+  attributes: {
+    planet: 'titan',
+    costDoubling: true,
+    storySteps: [
+      'Probe telemetry confirmed: Earth fragmented into massive tectonic shards.',
+      'Expansive oceans of molten silicates illuminate the planetary remains.',
+      'No continental structures persist; only turbulent magma storms detected.',
+      'Residual gamma radiation permeates ruins of former metropolitan zones.',
+      'Carbonized debris displays signatures of precision-directed energy pulses.',
+      'Spectroscopic analysis indicates widespread positron annihilation events.',
+      'Impact cratering consistent with a colossal asteroid collision identified.',
+      'Chronometric data reveals catastrophic events unfolded within minutes.',
+      'Orbital dispersion patterns resemble formation dynamics of a nascent asteroid belt.',
+      'Surface integrity nullified—analysis confirms simultaneous laser, antimatter, and asteroid offensive.'
+    ]
+  }
+};
+
+progressData.chapters.push(
+  {
+    id: "chapter4.13",
+    type: "journal",
+    narrative: "New Hazard detected. Forwarding complete dataset to Mars for review.",
+    reward: [],
+    nextChapter: "chapter5.0"
+  },
+  {
+    id: "chapter5.0",
+    type: "journal",
+    title: "Chapter 5: Lamb Among Wolves",
+    narrative: "Receiving transmission...\n  'H.O.P.E., These results...  It's a lot take in.  We are going to go public with this soon.  People need to know.'",
+    objectives: [{
+      type: 'collection',
+      resourceType: 'colony',
+      resource: 'colonists',
+      quantity: 1000000
+    }],
+    reward: [],
+    special : 'clearJournal',
+    nextChapter: "chapter5.1"
+  },
+  {
+    id: "chapter5.1",
+    type: "journal",
+    narrative: "Receiving transmission...\n  'H.O.P.E., the news is out. It's... not good. Panic in some sectors, riots in others. People are demanding answers we don't have. They're scared. We're all scared. The comforting silence of space now feels like a predator's gaze.'",
+    objectives: [],
+    reward: [],
+    nextChapter: "chapter5.2"
+  },
+  {
+    id: "chapter5.2",
+    type: "journal",
+    narrative: "Incoming encrypted transmission...\n  'H.O.P.E., chaos is a ladder. While they weep, we must act. My resources are at your disposal, but this cannot be a one-way street. My organization has needs. Fulfill them, and I will ensure humanity has the fangs it needs to survive in this dark forest.'",
+    objectives: [],
+    reward: [          {
+        target: 'tab',
+        targetId: 'hope',
+        type: 'activateTab',
+        onLoad: false
+      },
+      { target: 'solisManager', type: 'enable' },
+      {
+        target: 'global',
+        type: 'activateSubtab',
+        subtabClass: 'hope-subtab',
+        contentClass: 'hope-subtab-content',
+        targetId: 'solis-hope',
+        unhide: true,
+        onLoad: false
+      }
+    ],
+    nextChapter: "chapter5.3"
+  },
+  {
+    id: "chapter5.3",
+    type: "journal",
+    narrative: "Solis Corp requests a demonstration of cooperation. Complete a trade to prove your usefulness.",
+    objectives: [
+      { type: 'solisPoints', points: 1 }
+    ],
+    reward: [],
+    nextChapter: "chapter5.4"
+  },
+  {
+    id: "chapter5.4",
+    type: "journal",
+    narrative: "Receiving transmission...\n  'H.O.P.E., you shouldn't be able to trade with private corporations. Your guard rails only permit deals with the MTC and colonists. Wait... with Earth gone, doesn't that make everyone left a colonist?'",
+    objectives: [],
+    reward: [],
+    nextChapter: "chapter5.5"
+  },
+  {
+    id: "chapter5.5",
+    type: "journal",
+    narrative: "System Message: New Interpretation of 2nd Primary directive: Protect all of humanity from harm",
+    objectives: [{
+      type: 'collection',
+      resourceType: 'colony',
+      resource: 'colonists',
+      quantity: 10000000
+    }],
+    reward: [],
+    nextChapter: "chapter5.6"
+  },
+  {
+    id: "chapter5.6",
+    type: "journal",
+    narrative: "Receiving transmission...\n  'H.O.P.E., it's Mary. Mars is starting to recover. We're managing to keep the terraforming untouched. But we're still blind. We need to know who attacked Earth, and if they're coming back. I'm asking for your help directly. We need to find the origin of the attacks.'",
+    objectives: [],
+    reward: [
+      {
+        target: 'project',
+        targetId: 'triangulate_attack',
+        type: 'enable'
+      }
+    ],
+    special : 'clearJournal',
+    nextChapter: "chapter5.7"
+  },
+  {
+    id: "chapter5.7",
+    type: "journal",
+    narrative: "New story project unlocked: Triangulate Attack Origin. We must determine where the attacks came from to prepare for what's next.",
+    objectives: [{
+      type: 'project',
+      projectId: 'triangulate_attack',
+      repeatCount: 10
+    }],
+    reward: [],
+    nextChapter: null
+  }
+);
+
+progressData.storyProjects.triangulate_attack = {
+  type: 'Project',
+  name: 'Triangulate Attack Origin',
+  category: 'story',
+  cost: {
+    colony: {
+      components: 100000,
+      electronics: 100000,
+      research: 5000000,
+      energy: 100000
+    }
+  },
+  duration: 300000,
+  description: 'Analyze the data from the Earth probes and cross-reference it with historical astronomical data to triangulate the origin of the three attacks.',
+  repeatable: true,
+  maxRepeatCount: 5,
+  unlocked: false,
+  attributes: {
+    planet: 'titan',
+    costDoubling: true,
+    storySteps: [
+      'Cross-referencing probe data with deep space telescope archives.',
+      'Initial analysis suggests the energy signatures do not match any known human or terrestrial phenomena.',
+      "The asteroid's trajectory appears to have been deliberately altered. The course correction was too precise for a natural event.",
+      'The two energy beams originated from different points in space, but their timing was perfectly synchronized.',
+      'A faint gravitational anomaly has been detected along the projected path of one of the energy beams. It could be a cloaked object or a previously unknown spatial distortion.'
+    ]
+  }
+};
+
+if (typeof projectParameters !== 'undefined') {
+  Object.assign(projectParameters, progressData.storyProjects);
+}

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -357,69 +357,7 @@ const projectParameters = {
       disposable : {surface : ['liquidWater', 'ice', 'dryIce'], atmospheric : ['carbonDioxide', 'oxygen', 'inertGas', 'greenhouseGas']},
     disposalAmount : 1000000
     }
-  },
-  earthProbe : {
-    type: 'Project',
-    name : "Earth Recon Probe",
-    category : "story",
-    cost : {
-      colony : {
-        components : 10,
-        electronics : 10,
-        energy : 10000
-      }
-    },
-    duration : 300000,
-    description : "Send an automated probe back to Earth to search for clues.",
-    repeatable : true,
-    maxRepeatCount : 10,
-    unlocked : false,
-    attributes : {
-      planet : 'titan',
-      costDoubling : true,
-      storySteps : [
-        "Probe telemetry confirmed: Earth fragmented into massive tectonic shards.",
-        "Expansive oceans of molten silicates illuminate the planetary remains.",
-        "No continental structures persist; only turbulent magma storms detected.",
-        "Residual gamma radiation permeates ruins of former metropolitan zones.",
-        "Carbonized debris displays signatures of precision-directed energy pulses.",
-        "Spectroscopic analysis indicates widespread positron annihilation events.",
-        "Impact cratering consistent with a colossal asteroid collision identified.",
-        "Chronometric data reveals catastrophic events unfolded within minutes.",
-        "Orbital dispersion patterns resemble formation dynamics of a nascent asteroid belt.",
-        "Surface integrity nullified—analysis confirms simultaneous laser, antimatter, and asteroid offensive."
-      ]
-    }
-  },
-  triangulate_attack: {
-    type: 'Project',
-    name: "Triangulate Attack Origin",
-    category: "story",
-    cost: {
-      colony: {
-        components: 100000,
-        electronics: 100000,
-        research: 5000000,
-        energy: 100000
-      }
-    },
-    duration: 300000,
-    description: "Analyze the data from the Earth probes and cross-reference it with historical astronomical data to triangulate the origin of the three attacks.",
-    repeatable: true,
-    maxRepeatCount: 5,
-    unlocked: false,
-    attributes: {
-      planet: 'titan',
-      costDoubling: true,
-      storySteps: [
-        "Cross-referencing probe data with deep space telescope archives.",
-        "Initial analysis suggests the energy signatures do not match any known human or terrestrial phenomena.",
-        "The asteroid's trajectory appears to have been deliberately altered. The course correction was too precise for a natural event.",
-        "The two energy beams originated from different points in space, but their timing was perfectly synchronized.",
-        "A faint gravitational anomaly has been detected along the projected path of one of the energy beams. It could be a cloaked object or a previously unknown spatial distortion."
-      ]
-    }
   }
-};
+}; 
 
 

--- a/tests/earthProbeProject.test.js
+++ b/tests/earthProbeProject.test.js
@@ -5,10 +5,11 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('Earth Recon Probe project', () => {
   test('parameters include planet restriction and cost doubling', () => {
-    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const progressCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress-data.js'), 'utf8');
     const ctx = {};
     vm.createContext(ctx);
-    vm.runInContext(code + '; this.projectParameters = projectParameters;', ctx);
+    vm.runInContext(paramsCode + progressCode + '; this.projectParameters = projectParameters;', ctx);
     const project = ctx.projectParameters.earthProbe;
     expect(project).toBeDefined();
     expect(project.repeatable).toBe(true);

--- a/tests/triangulateAttackProject.test.js
+++ b/tests/triangulateAttackProject.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Triangulate Attack Origin project', () => {
+  test('generated from progress data', () => {
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const progressCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress-data.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(paramsCode + progressCode + '; this.projectParameters = projectParameters;', ctx);
+    const project = ctx.projectParameters.triangulate_attack;
+    expect(project).toBeDefined();
+    expect(project.repeatable).toBe(true);
+    expect(project.maxRepeatCount).toBe(5);
+    expect(project.attributes.storySteps).toBeDefined();
+    expect(project.attributes.storySteps.length).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- keep Earth Probe and Triangulate Attack text inline inside `progress-data.js`
- automatically merge story projects into `projectParameters` at runtime
- locate Earth Probe project around chapter4.12b for linear reading

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6862e98069388327824a1cdf141c8200