### PR TITLE
Fix vertical scaling for UI panels

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -59,12 +59,14 @@ body {
 .resource-wrapper {
     flex: 0 0 16%; /* Takes up 20% of the space */
     min-width: 16%;
-    min-height: 800px;
+    height: calc(100vh - 100px); /* Scale with window height minus top area */
+    overflow-y: auto; /* Scroll if content exceeds space */
 }
 
 .tab-content-wrapper {
     display: flex;
     gap: 30px;
+    height: calc(100vh - 100px); /* Fill remaining vertical space below tabs */
 }
 
 /* Adjusts the main content area (tab-content) to take all remaining space */
@@ -123,7 +125,7 @@ body {
     padding: 15px; /* Adds padding to the journal text */
     box-sizing: border-box; /* Ensures padding is inside the element width */
     overflow-y: auto; /* Allows scrolling if content exceeds height */
-    max-height: 87vh; /* Limit to one screen height */
+    height: calc(100vh - 100px); /* Scale with window height minus top area */
 }
 
 /* Journal entries */


### PR DESCRIPTION
## Summary
- scale resource panel and journal height based on viewport
- reserve vertical space below tabs for main content

## Testing
- `npm test` *(fails: 1 failed, 188 passed)*

------
https://chatgpt.com/codex/tasks/task_b_686ec74b9bdc8327a724d0b8d32b02e3