### PR TITLE
Implement Dyson Swarm foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ scripts implement the tabs, pop-ups and other interface elements.
 - **autobuild.js** automatically constructs buildings based on population ratios when auto-build is enabled.
 - **milestones.js** and **milestonesUI.js** track long term objectives and unlock rewards.
 - **solis.js** and **solisUI.js** manage the Solis shop and quest system which grants Solis points for completing delivery quests.
+
+## Dyson Swarm Receiver
+The Dyson Swarm project begins with research into a large orbital array. An advanced research unlocks the concept and a follow-up energy research enables the **Dyson Swarm Receiver** special project. The receiver currently costs massive resources (10M metal, 1M components, 100k electronics) and takes five minutes to build but provides no effect yet.
 - **save.js** manages localStorage save slots and autosaving of resources, structures, research and story progress.
 - **projects.js** and **projectsUI.js** handle special missions such as asteroid mining, cargo exports and other repeatable tasks.
 - **spaceship.js** with **spaceshipUI.js** allows producing spaceships and assigning them to projects.

--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@
           <div class="projects-subtabs">
             <div id="resources-projects-tab" class="projects-subtab active" data-subtab="resources-projects">Resources</div>
             <div id="infrastructure-projects-tab" class="projects-subtab" data-subtab="infrastructure-projects">Infrastructure</div>
+            <div id="mega-projects-tab" class="projects-subtab hidden" data-subtab="mega-projects">Mega</div>
             <div id="story-projects-tab" class="projects-subtab hidden" data-subtab="story-projects">Story</div>
           </div>
           <div class="projects-subtab-content-wrapper">
@@ -224,6 +225,9 @@
             </div>
             <div id="infrastructure-projects" class="projects-subtab-content">
               <div class="projects-list" id="infrastructure-projects-list"></div>
+            </div>
+            <div id="mega-projects" class="projects-subtab-content hidden">
+              <div class="projects-list" id="mega-projects-list"></div>
             </div>
             <div id="story-projects" class="projects-subtab-content hidden">
               <div class="projects-list" id="story-projects-list"></div>

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -341,6 +341,23 @@ const projectParameters = {
       ]
     }
   },
+  dysonSwarmReceiver : {
+    type: 'DysonSwarmReceiverProject',
+    name : 'Dyson Swarm Receiver',
+    category : 'mega',
+    cost: {
+      colony: {
+        metal: 10000000,
+        components: 1000000,
+        electronics: 100000
+      }
+    },
+    duration: 300000,
+    description: 'Construct the ground-based receiver array for the Dyson Swarm. Currently provides no benefits.',
+    repeatable: false,
+    unlocked: false,
+    attributes: { }
+  },
   disposeResources : {
     type: 'SpaceDisposalProject',
     name : "Resource Disposal",

--- a/src/js/projects/DysonSwarmReceiverProject.js
+++ b/src/js/projects/DysonSwarmReceiverProject.js
@@ -1,0 +1,9 @@
+class DysonSwarmReceiverProject extends Project {}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.DysonSwarmReceiverProject = DysonSwarmReceiverProject;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = DysonSwarmReceiverProject;
+}

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
   updateStoryProjectsVisibility();
+  updateMegaProjectsVisibility();
 });
 
 function renderProjects() {
@@ -42,6 +43,7 @@ function renderProjects() {
 
   updateEmptyProjectMessages();
   updateStoryProjectsVisibility();
+  updateMegaProjectsVisibility();
 }
 
 function initializeProjectsUI() {
@@ -646,6 +648,30 @@ function updateStoryProjectsVisibility() {
         (typeof spaceManager !== 'undefined' && spaceManager.getCurrentPlanetKey &&
          spaceManager.getCurrentPlanetKey() === p.attributes.planet);
       return p.category === 'story' && p.unlocked && planetOk;
+    });
+  }
+
+  if (visible) {
+    subtab.classList.remove('hidden');
+    content.classList.remove('hidden');
+  } else {
+    subtab.classList.add('hidden');
+    content.classList.add('hidden');
+  }
+}
+
+function updateMegaProjectsVisibility() {
+  const subtab = document.querySelector('.projects-subtab[data-subtab="mega-projects"]');
+  const content = document.getElementById('mega-projects');
+  if (!subtab || !content) return;
+
+  let visible = false;
+  if (projectManager && projectManager.projects) {
+    visible = Object.values(projectManager.projects).some(p => {
+      const planetOk = !p.attributes.planet ||
+        (typeof spaceManager !== 'undefined' && spaceManager.getCurrentPlanetKey &&
+         spaceManager.getCurrentPlanetKey() === p.attributes.planet);
+      return p.category === 'mega' && p.unlocked && planetOk;
     });
   }
 

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1041,7 +1041,18 @@ const researchParameters = {
             type: 'enable'
           }
         ],
