### PR TITLE
Implement initial building productivity weighting

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -342,8 +342,15 @@ class Building extends EffectableEntity {
       if(this.requiresLand){
         resources.surface.land.reserve(this.requiresLand*buildCount);
       }
+      const oldActive = this.active;
+      const oldProductivity = this.productivity;
       this.count += buildCount;
       this.active += buildCount;
+      if(this.active > 0){
+        this.productivity = oldProductivity * (oldActive / this.active);
+      } else {
+        this.productivity = 0;
+      }
       this.updateResourceStorage();
       return true;
     }

--- a/tests/buildingProductivityWeighted.test.js
+++ b/tests/buildingProductivityWeighted.test.js
@@ -1,0 +1,39 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+
+function createBuilding(){
+  const config = {
+    name: 'Test',
+    category: 'test',
+    cost: {},
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: false,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new Building(config, 'testBuilding');
+}
+
+describe('build productivity weighting', () => {
+  beforeEach(() => {
+    global.resources = { colony:{}, surface:{}, underground:{}, atmospheric:{} };
+  });
+
+  test('newly built structures start inactive', () => {
+    const b = createBuilding();
+    b.count = 2;
+    b.active = 2;
+    b.productivity = 0.8;
+    b.build(1);
+    expect(b.count).toBe(3);
+    expect(b.active).toBe(3);
+    expect(b.productivity).toBeCloseTo(0.8 * 2 / 3);
+  });
+});


### PR DESCRIPTION
## Summary
- weight productivity when constructing new buildings
- test that new buildings start with weighted productivity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68692267f0dc8327acd79bcebb7f7fca