### PR TITLE
Add journal reconstruction helper

### DIFF
--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -316,13 +316,57 @@
     Terraforming.prototype.calculateEquilibriumConstants = calculateEquilibriumConstants;
   }
 
+  function reconstructJournalState(sm, pm, data = progressData, updateJournal = true) {
+    const entries = [];
+    const sources = [];
+    if (!sm || !data) return { entries, sources };
+
+    const completed = new Set([
+      ...(sm.completedEventIds instanceof Set ? Array.from(sm.completedEventIds) : sm.completedEventIds || []),
+      ...(sm.activeEventIds instanceof Set ? Array.from(sm.activeEventIds) : sm.activeEventIds || [])
+    ]);
+
+    const projects = pm && pm.projects ? pm.projects : {};
+    const storyProjects = data.storyProjects || {};
+
+    data.chapters.forEach(ch => {
+      if (completed.has(ch.id)) {
+        const text = ch.title ? `${ch.title}:\n${ch.narrative}` : ch.narrative;
+        entries.push(text);
+        sources.push({ type: 'chapter', id: ch.id });
+        if (ch.objectives) {
+          ch.objectives.forEach(obj => {
+            if (obj.type === 'project') {
+              const proj = projects[obj.projectId] || {};
+              const repeat = proj.repeatCount || 0;
+              const steps = storyProjects[obj.projectId]?.attributes?.storySteps || [];
+              const needed = obj.repeatCount || steps.length;
+              const count = Math.min(repeat, needed, steps.length);
+              for (let i = 0; i < count; i++) {
+                entries.push(steps[i]);
+                sources.push({ type: 'project', id: obj.projectId, step: i });
+              }
+            }
+          });
+        }
+      }
+    });
+
+    if (updateJournal && typeof loadJournalEntries === 'function') {
+      loadJournalEntries(entries, null, sources);
+    }
+
+    return { entries, sources };
+  }
+
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { fastForwardToEquilibrium, generateOverrideSnippet, calculateEquilibriumConstants };
+    module.exports = { fastForwardToEquilibrium, generateOverrideSnippet, calculateEquilibriumConstants, reconstructJournalState };
   } else {
     globalThis.fastForwardToEquilibrium = fastForwardToEquilibrium;
     globalThis.generateOverrideSnippet = generateOverrideSnippet;
     if (typeof Terraforming !== 'undefined') {
       globalThis.calculateEquilibriumConstants = calculateEquilibriumConstants;
     }
+    globalThis.reconstructJournalState = reconstructJournalState;
   }
 })();

--- a/tests/reconstructJournalState.test.js
+++ b/tests/reconstructJournalState.test.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const debugTools = require('../src/js/debug-tools.js');
+
+describe('reconstructJournalState', () => {
+  test('rebuilds journal with project steps', () => {
+    const data = {
+      chapters: [
+        { id: 'c1', type: 'journal', narrative: 'intro' },
+        { id: 'c2', type: 'journal', narrative: 'quest', objectives: [{ type: 'project', projectId: 'p1', repeatCount: 3 }] }
+      ],
+      storyProjects: { p1: { attributes: { storySteps: ['s1','s2','s3'] } } }
+    };
+    const sm = { completedEventIds: new Set(['c1','c2']), activeEventIds: new Set() };
+    const pm = { projects: { p1: { repeatCount: 2 } } };
+    const res = debugTools.reconstructJournalState(sm, pm, data);
+    expect(res.entries).toEqual(['intro','quest','s1','s2']);
+    expect(res.sources).toEqual([
+      { type:'chapter', id:'c1' },
+      { type:'chapter', id:'c2' },
+      { type:'project', id:'p1', step:0 },
+      { type:'project', id:'p1', step:1 }
+    ]);
+  });
+});

--- a/tests/reconstructJournalStateLoad.test.js
+++ b/tests/reconstructJournalStateLoad.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('reconstructJournalState UI update', () => {
+  test('loads entries into the journal when available', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const journalCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
+    vm.runInContext(journalCode, ctx);
+    const debugCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'debug-tools.js'), 'utf8');
+    vm.runInContext(debugCode, ctx);
+
+    ctx.progressData = {
+      chapters: [{ id: 'c1', type: 'journal', narrative: 'alpha' }],
+      storyProjects: {}
+    };
+    const sm = { completedEventIds: new Set(['c1']), activeEventIds: new Set() };
+
+    ctx.reconstructJournalState(sm, null);
+
+    const entries = dom.window.document.querySelectorAll('#journal-entries p');
+    expect(entries.length).toBe(1);
+    expect(entries[0].textContent).toBe('alpha');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `reconstructJournalState` debug helper for Story progress
- export the new function for browser and Node usage
- test journal reconstruction logic
- update helper to refresh the journal when called
- add unit test verifying DOM update

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6863e35d8bac832795d47664e7c59908