-      },   
+      },
+      {
+        id: 'dyson_swarm_receiver',
+        name: 'Dyson Swarm Receiver',
+        description: 'Enables construction of a receiver for orbital solar collectors.',
+        cost: { research: 10000000000 },
+        prerequisites: [],
+        requiredFlags: ['dysonSwarmUnlocked'],
+        effects: [
+          { target: 'project', targetId: 'dysonSwarmReceiver', type: 'enable' }
+        ]
+      },
     ],
     advanced: [
       {
@@ -1141,6 +1152,21 @@ const researchParameters = {
             type: 'booleanFlag',
             flagId: 'dayNightActivity',
             value: false
+          }
+        ]
+      },
+      {
+        id: 'dyson_swarm_concept',
+        name: 'Dyson Swarm Concept',
+        description: 'Opens research into building massive solar collectors in space.',
+        cost: { advancedResearch: 30000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'researchManager',
+            type: 'booleanFlag',
+            flagId: 'dysonSwarmUnlocked',
+            value: true
           }
         ]
       }

--- a/tests/dysonSwarmProject.test.js
+++ b/tests/dysonSwarmProject.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Dyson Swarm Receiver project', () => {
+  test('defined in parameters', () => {
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+    const project = ctx.projectParameters.dysonSwarmReceiver;
+    expect(project).toBeDefined();
+    expect(project.type).toBe('DysonSwarmReceiverProject');
+    expect(project.category).toBe('mega');
+    expect(project.cost.colony.metal).toBe(10000000);
+    expect(project.duration).toBe(300000);
+  });
+});

--- a/tests/dysonSwarmResearch.test.js
+++ b/tests/dysonSwarmResearch.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Dyson Swarm research parameters', () => {
+  test('advanced research sets unlock flag', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const adv = ctx.researchParameters.advanced;
+    const research = adv.find(r => r.id === 'dyson_swarm_concept');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(30000);
+    const flagEffect = research.effects.find(e => e.type === 'booleanFlag' && e.flagId === 'dysonSwarmUnlocked' && e.value === true);
+    expect(flagEffect).toBeDefined();
+  });
+
+  test('energy research requires unlock flag', () => {
+    const text = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research-parameters.js'), 'utf8');
+    expect(text).toMatch(/id:\s*'dyson_swarm_receiver'/);
+    expect(text).toMatch(/cost:\s*{\s*research:\s*10000000000\s*}/);
+    expect(text).toMatch(/requiredFlags:\s*\['dysonSwarmUnlocked'\]/);
+    expect(text).toMatch(/targetId:\s*'dysonSwarmReceiver'/);
+  });
+});

--- a/tests/megaProjectsVisibility.test.js
+++ b/tests/megaProjectsVisibility.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+
+describe('updateMegaProjectsVisibility', () => {
+  test('shows or hides the mega subtab based on unlocked projects', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab hidden" data-subtab="mega-projects"></div>
+      <div id="mega-projects" class="projects-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectManager = { projects: { receiver: { category: 'mega', unlocked: false, attributes: { planet: 'titan' } } } };
+    ctx.spaceManager = { getCurrentPlanetKey: () => 'titan' };
+    vm.createContext(ctx);
+    vm.runInContext(uiCode + '; this.updateMegaProjectsVisibility = updateMegaProjectsVisibility;', ctx);
+
+    ctx.updateMegaProjectsVisibility();
+    const subtab = dom.window.document.querySelector('[data-subtab="mega-projects"]');
+    const content = dom.window.document.getElementById('mega-projects');
+    expect(subtab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+
+    ctx.projectManager.projects.receiver.unlocked = true;
+    ctx.updateMegaProjectsVisibility();
+    expect(subtab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Mega projects subtab for special projects
- hook the subtab visibility logic in projectsUI
- add Dyson Swarm Receiver project and project class
- add advanced and energy research entries for the Dyson Swarm
- document the Dyson Swarm in AGENTS
- test new project visibility and research data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687284c799c48327bc9764864abafeee