### PR TITLE
Add colonist rocket upgrade to Solis shop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ scripts implement the tabs, pop-ups and other interface elements.
 - **milestones.js** and **milestonesUI.js** track long term objectives and unlock rewards.
 - **solis.js** and **solisUI.js** manage the Solis shop and quest system which grants Solis points for completing delivery quests.
 - The shop now offers a food upgrade granting +100 food per purchase.
+- A colonist rocket upgrade increases colonists delivered per import rocket by 1 for each purchase.
 - Resource upgrades now apply a base storage bonus effect to the purchased resource.
 - Resources calculate their storage cap from active baseStorageBonus effects instead of modifying the baseCap value.
 - The ResearchManager now persists between planets. Only advanced researches remain completed after travel; regular researches reset on each new planet.

--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -37,7 +37,8 @@ class SolisManager extends EffectableEntity {
       electronics: { baseCost: 1, purchases: 0 },
       glass: { baseCost: 1, purchases: 0 },
       water: { baseCost: 1, purchases: 0 },
-      androids: { baseCost: 10, purchases: 0 }
+      androids: { baseCost: 10, purchases: 0 },
+      colonistRocket: { baseCost: 1, purchases: 0 }
     };
   }
 
@@ -129,6 +130,17 @@ class SolisManager extends EffectableEntity {
         effectId: 'solisFunding',
         sourceId: 'solisShop'
       });
+    } else if (key === 'colonistRocket' && typeof addEffect === 'function') {
+      addEffect({
+        target: 'project',
+        targetId: 'import_colonists_1',
+        type: 'increaseResourceGain',
+        resourceCategory: 'colony',
+        resourceId: 'colonists',
+        value: up.purchases,
+        effectId: 'solisColonistRocket',
+        sourceId: 'solisShop'
+      });
     } else if (resources && resources.colony && resources.colony[key] &&
                typeof resources.colony[key].increase === 'function') {
       const amount = RESOURCE_UPGRADE_AMOUNTS[key] || 0;
@@ -157,6 +169,20 @@ class SolisManager extends EffectableEntity {
         type: 'fundingBonus',
         value: count,
         effectId: 'solisFunding',
+        sourceId: 'solisShop'
+      });
+    }
+
+    const rocketUpgrade = this.shopUpgrades.colonistRocket;
+    if (rocketUpgrade && rocketUpgrade.purchases > 0 && typeof addEffect === 'function') {
+      addEffect({
+        target: 'project',
+        targetId: 'import_colonists_1',
+        type: 'increaseResourceGain',
+        resourceCategory: 'colony',
+        resourceId: 'colonists',
+        value: rocketUpgrade.purchases,
+        effectId: 'solisColonistRocket',
         sourceId: 'solisShop'
       });
     }

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -10,6 +10,7 @@ const shopDescriptions = {
   glass: 'Increase starting glass and base storage by 100',
   water: 'Increase starting water and base storage by 1M',
   androids: 'Increase starting androids and base storage by 100',
+  colonistRocket: 'Increase colonists per import rocket by 1',
 };
 
 function showSolisTab() {
@@ -123,7 +124,7 @@ function initializeSolisUI() {
     title.textContent = 'Solis Shop';
     shopContainer.insertBefore(title, container);
     
-    ['funding', 'metal', 'food', 'components', 'electronics', 'glass', 'water', 'androids'].forEach(key => {
+    ['funding', 'metal', 'food', 'components', 'electronics', 'glass', 'water', 'androids', 'colonistRocket'].forEach(key => {
       container.appendChild(createShopItem(key));
     });
   }

--- a/tests/solisColonistRocketUpgrade.test.js
+++ b/tests/solisColonistRocketUpgrade.test.js
@@ -1,0 +1,27 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis colonist rocket upgrade', () => {
+  class DummyProject extends EffectableEntity {
+    constructor() {
+      super({ description: 'import' });
+    }
+  }
+
+  test('adds increaseResourceGain effect with each purchase', () => {
+    const project = new DummyProject();
+    global.projectManager = { projects: { import_colonists_1: project } };
+    global.addEffect = (effect) => project.addAndReplace(effect);
+
+    const manager = new SolisManager();
+    manager.solisPoints = 3;
+
+    manager.purchaseUpgrade('colonistRocket');
+    expect(project.activeEffects[0].value).toBe(1);
+
+    manager.purchaseUpgrade('colonistRocket');
+    expect(project.activeEffects.length).toBe(1);
+    expect(project.activeEffects[0].value).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add colonistRocket upgrade to SolisManager
- hook up colonistRocket item in Solis UI
- document new upgrade in `AGENTS.md`
- test colonistRocket upgrade behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872c0df8aa083279425e28f9fdedf6a