### PR TITLE
Add space mirror oversight feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
     <script src="src/js/colonyUI.js"></script>
     <script src="src/js/colonySliders.js"></script>
     <script src="src/js/colonySlidersUI.js"></script>
+    <script src="src/js/mirrorOversight.js"></script>
     <script src="src/js/projects.js"></script>
     <script src="src/js/projects/SpaceshipProject.js"></script>
     <script src="src/js/projects/ScannerProject.js"></script>

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -129,6 +129,9 @@ function initializeGameState(options = {}) {
   if (typeof resetColonySliders === 'function') {
     resetColonySliders();
   }
+  if (typeof resetMirrorOversightSettings === 'function') {
+    resetMirrorOversightSettings();
+  }
   const fundingRate = currentPlanetParameters.fundingRate || 0;
   fundingModule = new FundingModule(resources, fundingRate);
   populationModule = new PopulationModule(resources, currentPlanetParameters.populationParameters);

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -38,6 +38,7 @@ let ghgFactorySettings = {
   restartTimer: 0
 };
 
+
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
 let skillManager;
 let solisManager;

--- a/src/js/mirrorOversight.js
+++ b/src/js/mirrorOversight.js
@@ -1,0 +1,116 @@
+// Space mirror oversight controls
+
+// Default settings (reuse existing global if defined)
+var mirrorOversightSettings = globalThis.mirrorOversightSettings || {
+  percentage: 0, // 0-1 fraction of mirrors focused
+  zone: 'tropical'
+};
+
+function setMirrorFocusZone(zone) {
+  const valid = ['tropical', 'temperate', 'polar'];
+  if (valid.includes(zone)) {
+    mirrorOversightSettings.zone = zone;
+    updateMirrorOversightUI();
+  }
+}
+
+function setMirrorFocusPercentage(value) {
+  const v = Math.max(0, Math.min(100, value));
+  mirrorOversightSettings.percentage = v / 100;
+  updateMirrorOversightUI();
+}
+
+function resetMirrorOversightSettings() {
+  mirrorOversightSettings.zone = 'tropical';
+  mirrorOversightSettings.percentage = 0;
+  updateMirrorOversightUI();
+}
+
+function initializeMirrorOversightUI(container) {
+  if (!container) return;
+  const div = document.createElement('div');
+  div.id = 'mirror-oversight-container';
+  div.classList.add('mirror-oversight');
+  div.style.display = 'none';
+
+  const label = document.createElement('span');
+  label.textContent = 'Mirror Oversight ';
+  const tooltip = document.createElement('span');
+  tooltip.classList.add('info-tooltip-icon');
+  tooltip.title = 'Direct a percent of mirrors to focus on a specific zone.';
+  label.appendChild(tooltip);
+  div.appendChild(label);
+
+  const select = document.createElement('select');
+  select.id = 'mirror-oversight-zone';
+  ['tropical','temperate','polar'].forEach(z => {
+    const opt = document.createElement('option');
+    opt.value = z;
+    opt.textContent = z.charAt(0).toUpperCase() + z.slice(1);
+    select.appendChild(opt);
+  });
+  select.value = mirrorOversightSettings.zone;
+  select.addEventListener('change', () => setMirrorFocusZone(select.value));
+  div.appendChild(select);
+
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = 0;
+  slider.max = 100;
+  slider.step = 5;
+  slider.id = 'mirror-oversight-slider';
+  slider.value = mirrorOversightSettings.percentage * 100;
+  slider.addEventListener('input', () => {
+    const raw = slider.value;
+    const val = (typeof raw === 'number' || typeof raw === 'string') ? Number(raw) : 0;
+    valueSpan.textContent = val + '%';
+  });
+  slider.addEventListener('change', () => setMirrorFocusPercentage(parseInt(slider.value,10)));
+  div.appendChild(slider);
+
+  const valueSpan = document.createElement('span');
+  valueSpan.id = 'mirror-oversight-value';
+  valueSpan.classList.add('slider-value');
+  const initRaw = slider.value;
+  const initVal = (typeof initRaw === 'number' || typeof initRaw === 'string') ? Number(initRaw) : 0;
+  valueSpan.textContent = initVal + '%';
+  div.appendChild(valueSpan);
+
+  container.appendChild(div);
+}
+
+function updateMirrorOversightUI() {
+  if (typeof document === 'undefined') return;
+  const container = document.getElementById('mirror-oversight-container');
+  if (!container) return;
+  if (typeof projectManager !== 'undefined' && projectManager.isBooleanFlagSet &&
+      projectManager.isBooleanFlagSet('spaceMirrorFacilityOversight')) {
+    container.style.display = 'block';
+  } else {
+    container.style.display = 'none';
+  }
+  const slider = document.getElementById('mirror-oversight-slider');
+  const valueSpan = document.getElementById('mirror-oversight-value');
+  const select = document.getElementById('mirror-oversight-zone');
+  if (slider) slider.value = mirrorOversightSettings.percentage * 100;
+  if (valueSpan) valueSpan.textContent = Math.round(mirrorOversightSettings.percentage*100) + '%';
+  if (select) select.value = mirrorOversightSettings.zone;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    mirrorOversightSettings,
+    setMirrorFocusZone,
+    setMirrorFocusPercentage,
+    resetMirrorOversightSettings,
+    initializeMirrorOversightUI,
+    updateMirrorOversightUI
+  };
+} else {
+  globalThis.mirrorOversightSettings = mirrorOversightSettings;
+  globalThis.setMirrorFocusZone = setMirrorFocusZone;
+  globalThis.setMirrorFocusPercentage = setMirrorFocusPercentage;
+  globalThis.resetMirrorOversightSettings = resetMirrorOversightSettings;
+  globalThis.initializeMirrorOversightUI = initializeMirrorOversightUI;
+  globalThis.updateMirrorOversightUI = updateMirrorOversightUI;
+}

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -1,3 +1,11 @@
+// Import oversight UI helpers in Node environment
+if (typeof module !== 'undefined' && module.exports) {
+  var {
+    initializeMirrorOversightUI,
+    updateMirrorOversightUI,
+  } = require('../mirrorOversight.js');
+}
+
 class SpaceMirrorFacilityProject extends Project {
   renderUI(container) {
     const mirrorDetails = document.createElement('div');
@@ -8,6 +16,10 @@ class SpaceMirrorFacilityProject extends Project {
       <p>Total Power: <span id="total-power">0</span>W | Per m²: <span id="total-power-area">0</span>W/m²</p>
     `;
     container.appendChild(mirrorDetails);
+
+    if (typeof initializeMirrorOversightUI === 'function') {
+      initializeMirrorOversightUI(mirrorDetails);
+    }
     projectElements[this.name] = {
       ...projectElements[this.name],
       mirrorDetails: {
@@ -35,6 +47,10 @@ class SpaceMirrorFacilityProject extends Project {
     elements.mirrorDetails.powerPerMirrorArea.textContent = formatNumber(powerPerMirrorArea, false, 2);
     elements.mirrorDetails.totalPower.textContent = formatNumber(totalPower, false, 2);
     elements.mirrorDetails.totalPowerArea.textContent = formatNumber(totalPowerArea, false, 2);
+
+    if (typeof updateMirrorOversightUI === 'function') {
+      updateMirrorOversightUI();
+    }
   }
 }
 

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -23,6 +23,7 @@ function getGameState() {
     settings: gameSettings,
     colonySliderSettings: colonySliderSettings,
     ghgFactorySettings: ghgFactorySettings,
+    mirrorOversightSettings: globalThis.mirrorOversightSettings,
     playTimeSeconds: playTimeSeconds
   };
 }
@@ -237,6 +238,10 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.ghgFactorySettings){
       Object.assign(ghgFactorySettings, gameState.ghgFactorySettings);
+    }
+
+    if(gameState.mirrorOversightSettings){
+      Object.assign(mirrorOversightSettings, gameState.mirrorOversightSettings);
     }
 
     if(gameState.playTimeSeconds !== undefined){

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -633,7 +633,7 @@ function updateLifeBox() {
             <td><span id="albedo-delta"></span></td>
           </tr>
           <tr>
-            <td>Solar Flux (W/m²)</td>
+            <td>Solar Flux (W/m²) <span id="solar-flux-breakdown" class="info-tooltip-icon" title=""></span></td>
             <td><span id="modified-solar-flux">${terraforming.luminosity.modifiedSolarFlux.toFixed(1)}</span></td>
             <td><span id="solar-flux-delta"></span></td>
           </tr>
@@ -682,6 +682,12 @@ function updateLifeBox() {
     if (solarFluxDeltaEl) {
       const deltaF = terraforming.luminosity.modifiedSolarFlux - terraforming.luminosity.solarFlux;
       solarFluxDeltaEl.textContent = `${deltaF >= 0 ? '+' : ''}${formatNumber(deltaF, false, 2)}`;
+    }
+
+    const fluxTooltip = document.getElementById('solar-flux-breakdown');
+    if (fluxTooltip && terraforming.luminosity.zonalFluxes) {
+      const z = terraforming.luminosity.zonalFluxes;
+      fluxTooltip.title = `Tropical: ${z.tropical.toFixed(1)}\nTemperate: ${z.temperate.toFixed(1)}\nPolar: ${z.polar.toFixed(1)}`;
     }
 
     const solarPanelMultiplier = document.getElementById('solar-panel-multiplier');

--- a/tests/calculateZoneSolarFlux.test.js
+++ b/tests/calculateZoneSolarFlux.test.js
@@ -1,0 +1,54 @@
+const { getZoneRatio } = require('../src/js/zones.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const lifeParameters = require('../src/js/life-parameters.js');
+
+// globals expected by terraforming.js
+global.getZoneRatio = getZoneRatio;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+
+const Terraforming = require('../src/js/terraforming.js');
+
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+Terraforming.prototype.calculateLanternFlux = function(){ return 0; };
+
+function createTerraforming() {
+  return new Terraforming({}, { radius: 1, distanceFromSun: 1, albedo: 0, gravity: 1 });
+}
+
+describe('calculateZoneSolarFlux', () => {
+  test('applies mirror oversight percentage to selected zone', () => {
+    const terra = createTerraforming();
+    global.buildings = { spaceMirror: { surfaceArea: 500, active: 1 } };
+    global.projectManager = { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' };
+    global.mirrorOversightSettings = { percentage: 0.5, zone: 'tropical' };
+
+    terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
+    terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
+
+    const ratio = getZoneRatio('tropical') / 0.25;
+    const baseSolar = terra.luminosity.solarFlux;
+    const mirror = terra.calculateMirrorEffect().powerPerUnitArea * buildings.spaceMirror.active;
+    const expected = (baseSolar + mirror * 0.5) * ratio + mirror * 0.5;
+    const result = terra.calculateZoneSolarFlux('tropical');
+    expect(result).toBeCloseTo(expected, 5);
+  });
+
+  test('other zones receive only distributed mirrors', () => {
+    const terra = createTerraforming();
+    global.buildings = { spaceMirror: { surfaceArea: 500, active: 1 } };
+    global.projectManager = { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' };
+    global.mirrorOversightSettings = { percentage: 0.5, zone: 'tropical' };
+
+    terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
+    terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
+
+    const ratio = getZoneRatio('temperate') / 0.25;
+    const baseSolar = terra.luminosity.solarFlux;
+    const mirror = terra.calculateMirrorEffect().powerPerUnitArea * buildings.spaceMirror.active;
+    const expected = (baseSolar + mirror * 0.5) * ratio;
+    const result = terra.calculateZoneSolarFlux('temperate');
+    expect(result).toBeCloseTo(expected, 5);
+  });
+});

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -84,6 +84,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
   vm.runInContext('initializeGameState();', ctx);
 
   const settings = vm.runInContext('colonySliderSettings', ctx);
+  const oversight = vm.runInContext('mirrorOversightSettings', ctx);
 
   global.window = originalWindow;
   global.document = originalDocument;
@@ -94,4 +95,5 @@ test('initializeGameState resets colony sliders to defaults', () => {
   }
 
   expect(settings).toEqual({ workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 });
+  expect(oversight).toEqual({ percentage: 0, zone: 'tropical' });
 });

--- a/tests/mirrorOversightSettings.test.js
+++ b/tests/mirrorOversightSettings.test.js
@@ -1,0 +1,23 @@
+const {
+  setMirrorFocusZone,
+  setMirrorFocusPercentage,
+  resetMirrorOversightSettings,
+  mirrorOversightSettings
+} = require('../src/js/mirrorOversight.js');
+
+describe('mirror oversight settings', () => {
+  test('setters modify settings', () => {
+    setMirrorFocusZone('temperate');
+    setMirrorFocusPercentage(50);
+    expect(mirrorOversightSettings.zone).toBe('temperate');
+    expect(mirrorOversightSettings.percentage).toBeCloseTo(0.5);
+  });
+
+  test('reset restores defaults', () => {
+    mirrorOversightSettings.zone = 'polar';
+    mirrorOversightSettings.percentage = 0.8;
+    resetMirrorOversightSettings();
+    expect(mirrorOversightSettings.zone).toBe('tropical');
+    expect(mirrorOversightSettings.percentage).toBe(0);
+  });
+});

--- a/tests/spaceMirrorFacilityProject.test.js
+++ b/tests/spaceMirrorFacilityProject.test.js
@@ -24,6 +24,8 @@ describe('SpaceMirrorFacilityProject', () => {
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
     const mirrorCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMirrorFacilityProject.js'), 'utf8');
     vm.runInContext(mirrorCode + '; this.SpaceMirrorFacilityProject = SpaceMirrorFacilityProject;', ctx);
+    const oversCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'mirrorOversight.js'), 'utf8');
+    vm.runInContext(oversCode, ctx);
     const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
     vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
 
@@ -40,5 +42,13 @@ describe('SpaceMirrorFacilityProject', () => {
     const details = ctx.projectElements.spaceMirrorFacility.mirrorDetails;
     expect(details.numMirrors.textContent).toBe('5.00');
     expect(details.totalPower.textContent).toBe('50.00');
+
+    const oversight = dom.window.document.getElementById('mirror-oversight-container');
+    expect(oversight).not.toBeNull();
+    expect(oversight.style.display).toBe('none');
+
+    ctx.projectManager = { isBooleanFlagSet: () => true };
+    ctx.updateMirrorOversightUI();
+    expect(oversight.style.display).toBe('block');
   });
 });


### PR DESCRIPTION
## Summary
- implement space mirror oversight controls and UI
- persist oversight settings in saves
- adjust solar flux calculations per-zone
- display zonal flux in tooltip
- test resets and UI state for new oversight feature
- fix mirror flux allocation with oversight
- add zone flux tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6867ca36ffb48327aebd00780aec2484