### PR TITLE
Fix Solis upgrade reload duplication

### DIFF
--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -166,7 +166,9 @@ class SolisManager extends EffectableEntity {
       const res = resources && resources.colony && resources.colony[key];
       if (upgrade && upgrade.purchases > 0 && res && typeof res.increase === 'function') {
         const amount = RESOURCE_UPGRADE_AMOUNTS[key] * upgrade.purchases;
-        res.increase(amount);
+        if (!globalGameIsLoadingFromSave) {
+          res.increase(amount);
+        }
         if (typeof addEffect === 'function' && res.hasCap) {
           addEffect({
             target: 'resource',

--- a/tests/solisResourceUpgrades.test.js
+++ b/tests/solisResourceUpgrades.test.js
@@ -64,6 +64,7 @@ describe('Solis resource upgrades', () => {
       cols[k] = makeResource();
     }
     global.resources = { colony: cols };
+    global.globalGameIsLoadingFromSave = false;
     const manager = new SolisManager();
     for (const k of Object.keys(amounts)) {
       manager.shopUpgrades[k].purchases = k === 'metal' ? 2 : 1;
@@ -77,5 +78,24 @@ describe('Solis resource upgrades', () => {
         expect(cols[k].cap).toBe(amounts[k]);
       }
     }
+  });
+
+  test('reapplyEffects does not grant resources when loading from save', () => {
+    const cols = {};
+    for (const k of Object.keys(amounts)) {
+      cols[k] = makeResource();
+    }
+    global.resources = { colony: cols };
+    global.globalGameIsLoadingFromSave = true;
+    const manager = new SolisManager();
+    for (const k of Object.keys(amounts)) {
+      manager.shopUpgrades[k].purchases = 1;
+    }
+    manager.reapplyEffects();
+    for (const k of Object.keys(amounts)) {
+      expect(cols[k].value).toBe(0);
+      expect(cols[k].cap).toBe(amounts[k]);
+    }
+    global.globalGameIsLoadingFromSave = false;
   });
 });


### PR DESCRIPTION
## Summary
- avoid re-granting Solis shop resources when loading a save
- test SolisManager reapplyEffects when loading from save

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872b4030274832796d8a8ad5c662f81