### PR TITLE
Add Hyperion Lantern panel to mirror facility

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -1,7 +1,8 @@
 /* --- Base Card Styles --- */
 .project-card,
 .mirror-details-card,
-.mirror-oversight-card {
+.mirror-oversight-card,
+.lantern-details-card {
     background-color: #f8f9fa;
     border: 1px solid #dee2e6;
     border-radius: 6px;

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -186,6 +186,40 @@ class SpaceMirrorFacilityProject extends Project {
     `;
     container.appendChild(mirrorDetails);
 
+    const lanternDetails = document.createElement('div');
+    lanternDetails.classList.add('lantern-details-card');
+    lanternDetails.style.display = 'none';
+    lanternDetails.innerHTML = `
+      <div class="card-header">
+        <span class="card-title">Lantern Status</span>
+      </div>
+      <div class="card-body">
+        <div class="stats-grid">
+          <div class="stat-item">
+            <span class="stat-label">Lanterns:</span>
+            <span id="num-lanterns" class="stat-value">0</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label">Power/Lantern:</span>
+            <span id="power-per-lantern" class="stat-value">0 W</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label">Power/m²:</span>
+            <span id="power-per-lantern-area" class="stat-value">0 W/m²</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label">Total Power:</span>
+            <span id="total-lantern-power" class="stat-value">0 W</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label">Total Power/m²:</span>
+            <span id="total-lantern-area" class="stat-value">0 W/m²</span>
+          </div>
+        </div>
+      </div>
+    `;
+    container.appendChild(lanternDetails);
+
     if (typeof initializeMirrorOversightUI === 'function') {
       initializeMirrorOversightUI(mirrorDetails);
     }
@@ -197,6 +231,14 @@ class SpaceMirrorFacilityProject extends Project {
         powerPerMirrorArea: mirrorDetails.querySelector('#power-per-mirror-area'),
         totalPower: mirrorDetails.querySelector('#total-power'),
         totalPowerArea: mirrorDetails.querySelector('#total-power-area'),
+      },
+      lanternDetails: {
+        container: lanternDetails,
+        numLanterns: lanternDetails.querySelector('#num-lanterns'),
+        powerPerLantern: lanternDetails.querySelector('#power-per-lantern'),
+        powerPerLanternArea: lanternDetails.querySelector('#power-per-lantern-area'),
+        totalPower: lanternDetails.querySelector('#total-lantern-power'),
+        totalPowerArea: lanternDetails.querySelector('#total-lantern-area'),
       },
     };
   }
@@ -216,6 +258,26 @@ class SpaceMirrorFacilityProject extends Project {
     elements.mirrorDetails.powerPerMirrorArea.textContent = `${formatNumber(powerPerMirrorArea, false, 2)} W/m²`;
     elements.mirrorDetails.totalPower.textContent = formatNumber(totalPower, false, 2);
     elements.mirrorDetails.totalPowerArea.textContent = `${formatNumber(totalPowerArea, false, 2)} W/m²`;
+
+    if (elements.lanternDetails) {
+      const lantern = buildings.hyperionLantern;
+      const unlocked = lantern && lantern.unlocked;
+      elements.lanternDetails.container.style.display = unlocked ? 'block' : 'none';
+      if (unlocked) {
+        const area = terraforming.celestialParameters.crossSectionArea || terraforming.celestialParameters.surfaceArea;
+        const productivity = typeof lantern.productivity === 'number' ? lantern.productivity : 1;
+        const numLanterns = lantern.active || 0;
+        const powerPerLantern = lantern.powerPerBuilding || 0;
+        const powerPerLanternArea = area > 0 ? powerPerLantern / area : 0;
+        const totalLanternPower = powerPerLantern * numLanterns * productivity;
+        const totalLanternArea = powerPerLanternArea * numLanterns * productivity;
+        elements.lanternDetails.numLanterns.textContent = formatNumber(numLanterns, false, 2);
+        elements.lanternDetails.powerPerLantern.textContent = formatNumber(powerPerLantern, false, 2);
+        elements.lanternDetails.powerPerLanternArea.textContent = `${formatNumber(powerPerLanternArea, false, 2)} W/m²`;
+        elements.lanternDetails.totalPower.textContent = formatNumber(totalLanternPower, false, 2);
+        elements.lanternDetails.totalPowerArea.textContent = `${formatNumber(totalLanternArea, false, 2)} W/m²`;
+      }
+    }
 
     if (typeof updateMirrorOversightUI === 'function') {
       updateMirrorOversightUI();

--- a/tests/spaceMirrorFacilityProject.test.js
+++ b/tests/spaceMirrorFacilityProject.test.js
@@ -15,7 +15,7 @@ describe('SpaceMirrorFacilityProject', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.buildings = { spaceMirror: { active: 5 } };
+    ctx.buildings = { spaceMirror: { active: 5 }, hyperionLantern: { active: 2, powerPerBuilding: 100, productivity: 0.5, unlocked: false } };
     ctx.terraforming = {
       calculateMirrorEffect: () => ({ interceptedPower: 10, powerPerUnitArea: 0.5 }),
       calculateZoneSolarFlux: zone => ({ tropical: 100, temperate: 50, polar: 25 })[zone]
@@ -53,5 +53,45 @@ describe('SpaceMirrorFacilityProject', () => {
     expect(oversight.style.display).toBe('block');
     const fluxCell = dom.window.document.getElementById('mirror-flux-tropical');
     expect(fluxCell.textContent).toBe('100.00');
+  });
+
+  test('shows lantern details when unlocked', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 2, powerPerBuilding: 100, productivity: 0.5, unlocked: false } };
+    ctx.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      calculateZoneSolarFlux: () => 0,
+      celestialParameters: { crossSectionArea: 100, surfaceArea: 100 }
+    };
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const mirrorCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMirrorFacilityProject.js'), 'utf8');
+    vm.runInContext(mirrorCode + '; this.SpaceMirrorFacilityProject = SpaceMirrorFacilityProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.spaceMirrorFacility;
+    const project = new ctx.SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.updateUI();
+    const lanternCard = ctx.projectElements.spaceMirrorFacility.lanternDetails.container;
+    expect(lanternCard.style.display).toBe('none');
+
+    ctx.buildings.hyperionLantern.unlocked = true;
+    project.updateUI();
+    expect(lanternCard.style.display).toBe('block');
+    expect(ctx.projectElements.spaceMirrorFacility.lanternDetails.numLanterns.textContent).toBe('2.00');
+    expect(ctx.projectElements.spaceMirrorFacility.lanternDetails.totalPower.textContent).toBe('100.00');
   });
 });


### PR DESCRIPTION
## Summary
- style `.lantern-details-card` alongside other project cards
- expand SpaceMirrorFacilityProject UI with a lantern stats card
- show/hide lantern info depending on unlock status and update values
- test lantern details appear once unlocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68680f181eb483278a257db7ed5c2ec2