### PR TITLE
Add milestone alert system

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
     <div class="tab hidden" id="special-projects-tab" data-tab="special-projects">Special Projects</div>
     <div class="tab hidden" id="colonies-tab" data-tab="colonies">Colony</div>
     <div class="tab hidden" id="research-tab" data-tab="research">Research</div>
-    <div class="tab hidden" id="terraforming-tab" data-tab="terraforming">Terraforming</div>
+    <div class="tab hidden" id="terraforming-tab" data-tab="terraforming">Terraforming<span id="terraforming-alert" class="milestone-alert">!</span></div>
     <!-- *** NEW SPACE TAB BUTTON *** -->
     <div class="tab hidden" id="space-tab" data-tab="space">Space</div>
     <!-- *************************** -->
@@ -324,6 +324,9 @@
           </div>
           <div id = "milestone-terraforming" class="terraforming-subtab-content">
             <h2>Milestones</h2>
+            <div class="milestone-options">
+                <label><input type="checkbox" id="milestone-silence-toggle"> Silence milestone alert</label>
+            </div>
              <!-- Milestones UI goes here -->
           </div>
         </div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -199,6 +199,13 @@ body {
     margin-left: 4px;
 }
 
+.milestone-alert {
+    color: red;
+    font-weight: bold;
+    display: none;
+    margin-left: 4px;
+}
+
 .journal.collapsed {
     display: none;
 }

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -22,6 +22,7 @@ let gameSettings = {
   useCelsius: false,
   hideCompletedResearch: false,
   silenceSolisAlert: false,
+  silenceMilestoneAlert: false,
 };
 
 let colonySliderSettings = {

--- a/src/js/milestonesUI.js
+++ b/src/js/milestonesUI.js
@@ -1,3 +1,6 @@
+let milestoneAlertNeeded = false;
+let lastCompletableCount = 0;
+
 function createMilestonesUI() {
     const milestonesContainer = document.getElementById('milestone-terraforming');
     milestonesContainer.innerHTML = ''; // Clear any existing content
@@ -11,6 +14,25 @@ function createMilestonesUI() {
     const description = document.createElement('p');
     description.textContent = 'Track your progress and unlock up to 10% colony happiness as you achieve these terraforming milestones.  Each milestone completed will also start a festival.';
     milestonesContainer.appendChild(description);
+
+    const silenceDiv = document.createElement('div');
+    const silenceLabel = document.createElement('label');
+    const silenceToggle = document.createElement('input');
+    silenceToggle.type = 'checkbox';
+    silenceToggle.id = 'milestone-silence-toggle';
+    if (typeof gameSettings !== 'undefined') {
+        silenceToggle.checked = gameSettings.silenceMilestoneAlert || false;
+    }
+    silenceToggle.addEventListener('change', () => {
+        if (typeof gameSettings !== 'undefined') {
+            gameSettings.silenceMilestoneAlert = silenceToggle.checked;
+        }
+        updateMilestoneAlert();
+    });
+    silenceLabel.appendChild(silenceToggle);
+    silenceLabel.appendChild(document.createTextNode(' Silence milestone alert'));
+    silenceDiv.appendChild(silenceLabel);
+    milestonesContainer.appendChild(silenceDiv);
 
     // Add total bonuses display
     const totalBonuses = document.createElement('div');
@@ -104,4 +126,39 @@ function updateMilestonesUI() {
             milestonesManager.countdownElement = null;
         }
     }
+
+    checkMilestoneAlert();
+    updateMilestoneAlert();
+}
+
+function checkMilestoneAlert() {
+    const count = (typeof milestonesManager !== 'undefined' && milestonesManager.getCompletableMilestones)
+        ? milestonesManager.getCompletableMilestones().length
+        : 0;
+    if (count > lastCompletableCount) {
+        milestoneAlertNeeded = true;
+    }
+    lastCompletableCount = count;
+}
+
+function updateMilestoneAlert() {
+    const alertEl = document.getElementById('terraforming-alert');
+    if (!alertEl) return;
+    if (typeof gameSettings !== 'undefined' && gameSettings.silenceMilestoneAlert) {
+        alertEl.style.display = 'none';
+        return;
+    }
+    alertEl.style.display = milestoneAlertNeeded ? 'inline' : 'none';
+}
+
+function markMilestonesViewed() {
+    milestoneAlertNeeded = false;
+    lastCompletableCount = (typeof milestonesManager !== 'undefined' && milestonesManager.getCompletableMilestones)
+        ? milestonesManager.getCompletableMilestones().length
+        : 0;
+    updateMilestoneAlert();
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { checkMilestoneAlert, updateMilestoneAlert, markMilestonesViewed };
 }

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -228,6 +228,10 @@ function loadGame(slotOrCustomString) {
       if(silenceToggle){
         silenceToggle.checked = gameSettings.silenceSolisAlert;
       }
+      const milestoneToggle = document.getElementById('milestone-silence-toggle');
+      if(milestoneToggle){
+        milestoneToggle.checked = gameSettings.silenceMilestoneAlert;
+      }
       if (typeof completedResearchHidden !== 'undefined') {
         completedResearchHidden = gameSettings.hideCompletedResearch || false;
         if (typeof updateAllResearchButtons === 'function') {

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -44,6 +44,10 @@ function activateTerraformingSubtab(subtabId) {
   // Add active class to the clicked subtab and corresponding content
   document.querySelector(`[data-subtab="${subtabId}"]`).classList.add('active');
   document.getElementById(subtabId).classList.add('active');
+
+  if(subtabId === 'milestone-terraforming' && typeof markMilestonesViewed === 'function') {
+    markMilestonesViewed();
+  }
 }
 
 function createTerraformingSummaryUI() {

--- a/tests/milestoneAlert.test.js
+++ b/tests/milestoneAlert.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Terraforming tab alert for milestones', () => {
+  test('shows alert on new milestone and clears when viewed', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="terraforming-tab"><span id="terraforming-alert" class="milestone-alert">!</span></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.milestonesManager = { getCompletableMilestones: () => [] };
+    ctx.gameSettings = { silenceMilestoneAlert: false };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'milestonesUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.checkMilestoneAlert();
+    ctx.updateMilestoneAlert();
+    expect(dom.window.document.getElementById('terraforming-alert').style.display).toBe('none');
+
+    ctx.milestonesManager.getCompletableMilestones = () => [{}];
+    ctx.checkMilestoneAlert();
+    ctx.updateMilestoneAlert();
+    expect(dom.window.document.getElementById('terraforming-alert').style.display).toBe('inline');
+
+    ctx.markMilestonesViewed();
+    expect(dom.window.document.getElementById('terraforming-alert').style.display).toBe('none');
+  });
+});

--- a/tests/milestoneSilenceAlert.test.js
+++ b/tests/milestoneSilenceAlert.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('silence milestone alert setting', () => {
+  test('alert hidden when silenced', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="terraforming-tab"><span id="terraforming-alert" class="milestone-alert">!</span></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.milestonesManager = { getCompletableMilestones: () => [{}] };
+    ctx.gameSettings = { silenceMilestoneAlert: true };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'milestonesUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.checkMilestoneAlert();
+    ctx.updateMilestoneAlert();
+    expect(dom.window.document.getElementById('terraforming-alert').style.display).toBe('none');
+
+    ctx.gameSettings.silenceMilestoneAlert = false;
+    ctx.updateMilestoneAlert();
+    expect(dom.window.document.getElementById('terraforming-alert').style.display).toBe('inline');
+  });
+});


### PR DESCRIPTION
## Summary
- show an alert on the Terraforming tab when a milestone becomes available
- allow the alert to be silenced via checkbox on the milestone subtab
- save/load milestone alert setting in saved games
- hide the alert once the player views the milestones
- add tests covering alert behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686f30b6279c8327a9f6e30ea3345b3a