### PR TITLE
Fix journal navigation enabling after chapter zero

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -36,7 +36,7 @@ function getJournalChapterGroups() {
     if (chNum !== null) {
       if (chNum !== currentNum) {
         currentNum = chNum;
-        current = chNum > 0 ? { chapterId: src.id, chapterNum: chNum, entries: [], sources: [] } : null;
+        current = chNum >= 0 ? { chapterId: src.id, chapterNum: chNum, entries: [], sources: [] } : null;
         if (current) groups.push(current);
       }
     } else if (!current) {


### PR DESCRIPTION
## Summary
- include chapter 0 entries when grouping journal chapters
- this allows the left arrow to become active after moving to chapter 1

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686887fa4844832790059d65dca71d23