### PR TITLE
Fix journal reconstruction rules

### DIFF
--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -331,9 +331,15 @@
 
     data.chapters.forEach(ch => {
       if (completed.has(ch.id)) {
+        if (ch.special === 'clearJournal') {
+          entries.length = 0;
+          sources.length = 0;
+        }
         const text = ch.title ? `${ch.title}:\n${ch.narrative}` : ch.narrative;
-        entries.push(text);
-        sources.push({ type: 'chapter', id: ch.id });
+        if (text != null) {
+          entries.push(text);
+          sources.push({ type: 'chapter', id: ch.id });
+        }
         if (ch.objectives) {
           ch.objectives.forEach(obj => {
             if (obj.type === 'project') {
@@ -343,8 +349,11 @@
               const needed = obj.repeatCount || steps.length;
               const count = Math.min(repeat, needed, steps.length);
               for (let i = 0; i < count; i++) {
-                entries.push(steps[i]);
-                sources.push({ type: 'project', id: obj.projectId, step: i });
+                const stepText = steps[i];
+                if (stepText != null) {
+                  entries.push(stepText);
+                  sources.push({ type: 'project', id: obj.projectId, step: i });
+                }
               }
             }
           });

--- a/tests/reconstructJournalStateClear.test.js
+++ b/tests/reconstructJournalStateClear.test.js
@@ -1,0 +1,23 @@
+const debugTools = require('../src/js/debug-tools.js');
+
+describe('reconstructJournalState clearJournal handling', () => {
+  test('skips entries before clearJournal and ignores null steps', () => {
+    const data = {
+      chapters: [
+        { id: 'c1', type: 'journal', narrative: 'first' },
+        { id: 'c2', type: 'journal', narrative: 'reset', special: 'clearJournal' },
+        { id: 'c3', type: 'journal', narrative: 'after', objectives: [ { type: 'project', projectId: 'p1', repeatCount: 2 } ] }
+      ],
+      storyProjects: { p1: { attributes: { storySteps: [null, 'step2'] } } }
+    };
+    const sm = { completedEventIds: new Set(['c1','c2','c3']), activeEventIds: new Set() };
+    const pm = { projects: { p1: { repeatCount: 2 } } };
+    const res = debugTools.reconstructJournalState(sm, pm, data);
+    expect(res.entries).toEqual(['reset','after','step2']);
+    expect(res.sources).toEqual([
+      { type: 'chapter', id: 'c2' },
+      { type: 'chapter', id: 'c3' },
+      { type: 'project', id: 'p1', step: 1 }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- filter out null text when rebuilding the journal
- ignore entries before `clearJournal` specials
- test clearJournal and null handling for reconstruction

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6863e858b6848327b9ff62786536c274