### PR TITLE
Fix story reset on load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,9 @@ to be redrawn so elements bind to the new instances.
   back to Mars and internally invokes `initializeGameState()`. This function
   rebuilds resource displays, building/colony buttons and other UI sections.
 - **Loading a save file** – `loadGame()` parses the saved state then calls
-  `initializeGameState()` to rebuild managers and UI from scratch before
-  applying the loaded data.
+  `initializeGameState({ skipStoryInitialization: true })` to rebuild managers
+  and UI before applying the loaded data. This prevents the introductory story
+  event from triggering again during the load sequence.
 - **Moving to another planet** – `selectPlanet(key)` in `spaceUI.js` first asks
   the `SpaceManager` to change the current planet, then calls
   `initializeGameState({preserveManagers: true})` followed by `updateSpaceUI()`

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -97,6 +97,7 @@ function create() {
 function initializeGameState(options = {}) {
   const preserveManagers = options.preserveManagers || false;
   const preserveJournal = options.preserveJournal || false;
+  const skipStoryInitialization = options.skipStoryInitialization || false;
   let savedAdvancedResearch = null;
   if (preserveManagers && resources && resources.colony && resources.colony.advancedResearch) {
     savedAdvancedResearch = {
@@ -173,7 +174,9 @@ function initializeGameState(options = {}) {
   milestonesManager = new MilestonesManager();
   if (!preserveManagers) {
     storyManager = new StoryManager(progressData);  // Pass the progressData object
-    storyManager.initializeStory();
+    if (!skipStoryInitialization) {
+      storyManager.initializeStory();
+    }
     spaceManager = new SpaceManager(planetParameters);
   }
 

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -65,7 +65,7 @@ function loadGame(slotOrCustomString) {
         }
 
         // Reinitialize game state using the loaded planet parameters
-        initializeGameState();
+        initializeGameState({ skipStoryInitialization: true });
         if (typeof tabManager.resetVisibility === 'function') {
           tabManager.resetVisibility(tabParameters);
         }


### PR DESCRIPTION
## Summary
- avoid triggering intro story when loading saves
- skip initial story with new `skipStoryInitialization` option
- document the new option in `AGENTS.md`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687294969db08327aec28a8360707baf