### PR TITLE
Fix repeated story step text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ scripts implement the tabs, pop-ups and other interface elements.
 The Dyson Swarm project begins with research into a large orbital array. An advanced research unlocks the concept and a follow-up energy research enables the **Dyson Swarm Receiver** special project. The receiver currently costs massive resources (10M metal, 1M components, 100k electronics) and takes five minutes to build but provides no effect yet.
 - **save.js** manages localStorage save slots and autosaving of resources, structures, research and story progress.
 - **projects.js** and **projectsUI.js** handle special missions such as asteroid mining, cargo exports and other repeatable tasks.
+- Story project progress now stores which narrative steps have already been shown so repeating or reloading a project will never reprint earlier text.
 - **spaceship.js** with **spaceshipUI.js** allows producing spaceships and assigning them to projects.
 - **day-night-cycle.js** updates a UI progress bar showing planetary time and affects building productivity.
 - **journal.js** maintains a log of story messages with typing effects and history display.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -448,6 +448,7 @@ class ProjectManager extends EffectableEntity {
         repeatCount: project.repeatCount,
         pendingResourceGains: project.pendingResourceGains || [],
         autoStart : project.autoStart,
+        shownStorySteps: Array.from(project.shownStorySteps),
       };
 
       if (typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject) {
@@ -494,6 +495,7 @@ class ProjectManager extends EffectableEntity {
         }
         project.effects = [];
         project.autoStart = savedProject.autoStart;
+        project.shownStorySteps = new Set(savedProject.shownStorySteps || []);
         if (typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject) {
           project.assignedSpaceships = savedProject.assignedSpaceships;
           project.autoAssignSpaceships = savedProject.autoAssignSpaceships;

--- a/tests/projectStoryStepPersistence.test.js
+++ b/tests/projectStoryStepPersistence.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('story step persistence across save/load', () => {
+  test('shown steps are kept after reload', () => {
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const progressCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress-data.js'), 'utf8');
+
+    const ctx = {
+      console,
+      EffectableEntity,
+      addJournalEntry: jest.fn(),
+      addEffect: () => {},
+      removeEffect: () => {},
+      resources: {},
+      buildings: {},
+      colonies: {},
+      document: { getElementById: () => null }
+    };
+    vm.createContext(ctx);
+    vm.runInContext(projectCode + paramsCode + progressCode + '; this.Project = Project; this.ProjectManager = ProjectManager; this.projectParameters = projectParameters;', ctx);
+
+    const manager = new ctx.ProjectManager();
+    manager.initializeProjects(ctx.projectParameters);
+    const proj = manager.projects.interrogate_alien;
+
+    // complete first step
+    proj.isActive = true;
+    proj.remainingTime = 0;
+    proj.complete();
+    expect(proj.shownStorySteps.has(0)).toBe(true);
+
+    const saved = manager.saveState();
+
+    // load into new manager
+    const manager2 = new ctx.ProjectManager();
+    manager2.initializeProjects(ctx.projectParameters);
+    manager2.loadState(saved);
+    const loaded = manager2.projects.interrogate_alien;
+    expect(loaded.shownStorySteps.has(0)).toBe(true);
+
+    loaded.isActive = true;
+    loaded.remainingTime = 0;
+    loaded.complete();
+    expect(ctx.addJournalEntry).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- remember which story steps were already shown for each project
- restore recorded steps on load
- test persistence of project story text
- document the new persistence behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6872d9b197b08327a2a1c30bdb50afca