### PR TITLE
Rebuild journal from story data

### DIFF
--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -564,9 +564,9 @@ class StoryEvent {
                 break;
             case "journal":
                  if (this.title) {
-                    addJournalEntry(`${this.title}:\n${this.narrative}`, this.id); // Combine if title exists
+                    addJournalEntry(`${this.title}:\n${this.narrative}`, this.id, { type: 'chapter', id: this.id });
                  } else {
-                    addJournalEntry(this.narrative, this.id);
+                    addJournalEntry(this.narrative, this.id, { type: 'chapter', id: this.id });
                  }
                 break;
             default:

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -186,7 +186,7 @@ class Project extends EffectableEntity {
       const stepIndex = this.repeatCount - 1;
       const step = this.attributes.storySteps[stepIndex];
       if (step && typeof addJournalEntry === 'function' && !this.shownStorySteps.has(stepIndex)) {
-        addJournalEntry(step);
+        addJournalEntry(step, null, { type: 'project', id: this.name, step: stepIndex });
         this.shownStorySteps.add(stepIndex);
       }
     }

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -11,8 +11,8 @@ function getGameState() {
     oreScanning: oreScanner.saveState(),
     terraforming: terraforming.saveState(),
     story: storyManager.saveState(),
-    journalEntries: journalEntriesData,
-    journalHistory: journalHistoryData,
+    journalEntrySources: journalEntrySources,
+    journalHistorySources: journalHistorySources,
     goldenAsteroid: goldenAsteroid.saveState(),
     solisManager: solisManager.saveState(),
     lifeDesigner: lifeDesigner.saveState(),
@@ -157,9 +157,14 @@ function loadGame(slotOrCustomString) {
       terraforming.loadState(gameState.terraforming);
     }
 
-      if (gameState.journalEntries) {
+      if (gameState.journalEntrySources) {
+        const entries = mapSourcesToText(gameState.journalEntrySources);
+        const historySources = gameState.journalHistorySources || gameState.journalEntrySources;
+        const history = mapSourcesToText(historySources);
+        loadJournalEntries(entries, history, gameState.journalEntrySources, historySources);
+      } else if (gameState.journalEntries) {
         const history = gameState.journalHistory || gameState.journalEntries;
-        loadJournalEntries(gameState.journalEntries, history); // Restore journal
+        loadJournalEntries(gameState.journalEntries, history);
       }
 
       // Restore research progress

--- a/tests/journalReconstruction.test.js
+++ b/tests/journalReconstruction.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('journal reconstruction from sources', () => {
+  test('mapSourcesToText returns updated text', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.progressData = {
+      chapters: [ { id: 'c1', type: 'journal', narrative: 'alpha' } ],
+      storyProjects: { p1: { attributes: { storySteps: ['step1'] } } }
+    };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    const res = ctx.mapSourcesToText([{type:'chapter', id:'c1'}, {type:'project', id:'p1', step:0}]);
+    expect(res).toEqual(['alpha', 'step1']);
+  });
+});

--- a/tests/jumpToChapter.test.js
+++ b/tests/jumpToChapter.test.js
@@ -39,7 +39,7 @@ describe('StoryManager jumpToChapter', () => {
 
     expect(Array.from(manager.completedEventIds)).toEqual(['c1']);
     expect(manager.activeEventIds.has('c2')).toBe(true);
-    expect(context.addJournalEntry).toHaveBeenCalledWith('two', 'c2');
+    expect(context.addJournalEntry).toHaveBeenCalledWith('two', 'c2', { type: 'chapter', id: 'c2' });
     expect(context.addEffect).toHaveBeenCalledWith({ target: 'global', type: 'dummy' });
   });
 });


### PR DESCRIPTION
## Summary
- store journal entry sources instead of text
- track journal sources when adding entries
- reconstruct journal text on load using progress data
- update project and story event handlers to pass entry info
- add regression tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863df227d5c8327bf7caf2a83193363