### PR TITLE
Implement water overflow leakage

### DIFF
--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -318,6 +318,10 @@ function updateResourceRateDisplay(resource){
       tooltipContent += '</div>';
     }
 
+    if (resource.overflowRate && Math.abs(resource.overflowRate) > 0) {
+      tooltipContent += `<br><strong>Overflow:</strong> ${resource.overflowRate >= 0 ? '+' : ''}${formatNumber(resource.overflowRate, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s`;
+    }
+
     if (typeof autobuildCostTracker !== 'undefined') {
       const avgCost = autobuildCostTracker.getAverageCost(resource.category, resource.name);
       if (avgCost > 0) {

--- a/tests/waterLeak.test.js
+++ b/tests/waterLeak.test.js
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { getZonePercentage } = require('../src/js/zones.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('water leaks when colony storage full', () => {
+  function setupTerraforming(tempAbove) {
+    const temps = tempAbove ? { tropical: 280, temperate: 250, polar: 260 } : { tropical: 260, temperate: 250, polar: 260 };
+    return {
+      zonalWater: {
+        tropical: { liquid: 0, ice: 0, buriedIce: 0 },
+        temperate: { liquid: 0, ice: 0, buriedIce: 0 },
+        polar: { liquid: 0, ice: 0, buriedIce: 0 },
+      },
+      temperature: { zones: {
+        tropical: { value: temps.tropical },
+        temperate: { value: temps.temperate },
+        polar: { value: temps.polar },
+      } },
+      updateResources: () => {}
+    };
+  }
+
+  function createContext(tempAbove) {
+    const ctx = { console };
+    vm.createContext(ctx);
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.getZonePercentage = getZonePercentage;
+    ctx.structures = {};
+    ctx.dayNightCycle = { isDay: () => true };
+    ctx.buildings = {};
+    ctx.terraforming = setupTerraforming(tempAbove);
+    ctx.fundingModule = null;
+    ctx.lifeManager = null;
+    ctx.researchManager = null;
+    ctx.projectManager = null;
+    function stubResource(value = 0, cap = Infinity) {
+      return {
+        value,
+        cap,
+        hasCap: cap !== Infinity,
+        overflowRate: 0,
+        updateStorageCap: () => {},
+        resetRates: function () { this.overflowRate = 0; },
+        recalculateTotalRates: () => {},
+        modifyRate: () => {}
+      };
+    }
+    ctx.resources = {
+      colony: {
+        water: { name: 'water', ...stubResource(100, 100) }
+      },
+      surface: { liquidWater: stubResource(), ice: stubResource() },
+      atmospheric: {},
+      underground: {},
+      special: { albedoUpgrades: stubResource() }
+    };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resource.js'), 'utf8');
+    vm.runInContext(code + '; this.produceResources = produceResources;', ctx);
+    return ctx;
+  }
+
+  function makeBuilding() {
+    return {
+      displayName: 'WaterMaker',
+      active: 1,
+      dayNightActivity: false,
+      productivity: 1,
+      production: { colony: { water: 10 } },
+      consumption: {},
+      getProductionRatio: () => 1,
+      getEffectiveProductionMultiplier: () => 1,
+      getEffectiveResourceProductionMultiplier: () => 1,
+      getConsumptionRatio: () => 1,
+      getEffectiveConsumptionMultiplier: () => 1,
+      getEffectiveResourceConsumptionMultiplier: () => 1,
+      updateProductivity: () => {},
+      produce(acc, dt) { acc.colony.water += 10 * (dt/1000); },
+      consume: () => {},
+      applyMaintenance: () => {}
+    };
+  }
+
+  test('leaks as liquid when any zone above 0C', () => {
+    const ctx = createContext(true);
+    const b = makeBuilding();
+    ctx.b = b;
+    vm.runInContext('produceResources(1000, {b})', ctx, { filename: 'vm' });
+    const tropExp = 10 * getZonePercentage('tropical');
+    const tempExp = 10 * getZonePercentage('temperate');
+    const polarExp = 10 * getZonePercentage('polar');
+    expect(ctx.terraforming.zonalWater.tropical.liquid).toBeCloseTo(tropExp);
+    expect(ctx.terraforming.zonalWater.temperate.liquid).toBeCloseTo(tempExp);
+    expect(ctx.terraforming.zonalWater.polar.liquid).toBeCloseTo(polarExp);
+    expect(ctx.resources.colony.water.value).toBe(100);
+    expect(ctx.resources.colony.water.overflowRate).toBeCloseTo(10);
+    expect(ctx.resources.surface.liquidWater.overflowRate).toBeCloseTo(10);
+  });
+
+  test('leaks as ice when all zones below 0C', () => {
+    const ctx = createContext(false);
+    const b = makeBuilding();
+    ctx.b = b;
+    vm.runInContext('produceResources(1000, {b})', ctx, { filename: 'vm' });
+    const tropExp = 10 * getZonePercentage('tropical');
+    const tempExp = 10 * getZonePercentage('temperate');
+    const polarExp = 10 * getZonePercentage('polar');
+    expect(ctx.terraforming.zonalWater.tropical.ice).toBeCloseTo(tropExp);
+    expect(ctx.terraforming.zonalWater.temperate.ice).toBeCloseTo(tempExp);
+    expect(ctx.terraforming.zonalWater.polar.ice).toBeCloseTo(polarExp);
+    expect(ctx.resources.colony.water.value).toBe(100);
+    expect(ctx.resources.colony.water.overflowRate).toBeCloseTo(10);
+    expect(ctx.resources.surface.ice.overflowRate).toBeCloseTo(10);
+  });
+});

--- a/tests/waterOverflowTooltip.test.js
+++ b/tests/waterOverflowTooltip.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('overflow rate appears in tooltip', () => {
+  function setup() {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.oreScanner = { scanData: {} };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    return { dom, ctx };
+  }
+
+  test('shows on colony water and liquid water', () => {
+    const { dom, ctx } = setup();
+    const colonyWater = {
+      name: 'water', displayName: 'Water', category: 'colony',
+      value: 100, cap: 100, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 0, productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton',
+      overflowRate: 5
+    };
+    const liquid = {
+      name: 'liquidWater', displayName: 'Water', category: 'surface',
+      value: 0, cap: 0, hasCap: false, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 0, productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton',
+      overflowRate: 5
+    };
+    ctx.createResourceDisplay({ colony: { water: colonyWater }, surface: { liquidWater: liquid } });
+    ctx.updateResourceRateDisplay(colonyWater);
+    ctx.updateResourceRateDisplay(liquid);
+    const cw = dom.window.document.getElementById('water-tooltip').innerHTML;
+    const lw = dom.window.document.getElementById('liquidWater-tooltip').innerHTML;
+    expect(cw).toContain('Overflow');
+    expect(cw).toContain(numbers.formatNumber(5, false, 2));
+    expect(lw).toContain('Overflow');
+    expect(lw).toContain(numbers.formatNumber(5, false, 2));
+  });
+
+  test('shows on colony water and ice', () => {
+    const { dom, ctx } = setup();
+    const colonyWater = {
+      name: 'water', displayName: 'Water', category: 'colony',
+      value: 100, cap: 100, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 0, productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton',
+      overflowRate: 2
+    };
+    const ice = {
+      name: 'ice', displayName: 'Ice', category: 'surface',
+      value: 0, cap: 0, hasCap: false, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 0, productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton',
+      overflowRate: 2
+    };
+    ctx.createResourceDisplay({ colony: { water: colonyWater }, surface: { ice: ice } });
+    ctx.updateResourceRateDisplay(colonyWater);
+    ctx.updateResourceRateDisplay(ice);
+    const cw = dom.window.document.getElementById('water-tooltip').innerHTML;
+    const iw = dom.window.document.getElementById('ice-tooltip').innerHTML;
+    expect(cw).toContain('Overflow');
+    expect(cw).toContain(numbers.formatNumber(2, false, 2));
+    expect(iw).toContain('Overflow');
+    expect(iw).toContain(numbers.formatNumber(2, false, 2));
+  });
+});


### PR DESCRIPTION
## Summary
- handle overflow water in `produceResources`
- leak excess water into zonal water stores
- track overflow rate and show it in resource tooltips
- add unit tests for new leakage and tooltip display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68642fc07d18832791546a2c84dc612e