### PR TITLE
Fix manager initialization on load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,9 +117,8 @@ to be redrawn so elements bind to the new instances.
   back to Mars and internally invokes `initializeGameState()`. This function
   rebuilds resource displays, building/colony buttons and other UI sections.
 - **Loading a save file** – `loadGame()` parses the saved state then calls
-  `initializeGameState({preserveManagers: true})` to refresh UI elements while
-  keeping existing managers and effects. It then applies the loaded data to the
-  newly created objects.
+  `initializeGameState()` to rebuild managers and UI from scratch before
+  applying the loaded data.
 - **Moving to another planet** – `selectPlanet(key)` in `spaceUI.js` first asks
   the `SpaceManager` to change the current planet, then calls
   `initializeGameState({preserveManagers: true})` followed by `updateSpaceUI()`

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -65,7 +65,7 @@ function loadGame(slotOrCustomString) {
         }
 
         // Reinitialize game state using the loaded planet parameters
-        initializeGameState({preserveManagers: true});
+        initializeGameState();
         if (typeof tabManager.resetVisibility === 'function') {
           tabManager.resetVisibility(tabParameters);
         }


### PR DESCRIPTION
## Summary
- load managers fresh when loading a save file
- document the new initializeGameState call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872936f39188327a2680354ad38b109