### PR TITLE
Add Atmospheric Monitoring research

### DIFF
--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -743,6 +743,29 @@ const researchParameters = {
           }
         ],
       },
+      {
+        id: 'atmospheric_monitoring',
+        name: 'Atmospheric Monitoring',
+        description: 'Enables setting limits on atmospheric mining special projects.',
+        cost: { research: 1000000000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'project',
+            targetId: 'carbonSpaceMining',
+            type: 'booleanFlag',
+            flagId: 'atmosphericMonitoring',
+            value: true
+          },
+          {
+            target: 'project',
+            targetId: 'nitrogenSpaceMining',
+            type: 'booleanFlag',
+            flagId: 'atmosphericMonitoring',
+            value: true
+          }
+        ],
+      },
     ],
     terraforming: [
       {
@@ -992,7 +1015,7 @@ const researchParameters = {
             type: 'enable'
           }
         ],
-      },   
+      },
       {
         id: 'nitrogenImport',
         name: 'Nitrogen Importation',

--- a/tests/atmosphericMonitoringResearch.test.js
+++ b/tests/atmosphericMonitoringResearch.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Atmospheric Monitoring research', () => {
+  test('adds flag to carbon and nitrogen mining projects', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const colonization = ctx.researchParameters.colonization;
+    const research = colonization.find(r => r.id === 'atmospheric_monitoring');
+    expect(research).toBeDefined();
+    expect(research.cost.research).toBe(1000000000);
+    const carbonFlag = research.effects.find(e =>
+      e.target === 'project' &&
+      e.targetId === 'carbonSpaceMining' &&
+      e.type === 'booleanFlag' &&
+      e.flagId === 'atmosphericMonitoring' &&
+      e.value === true
+    );
+    const nitrogenFlag = research.effects.find(e =>
+      e.target === 'project' &&
+      e.targetId === 'nitrogenSpaceMining' &&
+      e.type === 'booleanFlag' &&
+      e.flagId === 'atmosphericMonitoring' &&
+      e.value === true
+    );
+    expect(carbonFlag).toBeDefined();
+    expect(nitrogenFlag).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add new colonization research `Atmospheric Monitoring`
- tie a boolean flag to carbon and nitrogen asteroid mining projects
- test the new research

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867caa93f7083278fb7f7c32abd8392