### PR TITLE
Fix journal arrow update when chapters advance

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -100,10 +100,17 @@ function processNextJournalEntry() {
   journalEntries.appendChild(entry); // Append the empty paragraph first
 
   const srcObj = source || (eventId ? { type: 'chapter', id: eventId } : null);
+  const prevGroupsLength = getJournalChapterGroups().length;
   journalEntriesData.push(text); // Store the journal entry in the array
   journalHistoryData.push(text); // Also keep it in the full history
   journalEntrySources.push(srcObj);
   journalHistorySources.push(srcObj);
+
+  // If this entry started a new chapter, automatically move to it
+  const newGroupsLength = getJournalChapterGroups().length;
+  if (newGroupsLength > prevGroupsLength) {
+    journalChapterIndex = newGroupsLength - 1;
+  }
   updateJournalNavArrows();
 
   let index = 0;


### PR DESCRIPTION
## Summary
- update journal chapter index when a new chapter begins so nav arrows show correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6868896d3f18832798c71e1f2be76667