### PR TITLE
Add day-night icons for buildings

### DIFF
--- a/src/css/structure.css
+++ b/src/css/structure.css
@@ -99,6 +99,10 @@
     font-size: 0.85em;
 }
 
+.day-night-icon {
+    margin-left: 4px;
+}
+
 .build-count-display {
     display: inline-block; /* Reserve consistent space for the count */
     width: 2em;           /* Keep x10 and /10 buttons aligned */

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -200,6 +200,14 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     productivityValue.textContent = `${Math.round(structure.productivity * 100)}%`;
     productivityContainer.appendChild(productivityValue);
 
+    if (structure.dayNightActivity) {
+      const dayNightIcon = document.createElement('span');
+      dayNightIcon.id = `${structure.name}-day-night-icon`;
+      dayNightIcon.classList.add('day-night-icon');
+      dayNightIcon.textContent = dayNightCycle.isDay() ? '☀️' : '🌙';
+      productivityContainer.appendChild(dayNightIcon);
+    }
+
     constructedCountContainer.appendChild(productivityContainer);
   }
 
@@ -600,7 +608,7 @@ function updateDecreaseButtonText(button, buildCount) {
       if (productivityElement) {
         const productivityValue = Math.round((structure.productivity * 100));
         productivityElement.textContent = `${productivityValue}%`;
-      
+
         if (structure.dayNightActivity && dayNightCycle.isNight()) {
           productivityElement.style.color = 'darkblue';
         } else if (productivityValue < 100) {
@@ -608,6 +616,11 @@ function updateDecreaseButtonText(button, buildCount) {
         } else {
           productivityElement.style.color = 'inherit';
         }
+      }
+
+      const iconElement = document.getElementById(`${structureName}-day-night-icon`);
+      if (iconElement) {
+        iconElement.textContent = dayNightCycle.isDay() ? '☀️' : '🌙';
       }
   
       const button = document.getElementById(`build-${structureName}`);

--- a/tests/dayNightIconDisplay.test.js
+++ b/tests/dayNightIconDisplay.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('day night icon display', () => {
+  test('updates sun and moon icon next to productivity', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.formatNumber = n => n;
+    ctx.formatBigInteger = n => String(n);
+    ctx.formatBuildingCount = n => String(n);
+    ctx.multiplyByTen = n => n * 10;
+    ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
+    ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0 } } };
+    ctx.globalEffects = { isBooleanFlagSet: () => false };
+    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    ctx.dayNightCycle = { isNight: () => false, isDay: () => true };
+    ctx.toDisplayTemperature = () => 0;
+    ctx.getTemperatureUnit = () => 'K';
+    ctx.formatResourceDetails = () => '';
+    ctx.formatStorageDetails = () => '';
+    ctx.updateColonyDetailsDisplay = () => {};
+    ctx.createColonyDetails = () => dom.window.document.createElement('div');
+    ctx.Colony = class {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const structure = {
+      name: 'testPanel',
+      displayName: 'Test',
+      category: 'energy',
+      canBeToggled: false,
+      count: 1,
+      active: 1,
+      unlocked: true,
+      isHidden: false,
+      requiresProductivity: true,
+      dayNightActivity: true,
+      autoBuildEnabled: false,
+      autoBuildPercent: 0,
+      autoBuildPriority: false,
+      getTotalWorkerNeed: () => 0,
+      getEffectiveWorkerMultiplier: () => 1,
+      getEffectiveCost: () => ({}),
+      canAfford: () => true,
+      canAffordLand: () => true,
+      requiresLand: 0,
+      getModifiedStorage: () => ({}),
+      powerPerBuilding: null,
+      activeEffects: [],
+      getEffectiveProductionMultiplier: () => 1,
+      getModifiedProduction: () => ({}),
+      getModifiedConsumption: () => ({}),
+      requiresMaintenance: false,
+      maintenanceCost: {},
+      description: ''
+    };
+
+    const row = ctx.createStructureRow(structure, () => {}, () => {}, false);
+    dom.window.document.body.appendChild(row);
+
+    ctx.buildings = { [structure.name]: structure };
+    ctx.updateStructureDisplay(ctx.buildings);
+
+    const icon = dom.window.document.getElementById(`${structure.name}-day-night-icon`);
+    expect(icon.textContent).toBe('☀️');
+
+    ctx.dayNightCycle.isNight = () => true;
+    ctx.dayNightCycle.isDay = () => false;
+
+    ctx.updateStructureDisplay(ctx.buildings);
+    expect(icon.textContent).toBe('🌙');
+  });
+});


### PR DESCRIPTION
## Summary
- show a sun or moon icon next to productivity for day/night buildings
- keep the icon updated as the cycle changes
- style the new day-night icon
- add unit test for the new icon behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686d3b130ac483278329b7fcd464bd28