### PR TITLE
Handle queued journal entries on chapter change

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -188,6 +188,13 @@ function loadJournalEntries(entries, history = null, entrySources = null, histor
 function clearJournal() {
   const journalEntries = document.getElementById('journal-entries');
   const journalContainer = document.getElementById('journal');
+  if (journalQueue && journalQueue.length) {
+    journalQueue.forEach(({ text, eventId, source }) => {
+      const srcObj = source || (eventId ? { type: 'chapter', id: eventId } : null);
+      journalHistoryData.push(text);
+      journalHistorySources.push(srcObj);
+    });
+  }
   journalEntries.innerHTML = ''; // Remove all entries from the display
   journalEntriesData = []; // Clear the stored data array but keep history
   journalEntrySources = [];

--- a/tests/journalClearQueueHistory.test.js
+++ b/tests/journalClearQueueHistory.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('clearJournal moves queued entries to history', () => {
+  test('queued entries are preserved when clearing', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    jest.useFakeTimers();
+    ctx.addJournalEntry('first');
+    jest.runAllTimers();
+    ctx.addJournalEntry('second');
+    ctx.clearJournal();
+    jest.useRealTimers();
+
+    const history = vm.runInContext('journalHistoryData', ctx);
+    const entries = vm.runInContext('journalEntriesData', ctx);
+    const queueLen = vm.runInContext('journalQueue.length', ctx);
+    expect(history).toEqual(['first', 'second']);
+    expect(entries).toEqual([]);
+    expect(queueLen).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure pending journal entries move to history when clearing
- add regression test for journal queue preservation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68688667b21883279468e9311f3b4810