### PR TITLE
Extend mirror oversight to hyperion lantern

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -2,6 +2,7 @@
 var mirrorOversightSettings = globalThis.mirrorOversightSettings || {
   percentage: 0,
   zone: 'tropical',
+  applyToLantern: false,
 };
 
 function setMirrorFocusZone(zone) {
@@ -21,6 +22,7 @@ function setMirrorFocusPercentage(value) {
 function resetMirrorOversightSettings() {
   mirrorOversightSettings.zone = 'tropical';
   mirrorOversightSettings.percentage = 0;
+  mirrorOversightSettings.applyToLantern = false;
   updateMirrorOversightUI();
 }
 
@@ -73,6 +75,23 @@ function initializeMirrorOversightUI(container) {
   valueSpan.textContent = initVal + '%';
   div.appendChild(valueSpan);
 
+  const lanternDiv = document.createElement('div');
+  lanternDiv.id = 'mirror-oversight-lantern-div';
+  const lanternCheckbox = document.createElement('input');
+  lanternCheckbox.type = 'checkbox';
+  lanternCheckbox.id = 'mirror-oversight-lantern';
+  lanternCheckbox.checked = mirrorOversightSettings.applyToLantern;
+  lanternCheckbox.addEventListener('change', () => {
+    mirrorOversightSettings.applyToLantern = lanternCheckbox.checked;
+    updateMirrorOversightUI();
+  });
+  const lanternLabel = document.createElement('label');
+  lanternLabel.htmlFor = 'mirror-oversight-lantern';
+  lanternLabel.textContent = 'Apply to Hyperion Lantern';
+  lanternDiv.appendChild(lanternCheckbox);
+  lanternDiv.appendChild(lanternLabel);
+  div.appendChild(lanternDiv);
+
   container.appendChild(div);
 }
 
@@ -96,9 +115,16 @@ function updateMirrorOversightUI() {
   const slider = document.getElementById('mirror-oversight-slider');
   const valueSpan = document.getElementById('mirror-oversight-value');
   const select = document.getElementById('mirror-oversight-zone');
+  const lantern = document.getElementById('mirror-oversight-lantern');
+  const lanternDiv = document.getElementById('mirror-oversight-lantern-div');
   if (slider) slider.value = mirrorOversightSettings.percentage * 100;
   if (valueSpan) valueSpan.textContent = Math.round(mirrorOversightSettings.percentage * 100) + '%';
   if (select) select.value = mirrorOversightSettings.zone;
+  if (lantern) lantern.checked = !!mirrorOversightSettings.applyToLantern;
+  if (lanternDiv) {
+    const unlocked = typeof buildings !== 'undefined' && buildings.hyperionLantern && buildings.hyperionLantern.unlocked;
+    lanternDiv.style.display = unlocked ? 'block' : 'none';
+  }
 }
 
 class SpaceMirrorFacilityProject extends Project {

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1064,6 +1064,8 @@ class Terraforming extends EffectableEntity{
 
       let distributedMirror = mirrorFlux;
       let focusedMirror = 0;
+      let distributedLantern = lanternFlux;
+      let focusedLantern = 0;
 
       if (
         typeof projectManager !== 'undefined' &&
@@ -1074,14 +1076,20 @@ class Terraforming extends EffectableEntity{
         const perc = mirrorOversightSettings.percentage || 0;
         if (perc > 0) {
           distributedMirror = mirrorFlux * (1 - perc);
+          if (mirrorOversightSettings.applyToLantern) {
+            distributedLantern = lanternFlux * (1 - perc);
+          }
           if (mirrorOversightSettings.zone === zone) {
             focusedMirror = mirrorFlux * perc;
+            if (mirrorOversightSettings.applyToLantern) {
+              focusedLantern = lanternFlux * perc;
+            }
           }
         }
       }
 
-      const base = (baseSolar + lanternFlux + distributedMirror) * ratio;
-      return base + focusedMirror;
+      const base = (baseSolar + distributedLantern + distributedMirror) * ratio;
+      return base + focusedMirror + focusedLantern;
     }
 
     calculateSolarPanelMultiplier(){

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -95,5 +95,5 @@ test('initializeGameState resets colony sliders to defaults', () => {
   }
 
   expect(settings).toEqual({ workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 });
-  expect(oversight).toEqual({ percentage: 0, zone: 'tropical' });
+  expect(oversight).toEqual({ percentage: 0, zone: 'tropical', applyToLantern: false });
 });

--- a/tests/mirrorOversightSettings.test.js
+++ b/tests/mirrorOversightSettings.test.js
@@ -21,15 +21,19 @@ describe('mirror oversight settings', () => {
   test('setters modify settings', () => {
     setMirrorFocusZone('temperate');
     setMirrorFocusPercentage(50);
+    mirrorOversightSettings.applyToLantern = true;
     expect(mirrorOversightSettings.zone).toBe('temperate');
     expect(mirrorOversightSettings.percentage).toBeCloseTo(0.5);
+    expect(mirrorOversightSettings.applyToLantern).toBe(true);
   });
 
   test('reset restores defaults', () => {
     mirrorOversightSettings.zone = 'polar';
     mirrorOversightSettings.percentage = 0.8;
+    mirrorOversightSettings.applyToLantern = true;
     resetMirrorOversightSettings();
     expect(mirrorOversightSettings.zone).toBe('tropical');
     expect(mirrorOversightSettings.percentage).toBe(0);
+    expect(mirrorOversightSettings.applyToLantern).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add `applyToLantern` field to mirror oversight settings
- provide checkbox in Space Mirror Facility UI to toggle applying oversight to the Hyperion Lantern
- update UI refresh logic and reset function
- distribute lantern flux in `calculateZoneSolarFlux` when oversight checkbox is active
- update related unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867dd42561883278d8d429b67d80a0c