### PR TITLE
Improve journal scroll handling

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -95,6 +95,7 @@ function processNextJournalEntry() {
   const { text, eventId, source } = journalQueue.shift();
   journalCurrentEventId = eventId;
   const journalEntries = document.getElementById('journal-entries');
+  const journalContainer = document.getElementById('journal');
   const entry = document.createElement('p');
   journalEntries.appendChild(entry); // Append the empty paragraph first
 
@@ -116,11 +117,15 @@ function processNextJournalEntry() {
       }
       index++;
 
+      if (!journalUserScrolling && journalContainer) {
+        journalContainer.scrollTop = journalContainer.scrollHeight;
+      }
+
       let delay = (text[index - 1] === '.' || text[index - 1] === '\n') ? 250 : 50;
       setTimeout(typeLetter, delay);
     } else {
-      if (!journalUserScrolling) {
-        journalEntries.scrollTop = journalEntries.scrollHeight; // Scroll to the latest entry
+      if (!journalUserScrolling && journalContainer) {
+        journalContainer.scrollTop = journalContainer.scrollHeight; // Scroll to the latest entry
       }
 
       console.log("Journal typing complete, dispatching storyJournalFinishedTyping event.");
@@ -142,6 +147,7 @@ function processNextJournalEntry() {
 
 function loadJournalEntries(entries, history = null, entrySources = null, historySourcesParam = null) {
   const journalEntries = document.getElementById('journal-entries');
+  const journalContainer = document.getElementById('journal');
   journalEntries.innerHTML = ''; // Clear existing journal entries
   journalQueue = [];
   journalTyping = false;
@@ -160,8 +166,8 @@ function loadJournalEntries(entries, history = null, entrySources = null, histor
     journalEntries.appendChild(entry);
   });
 
-  if (!journalUserScrolling) {
-    journalEntries.scrollTop = journalEntries.scrollHeight; // Scroll to the latest entry
+  if (!journalUserScrolling && journalContainer) {
+    journalContainer.scrollTop = journalContainer.scrollHeight; // Scroll to the latest entry
   }
   journalEntriesData = entries;
   journalEntrySources = entrySources ? entrySources.slice() : new Array(entries.length).fill(null);
@@ -181,6 +187,7 @@ function loadJournalEntries(entries, history = null, entrySources = null, histor
  */
 function clearJournal() {
   const journalEntries = document.getElementById('journal-entries');
+  const journalContainer = document.getElementById('journal');
   journalEntries.innerHTML = ''; // Remove all entries from the display
   journalEntriesData = []; // Clear the stored data array but keep history
   journalEntrySources = [];
@@ -188,7 +195,7 @@ function clearJournal() {
   journalTyping = false;
   journalCurrentEventId = null;
   journalUserScrolling = false;
-  journalEntries.scrollTop = 0;
+  if (journalContainer) journalContainer.scrollTop = 0;
   journalChapterIndex = getJournalChapterGroups().length - 1;
   updateJournalNavArrows();
 }
@@ -309,7 +316,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-  const entriesDiv = document.getElementById('journal-entries');
+  const entriesDiv = document.getElementById('journal');
   if (entriesDiv) {
     entriesDiv.addEventListener('scroll', () => {
       const atBottom = entriesDiv.scrollHeight - entriesDiv.scrollTop <= entriesDiv.clientHeight + 5;

--- a/tests/journalAutoScroll.test.js
+++ b/tests/journalAutoScroll.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('journal auto scroll', () => {
+  test('container scrolls to bottom after typing', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal" style="height:100px; overflow:auto;"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const journal = dom.window.document.getElementById('journal');
+    Object.defineProperty(journal, 'scrollHeight', { value: 200, configurable: true });
+
+    jest.useFakeTimers();
+    ctx.addJournalEntry('abc');
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    expect(journal.scrollTop).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- auto-scroll journal container on each typed letter
- respect user scroll state in multiple journal functions
- attach scroll listener to journal container element
- add regression test for auto scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68687db2b840832794a7ead6d6fd9e8d