### PR TITLE
Ensure Solis resources deliver on first planet visit

### DIFF
--- a/tests/solisTravelResourceDelivery.test.js
+++ b/tests/solisTravelResourceDelivery.test.js
@@ -1,0 +1,36 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis resource delivery on planet travel', () => {
+  test('resources are granted only on first visit to a planet', () => {
+    let currentPlanet = 'mars';
+    global.spaceManager = { getCurrentPlanetKey: () => currentPlanet };
+
+    // resources for mars
+    const marsRes = { colony: { metal: { value: 0, increase(v){ this.value += v; } } } };
+    global.resources = marsRes;
+
+    const manager = new SolisManager();
+    manager.solisPoints = 5;
+    expect(manager.purchaseUpgrade('metal')).toBe(true);
+    expect(marsRes.colony.metal.value).toBe(100);
+
+    // travel to titan
+    currentPlanet = 'titan';
+    const titanRes = { colony: { metal: { value: 0, increase(v){ this.value += v; } } } };
+    global.resources = titanRes;
+    manager.reapplyEffects();
+    expect(titanRes.colony.metal.value).toBe(100);
+
+    // reapply should not grant again
+    manager.reapplyEffects();
+    expect(titanRes.colony.metal.value).toBe(100);
+
+    // travel back to mars, ensure no extra gain
+    currentPlanet = 'mars';
+    global.resources = marsRes;
+    manager.reapplyEffects();
+    expect(marsRes.colony.metal.value).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- track per-planet resource deliveries in `SolisManager`
- supply Solis resource upgrades when visiting a planet for the first time
- persist delivered planets on save/load
- test resource delivery when travelling between planets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871c5eb69b88327acfd3daf1cfb33b9