### PR TITLE
Add journal reconstruction helper

### DIFF
--- a/tests/reconstructJournalState.test.js
+++ b/tests/reconstructJournalState.test.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const debugTools = require('../src/js/debug-tools.js');
+
+describe('reconstructJournalState', () => {
+  test('rebuilds journal with project steps', () => {
+    const data = {
+      chapters: [
+        { id: 'c1', type: 'journal', narrative: 'intro' },
+        { id: 'c2', type: 'journal', narrative: 'quest', objectives: [{ type: 'project', projectId: 'p1', repeatCount: 3 }] }
+      ],
+      storyProjects: { p1: { attributes: { storySteps: ['s1','s2','s3'] } } }
+    };
+    const sm = { completedEventIds: new Set(['c1','c2']), activeEventIds: new Set() };
+    const pm = { projects: { p1: { repeatCount: 2 } } };
+    const res = debugTools.reconstructJournalState(sm, pm, data);
+    expect(res.entries).toEqual(['intro','quest','s1','s2']);
+    expect(res.sources).toEqual([
+      { type:'chapter', id:'c1' },
+      { type:'chapter', id:'c2' },
+      { type:'project', id:'p1', step:0 },
+      { type:'project', id:'p1', step:1 }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `reconstructJournalState` debug helper for Story progress
- export the new function for browser and Node usage
- test journal reconstruction logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6863e35d8bac832795d47664e7c59908