### PR TITLE
Add tooltip for Polar life requirement

### DIFF
--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -91,7 +91,7 @@ function initializeLifeTerraformingDesignerUI() {
                         <th style="border: 1px solid #ccc; padding: 5px; text-align: center;">Global</th>
                         <th style="border: 1px solid #ccc; padding: 5px; text-align: center;">Tropical</th>
                         <th style="border: 1px solid #ccc; padding: 5px; text-align: center;">Temperate</th>
-                        <th style="border: 1px solid #ccc; padding: 5px; text-align: center;">Polar</th>
+                        <th style="border: 1px solid #ccc; padding: 5px; text-align: center;">Polar <span class="info-tooltip-icon" title="not required to complete terraforming.  Can be ignored.  Or not.">&#9432;</span></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/tests/lifeUIPolarTooltip.test.js
+++ b/tests/lifeUIPolarTooltip.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const physics = require('../src/js/physics.js');
+const numbers = require('../src/js/numbers.js');
+
+describe('lifeUI polar tooltip', () => {
+  test('polar column header includes tooltip', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { day: 280, night: 280 }, temperate: { day: 280, night: 280 }, polar: { day: 280, night: 280 } } },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,0,0,0,0,0,0,0);
+
+    ctx.initializeLifeTerraformingDesignerUI();
+
+    const header = dom.window.document.querySelector('#life-status-table th:nth-child(5)');
+    const icon = header.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    expect(icon.title).toBe('not required to complete terraforming.  Can be ignored.  Or not.');
+  });
+});


### PR DESCRIPTION
## Summary
- show a tooltip icon next to the **Polar** column in the life requirements table
- test that the tooltip is present with the expected text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6870706a25bc83278a9758eb493626ab