### PR TITLE
Adjust lifeDesigner point costs

### DIFF
--- a/src/js/life.js
+++ b/src/js/life.js
@@ -10,7 +10,7 @@ const baseTemperatureRanges = {
 };
 
 const lifeDesignerConfig = {
-  maxPoints : 50
+  maxPoints : 0
 }
 
 const BASE_MAX_BIOMASS_DENSITY = 0.1; // Base max biomass in tons per m^2
@@ -343,8 +343,8 @@ class LifeDesigner extends EffectableEntity {
     this.totalTime = this.getTentativeDuration();
     this.elapsedTime = 0;
 
-    this.basePointCost = 1000;
-    this.pointCostMultiplier = 10;
+    this.basePointCost = 100;
+    this.pointCostMultiplier = 2;
 
     this.purchaseCounts = {
       research: 0,

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -266,7 +266,8 @@ function initializeLifeTerraformingDesignerUI() {
       
         // Add button
         const button = document.createElement('button');
-        button.textContent = `Buy with ${category.name} Point`;
+        const initialCost = lifeDesigner.getPointCost(category.name);
+        button.textContent = `Buy with ${category.name} (${formatNumber(initialCost, true)})`;
         button.dataset.category = category.name;
         button.classList.add('life-point-shop-btn');
         categoryContainer.appendChild(button);

--- a/tests/lifeDesignPointBonus.test.js
+++ b/tests/lifeDesignPointBonus.test.js
@@ -39,16 +39,16 @@ describe('lifeDesignPointBonus effect', () => {
 
   test('adds bonus points to maxLifeDesignPoints', () => {
     const designer = context.lifeDesigner;
-    expect(designer.maxLifeDesignPoints()).toBe(50);
+    expect(designer.maxLifeDesignPoints()).toBe(0);
     designer.addAndReplace({ type: 'lifeDesignPointBonus', value: 10, effectId: 'skill', sourceId: 'skill' });
-    expect(designer.maxLifeDesignPoints()).toBe(60);
+    expect(designer.maxLifeDesignPoints()).toBe(10);
   });
 
   test('replacing bonus effect does not stack previous values', () => {
     const designer = context.lifeDesigner;
     designer.addAndReplace({ type: 'lifeDesignPointBonus', value: 10, effectId: 'skill', sourceId: 'skill' });
-    expect(designer.maxLifeDesignPoints()).toBe(60);
+    expect(designer.maxLifeDesignPoints()).toBe(10);
     designer.addAndReplace({ type: 'lifeDesignPointBonus', value: 20, effectId: 'skill', sourceId: 'skill' });
-    expect(designer.maxLifeDesignPoints()).toBe(70);
+    expect(designer.maxLifeDesignPoints()).toBe(20);
   });
 });

--- a/tests/lifePointCostPurchase.test.js
+++ b/tests/lifePointCostPurchase.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('LifeDesigner purchase updates cost', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+
+    ctx.resources = { surface: { biomass: { value: 0 } }, colony: {}, atmospheric: {} };
+    ['research','funding','androids','components','electronics'].forEach(key => {
+      ctx.resources.colony[key] = { value: 1000, decrease(v){ this.value -= v; } };
+    });
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.projectManager = { projects: {} };
+    ctx.populationModule = {};
+    ctx.tabManager = {};
+    ctx.fundingModule = {};
+    ctx.terraforming = { zonalSurface: { tropical:{}, temperate:{}, polar:{} }, zonalWater:{}, celestialParameters:{surfaceArea:1,gravity:1,radius:1}, zonalTemperature:{}, getMagnetosphereStatus:()=>true };
+    ctx.lifeManager = {};
+    ctx.oreScanner = {};
+
+    global.resources = ctx.resources;
+    global.buildings = ctx.buildings;
+    global.colonies = ctx.colonies;
+    global.projectManager = ctx.projectManager;
+    global.populationModule = ctx.populationModule;
+    global.tabManager = ctx.tabManager;
+    global.fundingModule = ctx.fundingModule;
+    global.terraforming = ctx.terraforming;
+    global.lifeManager = ctx.lifeManager;
+    global.oreScanner = ctx.oreScanner;
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    global.lifeDesigner = ctx.lifeDesigner;
+  });
+
+  test('cost doubles after each buy', () => {
+    const designer = ctx.lifeDesigner;
+    expect(designer.getPointCost('research')).toBe(100);
+    designer.buyPoint('research');
+    expect(designer.getPointCost('research')).toBe(200);
+    designer.buyPoint('research');
+    expect(designer.getPointCost('research')).toBe(400);
+  });
+});

--- a/tests/lifePointCostScaling.test.js
+++ b/tests/lifePointCostScaling.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('LifeDesigner point cost scaling', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+
+    ctx.resources = { surface: { biomass: { value: 0 } }, colony: {}, atmospheric: {} };
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.projectManager = { projects: {} };
+    ctx.populationModule = {};
+    ctx.tabManager = {};
+    ctx.fundingModule = {};
+    ctx.terraforming = { zonalSurface: { tropical:{}, temperate:{}, polar:{} }, zonalWater:{}, celestialParameters:{surfaceArea:1,gravity:1,radius:1}, zonalTemperature:{}, getMagnetosphereStatus:()=>true };
+    ctx.lifeManager = {};
+    ctx.oreScanner = {};
+
+    global.resources = ctx.resources;
+    global.buildings = ctx.buildings;
+    global.colonies = ctx.colonies;
+    global.projectManager = ctx.projectManager;
+    global.populationModule = ctx.populationModule;
+    global.tabManager = ctx.tabManager;
+    global.fundingModule = ctx.fundingModule;
+    global.terraforming = ctx.terraforming;
+    global.lifeManager = ctx.lifeManager;
+    global.oreScanner = ctx.oreScanner;
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    global.lifeDesigner = ctx.lifeDesigner;
+  });
+
+  test('cost starts at 100 and doubles with each purchase', () => {
+    const designer = ctx.lifeDesigner;
+    expect(designer.getPointCost('research')).toBe(100);
+    designer.purchaseCounts.research = 1;
+    expect(designer.getPointCost('research')).toBe(200);
+    designer.purchaseCounts.research = 2;
+    expect(designer.getPointCost('research')).toBe(400);
+  });
+});
+


### PR DESCRIPTION
## Summary
- initialize LifeDesigner with 0 base points
- reduce point shop base cost and use exponential doubling
- show formatted cost in Life UI when creating buttons
- update LifeDesignPointBonus test expectations
- make the base life point cost 100 and test cost scaling
- test LifeDesigner cost update on purchases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686334b364208327825ed3036d1bd15c