### PR TITLE
Fix Solis quest cost display

### DIFF
--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -151,7 +151,9 @@ function updateSolisUI() {
   const quest = solisManager.currentQuest;
   if (questText) {
     if (quest) {
-      questText.innerHTML = `Deliver <span class="solis-quest-quantity">${quest.quantity}</span> units of <span class="solis-quest-resource">${quest.resource}</span>`;
+      const format = typeof formatNumber === 'function' ? formatNumber : (n => n);
+      const qty = format(quest.quantity, true);
+      questText.innerHTML = `Deliver <span class="solis-quest-quantity">${qty}</span> units of <span class="solis-quest-resource">${quest.resource}</span>`;
     } else {
       questText.textContent = 'No new quest available at this time.';
     }

--- a/tests/solisQuestCostDisplay.test.js
+++ b/tests/solisQuestCostDisplay.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis quest cost display', () => {
+  test('formats quest quantity with formatNumber', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="solis-quest-text"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.solisManager = new SolisManager();
+    ctx.solisManager.currentQuest = { resource: 'metal', quantity: 1500 };
+    ctx.resources = { colony: { metal: { value: 2000 } } };
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'solisUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+
+    ctx.updateSolisUI();
+
+    const html = dom.window.document.getElementById('solis-quest-text').innerHTML;
+    expect(html).toContain(numbers.formatNumber(1500, true));
+  });
+});


### PR DESCRIPTION
## Summary
- format Solis quest quantity using `formatNumber`
- add regression test for formatted quest quantity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68631352d25c8327b5054d74745bec2b