### PR TITLE
Swap skill tree research and automation

### DIFF
--- a/src/js/skills-parameters.js
+++ b/src/js/skills-parameters.js
@@ -25,7 +25,7 @@ const skillParameters = {
       baseValue: 0.2,
       perRank: true
     },
-    requires: ['research_boost']
+    requires: ['worker_reduction']
   },
   worker_reduction: {
     id: 'worker_reduction',
@@ -110,7 +110,7 @@ const skillParameters = {
       baseValue: 0.15,
       perRank: true
     },
-    requires: ['worker_reduction']
+    requires: ['research_boost']
   },
   life_design_points: {
     id: 'life_design_points',

--- a/src/js/skillsUI.js
+++ b/src/js/skillsUI.js
@@ -17,8 +17,8 @@ function canUnlockSkill(id) {
 
 const skillLayout = {
     build_cost: { row: 0, col: 3 },
-    worker_reduction: { row: 1, col: 2 },
-    research_boost: { row: 1, col: 4 },
+    research_boost: { row: 1, col: 2 },
+    worker_reduction: { row: 1, col: 4 },
     maintenance_reduction: { row: 3, col: 4 },
     pop_growth: { row: 2, col: 4 },
     android_efficiency: { row: 3, col: 0 },

--- a/tests/newSkillsParameters.test.js
+++ b/tests/newSkillsParameters.test.js
@@ -5,7 +5,7 @@ describe('new skill parameter definitions', () => {
     const skill = skillParams.project_speed;
     expect(skill).toBeDefined();
     expect(skill.maxRank).toBe(5);
-    expect(skill.requires).toContain('worker_reduction');
+    expect(skill.requires).toContain('research_boost');
   });
 
   test('life_design_points skill exists with correct config', () => {
@@ -15,9 +15,9 @@ describe('new skill parameter definitions', () => {
     expect(skill.requires).toContain('pop_growth');
   });
 
-  test('pop_growth requires research_boost after swap', () => {
+  test('pop_growth requires worker_reduction after swap', () => {
     const skill = skillParams.pop_growth;
-    expect(skill.requires).toContain('research_boost');
+    expect(skill.requires).toContain('worker_reduction');
   });
 
   test('android_efficiency requires project_speed', () => {


### PR DESCRIPTION
## Summary
- swap research_boost and worker_reduction requirements
- update skill positions in the UI layout
- adjust tests for swapped prerequisites

## Testing
- `npm test` *(fails: colonySliders.test.js due to hidden/invisible class mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_68691f1b4fac83278b2165892272ce67