### PR TITLE
Use weighted zonal average for planet temperature

### DIFF
--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -893,11 +893,8 @@ class Terraforming extends EffectableEntity{
         gSurface: gSurface
       };
 
-      const globalTemps = dayNightTemperaturesModel(baseParams);
-      this.temperature.value = globalTemps.mean;
-      this.temperature.effectiveTempNoAtmosphere = effectiveTemp(surfaceAlbedoMix(groundAlbedo, surfaceFractions), modifiedSolarFlux);
-
       this.luminosity.zonalFluxes = {};
+      let weightedTemp = 0;
       for (const zone in this.temperature.zones) {
         const zoneFlux = this.calculateZoneSolarFlux(zone);
         this.luminosity.zonalFluxes[zone] = zoneFlux;
@@ -905,7 +902,11 @@ class Terraforming extends EffectableEntity{
         this.temperature.zones[zone].value = zoneTemps.mean;
         this.temperature.zones[zone].day = zoneTemps.day;
         this.temperature.zones[zone].night = zoneTemps.night;
+        const zonePct = getZonePercentage(zone);
+        weightedTemp += zoneTemps.mean * zonePct;
       }
+      this.temperature.value = weightedTemp;
+      this.temperature.effectiveTempNoAtmosphere = effectiveTemp(surfaceAlbedoMix(groundAlbedo, surfaceFractions), modifiedSolarFlux);
     }
 
     calculateEffectiveAlbedo() {

--- a/tests/initialTemperature.test.js
+++ b/tests/initialTemperature.test.js
@@ -66,16 +66,21 @@ function expectedTemperature(terra, params, resources) {
     biomass: calculateAverageCoverage(terra, 'biomass')
   };
 
-  const temps = physics.dayNightTemperaturesModel({
-    groundAlbedo,
-    flux: modifiedFlux,
-    rotationPeriodH: rotation,
-    surfacePressureBar: pressureBar,
-    composition,
-    surfaceFractions,
-    gSurface: g
-  });
-  return temps.mean;
+  let weighted = 0;
+  for (const zone of ['tropical', 'temperate', 'polar']) {
+    const zoneFlux = terra.calculateZoneSolarFlux(zone);
+    const zTemps = physics.dayNightTemperaturesModel({
+      groundAlbedo,
+      flux: zoneFlux,
+      rotationPeriodH: rotation,
+      surfacePressureBar: pressureBar,
+      composition,
+      surfaceFractions,
+      gSurface: g
+    });
+    weighted += zTemps.mean * getZonePercentage(zone);
+  }
+  return weighted;
 }
 
 describe('initial planetary temperatures', () => {


### PR DESCRIPTION
## Summary
- update `updateSurfaceTemperature` to compute global temperature as the zonal weighted average
- adjust tests for initial temperature calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68697554b6a48327afdd9fef68964a29