### PR TITLE
Ensure journal rebuild on chapter change

### DIFF
--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -139,14 +139,19 @@ class StoryManager {
             return;
         }
         const eventChapter = event.chapter;
+        let chapterChanged = false;
         if (this.currentChapter === null) {
             this.currentChapter = eventChapter;
         } else if (eventChapter !== this.currentChapter) {
             clearJournal();
             this.currentChapter = eventChapter;
+            chapterChanged = true;
         }
         console.log(`Activating event: ${event.id}`);
         this.activeEventIds.add(event.id);
+        if (chapterChanged && typeof reconstructJournalState === 'function') {
+            reconstructJournalState(this, typeof projectManager !== 'undefined' ? projectManager : undefined);
+        }
         event.trigger(); // Calls addJournalEntry if it's a journal type
     }
 

--- a/tests/chapterJournalReconstruct.test.js
+++ b/tests/chapterJournalReconstruct.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('StoryManager journal reconstruction on chapter change', () => {
+  test('reconstructJournalState called when chapter advances', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress.js'), 'utf8');
+    const context = {
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      document: {
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        getElementById: () => null,
+        dispatchEvent: () => {}
+      },
+      window: { popupActive: false },
+      clearJournal: jest.fn(),
+      reconstructJournalState: jest.fn(),
+      createPopup: () => {},
+      addJournalEntry: () => {},
+      addEffect: () => {},
+      removeEffect: () => {},
+      buildings: {},
+      colonies: {},
+      resources: {},
+      terraforming: {}
+    };
+    vm.createContext(context);
+    vm.runInContext(code + '; this.StoryManager = StoryManager;', context);
+
+    const data = {
+      chapters: [
+        { id: 'chapter1.1', chapter: 1, type: 'journal', narrative: 'a' },
+        { id: 'chapter2.1', chapter: 2, type: 'journal', narrative: 'b', prerequisites: ['chapter1.1'] }
+      ]
+    };
+
+    const manager = new context.StoryManager(data);
+    context.window.storyManager = manager;
+
+    const e1 = manager.findEventById('chapter1.1');
+    manager.activateEvent(e1);
+    manager.processEventCompletion('chapter1.1');
+
+    const e2 = manager.findEventById('chapter2.1');
+    manager.activateEvent(e2);
+
+    expect(context.reconstructJournalState).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- trigger journal reconstruction when activating a chapter from `StoryManager`
- add test verifying `reconstructJournalState` runs on chapter transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686881282cdc83279e45b05f66dc7027