### PR TITLE
Show zone distribution in life tooltip

### DIFF
--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -486,7 +486,10 @@ function createWaterBox(row) {
     lifeBox.id = 'life-box';
     const lifeInfo = document.createElement('span');
     lifeInfo.classList.add('info-tooltip-icon');
-    lifeInfo.title = 'Life is the pinnacle of the terraforming process. It is introduced via the Life Designer and its success depends on environmental conditions.\n\n- Environmental Tolerance: Each lifeform has specific temperature and moisture ranges required for survival and growth. It can only spread in zones where these conditions are met.\n- Atmospheric Interaction: Life can significantly alter the atmosphere through processes like photosynthesis (consuming CO2, producing O2) and respiration.\n- Terraforming Goal: Achieving a high percentage of biomass coverage is a key objective for completing the terraforming of a planet.';
+    const tropPct = (getZonePercentage('tropical') * 100).toFixed(1);
+    const tempPct = (getZonePercentage('temperate') * 100).toFixed(1);
+    const polPct  = (getZonePercentage('polar') * 100).toFixed(1);
+    lifeInfo.title = 'Life is the pinnacle of the terraforming process. It is introduced via the Life Designer and its success depends on environmental conditions.\n\n- Environmental Tolerance: Each lifeform has specific temperature and moisture ranges required for survival and growth. It can only spread in zones where these conditions are met.\n- Atmospheric Interaction: Life can significantly alter the atmosphere through processes like photosynthesis (consuming CO2, producing O2) and respiration.\n- Terraforming Goal: Achieving a high percentage of biomass coverage is a key objective for completing the terraforming of a planet.\n\nSurface distribution:\n- Tropical: ' + tropPct + '%\n- Temperate: ' + tempPct + '%\n- Polar: ' + polPct + '%';
     lifeInfo.innerHTML = '&#9432;';
     // Use static text/placeholders, values will be filled by updateLifeBox
     lifeBox.innerHTML = `

--- a/tests/atmosphereOpticalDepthUI.test.js
+++ b/tests/atmosphereOpticalDepthUI.test.js
@@ -12,6 +12,7 @@ describe('atmosphere UI optical depth', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.toDisplayTemperature = numbers.toDisplayTemperature;
     ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
 
     ctx.resources = { atmospheric: { o2: { displayName: 'O2' } } };
     ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };

--- a/tests/lifeCoverageTable.test.js
+++ b/tests/lifeCoverageTable.test.js
@@ -12,6 +12,7 @@ describe('life coverage table', () => {
     const ctx = dom.getInternalVMContext();
 
     ctx.ZONES = ['tropical', 'temperate', 'polar'];
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
     ctx.calculateAverageCoverage = () => 0.25;
     ctx.calculateZonalCoverage = (tf, zone) => {
       switch(zone){

--- a/tests/lifeLuminosityTable.test.js
+++ b/tests/lifeLuminosityTable.test.js
@@ -10,6 +10,7 @@ describe('life luminosity table', () => {
     const ctx = dom.getInternalVMContext();
 
     ctx.ZONES = ['tropical', 'temperate', 'polar'];
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
     ctx.calculateAverageCoverage = () => 0.25;
     ctx.calculateZonalCoverage = () => 0; // not needed
     ctx.terraforming = {

--- a/tests/lifeTooltipZones.test.js
+++ b/tests/lifeTooltipZones.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const zones = require('../src/js/zones.js');
+
+describe('life tooltip zone percentages', () => {
+  test('tooltip includes surface distribution percentages', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div class="row"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.getZonePercentage = zones.getZonePercentage;
+    ctx.calculateAverageCoverage = () => 0;
+    ctx.calculateZonalCoverage = () => 0;
+    ctx.terraforming = {
+      life: { target: 0.5 },
+      zonalSurface: { tropical:{}, temperate:{}, polar:{} },
+      celestialParameters: { surfaceArea: 1 },
+      calculateZonalSolarPanelMultiplier: () => 1
+    };
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const row = dom.window.document.querySelector('.row');
+    ctx.createLifeBox(row);
+
+    const icon = row.querySelector('.info-tooltip-icon');
+    const title = icon.getAttribute('title');
+    const t = (zones.getZonePercentage('tropical') * 100).toFixed(1);
+    const m = (zones.getZonePercentage('temperate') * 100).toFixed(1);
+    const p = (zones.getZonePercentage('polar') * 100).toFixed(1);
+
+    expect(title).toContain('Tropical: ' + t + '%');
+    expect(title).toContain('Temperate: ' + m + '%');
+    expect(title).toContain('Polar: ' + p + '%');
+  });
+});

--- a/tests/terraformingBoxTooltips.test.js
+++ b/tests/terraformingBoxTooltips.test.js
@@ -12,6 +12,7 @@ describe('terraforming box tooltips', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.toDisplayTemperature = numbers.toDisplayTemperature;
     ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
 
     ctx.resources = { atmospheric: { o2: { displayName: 'O2', value: 0 } } };
     ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };

--- a/tests/terraformingSummaryUICreation.test.js
+++ b/tests/terraformingSummaryUICreation.test.js
@@ -12,6 +12,7 @@ describe('terraforming summary UI creation', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.toDisplayTemperature = numbers.toDisplayTemperature;
     ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
 
     ctx.resources = { atmospheric: { o2: { displayName: 'O2' } } };
     ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };


### PR DESCRIPTION
## Summary
- display surface area breakdown in the Life tooltip
- ensure `getZonePercentage` is available to UI tests
- test Life tooltip zone percentages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68706f8f1d2083278e8fdc32050ec2d1