### PR TITLE
Show zonal solar flux in Mirror Oversight

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -244,3 +244,19 @@
     min-width: 45px;
     text-align: left;
 }
+
+/* Table for zonal solar flux */
+#mirror-flux-table {
+    margin-top: 8px;
+    border-collapse: collapse;
+}
+#mirror-flux-table th,
+#mirror-flux-table td {
+    border: 1px solid #ccc;
+    padding: 2px 4px;
+    text-align: right;
+}
+#mirror-flux-table th:first-child,
+#mirror-flux-table td:first-child {
+    text-align: left;
+}

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -92,7 +92,24 @@ function initializeMirrorOversightUI(container) {
   lanternDiv.appendChild(lanternLabel);
   div.appendChild(lanternDiv);
 
+  // Table showing zonal solar flux
+  const fluxTable = document.createElement('table');
+  fluxTable.id = 'mirror-flux-table';
+  fluxTable.innerHTML = `
+    <thead>
+      <tr><th>Zone</th><th>Solar Flux (W/m²)</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Tropical</td><td id="mirror-flux-tropical">0</td></tr>
+      <tr><td>Temperate</td><td id="mirror-flux-temperate">0</td></tr>
+      <tr><td>Polar</td><td id="mirror-flux-polar">0</td></tr>
+    </tbody>
+  `;
+  div.appendChild(fluxTable);
+
   container.appendChild(div);
+
+  updateZonalFluxTable();
 }
 
 function updateMirrorOversightUI() {
@@ -125,6 +142,24 @@ function updateMirrorOversightUI() {
     const unlocked = typeof buildings !== 'undefined' && buildings.hyperionLantern && buildings.hyperionLantern.unlocked;
     lanternDiv.style.display = unlocked ? 'block' : 'none';
   }
+
+  if (enabled) {
+    updateZonalFluxTable();
+  }
+}
+
+function updateZonalFluxTable() {
+  if (typeof document === 'undefined' || typeof terraforming === 'undefined') return;
+  const zones = ['tropical', 'temperate', 'polar'];
+  zones.forEach(zone => {
+    const cell = document.getElementById(`mirror-flux-${zone}`);
+    if (!cell) return;
+    let flux = 0;
+    if (typeof terraforming.calculateZoneSolarFlux === 'function') {
+      flux = terraforming.calculateZoneSolarFlux(zone);
+    }
+    cell.textContent = formatNumber(flux, false, 2);
+  });
 }
 
 class SpaceMirrorFacilityProject extends Project {
@@ -184,6 +219,7 @@ if (typeof globalThis !== 'undefined') {
   globalThis.resetMirrorOversightSettings = resetMirrorOversightSettings;
   globalThis.initializeMirrorOversightUI = initializeMirrorOversightUI;
   globalThis.updateMirrorOversightUI = updateMirrorOversightUI;
+  globalThis.updateZonalFluxTable = updateZonalFluxTable;
 }
 
 if (typeof module !== 'undefined' && module.exports) {
@@ -195,5 +231,6 @@ if (typeof module !== 'undefined' && module.exports) {
     resetMirrorOversightSettings,
     initializeMirrorOversightUI,
     updateMirrorOversightUI,
+    updateZonalFluxTable,
   };
 }

--- a/tests/spaceMirrorFacilityProject.test.js
+++ b/tests/spaceMirrorFacilityProject.test.js
@@ -16,7 +16,10 @@ describe('SpaceMirrorFacilityProject', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
     ctx.buildings = { spaceMirror: { active: 5 } };
-    ctx.terraforming = { calculateMirrorEffect: () => ({ interceptedPower: 10, powerPerUnitArea: 0.5 }) };
+    ctx.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 10, powerPerUnitArea: 0.5 }),
+      calculateZoneSolarFlux: zone => ({ tropical: 100, temperate: 50, polar: 25 })[zone]
+    };
 
     const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
@@ -46,7 +49,9 @@ describe('SpaceMirrorFacilityProject', () => {
     expect(oversight.style.display).toBe('none');
 
     ctx.projectManager = { isBooleanFlagSet: () => true };
-    ctx.updateMirrorOversightUI();
+    project.updateUI();
     expect(oversight.style.display).toBe('block');
+    const fluxCell = dom.window.document.getElementById('mirror-flux-tropical');
+    expect(fluxCell.textContent).toBe('100.00');
   });
 });


### PR DESCRIPTION
## Summary
- display a table of zonal solar flux in the Mirror Oversight controls
- update Mirror Oversight UI when oversight is unlocked
- style the new table in projects.css
- extend SpaceMirrorFacilityProject test for the flux table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867df14a8148327a8ac43c1c64a2b0d