### PR TITLE
Improve autobuild cost tooltip

### DIFF
--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -319,9 +319,21 @@ function updateResourceRateDisplay(resource){
     }
 
     if (typeof autobuildCostTracker !== 'undefined') {
-      const cost = autobuildCostTracker.getLastSecondCost(resource.category, resource.name);
-      if (cost > 0) {
-        tooltipContent += `<br><strong>Autobuild Cost (last 1s):</strong> ${formatNumber(cost, false, 2)}${resource.unit ? ' ' + resource.unit : ''}`;
+      const avgCost = autobuildCostTracker.getAverageCost(resource.category, resource.name);
+      if (avgCost > 0) {
+        tooltipContent += `<br><strong>Autobuild Cost (avg 10s):</strong> ${formatNumber(avgCost, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s`;
+        const breakdown = autobuildCostTracker.getAverageCostBreakdown(resource.category, resource.name);
+        if (breakdown.length > 0) {
+          tooltipContent += '<div style="display: table; width: 100%;">';
+          breakdown.forEach(([building, cost]) => {
+            tooltipContent += `
+          <div style="display: table-row;">
+            <div style="display: table-cell; text-align: left; padding-right: 10px;">${building}</div>
+            <div style="display: table-cell; text-align: right;">${formatNumber(cost, false, 2)}/s</div>
+          </div>`;
+          });
+          tooltipContent += '</div>';
+        }
       }
     }
 

--- a/tests/resourceTooltipAutobuildCost.test.js
+++ b/tests/resourceTooltipAutobuildCost.test.js
@@ -7,7 +7,7 @@ const vm = require('vm');
 const numbers = require('../src/js/numbers.js');
 
 describe('resource tooltip autobuild cost', () => {
-  test('shows last second autobuild cost', () => {
+  test('shows averaged autobuild cost with breakdown', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
@@ -35,7 +35,7 @@ describe('resource tooltip autobuild cost', () => {
     };
 
     ctx.createResourceDisplay({ colony: { metal: resource } });
-    ctx.autobuildCostTracker.recordCost({ colony: { metal: 5 } });
+    ctx.autobuildCostTracker.recordCost('Habitat', { colony: { metal: 5 } });
     ctx.autobuildCostTracker.update(1000);
 
     ctx.updateResourceRateDisplay(resource);
@@ -43,5 +43,6 @@ describe('resource tooltip autobuild cost', () => {
     const html = dom.window.document.getElementById('metal-tooltip').innerHTML;
     expect(html).toContain('Autobuild Cost');
     expect(html).toContain(numbers.formatNumber(5, false, 2));
+    expect(html).toContain('Habitat');
   });
 });


### PR DESCRIPTION
## Summary
- track autobuild costs over a 10 second window with per-building detail
- surface the averaged cost and a breakdown in the resource tooltip
- update tests for new tooltip format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863165a17308327bc2c64082dbf098e