### PR TITLE
Fix journal reward effects on load

### DIFF
--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -526,6 +526,22 @@ class StoryManager {
              const effectKey = JSON.stringify(effect);
              if (!effect.oneTimeFlag) { uniqueEffectsToApply.set(effectKey, effect); }
          });
+
+         // Ensure completed chapter rewards are applied even if not saved
+         this.completedEventIds.forEach(eventId => {
+             const event = this.findEventById(eventId);
+             if (!event || event.type !== 'journal' || !Array.isArray(event.reward)) return;
+             event.reward.forEach(effect => {
+                 if (effect && !effect.oneTimeFlag) {
+                     const effectKey = JSON.stringify(effect);
+                     if (!uniqueEffectsToApply.has(effectKey)) {
+                         uniqueEffectsToApply.set(effectKey, effect);
+                         this.appliedEffects.push(effect);
+                     }
+                 }
+             });
+         });
+
          uniqueEffectsToApply.forEach(effect => {
              addEffect(effect);
              // console.log(`Reapplied effect on load: ${effect.type} to ${effect.targetId}`);

--- a/tests/storyLoadMissingEffects.test.js
+++ b/tests/storyLoadMissingEffects.test.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('StoryManager loads missing effects from completed chapters', () => {
+  test('reapplies unsaved journal rewards', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress.js'), 'utf8');
+    const context = {
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      document: { addEventListener: () => {}, removeEventListener: () => {} },
+      clearJournal: () => {},
+      createPopup: () => {},
+      addJournalEntry: () => {},
+      addEffect: jest.fn(),
+      removeEffect: () => {},
+      buildings: {},
+      colonies: {},
+      resources: {},
+      terraforming: {},
+      progressData: {
+        chapters: [
+          { id: 'c1', type: 'journal', narrative: 'n', reward: [{ target: 'global', type: 'dummy' }], rewardDelay: 0 }
+        ]
+      }
+    };
+    vm.createContext(context);
+    vm.runInContext(`${code}; this.StoryManager = StoryManager;`, context);
+
+    const manager = new context.StoryManager(context.progressData);
+    context.window = { storyManager: manager };
+
+    const state = {
+      activeEventIds: [],
+      completedEventIds: ['c1'],
+      appliedEffects: [],
+      waitingForJournalEventId: null
+    };
+
+    manager.loadState(state);
+
+    expect(context.addEffect).toHaveBeenCalledWith({ target: 'global', type: 'dummy' });
+    expect(manager.appliedEffects).toContainEqual({ target: 'global', type: 'dummy' });
+  });
+
+  test('oneTimeFlag rewards are not reapplied', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress.js'), 'utf8');
+    const context = {
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      document: { addEventListener: () => {}, removeEventListener: () => {} },
+      clearJournal: () => {},
+      createPopup: () => {},
+      addJournalEntry: () => {},
+      addEffect: jest.fn(),
+      removeEffect: () => {},
+      buildings: {},
+      colonies: {},
+      resources: {},
+      terraforming: {},
+      progressData: {
+        chapters: [
+          { id: 'c1', type: 'journal', narrative: 'n', reward: [{ target: 'global', type: 'dummy', oneTimeFlag: true }], rewardDelay: 0 }
+        ]
+      }
+    };
+    vm.createContext(context);
+    vm.runInContext(`${code}; this.StoryManager = StoryManager;`, context);
+
+    const manager = new context.StoryManager(context.progressData);
+    context.window = { storyManager: manager };
+
+    const state = {
+      activeEventIds: [],
+      completedEventIds: ['c1'],
+      appliedEffects: [],
+      waitingForJournalEventId: null
+    };
+
+    manager.loadState(state);
+
+    expect(context.addEffect).not.toHaveBeenCalled();
+    expect(manager.appliedEffects).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- apply missing journal rewards during loadState
- test that unsaved journal effects are reapplied on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6871ccf685b08327955febb6c2a5b85b