### PR TITLE
Journal navigation arrows and reconstruction module

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
     <script src="src/js/population.js"></script>
     <script src="src/js/pop-up.js"></script>
     <script src="src/js/journal.js"></script>
+    <script src="src/js/journal-reconstruction.js"></script>
     <script src="src/js/progress.js"></script>
     <script src="src/js/physics.js"></script>
     <script src="src/js/hydrology.js"></script>
@@ -129,7 +130,6 @@
       <div id="day-night-progress-bar" class="day-night-progress-bar"></div>
     </div>
     <button id="toggle-journal-button" class="journal-toggle">Hide Journal</button>
-    <button id="show-history-button" class="journal-history">Show History</button>
     <span id="journal-alert" class="journal-alert">!</span>
   </div>
 
@@ -464,7 +464,7 @@
 
     <!-- Journal Section -->
     <div id="journal" class="journal">
-        <h3>Journal</h3>
+        <h3>Journal <span id="journal-prev" class="journal-nav">&#9664;</span><span id="journal-next" class="journal-nav">&#9654;</span></h3>
         <div id="current-objective" class="current-objective"></div>
         <div id="journal-entries">
             <!-- Journal entries will be dynamically inserted here -->

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -157,8 +157,17 @@ body {
     padding: 5px 10px;
 }
 
