### PR TITLE
Add food upgrade in Solis shop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ scripts implement the tabs, pop-ups and other interface elements.
 - **autobuild.js** automatically constructs buildings based on population ratios when auto-build is enabled.
 - **milestones.js** and **milestonesUI.js** track long term objectives and unlock rewards.
 - **solis.js** and **solisUI.js** manage the Solis shop and quest system which grants Solis points for completing delivery quests.
+- The shop now offers a food upgrade granting +100 food per purchase.
 - The ResearchManager now persists between planets. Only advanced researches remain completed after travel; regular researches reset on each new planet.
 
 ## Dyson Swarm Receiver

--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -4,7 +4,8 @@ const RESOURCE_UPGRADE_AMOUNTS = {
   electronics: 100,
   glass: 100,
   water: 1000000,
-  androids: 100
+  androids: 100,
+  food: 100
 };
 
 class SolisManager extends EffectableEntity {
@@ -16,6 +17,7 @@ class SolisManager extends EffectableEntity {
       electronics: 20,
       androids: 50,
       superconductors: 100,
+      food: 5,
     }, resourceValues);
     this.solisPoints = 0;
     this.rewardMultiplier = 1;
@@ -34,7 +36,8 @@ class SolisManager extends EffectableEntity {
       electronics: { baseCost: 1, purchases: 0 },
       glass: { baseCost: 1, purchases: 0 },
       water: { baseCost: 1, purchases: 0 },
-      androids: { baseCost: 10, purchases: 0 }
+      androids: { baseCost: 10, purchases: 0 },
+      food: { baseCost: 1, purchases: 0 }
     };
   }
 

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -8,7 +8,8 @@ const shopDescriptions = {
   electronics: 'Increase starting electronics by 100',
   glass: 'Increase starting glass by 100',
   water: 'Increase starting water by 1M',
-  androids: 'Increase starting androids by 100'
+  androids: 'Increase starting androids by 100',
+  food: 'Increase starting food by 100'
 };
 
 function showSolisTab() {
@@ -122,7 +123,7 @@ function initializeSolisUI() {
     title.textContent = 'Solis Shop';
     shopContainer.insertBefore(title, container);
     
-    ['funding', 'metal', 'components', 'electronics', 'glass', 'water', 'androids'].forEach(key => {
+    ['funding', 'metal', 'components', 'electronics', 'glass', 'water', 'androids', 'food'].forEach(key => {
       container.appendChild(createShopItem(key));
     });
   }

--- a/tests/solisResourceUpgrades.test.js
+++ b/tests/solisResourceUpgrades.test.js
@@ -9,7 +9,8 @@ describe('Solis resource upgrades', () => {
     electronics: 100,
     glass: 100,
     water: 1000000,
-    androids: 100
+    androids: 100,
+    food: 100
   };
 
   for (const key of Object.keys(amounts)) {


### PR DESCRIPTION
## Summary
- allow buying food from the Solis shop
- display the new item in the Solis UI
- adjust tests for Solis resource upgrades
- document the feature in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872a1ff35788327a0fee1fdc9582346