### PR TITLE
Enable fractional pressure threshold input

### DIFF
--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -48,7 +48,7 @@ class SpaceMiningProject extends SpaceshipProject {
   
     const input = document.createElement('input');
     input.type = 'number';
-    input.step = 1;
+    input.step = 'any';
     input.classList.add('pressure-input');
     input.value = this.disablePressureThreshold;
     input.addEventListener('input', () => {

--- a/tests/spaceMiningPressureInput.test.js
+++ b/tests/spaceMiningPressureInput.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceMiningProject pressure control', () => {
+  test('pressure input step allows floats', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectElements = {};
+    ctx.EffectableEntity = EffectableEntity;
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+
+    const config = {
+      name: 'Mine',
+      category: 'resources',
+      cost: {},
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { spaceMining: true }
+    };
+    const project = new ctx.SpaceMiningProject(config, 'mine');
+    const control = project.createPressureControl();
+    const input = control.querySelector('.pressure-input');
+    expect(input.step).toBe('any');
+  });
+});


### PR DESCRIPTION
## Summary
- allow decimal inputs when disabling space mining above a pressure
- add a regression test to verify number input step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686f2d9310a4832789e03f1df1d24824