### PR TITLE
Reset tab visibility when loading

### DIFF
--- a/src/js/save.js
+++ b/src/js/save.js
@@ -60,6 +60,9 @@ function loadGame(slotOrCustomString) {
         }
         // Reinitialize game state using the loaded planet parameters
         initializeGameState({preserveManagers: true});
+        if (typeof tabManager.resetVisibility === 'function') {
+          tabManager.resetVisibility(tabParameters);
+        }
       }
 
       // Restore day/night cycle progress

--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -57,6 +57,27 @@ const tabParameters = {
       this.tabs = {}; // Object to store tab elements by their ID
       this.loadTabs(tabParams); // Initialize tabs from parameters
     }
+
+    // Reset visibility of all managed tabs according to provided parameters
+    resetVisibility(tabParams) {
+      // Clear active and hidden classes from every tab
+      document.querySelectorAll('.tab').forEach(t => {
+        t.classList.remove('active');
+        t.classList.remove('hidden');
+      });
+
+      // Apply default hidden state from parameters
+      tabParams.tabs.forEach(tabConfig => {
+        const tab = this.tabs[tabConfig.id];
+        if (tab) {
+          if (tabConfig.isHidden) {
+            tab.classList.add('hidden');
+          } else {
+            tab.classList.remove('hidden');
+          }
+        }
+      });
+    }
   
     // Method to load tabs from the provided tab parameters
     loadTabs(tabParams) {

--- a/tests/tabVisibilityReset.test.js
+++ b/tests/tabVisibilityReset.test.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('tab visibility reset on load', () => {
+  test('hidden tabs revert to default when loading a save', () => {
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const tabCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'tab.js'), 'utf8');
+    const saveCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'save.js'), 'utf8');
+
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="tab" id="buildings-tab" data-tab="buildings"></div>
+      <div class="tab hidden" id="research-tab" data-tab="research"></div>
+      <div id="buildings" class="tab-content"></div>
+      <div id="research" class="tab-content"></div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.window = dom.window;
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+
+    vm.runInContext(effectCode + tabCode + saveCode + '; this.TabManagerRef = TabManager; this.tabParameters = tabParameters;', ctx);
+
+    // stub globals required by save.js
+    ctx.dayNightCycle = { saveState: () => ({}), loadState: () => {} };
+    ctx.resources = {};
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.projectManager = { saveState: () => ({}), loadState: () => {} };
+    ctx.researchManager = { saveState: () => ({}), loadState: () => {}, researches:{} };
+    ctx.oreScanner = { saveState: () => ({}), loadState: () => {} };
+    ctx.terraforming = { saveState: () => ({}), loadState: () => {} };
+    ctx.storyManager = { saveState: () => ({}), loadState: () => {} };
+    ctx.journalEntrySources = [];
+    ctx.journalHistorySources = [];
+    ctx.goldenAsteroid = { saveState: () => ({}), loadState: () => {} };
+    ctx.solisManager = { saveState: () => ({}), loadState: () => {}, reapplyEffects: () => {} };
+    ctx.lifeDesigner = { saveState: () => ({}), loadState: () => {} };
+    ctx.milestonesManager = { saveState: () => ({}), loadState: () => {} };
+    ctx.skillManager = { saveState: () => ({}), loadState: () => {} };
+    ctx.spaceManager = { saveState: () => ({}), loadState: () => {}, getCurrentPlanetKey: () => 'mars' };
+    ctx.selectedBuildCounts = {};
+    ctx.gameSettings = {};
+    ctx.colonySliderSettings = {};
+    ctx.ghgFactorySettings = {};
+    ctx.mirrorOversightSettings = {};
+    ctx.playTimeSeconds = 0;
+    ctx.planetParameters = { mars: { resources:{} } };
+    ctx.currentPlanetParameters = ctx.planetParameters.mars;
+    ctx.buildingsParameters = {};
+    ctx.colonyParameters = {};
+
+    ctx.createBuildingButtons = () => {};
+    ctx.createColonyButtons = () => {};
+    ctx.initializeProjectsUI = () => {};
+    ctx.renderProjects = () => {};
+    ctx.initializeColonySlidersUI = () => {};
+    ctx.initializeResearchUI = () => {};
+    ctx.initializeHopeUI = () => {};
+    ctx.createMilestonesUI = () => {};
+    ctx.initializeSpaceUI = () => {};
+    ctx.updateSpaceUI = () => {};
+    ctx.createResourceDisplay = () => {};
+    ctx.updateDayNightDisplay = () => {};
+    ctx.updateBuildingDisplay = () => {};
+    ctx.updateResearchUI = () => {};
+    ctx.updateTerraformingUI = () => {};
+    ctx.updateWarnings = () => {};
+    ctx.updateMilestonesUI = () => {};
+    ctx.updateHopeUI = () => {};
+    ctx.renderProjects = () => {};
+    ctx.autosave = () => {};
+    ctx.startNewGame = () => {};
+
+    ctx.initializeGameState = () => {
+      ctx.tabManager = new ctx.TabManagerRef({ description: 'test' }, ctx.tabParameters);
+    };
+
+    // initial setup
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('tabManager.enable("research-tab");', ctx);
+
+    const saveString = JSON.stringify({ spaceManager: {} });
+    ctx.saved = saveString;
+    vm.runInContext('loadGame(saved);', ctx);
+
+    const hidden = ctx.document.getElementById('research-tab').classList.contains('hidden');
+    expect(hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `resetVisibility` to `TabManager`
- call it from `loadGame` so tabs revert to defaults before save data effects are applied
- test that loading a save hides previously unlocked tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68692237cb108327a7bfd0da0f127ea6