### PR TITLE
Add atmospheric monitoring controls to mining projects

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -180,3 +180,9 @@
   margin: 0;
   padding: 0;
 }
+
+.pressure-control {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -370,6 +370,10 @@ class ProjectManager extends EffectableEntity {
         state.autoAssignSpaceships = project.autoAssignSpaceships;
         state.selectedDisposalResource = project.selectedDisposalResource;
         state.waitForCapacity = project.waitForCapacity;
+        if (typeof SpaceMiningProject !== 'undefined' && project instanceof SpaceMiningProject) {
+          state.disableAbovePressure = project.disableAbovePressure;
+          state.disablePressureThreshold = project.disablePressureThreshold;
+        }
       }
 
       projectState[projectName] = state;
@@ -404,6 +408,10 @@ class ProjectManager extends EffectableEntity {
           project.selectedDisposalResource = savedProject.selectedDisposalResource || project.attributes.defaultDisposal;
           if(savedProject.waitForCapacity !== undefined){
             project.waitForCapacity = savedProject.waitForCapacity;
+          }
+          if (typeof SpaceMiningProject !== 'undefined' && project instanceof SpaceMiningProject) {
+            project.disableAbovePressure = savedProject.disableAbovePressure || false;
+            project.disablePressureThreshold = savedProject.disablePressureThreshold || 0;
           }
         }
         if(project.attributes.completionEffect && (project.isCompleted || project.repeatCount > 0)){

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -1,10 +1,74 @@
 class SpaceMiningProject extends SpaceshipProject {
+  constructor(config, name) {
+    super(config, name);
+    this.disableAbovePressure = false;
+    this.disablePressureThreshold = 0;
+  }
+
+  createPressureControl(row) {
+    const control = document.createElement('div');
+    control.classList.add('pressure-control');
+    control.id = `${this.name}-pressure-control`;
+    control.style.display = this.isBooleanFlagSet('atmosphericMonitoring') ? 'flex' : 'none';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.classList.add('pressure-checkbox');
+    checkbox.checked = this.disableAbovePressure;
+    checkbox.addEventListener('change', () => {
+      this.disableAbovePressure = checkbox.checked;
+    });
+    control.appendChild(checkbox);
+
+    const label = document.createElement('span');
+    label.textContent = 'Disable if pressure above: ';
+    control.appendChild(label);
+
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = 1;
+    input.classList.add('pressure-input');
+    input.value = this.disablePressureThreshold;
+    input.addEventListener('input', () => {
+      this.disablePressureThreshold = parseFloat(input.value) || 0;
+    });
+    control.appendChild(input);
+
+    const unit = document.createElement('span');
+    unit.textContent = 'kPa';
+    control.appendChild(unit);
+
+    row.appendChild(control);
+
+    projectElements[this.name] = {
+      ...projectElements[this.name],
+      pressureControl: control,
+      pressureCheckbox: checkbox,
+      pressureInput: input,
+    };
+  }
+
   renderUI(container) {
     super.renderUI(container);
+    const row = projectElements[this.name]?.checkboxRowContainer;
+    if (row) {
+      this.createPressureControl(row);
+    }
   }
 
   updateUI() {
     super.updateUI();
+    const elements = projectElements[this.name];
+    if (!elements) return;
+    if (elements.pressureControl) {
+      elements.pressureControl.style.display = this.isBooleanFlagSet('atmosphericMonitoring') ? 'flex' : 'none';
+    }
+    if (elements.pressureCheckbox) {
+      elements.pressureCheckbox.checked = this.disableAbovePressure;
+    }
+    if (elements.pressureInput) {
+      elements.pressureInput.value = this.disablePressureThreshold;
+    }
   }
 }
 

--- a/tests/spaceMiningPressureSettings.test.js
+++ b/tests/spaceMiningPressureSettings.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceMiningProject pressure settings persistence', () => {
+  test('saveState and loadState preserve pressure fields', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+
+    ctx.resources = { colony: { metal: { value: 0 } }, special: { spaceships: { value: 0 } } };
+    ctx.projectManager = new ctx.ProjectManager();
+    const params = { mine: { type: 'SpaceMiningProject', name: 'Mine', category: 'resources', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: { spaceMining: true } } };
+    ctx.projectManager.initializeProjects(params);
+
+    const project = ctx.projectManager.projects.mine;
+    project.disableAbovePressure = true;
+    project.disablePressureThreshold = 50;
+
+    const saved = ctx.projectManager.saveState();
+    const manager2 = new ctx.ProjectManager();
+    manager2.initializeProjects(params);
+    manager2.loadState(saved);
+
+    const loaded = manager2.projects.mine;
+    expect(loaded.disableAbovePressure).toBe(true);
+    expect(loaded.disablePressureThreshold).toBe(50);
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend `SpaceMiningProject` with pressure threshold settings
- persist pressure settings in `ProjectManager`
- add a pressure control UI component and matching CSS
- cover new persistence logic with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867d59f24ec8327a6e94c1c59da6ec7