### PR TITLE
Prevent duplicate space UI generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ scripts implement the tabs, pop-ups and other interface elements.
 
 - **skills.js** and **skillsUI.js** implement the H.O.P.E. skill tree which grants global bonuses as skill points are earned.
 - **life.js** with **lifeUI.js** lets players design custom lifeforms by spending design points on attributes like temperature tolerance and radiation resistance.
-- **space.js** and **spaceUI.js** handle interplanetary travel once a planet is fully terraformed. `initializeSpaceUI` now renders planet entries once and `updateSpaceUI` simply toggles visibility and button text using SpaceManager status.
+- **space.js** and **spaceUI.js** handle interplanetary travel once a planet is fully terraformed. `initializeSpaceUI` now renders planet entries once and `updateSpaceUI` simply toggles visibility and button text using SpaceManager status. The initializer checks for existing elements so loading a save doesn't duplicate the planet options.
 - `game.js` now calls `updateSpaceUI()` each tick so newly enabled planets become visible right away.
 - **gold-asteroid.js** spawns a temporary event that awards large production multipliers when clicked.
 - **autobuild.js** automatically constructs buildings based on population ratios when auto-build is enabled.

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -4,6 +4,8 @@
 let _spaceManagerInstance = null;
 // Cache of DOM nodes for each planet keyed by planet id
 const planetUIElements = {};
+// Track whether the space UI has been generated already
+let spaceUIInitialized = false;
 
 /**
  * Initializes the Space Tab UI elements and stores the SpaceManager instance.
@@ -16,6 +18,13 @@ function initializeSpaceUI(spaceManager) {
     }
     _spaceManagerInstance = spaceManager; // Store the instance for later use
     console.log("Initializing Space UI with SpaceManager reference.");
+
+    // If the UI has already been generated, just update with the new instance
+    if (spaceUIInitialized) {
+        updateSpaceUI();
+        return;
+    }
+    spaceUIInitialized = true;
 
     const optionsContainer = document.getElementById('planet-selection-options');
     const statusContainer = document.getElementById('travel-status');

--- a/tests/spaceUIInitializeOnce.test.js
+++ b/tests/spaceUIInitializeOnce.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+
+function loadScript(file, ctx) {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', file), 'utf8');
+  vm.runInContext(code, ctx);
+}
+
+describe('initializeSpaceUI only generates elements once', () => {
+  test('calling initializeSpaceUI twice does not duplicate planet options', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="planet-selection-options"></div><div id="travel-status"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.console = console;
+    ctx.planetParameters = planetParameters;
+
+    vm.runInContext(`${effectCode}\n${spaceCode}; this.EffectableEntity = EffectableEntity; this.SpaceManager = SpaceManager;`, ctx);
+    loadScript('spaceUI.js', ctx);
+
+    ctx.spaceManager = new ctx.SpaceManager(planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+
+    const container = dom.window.document.getElementById('planet-selection-options');
+    const initialCount = container.querySelectorAll('.planet-option').length;
+
+    ctx.spaceManager = new ctx.SpaceManager(planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+
+    const countAfter = container.querySelectorAll('.planet-option').length;
+    expect(initialCount).toBe(Object.keys(planetParameters).length);
+    expect(countAfter).toBe(initialCount);
+  });
+});
+


### PR DESCRIPTION
## Summary
- guard against multiple calls to `initializeSpaceUI` so DOM elements aren't duplicated
- note this behaviour in `AGENTS.md`
- test that the initializer only renders once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68729ef7cae8832792436b89298ad525