### PR TITLE
Always rebuild journal on load

### DIFF
--- a/src/js/save.js
+++ b/src/js/save.js
@@ -167,12 +167,9 @@ function loadGame(slotOrCustomString) {
         loadJournalEntries(gameState.journalEntries, history);
       }
 
-      // If journal ends up blank after loading, rebuild it from story state
+      // Always rebuild the journal from story state after loading
       if (typeof reconstructJournalState === 'function') {
-        const blank = !journalEntriesData || journalEntriesData.every(e => !e || e.trim() === '');
-        if (blank) {
-          reconstructJournalState(storyManager, projectManager);
-        }
+        reconstructJournalState(storyManager, projectManager);
       }
 
       // Restore research progress


### PR DESCRIPTION
## Summary
- rebuild journal state every time a save file loads so the journal matches story progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867caf1fd4883279297192de36f6721