### PR TITLE
Format large building counts

### DIFF
--- a/src/js/numbers.js
+++ b/src/js/numbers.js
@@ -57,10 +57,18 @@ function getTemperatureUnit() {
     return parts.join(' ');
   }
 
+function formatBuildingCount(value) {
+  if (Math.abs(value) > 1e6) {
+    return formatNumber(value, false, 3);
+  }
+  return formatBigInteger(value);
+}
+
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
       formatNumber,
       formatBigInteger,
+      formatBuildingCount,
       toDisplayTemperature,
       getTemperatureUnit,
       formatPlayTime,

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -175,11 +175,11 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
   if (structure.canBeToggled) {
     constructedCountElement.innerHTML = `
-      <strong>Constructed:</strong> <span id="${structure.name}-count-active">${structure.active}/${structure.count}</span>
+      <strong>Constructed:</strong> <span id="${structure.name}-count-active">${formatBuildingCount(structure.active)}/${formatBuildingCount(structure.count)}</span>
     `;
   } else {
     constructedCountElement.innerHTML = `
-      <strong>Constructed:</strong> <span id="${structure.name}-count">${structure.count}</span>
+      <strong>Constructed:</strong> <span id="${structure.name}-count">${formatBuildingCount(structure.count)}</span>
     `;
   }
 
@@ -513,9 +513,9 @@ function updateDecreaseButtonText(button, buildCount) {
       }
   
       if (countElement) {
-        countElement.textContent = structure.count;
+        countElement.textContent = formatBuildingCount(structure.count);
       } else if (countActiveElement) {
-        countActiveElement.textContent = `${formatBigInteger(structure.active)}/${formatBigInteger(structure.count)}`;
+        countActiveElement.textContent = `${formatBuildingCount(structure.active)}/${formatBuildingCount(structure.count)}`;
       }
 
       if (buildDisplay) {

--- a/tests/numbers.test.js
+++ b/tests/numbers.test.js
@@ -1,4 +1,4 @@
-const { formatNumber, formatBigInteger, formatPlayTime } = require('../src/js/numbers.js');
+const { formatNumber, formatBigInteger, formatBuildingCount, formatPlayTime } = require('../src/js/numbers.js');
 
 describe('formatNumber', () => {
   test('formats thousands with suffix k', () => {
@@ -13,6 +13,16 @@ describe('formatNumber', () => {
 describe('formatBigInteger', () => {
   test('adds commas', () => {
     expect(formatBigInteger(1234567)).toBe('1,234,567');
+  });
+});
+
+describe('formatBuildingCount', () => {
+  test('uses comma formatting below a million', () => {
+    expect(formatBuildingCount(500000)).toBe('500,000');
+  });
+
+  test('uses abbreviated format above a million', () => {
+    expect(formatBuildingCount(2500000)).toBe('2.500M');
   });
 });
 

--- a/tests/toggleButtonLoad.test.js
+++ b/tests/toggleButtonLoad.test.js
@@ -12,6 +12,7 @@ describe('toggle button count after load', () => {
     // minimal stubs required by structuresUI.js
     ctx.formatNumber = n => n;
     ctx.formatBigInteger = n => String(n);
+    ctx.formatBuildingCount = n => String(n);
     ctx.multiplyByTen = n => n * 10;
     ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
     ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0 } } };


### PR DESCRIPTION
## Summary
- add `formatBuildingCount` helper for building display
- show formatted counts in `structuresUI.js`
- update tests for new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863cbe217ec8327b62c0df31c2fa87a