### PR TITLE
Add Callisto chapter and unlocks

### DIFF
--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -508,7 +508,8 @@ function addOrRemoveEffect(effect, action) {
     'lifeManager': lifeManager,
     'oreScanner': oreScanner,
     'researchManager' : researchManager,
-    'solisManager' : solisManager
+    'solisManager' : solisManager,
+    'spaceManager' : spaceManager
   };
 
   if (effect.target in targetHandlers) {

--- a/src/js/progress-data.js
+++ b/src/js/progress-data.js
@@ -1250,6 +1250,29 @@ progressData.chapters.push(
     objectives: [
 
     ],
+    reward: [
+      {
+        target: 'spaceManager',
+        targetId: 'callisto',
+        type: 'enable'
+      }
+    ]
+  }
+);
+
+progressData.chapters.push(
+  {
+    id: "chapter6.4",
+    type: "journal",
+    chapter: 6,
+    narrative: "Callisto is the next designation for terraforming. Prepare for deployment.",
+    prerequisites: ["chapter6.3b"],
+    objectives: [
+      {
+        type: 'currentPlanet',
+        planetId: 'callisto'
+      }
+    ],
     reward: []
   }
 );

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -1,7 +1,8 @@
 // space.js
 
-class SpaceManager {
+class SpaceManager extends EffectableEntity {
     constructor(planetsData) { // Keep planetsData for validation
+        super({ description: 'Manages planetary travel' });
         if (!planetsData) {
             throw new Error("SpaceManager requires planetsData during construction.");
         }
@@ -72,6 +73,10 @@ class SpaceManager {
         }
         console.warn(`SpaceManager: Cannot enable unknown planet ${planetKey}`);
         return false;
+    }
+
+    enable(planetKey) {
+        this.enablePlanet(planetKey);
     }
 
     /**
@@ -223,4 +228,8 @@ class SpaceManager {
 
          console.log("SpaceManager state loaded:", this.saveState());
     }
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = SpaceManager;
 }

--- a/tests/callistoChapter.test.js
+++ b/tests/callistoChapter.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Callisto chapter and unlock', () => {
+  test('chapter6.3b enables Callisto and chapter6.4 requires traveling there', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress-data.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code, ctx);
+    const chapters = ctx.progressData.chapters;
+    const ch63b = chapters.find(c => c.id === 'chapter6.3b');
+    const ch64 = chapters.find(c => c.id === 'chapter6.4');
+    expect(ch63b).toBeDefined();
+    expect(ch64).toBeDefined();
+    const reward = ch63b.reward.find(r => r.target === 'spaceManager' && r.targetId === 'callisto' && r.type === 'enable');
+    expect(reward).toBeDefined();
+    expect(ch64.prerequisites).toContain('chapter6.3b');
+    const obj = ch64.objectives && ch64.objectives[0];
+    expect(obj).toEqual({ type: 'currentPlanet', planetId: 'callisto' });
+  });
+});

--- a/tests/callistoUnlock.test.js
+++ b/tests/callistoUnlock.test.js
@@ -2,12 +2,13 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
 const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
 const { planetParameters } = require('../src/js/planet-parameters.js');
 
 const ctx = { console };
 vm.createContext(ctx);
-vm.runInContext(`${spaceCode}; this.SpaceManager = SpaceManager;`, ctx);
+vm.runInContext(`${effectCode}\n${spaceCode}; this.EffectableEntity = EffectableEntity; this.SpaceManager = SpaceManager;`, ctx);
 
 describe('enablePlanet allows unlocking new planets', () => {
   test('Callisto starts disabled and can be enabled', () => {

--- a/tests/hopeTabUnlock.test.js
+++ b/tests/hopeTabUnlock.test.js
@@ -10,7 +10,7 @@ describe('HOPE tab unlock chapter', () => {
     vm.runInContext(code, ctx);
     const chapters = ctx.progressData.chapters;
     const last = chapters[chapters.length - 1];
-    expect(last.id).toBe('chapter6.3b');
+    expect(last.id).toBe('chapter6.4');
     const hopeChapter = chapters.find(c => c.id === 'chapter4.9');
     expect(hopeChapter).toBeDefined();
     const effect = hopeChapter.reward.find(r => r.targetId === 'hope-tab' && r.type === 'enable');

--- a/tests/spaceManagerEnableEffect.test.js
+++ b/tests/spaceManagerEnableEffect.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+
+describe('enable effect on SpaceManager', () => {
+  test('addAndReplace enables a planet', () => {
+    const ctx = { console, planetParameters };
+    vm.createContext(ctx);
+    vm.runInContext(`${effectCode}\n${spaceCode}; this.EffectableEntity = EffectableEntity; this.SpaceManager = SpaceManager;`, ctx);
+    ctx.spaceManager = new ctx.SpaceManager(planetParameters);
+    expect(ctx.spaceManager.isPlanetEnabled('callisto')).toBe(false);
+    ctx.spaceManager.addAndReplace({ type: 'enable', targetId: 'callisto', effectId: 't1', sourceId: 't1' });
+    expect(ctx.spaceManager.isPlanetEnabled('callisto')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reward in chapter 6.3b to enable Callisto
- add new chapter 6.4 with an objective to travel to Callisto
- route effects for the space manager
- support `enable` for `SpaceManager`
- adjust and add tests for Callisto unlocking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871c86061488327824a3d68a1021e97