### PR TITLE
Fix journal navigation after reset

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -56,6 +56,13 @@ function updateJournalNavArrows() {
   const prev = document.getElementById('journal-prev');
   const next = document.getElementById('journal-next');
   const groups = getJournalChapterGroups();
+  // Clamp index to valid range so new games don't start at -1
+  if (groups.length === 0) {
+    journalChapterIndex = 0;
+  } else {
+    journalChapterIndex = Math.min(Math.max(journalChapterIndex, 0), groups.length - 1);
+  }
+
   if (prev && next) {
     prev.classList.toggle('disabled', journalChapterIndex <= 0);
     next.classList.toggle('disabled', journalChapterIndex >= groups.length - 1);

--- a/tests/journalArrowDisabled.test.js
+++ b/tests/journalArrowDisabled.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('journal nav arrows on new game', () => {
+  test('arrows disabled when only one chapter exists', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal">
+        <h3>Journal <span id="journal-nav-container"><span id="journal-prev" class="journal-nav">◀</span><span id="journal-next" class="journal-nav">▶</span></span></h3>
+        <div id="journal-entries"></div>
+      </div>
+    </body></html>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.progressData = {
+      chapters: [ { id: 'c1', type: 'journal', chapter: 1, narrative: 'A' } ]
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+    ctx.resetJournal();
+    jest.useFakeTimers();
+    ctx.addJournalEntry('A', 'c1', { type: 'chapter', id: 'c1' });
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    const prev = dom.window.document.getElementById('journal-prev');
+    const next = dom.window.document.getElementById('journal-next');
+    expect(prev.classList.contains('disabled')).toBe(true);
+    expect(next.classList.contains('disabled')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- clamp `journalChapterIndex` inside `updateJournalNavArrows`
- add regression test for arrow state when starting a new game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686471e62568832797518e3f8d5e2484