### PR TITLE
Hide locked planets until unlocked

### DIFF
--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -249,7 +249,18 @@ const titanOverrides = {
     gravity: 1.35,
     radius: 2574.7,
     albedo: 0.22,
-    rotationPeriod: 382.7,
+  rotationPeriod: 382.7,
+  }
+};
+
+const callistoOverrides = {
+  name: 'Callisto',
+  celestialParameters: {
+    distanceFromSun: 5.2,
+    gravity: 1.24,
+    radius: 2410,
+    albedo: 0.2,
+    rotationPeriod: 400,
   }
 };
 
@@ -257,7 +268,8 @@ const titanOverrides = {
 
 const planetSpecificOverrides = {
   mars: marsOverrides,
-  titan: titanOverrides
+  titan: titanOverrides,
+  callisto: callistoOverrides
   // Add future planets here by defining their override objects
 };
 
@@ -288,7 +300,8 @@ function getPlanetParameters(planetName) {
 
 const planetParameters = {
     mars: getPlanetParameters('mars'),
-    titan: getPlanetParameters('titan')
+    titan: getPlanetParameters('titan'),
+    callisto: getPlanetParameters('callisto')
 };
 
 // If the codebase evolves to use the getPlanetParameters function directly,

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -25,8 +25,16 @@ class SpaceManager {
             this.planetStatuses[key] = {
                 terraformed: false,
                 visited: false,
+                enabled: false, // visible/selectable in UI
                 // Add other statuses later if needed (e.g., colonized: false)
             };
+        });
+
+        // Mars and Titan are available from the start
+        ['mars', 'titan'].forEach(p => {
+            if (this.planetStatuses[p]) {
+                this.planetStatuses[p].enabled = true;
+            }
         });
     }
 
@@ -41,6 +49,29 @@ class SpaceManager {
      */
     isPlanetTerraformed(planetKey) {
         return this.planetStatuses[planetKey]?.terraformed || false;
+    }
+
+    /**
+     * Checks if a planet is enabled/visible.
+     * @param {string} planetKey
+     * @returns {boolean}
+     */
+    isPlanetEnabled(planetKey) {
+        return !!this.planetStatuses[planetKey]?.enabled;
+    }
+
+    /**
+     * Enable a planet so it appears in the UI.
+     * @param {string} planetKey
+     * @returns {boolean} True if the planet exists and was enabled.
+     */
+    enablePlanet(planetKey) {
+        if (this.planetStatuses[planetKey]) {
+            this.planetStatuses[planetKey].enabled = true;
+            return true;
+        }
+        console.warn(`SpaceManager: Cannot enable unknown planet ${planetKey}`);
+        return false;
     }
 
     /**
@@ -85,7 +116,7 @@ class SpaceManager {
             }
              // Ensure status object exists for the new current planet
              if (!this.planetStatuses[key]) {
-                  this.planetStatuses[key] = { terraformed: false, visited: false };
+                  this.planetStatuses[key] = { terraformed: false, visited: false, enabled: false };
                   console.warn(`SpaceManager: Initialized missing status for planet ${key}.`);
              }
            return true;
@@ -101,6 +132,14 @@ class SpaceManager {
      * @returns {boolean} - True if the planet was changed.
      */
     changeCurrentPlanet(key) {
+        if (!this.isPlanetEnabled(key)) {
+            console.warn(`SpaceManager: Planet ${key} is not enabled.`);
+            return false;
+        }
+        if (this.isPlanetTerraformed(key)) {
+            console.warn(`SpaceManager: Planet ${key} already terraformed.`);
+            return false;
+        }
         return this._setCurrentPlanetKey(key);
     }
 
@@ -166,6 +205,9 @@ class SpaceManager {
                     }
                     if (typeof savedData.planetStatuses[planetKey].visited === 'boolean') {
                         this.planetStatuses[planetKey].visited = savedData.planetStatuses[planetKey].visited;
+                    }
+                    if (typeof savedData.planetStatuses[planetKey].enabled === 'boolean') {
+                        this.planetStatuses[planetKey].enabled = savedData.planetStatuses[planetKey].enabled;
                     }
                 }
             });

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -60,6 +60,7 @@ function updateSpaceUI() {
 
     Object.entries(allPlanetData).forEach(([key, data]) => {
         if (!data || !data.celestialParameters || !data.name) return; // Skip bad data
+        if (!_spaceManagerInstance.isPlanetEnabled(key)) return; // hide if disabled
 
         const celestial = data.celestialParameters;
         const planetDiv = document.createElement('div');
@@ -99,16 +100,14 @@ function updateSpaceUI() {
             selectButton.textContent = 'Current Location';
             selectButton.disabled = true;
             selectButton.title = `You are currently at ${data.name}.`;
+        } else if (isTerraformed) {
+            selectButton.textContent = 'Already Terraformed';
+            selectButton.disabled = true;
+            selectButton.title = `${data.name} has already been terraformed.`;
         } else {
-            // Disable button if the target planet is already terraformed? (Gameplay decision)
-            // if (isTerraformed) {
-            //    selectButton.textContent = 'Already Terraformed';
-            //    selectButton.disabled = true;
-            //} else {
-                selectButton.textContent = `Select ${data.name}`;
-                selectButton.disabled = !canChangePlanet; // Enable only if current planet terraformed
-                selectButton.title = canChangePlanet ? `Travel to ${data.name}` : 'Finish terraforming before traveling';
-            //}
+            selectButton.textContent = `Select ${data.name}`;
+            selectButton.disabled = !canChangePlanet;
+            selectButton.title = canChangePlanet ? `Travel to ${data.name}` : 'Finish terraforming before traveling';
         }
         planetDiv.appendChild(selectButton);
         optionsContainer.appendChild(planetDiv);
@@ -136,6 +135,14 @@ function selectPlanet(planetKey){
     const currentKey = _spaceManagerInstance.getCurrentPlanetKey();
     if(!_spaceManagerInstance.isPlanetTerraformed(currentKey)) {
         console.warn('Cannot travel until current planet is terraformed.');
+        return;
+    }
+    if(!_spaceManagerInstance.isPlanetEnabled(planetKey)) {
+        console.warn('Planet not yet available.');
+        return;
+    }
+    if(_spaceManagerInstance.isPlanetTerraformed(planetKey)) {
+        console.warn('Target planet already terraformed.');
         return;
     }
     if(!_spaceManagerInstance.changeCurrentPlanet(planetKey)) return;

--- a/tests/callistoUnlock.test.js
+++ b/tests/callistoUnlock.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+
+const ctx = { console };
+vm.createContext(ctx);
+vm.runInContext(`${spaceCode}; this.SpaceManager = SpaceManager;`, ctx);
+
+describe('enablePlanet allows unlocking new planets', () => {
+  test('Callisto starts disabled and can be enabled', () => {
+    const manager = new ctx.SpaceManager(planetParameters);
+    expect(manager.isPlanetEnabled('callisto')).toBe(false);
+    manager.enablePlanet('callisto');
+    expect(manager.isPlanetEnabled('callisto')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Callisto planet definition
- track an `enabled` flag for planets
- show only enabled planets and disable selecting terraformed ones
- check planet availability in `selectPlanet`
- add a test verifying Callisto can be unlocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871c5a47c5883278500417c673e906f