-.journal-history {
-    padding: 5px 10px;
+
+.journal-nav {
+    cursor: pointer;
+    margin-left: 5px;
+    user-select: none;
+}
+
+.journal-nav.disabled {
+    color: gray;
+    cursor: default;
+    pointer-events: none;
 }
 
 .journal-alert {

--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -8,7 +8,8 @@
       calculateMethaneCondensationRateFactor,
       calculateMethaneEvaporationRate,
       getZonePercentage,
-      getZoneRatio;
+      getZoneRatio,
+      reconstructJournalState;
   if (isNode) {
     const utils = require('./terraforming-utils.js');
     calculateEvaporationSublimationRates = utils.calculateEvaporationSublimationRates;
@@ -26,6 +27,8 @@
     getZonePercentage = zonesMod.getZonePercentage;
     getZoneRatio = zonesMod.getZoneRatio;
     globalThis.ZONES = zonesMod.ZONES;
+
+    reconstructJournalState = require('./journal-reconstruction.js');
   } else {
     calculateEvaporationSublimationRates = globalThis.calculateEvaporationSublimationRates;
     calculatePrecipitationRateFactor = globalThis.calculatePrecipitationRateFactor;
@@ -35,6 +38,7 @@
     calculateMethaneEvaporationRate = globalThis.calculateMethaneEvaporationRate;
     getZonePercentage = globalThis.getZonePercentage;
     getZoneRatio = globalThis.getZoneRatio;
+    reconstructJournalState = globalThis.reconstructJournalState;
   }
   function captureValues() {
     const globalVals = {
@@ -316,59 +320,6 @@
     Terraforming.prototype.calculateEquilibriumConstants = calculateEquilibriumConstants;
   }
 
-  function reconstructJournalState(sm, pm, data = progressData, updateJournal = true) {
-    const entries = [];
-    const sources = [];
-    if (!sm || !data) return { entries, sources };
-
-    const completed = new Set([
-      ...(sm.completedEventIds instanceof Set ? Array.from(sm.completedEventIds) : sm.completedEventIds || []),
-      ...(sm.activeEventIds instanceof Set ? Array.from(sm.activeEventIds) : sm.activeEventIds || [])
-    ]);
-
-    const projects = pm && pm.projects ? pm.projects : {};
-    const storyProjects = data.storyProjects || {};
-
-    let currentChapter = null;
-    data.chapters.forEach(ch => {
-      if (completed.has(ch.id)) {
-        if (currentChapter === null || ch.chapter !== currentChapter) {
-          currentChapter = ch.chapter;
-          entries.length = 0;
-          sources.length = 0;
-        }
-        const text = ch.title ? `${ch.title}:\n${ch.narrative}` : ch.narrative;
-        if (text != null) {
-          entries.push(text);
-          sources.push({ type: 'chapter', id: ch.id });
-        }
-        if (ch.objectives) {
-          ch.objectives.forEach(obj => {
-            if (obj.type === 'project') {
-              const proj = projects[obj.projectId] || {};
-              const repeat = proj.repeatCount || 0;
-              const steps = storyProjects[obj.projectId]?.attributes?.storySteps || [];
-              const needed = obj.repeatCount || steps.length;
-              const count = Math.min(repeat, needed, steps.length);
-              for (let i = 0; i < count; i++) {
-                const stepText = steps[i];
-                if (stepText != null) {
-                  entries.push(stepText);
-                  sources.push({ type: 'project', id: obj.projectId, step: i });
-                }
-              }
-            }
-          });
-        }
-      }
-    });
-
-    if (updateJournal && typeof loadJournalEntries === 'function') {
-      loadJournalEntries(entries, null, sources);
-    }
-
-    return { entries, sources };
-  }
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { fastForwardToEquilibrium, generateOverrideSnippet, calculateEquilibriumConstants, reconstructJournalState };

--- a/src/js/journal-reconstruction.js
+++ b/src/js/journal-reconstruction.js
@@ -1,0 +1,61 @@
+(function(){
+  function reconstructJournalState(sm, pm, data = progressData, updateJournal = true) {
+    const entries = [];
+    const sources = [];
+    if (!sm || !data) return { entries, sources };
+
+    const completed = new Set([
+      ...(sm.completedEventIds instanceof Set ? Array.from(sm.completedEventIds) : sm.completedEventIds || []),
+      ...(sm.activeEventIds instanceof Set ? Array.from(sm.activeEventIds) : sm.activeEventIds || [])
+    ]);
+
+    const projects = pm && pm.projects ? pm.projects : {};
+    const storyProjects = data.storyProjects || {};
+
+    let currentChapter = null;
+    data.chapters.forEach(ch => {
+      if (completed.has(ch.id)) {
+        if (currentChapter === null || ch.chapter !== currentChapter) {
+          currentChapter = ch.chapter;
+          entries.length = 0;
+          sources.length = 0;
+        }
+        const text = ch.title ? `${ch.title}:\n${ch.narrative}` : ch.narrative;
+        if (text != null) {
+          entries.push(text);
+          sources.push({ type: 'chapter', id: ch.id });
+        }
+        if (ch.objectives) {
+          ch.objectives.forEach(obj => {
+            if (obj.type === 'project') {
+              const proj = projects[obj.projectId] || {};
+              const repeat = proj.repeatCount || 0;
+              const steps = storyProjects[obj.projectId]?.attributes?.storySteps || [];
+              const needed = obj.repeatCount || steps.length;
+              const count = Math.min(repeat, needed, steps.length);
+              for (let i = 0; i < count; i++) {
+                const stepText = steps[i];
+                if (stepText != null) {
+                  entries.push(stepText);
+                  sources.push({ type: 'project', id: obj.projectId, step: i });
+                }
+              }
+            }
+          });
+        }
+      }
+    });
+
+    if (updateJournal && typeof loadJournalEntries === 'function') {
+      loadJournalEntries(entries, null, sources);
+    }
+
+    return { entries, sources };
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = reconstructJournalState;
+  } else {
+    globalThis.reconstructJournalState = reconstructJournalState;
+  }
+})();

--- a/tests/journalNavigation.test.js
+++ b/tests/journalNavigation.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('journal chapter navigation', () => {
+  test('arrows switch between chapters', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal">
+        <h3>Journal <span id="journal-prev" class="journal-nav">\u25C0</span><span id="journal-next" class="journal-nav">\u25B6</span></h3>
+        <div id="journal-entries"></div>
+      </div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.progressData = {
+      chapters: [
+        { id: 'c1', type: 'journal', chapter: 1, narrative: 'A' },
+        { id: 'c2', type: 'journal', chapter: 2, narrative: 'B' }
+      ]
+    };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+    ctx.loadJournalEntries(['B'], ['A','B'], [{type:'chapter', id:'c2'}], [{type:'chapter', id:'c1'}, {type:'chapter', id:'c2'}]);
+
+    const prev = dom.window.document.getElementById('journal-prev');
+    prev.dispatchEvent(new dom.window.Event('click'));
+    let entries = dom.window.document.querySelectorAll('#journal-entries p');
+    expect(entries.length).toBe(1);
+    expect(entries[0].textContent).toBe('A');
+
+    const next = dom.window.document.getElementById('journal-next');
+    next.dispatchEvent(new dom.window.Event('click'));
+    entries = dom.window.document.querySelectorAll('#journal-entries p');
+    expect(entries.length).toBe(1);
+    expect(entries[0].textContent).toBe('B');
+  });
+});

--- a/tests/reconstructJournalStateLoad.test.js
+++ b/tests/reconstructJournalStateLoad.test.js
@@ -12,6 +12,8 @@ describe('reconstructJournalState UI update', () => {
     const ctx = dom.getInternalVMContext();
     const journalCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
     vm.runInContext(journalCode, ctx);
+    const reconCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal-reconstruction.js'), 'utf8');
+    vm.runInContext(reconCode, ctx);
     const debugCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'debug-tools.js'), 'utf8');
     vm.runInContext(debugCode, ctx);
 


### PR DESCRIPTION
## Summary
- replace the Show History button with prev/next arrows next to the Journal header
- style navigation arrows and disable them when no chapters exist
- update journal logic to handle chapter navigation
- move `reconstructJournalState` into new `journal-reconstruction.js` and export it globally
- adjust debug tools and tests for the new module
- add test for journal chapter navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863ff615a28832798969b219a15cbc2