### PR TITLE
Reverse story project list

### DIFF
--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -288,14 +288,24 @@ class ProjectManager extends EffectableEntity {
   }
 
   initializeProjects(projectParameters) {
+    const storyProjects = [];
+    const otherProjects = [];
+
     for (const projectName in projectParameters) {
       const projectData = projectParameters[projectName];
       const type = projectData.type || 'Project';
       const globalObj = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : {});
       const Ctor = globalObj && globalObj[type] ? globalObj[type] : Project;
       this.projects[projectName] = new Ctor(projectData, projectName);
-      this.projectOrder.push(projectName);
+
+      if (projectData.category === 'story') {
+        storyProjects.push(projectName);
+      } else {
+        otherProjects.push(projectName);
+      }
     }
+
+    this.projectOrder = storyProjects.reverse().concat(otherProjects);
   }
 
   startProject(projectName) {

--- a/tests/storyProjectOrder.test.js
+++ b/tests/storyProjectOrder.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('default story project order', () => {
+  test('story projects appear in reverse order', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const progressCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress-data.js'), 'utf8');
+    vm.runInContext(paramsCode + progressCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.initializeProjects(ctx.projectParameters);
+
+    const order = ctx.projectManager.getProjectStatuses()
+      .filter(p => p.category === 'story')
+      .map(p => p.name);
+
+    expect(order.slice(0, 4)).toEqual([
+      'interrogate_alien',
+      'sticky_dust_trap',
+      'triangulate_attack',
+      'earthProbe'
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- reverse default order of story projects when initializing
- add tests for story project ordering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68706d3f4ecc83279a3bccac6de1ba48