### PR TITLE
Implement metal mining penalty without elevator

### DIFF
--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -174,7 +174,7 @@ const projectParameters = {
     category :"resources",
     cost: {},
     duration: 100000,
-    description: "Use your spaceships to mine asteroids for metal. The first 100 spaceship assignments reduce the duration, every spaceship assignment afterward provides a multiplier.",
+    description: "Use your spaceships to mine asteroids for metal. The first 100 spaceship assignments reduce the duration, every spaceship assignment afterward provides a multiplier. Without a space elevator, the metal cost per ship reduces the metal returned.",
     repeatable: true,
     maxRepeatCount: Infinity,
     unlocked: false,

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -5,6 +5,28 @@ class SpaceMiningProject extends SpaceshipProject {
     this.disablePressureThreshold = 0;
   }
 
+  shouldPenalizeMetalProduction() {
+    const gainMetal = this.attributes.resourceGainPerShip?.colony?.metal;
+    const cost = this.calculateSpaceshipCost();
+    const metalCost = cost.colony?.metal || 0;
+    return !!gainMetal && metalCost > 0;
+  }
+
+  ignoreCostForResource(category, resource) {
+    return category === 'colony' && resource === 'metal' && this.shouldPenalizeMetalProduction();
+  }
+
+  applyMetalCostPenalty(gain) {
+    if (!this.shouldPenalizeMetalProduction()) return;
+    const cost = this.calculateSpaceshipCost();
+    const metalCost = cost.colony?.metal || 0;
+    const scaling = this.assignedSpaceships > 100 ? this.assignedSpaceships / 100 : 1;
+    const totalCost = metalCost * scaling;
+    if (gain.colony && typeof gain.colony.metal === 'number') {
+      gain.colony.metal = Math.max(0, gain.colony.metal - totalCost);
+    }
+  }
+
   createPressureControl() {
     const control = document.createElement('div');
     control.classList.add('checkbox-container', 'pressure-control');

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -69,7 +69,7 @@ class SpaceshipProject extends Project {
 
     if (elements.totalCostElement && this.assignedSpaceships != null) {
       const totalCost = this.calculateSpaceshipTotalCost();
-      elements.totalCostElement.innerHTML = formatTotalCostDisplay(totalCost);
+      elements.totalCostElement.innerHTML = formatTotalCostDisplay(totalCost, this);
     }
 
     if (elements.resourceGainPerShipElement && this.attributes.resourceGainPerShip) {
@@ -353,6 +353,9 @@ class SpaceshipProject extends Project {
     const totalSpaceshipCost = this.calculateSpaceshipTotalCost();
     for (const category in totalSpaceshipCost) {
       for (const resource in totalSpaceshipCost[category]) {
+        if (this.ignoreCostForResource && this.ignoreCostForResource(category, resource)) {
+          continue;
+        }
         if (resources[category][resource].value < totalSpaceshipCost[category][resource]) {
           return false;
         }
@@ -384,6 +387,9 @@ class SpaceshipProject extends Project {
       const totalSpaceshipCost = this.calculateSpaceshipTotalCost();
       for (const category in totalSpaceshipCost) {
         for (const resource in totalSpaceshipCost[category]) {
+          if (this.ignoreCostForResource && this.ignoreCostForResource(category, resource)) {
+            continue;
+          }
           resources[category][resource].decrease(totalSpaceshipCost[category][resource]);
         }
       }
@@ -404,6 +410,9 @@ class SpaceshipProject extends Project {
 
     if (this.attributes.spaceMining) {
       const gain = this.calculateSpaceshipTotalResourceGain();
+      if (this.applyMetalCostPenalty) {
+        this.applyMetalCostPenalty(gain);
+      }
       this.pendingResourceGains = this.pendingResourceGains || [];
       for (const category in gain) {
         for (const resource in gain[category]) {
@@ -440,6 +449,9 @@ class SpaceshipProject extends Project {
       const totalCost = this.calculateSpaceshipTotalCost();
       for (const category in totalCost) {
         for (const resource in totalCost[category]) {
+          if (this.ignoreCostForResource && this.ignoreCostForResource(category, resource)) {
+            continue;
+          }
           resources[category][resource].modifyRate(
             -1000 * totalCost[category][resource] / this.getEffectiveDuration(),
             'Spaceship Cost',

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -265,9 +265,11 @@ function updateCostDisplay(project) {
         const resourceDisplayName = resources[category]?.[resource]?.displayName ||
           resource.charAt(0).toUpperCase() + resource.slice(1);
         const resourceText = `${resourceDisplayName}: ${formatNumber(requiredAmount, true)}`;
-        const formattedResourceText = availableAmount >= requiredAmount
-          ? resourceText
-          : `<span style="color: red;">${resourceText}</span>`;
+        const highlight = availableAmount < requiredAmount &&
+          !(project.ignoreCostForResource && project.ignoreCostForResource(category, resource));
+        const formattedResourceText = highlight
+          ? `<span style="color: red;">${resourceText}</span>`
+          : resourceText;
         
         costArray.push(formattedResourceText);
       }
@@ -298,7 +300,7 @@ function updateTotalCostDisplay(project) {
   // Update the total cost display element
   const totalCostDisplay = document.getElementById(`${project.name}-total-cost-display`);
   if (totalCostDisplay) {
-    totalCostDisplay.innerHTML = formatTotalCostDisplay({colony : {funding : totalCost}});
+    totalCostDisplay.innerHTML = formatTotalCostDisplay({colony : {funding : totalCost}}, project);
   }
 }
 
@@ -522,7 +524,7 @@ function checkAndStartProjectAutomatically(project) {
   }
 }
 
-function formatTotalCostDisplay(totalCost) {
+function formatTotalCostDisplay(totalCost, project) {
   const costArray = [];
   for (const category in totalCost) {
     for (const resource in totalCost[category]) {
@@ -534,9 +536,11 @@ function formatTotalCostDisplay(totalCost) {
 
       // Check if the player has enough of this resource
       const resourceText = `${resourceDisplayName}: ${formatNumber(requiredAmount, true)}`;
-      const formattedResourceText = availableAmount >= requiredAmount
-        ? resourceText
-        : `<span style="color: red;">${resourceText}</span>`;
+      const highlight = availableAmount < requiredAmount &&
+        !(project && project.ignoreCostForResource && project.ignoreCostForResource(category, resource));
+      const formattedResourceText = highlight
+        ? `<span style="color: red;">${resourceText}</span>`
+        : resourceText;
 
       costArray.push(formattedResourceText);
     }

--- a/tests/spaceMiningMetalPenalty.test.js
+++ b/tests/spaceMiningMetalPenalty.test.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('metal production penalty without space elevator', () => {
+  let context;
+  beforeEach(() => {
+    context = {
+      console,
+      EffectableEntity,
+      shipEfficiency: 1,
+      resources: {},
+      buildings: {},
+      colonies: {},
+      projectManager: { projects: {}, durationMultiplier: 1 },
+      populationModule: {},
+      tabManager: {},
+      fundingModule: {},
+      terraforming: {},
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {},
+      globalEffects: new EffectableEntity({ description: 'global' })
+    };
+    vm.createContext(context);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', context);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', context);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', context);
+
+    context.resources = {
+      colony: {
+        metal: { value: 0, decrease: jest.fn(), increase: jest.fn() }
+      },
+      special: { spaceships: { value: 1 } }
+    };
+    global.resources = context.resources;
+    Object.assign(global, context);
+  });
+
+  test('metal gain reduced by metal cost', () => {
+    const config = {
+      name: 'Mine',
+      category: 'resources',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { metal: 10 } },
+        resourceGainPerShip: { colony: { metal: 100 } }
+      }
+    };
+    const project = new context.SpaceMiningProject(config, 'mine');
+    project.assignedSpaceships = 1;
+    expect(project.canStart()).toBe(true);
+    project.start(context.resources);
+    expect(project.pendingResourceGains).toEqual([
+      { category: 'colony', resource: 'metal', quantity: 90 }
+    ]);
+    expect(context.resources.colony.metal.decrease).not.toHaveBeenCalled();
+  });
+
+  test('no penalty when metal cost removed', () => {
+    const config = {
+      name: 'Mine',
+      category: 'resources',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { metal: 10 } },
+        resourceGainPerShip: { colony: { metal: 100 } }
+      }
+    };
+    const project = new context.SpaceMiningProject(config, 'mine');
+    project.assignedSpaceships = 1;
+    project.activeEffects.push({
+      type: 'resourceCostMultiplier',
+      resourceCategory: 'colony',
+      resourceId: 'metal',
+      value: 0
+    });
+    expect(project.canStart()).toBe(true);
+    project.start(context.resources);
+    expect(project.pendingResourceGains).toEqual([
+      { category: 'colony', resource: 'metal', quantity: 100 }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add note about penalty in metal asteroid mining project
- add penalty logic for space mining projects when metal cost is active
- ignore metal cost requirements and highlight when penalized
- ensure UI doesn't show missing metal in red
- test metal mining penalty behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68696aa656b88327add10b803a397f4c