### PR TITLE
Fix journal reset when travelling

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -96,11 +96,12 @@ function create() {
 
 function initializeGameState(options = {}) {
   const preserveManagers = options.preserveManagers || false;
+  const preserveJournal = options.preserveJournal || false;
   tabManager = new TabManager({
     description: 'Manages game tabs and unlocks them based on effects.',
   }, tabParameters);
 
-  if (typeof resetJournal === 'function') {
+  if (!preserveJournal && typeof resetJournal === 'function') {
     resetJournal();
   }
 

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -150,6 +150,6 @@ function selectPlanet(planetKey){
         currentPlanetParameters = planetParameters[planetKey];
     }
 
-    initializeGameState({preserveManagers: true});
+    initializeGameState({preserveManagers: true, preserveJournal: true});
     updateSpaceUI();
 }

--- a/tests/calculateZoneSolarFlux.test.js
+++ b/tests/calculateZoneSolarFlux.test.js
@@ -34,12 +34,11 @@ describe('calculateZoneSolarFlux', () => {
     const ratio = getZoneRatio('tropical') / 0.25;
     const zonePerc = getZonePercentage('tropical');
     const baseSolar = terra.luminosity.solarFlux;
-    const mirrorPPA = terra.calculateMirrorEffect().powerPerUnitArea;
-    const expected = (
-      baseSolar +
-      4 * mirrorPPA * buildings.spaceMirror.active * (1 - 0.5) +
-      4 * mirrorPPA * buildings.spaceMirror.active * 0.5 / zonePerc
-    ) * ratio;
+    const mirror = terra.calculateMirrorEffect();
+    const totalArea = terra.celestialParameters.surfaceArea;
+    const distributedMirror = (mirror.interceptedPower * (1 - 0.5) * buildings.spaceMirror.active) / totalArea;
+    const focusedMirror = (mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / (totalArea * zonePerc);
+    const expected = (baseSolar + distributedMirror + focusedMirror) * ratio;
     const result = terra.calculateZoneSolarFlux('tropical');
     expect(result).toBeCloseTo(expected, 5);
   });
@@ -58,11 +57,10 @@ describe('calculateZoneSolarFlux', () => {
 
     const ratio = getZoneRatio('temperate') / 0.25;
     const baseSolar = terra.luminosity.solarFlux;
-    const mirrorPPA = terra.calculateMirrorEffect().powerPerUnitArea;
-    const expected = (
-      baseSolar +
-      4 * mirrorPPA * buildings.spaceMirror.active * (1 - 0.5)
-    ) * ratio;
+    const mirror = terra.calculateMirrorEffect();
+    const totalArea = terra.celestialParameters.surfaceArea;
+    const distributedMirror = (mirror.interceptedPower * (1 - 0.5) * buildings.spaceMirror.active) / totalArea;
+    const expected = (baseSolar + distributedMirror) * ratio;
     const result = terra.calculateZoneSolarFlux('temperate');
     expect(result).toBeCloseTo(expected, 5);
   });
@@ -94,16 +92,15 @@ describe('calculateZoneSolarFlux', () => {
     const ratio = getZoneRatio('tropical') / 0.25;
     const zonePerc = getZonePercentage('tropical');
     const baseSolar = terra.luminosity.solarFlux;
-    const mirrorPPA = terra.calculateMirrorEffect().powerPerUnitArea;
-    const lantern = terra.calculateLanternFlux();
-    const areaFactor = terra.celestialParameters.crossSectionArea / terra.celestialParameters.surfaceArea;
-    const expected = (
-      baseSolar +
-      4 * mirrorPPA * buildings.spaceMirror.active * (1 - 0.5) +
-      4 * lantern * areaFactor * (1 - 0.5) +
-      4 * mirrorPPA * buildings.spaceMirror.active * 0.5 / zonePerc +
-      4 * lantern * areaFactor * 0.5 / zonePerc
-    ) * ratio;
+    const mirror = terra.calculateMirrorEffect();
+    const lanternFlux = terra.calculateLanternFlux();
+    const totalArea = terra.celestialParameters.surfaceArea;
+    const areaFactor = terra.celestialParameters.crossSectionArea / totalArea;
+    const distributedMirror = (mirror.interceptedPower * (1 - 0.5) * buildings.spaceMirror.active) / totalArea;
+    const focusedMirror = (mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / (totalArea * zonePerc);
+    const distributedLantern = lanternFlux * areaFactor * (1 - 0.5);
+    const focusedLantern = lanternFlux * areaFactor * 0.5 / zonePerc;
+    const expected = (baseSolar + distributedMirror + focusedMirror + distributedLantern + focusedLantern) * ratio;
     const result = terra.calculateZoneSolarFlux('tropical');
     expect(result).toBeCloseTo(expected, 5);
   });

--- a/tests/journalPersistOnTravel.test.js
+++ b/tests/journalPersistOnTravel.test.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('journal persists when traveling', () => {
+  test('changing planet does not clear journal arrays', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) { this.config = config; },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('journalEntriesData = ["old"]; journalEntrySources = [{type:"chapter", id:"c1"}]; journalHistoryData = ["old"]; journalHistorySources = [{type:"chapter", id:"c1"}];', ctx);
+
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const entriesLength = vm.runInContext('journalEntriesData.length', ctx);
+    const historyLength = vm.runInContext('journalHistoryData.length', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(entriesLength).toBe(1);
+    expect(historyLength).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- keep journal entries when switching planets
- add preserveJournal option to `initializeGameState`
- update planet selection to use the option
- fix zone solar flux tests for current mirror logic
- test that journal survives planet travel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686983f7408083278be461ddd5c7d3fe