### PR TITLE
Display error after terraforming completion

### DIFF
--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -736,6 +736,7 @@ function createCompleteTerraformingButton(container) {
         if (typeof updateCompleteTerraformingButton === 'function') {
             updateCompleteTerraformingButton();
         }
+        button.textContent = 'ERROR : MTC not responding';
     }
   });
 }
@@ -746,13 +747,28 @@ function updateCompleteTerraformingButton() {
 
   if (!button) return;
 
+  const planetTerraformed = (typeof spaceManager !== 'undefined' &&
+    typeof spaceManager.getCurrentPlanetKey === 'function' &&
+    typeof spaceManager.isPlanetTerraformed === 'function' &&
+    spaceManager.isPlanetTerraformed(spaceManager.getCurrentPlanetKey()));
+
+  if (planetTerraformed) {
+      button.textContent = 'ERROR : MTC not responding';
+      button.style.backgroundColor = 'gray';
+      button.style.cursor = 'not-allowed';
+      button.disabled = true;
+      return;
+  }
+
   if (terraforming.readyForCompletion) {
       button.style.backgroundColor = 'green';
       button.style.cursor = 'pointer';
       button.disabled = false; // Enable the button
+      button.textContent = 'Complete Terraforming';
   } else {
       button.style.backgroundColor = 'red';
       button.style.cursor = 'not-allowed';
       button.disabled = true; // Disable the button
+      button.textContent = 'Complete Terraforming';
   }
 }

--- a/tests/terraformingCompletionError.test.js
+++ b/tests/terraformingCompletionError.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('complete terraforming button error text', () => {
+  test('button shows error after completion and persists when planet is terraformed', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><body><div id="terraforming-container"></div><div id="planet-selection-options"></div><div id="travel-status"></div></body>`);
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    global.terraforming = { completed: false, readyForCompletion: true };
+    global.spaceManager = {
+      updateCurrentPlanetTerraformedStatus: jest.fn(),
+      getCurrentPlanetKey: () => 'mars',
+      isPlanetTerraformed: jest.fn().mockReturnValue(false)
+    };
+    global.updateSpaceUI = jest.fn();
+
+    const ctx = vm.createContext(global);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const container = document.getElementById('terraforming-container');
+    ctx.createCompleteTerraformingButton(container);
+    const button = document.getElementById('complete-terraforming-button');
+    button.disabled = false;
+    button.click();
+
+    expect(button.textContent).toBe('ERROR : MTC not responding');
+    expect(spaceManager.updateCurrentPlanetTerraformedStatus).toHaveBeenCalledWith(true);
+
+    // simulate save/load where planet status shows terraformed
+    spaceManager.isPlanetTerraformed.mockReturnValue(true);
+    ctx.updateCompleteTerraformingButton();
+    expect(button.textContent).toBe('ERROR : MTC not responding');
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+  });
+});


### PR DESCRIPTION
## Summary
- show the MTC error text when the Complete Terraforming button is used
- keep the error text when the planet is marked terraformed
- add unit test for the new button behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687148ce82b88327adbeedc1da5a4548