### PR TITLE
Display solar flux for space mirrors

### DIFF
--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -668,6 +668,13 @@ function updateDecreaseButtonText(button, buildCount) {
       providesParts.push(`${formatNumber(flux, true, 2)} W/m² solar flux`);
     }
 
+    // Include solar flux for space mirrors
+    if (structure.name === 'spaceMirror' && terraforming && typeof terraforming.calculateMirrorEffect === 'function') {
+      const mirrorFluxPerMirror = terraforming.calculateMirrorEffect().powerPerUnitArea;
+      const flux = mirrorFluxPerMirror * structure.active;
+      providesParts.push(`${formatNumber(flux, true, 2)} W/m² solar flux`);
+    }
+
     if (providesParts.length > 0) {
       detailsText += `<strong>Provides:</strong> ${providesParts.join(', ')}`;
     }

--- a/tests/spaceMirrorFluxDisplay.test.js
+++ b/tests/spaceMirrorFluxDisplay.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('Space Mirror UI display', () => {
+  test('shows solar flux from active mirrors', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="details"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.terraforming = {
+      calculateMirrorEffect: () => ({ powerPerUnitArea: 2 })
+    };
+
+    const structure = {
+      name: 'spaceMirror',
+      displayName: 'Space Mirror',
+      active: 3,
+      productivity: 1,
+      getModifiedStorage: () => ({}),
+      getModifiedProduction: () => ({}),
+      getModifiedConsumption: () => ({}),
+      requiresMaintenance: false,
+      maintenanceCost: {},
+      getEffectiveProductionMultiplier: () => 1
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const detailsElement = dom.window.document.getElementById('details');
+    ctx.updateProductionConsumptionDetails(structure, detailsElement);
+
+    expect(detailsElement.innerHTML).toContain('Provides');
+    expect(detailsElement.innerHTML).toContain('6 W/m² solar flux');
+  });
+});


### PR DESCRIPTION
## Summary
- show solar flux for space mirrors in building details similar to Hyperion Lantern
- test space mirror UI flux display

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68706d52d608832784aaee44d33fa596