### PR TITLE
Adjust optimal growth temperature defaults

### DIFF
--- a/src/js/life.js
+++ b/src/js/life.js
@@ -5,8 +5,8 @@ const baseTemperatureRanges = {
   }
 };
 
-// Default optimal growth temperature (15°C in Kelvin)
-const BASE_OPTIMAL_GROWTH_TEMPERATURE = 288.15;
+// Default optimal growth temperature (20°C in Kelvin)
+const BASE_OPTIMAL_GROWTH_TEMPERATURE = 293.15;
 
 const lifeDesignerConfig = {
   maxPoints : 0
@@ -78,7 +78,13 @@ class LifeDesign {
   ) {
     this.minTemperatureTolerance = new LifeAttribute('minTemperatureTolerance', minTemperatureTolerance, 'Minimum Temperature Tolerance', 'Lowest survivable temperature (day or night).', 50);
     this.maxTemperatureTolerance = new LifeAttribute('maxTemperatureTolerance', maxTemperatureTolerance, 'Maximum Temperature Tolerance', 'Highest survivable temperature (day or night).', 40);
-    this.optimalGrowthTemperature = new LifeAttribute('optimalGrowthTemperature', 0, 'Optimal Growth Temperature', 'Daytime temperature for peak growth. Costs no points to adjust.', 10);
+    this.optimalGrowthTemperature = new LifeAttribute(
+      'optimalGrowthTemperature',
+      0,
+      'Optimal Growth Temperature',
+      'Daytime temperature for peak growth. Costs 1 point per degree from the 20\xB0C base.',
+      15
+    );
     this.growthTemperatureTolerance = new LifeAttribute('growthTemperatureTolerance', growthTemperatureTolerance, 'Growth Temperature Tolerance', 'Controls how quickly growth falls off from the optimal temperature.', 40);
     this.photosynthesisEfficiency = new LifeAttribute('photosynthesisEfficiency', photosynthesisEfficiency, 'Photosynthesis Efficiency', 'Efficiency of converting light to energy; affects growth rate.', 500);
     this.moistureEfficiency = new LifeAttribute('moistureEfficiency', moistureEfficiency, 'Moisture Efficiency', 'Reduces atmospheric water vapor pressure needed for growth when liquid water is unavailable (fallback with penalty).', 30);
@@ -91,7 +97,10 @@ class LifeDesign {
 
   getDesignCost() {
     return Object.values(this).reduce((sum, attribute) => {
-      if (attribute instanceof LifeAttribute && attribute.name !== 'optimalGrowthTemperature') {
+      if (attribute instanceof LifeAttribute) {
+        if (attribute.name === 'optimalGrowthTemperature') {
+          return sum + Math.abs(attribute.value);
+        }
         return sum + attribute.value;
       }
       return sum;

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -246,12 +246,15 @@ function initializeLifeTerraformingDesignerUI() {
           const currentTentativeValue = parseInt(tentativeValueDisplay.textContent, 10);
           const maxUpgrades = lifeDesigner.tentativeDesign[attributeName].maxUpgrades;
 
-          const remainingPoints = lifeDesigner.maxLifeDesignPoints() - lifeDesigner.tentativeDesign.getDesignCost() + lifeDesigner.tentativeDesign[attributeName].value;
+          const remainingPoints =
+            lifeDesigner.maxLifeDesignPoints() -
+            lifeDesigner.tentativeDesign.getDesignCost() +
+            Math.abs(lifeDesigner.tentativeDesign[attributeName].value);
 
           let newValue = currentTentativeValue + changeAmount;
 
           if (attributeName === 'optimalGrowthTemperature') {
-              newValue = Math.max(-10, Math.min(10, newValue));
+              newValue = Math.max(-15, Math.min(15, newValue));
           } else {
               // Clamp the value between 0 and the allowed maximum and available points
               newValue = Math.max(0, Math.min(maxUpgrades, newValue));
@@ -477,22 +480,10 @@ function updateLifeUI() {
         
         let pointsRemaining = 0;
         if (lifeDesigner.tentativeDesign) {
-          // Calculate remaining based on TENTATIVE design
-          const pointsUsed = Object.values(lifeDesigner.tentativeDesign).reduce((sum, attribute) => {
-              if (attribute instanceof LifeAttribute) {
-                  return sum + attribute.value;
-              }
-              return sum;
-          }, 0);
+          const pointsUsed = lifeDesigner.tentativeDesign.getDesignCost();
           pointsRemaining = maxPoints - pointsUsed;
         } else {
-          // Calculate remaining based on CURRENT design when no tentative design exists
-           const pointsUsed = Object.values(lifeDesigner.currentDesign).reduce((sum, attribute) => {
-              if (attribute instanceof LifeAttribute) {
-                  return sum + attribute.value;
-              }
-              return sum;
-          }, 0);
+          const pointsUsed = lifeDesigner.currentDesign.getDesignCost();
           pointsRemaining = maxPoints - pointsUsed;
         }
         pointsRemainingSpan.textContent = pointsRemaining;

--- a/tests/optimalGrowthTemperatureCost.test.js
+++ b/tests/optimalGrowthTemperatureCost.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('optimal growth temperature cost', () => {
+  test('uses absolute value for cost', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesign = LifeDesign;', ctx);
+
+    const design = new ctx.LifeDesign(2, 0, 0, 0, 0, 0, 0, 0, 0);
+    design.optimalGrowthTemperature.value = -3;
+    expect(design.getDesignCost()).toBe(5); // 2 + | -3 | = 5
+
+    design.optimalGrowthTemperature.value = 4;
+    expect(design.getDesignCost()).toBe(6); // 2 + 4 = 6
+  });
+});

--- a/tests/temperatureMultiplierDisplay.test.js
+++ b/tests/temperatureMultiplierDisplay.test.js
@@ -26,7 +26,7 @@ describe('temperature multiplier display', () => {
       colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
     };
     ctx.terraforming = {
-      temperature: { zones: { tropical: { day: 288.15, night: 288.15 }, temperate: { day: 288.15, night: 288.15 }, polar: { day: 288.15, night: 288.15 } } },
+      temperature: { zones: { tropical: { day: 293.15, night: 293.15 }, temperate: { day: 293.15, night: 293.15 }, polar: { day: 293.15, night: 293.15 } } },
       zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
       zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
       getMagnetosphereStatus: () => true,


### PR DESCRIPTION
## Summary
- tweak life design default optimal growth temperature constant
- give `optimalGrowthTemperature` a cost and larger range
- include absolute value in life design cost calculations
- show remaining points correctly in UI
- add tests for new cost rules
- update test temps for new default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686740072bb48327ab0de3c61318f22b