### PR TITLE
Add journal reconstruction fallback

### DIFF
--- a/src/js/save.js
+++ b/src/js/save.js
@@ -167,6 +167,14 @@ function loadGame(slotOrCustomString) {
         loadJournalEntries(gameState.journalEntries, history);
       }
 
+      // If journal ends up blank after loading, rebuild it from story state
+      if (typeof reconstructJournalState === 'function') {
+        const blank = !journalEntriesData || journalEntriesData.every(e => !e || e.trim() === '');
+        if (blank) {
+          reconstructJournalState(storyManager, projectManager);
+        }
+      }
+
       // Restore research progress
       if (gameState.research) {
           researchManager.loadState(gameState.research);

--- a/tests/journalLoadReconstruct.test.js
+++ b/tests/journalLoadReconstruct.test.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('loadGame journal reconstruction fallback', () => {
+  test('rebuilds journal when loaded entries are empty', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = { AUTO: 'AUTO', Game: function(){} };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+    const overrides = `
+      createPopup=()=>{};
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      initializeSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class { activateTab(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext(`
+      var gs = getGameState();
+      gs.story.completedEventIds = ['chapter1'];
+      gs.story.activeEventIds = [];
+      gs.journalEntrySources = [];
+      gs.journalHistorySources = [];
+      var saved = JSON.stringify(gs);
+      loadGame(saved);
+    `, ctx);
+
+    const result = vm.runInContext('journalEntriesData.slice()', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toBe('Loading colony resources interface...');
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild journal from story state when loaded journal is blank
- test that loading an empty journal triggers reconstruction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863fbf0b7dc8327bf40c6db13d3d768