### PR TITLE
Show project sustain costs in resource rates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ The Dyson Swarm project begins with research into a large orbital array. An adva
 - **population.js** together with colony modules controls growth, worker allocation and happiness.
 - **ore-scanning.js** searches for underground resource deposits using adjustable scanning strength.
 - **warning.js** displays urgent alerts like colonist deaths or extreme greenhouse conditions.
+- Sustain costs for active projects now register as 'project' consumption in resource rate tooltips.
 
 # Effectable Entities Design
 

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -158,7 +158,11 @@ class Project extends EffectableEntity {
     for (const category in this.sustainCost) {
       for (const resource in this.sustainCost[category]) {
         const amount = this.sustainCost[category][resource] * seconds;
+        const rate = this.sustainCost[category][resource];
         resources[category][resource].decrease(amount);
+        if (resources[category][resource].modifyRate) {
+          resources[category][resource].modifyRate(-rate, this.displayName, 'project');
+        }
       }
     }
   }

--- a/tests/projectSustainRateDisplay.test.js
+++ b/tests/projectSustainRateDisplay.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('project sustain cost rates', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(code + '; this.Project = Project;', ctx);
+    ctx.resources = {
+      colony: {
+        energy: {
+          value: 100,
+          decrease(v){ this.value -= v; },
+          updateStorageCap: () => {},
+          modifyRate: jest.fn()
+        }
+      }
+    };
+    global.resources = ctx.resources;
+  });
+
+  test('sustain consumption updates resource rates', () => {
+    const config = {
+      name: 'Test',
+      category: 'story',
+      cost: { colony: { energy: 0 } },
+      sustainCost: { colony: { energy: 10 } },
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      unlocked: true
+    };
+    const project = new ctx.Project(config, 'test');
+    project.start(ctx.resources);
+    project.update(1000);
+    expect(ctx.resources.colony.energy.value).toBeCloseTo(90);
+    expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalledWith(-10, 'Test', 'project');
+  });
+});


### PR DESCRIPTION
## Summary
- track sustain cost use by calling `modifyRate` in `deductSustainResources`
- mention new rate tracking in AGENTS docs
- test that sustain project consumption updates resource rates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872e6dc34388327b044b844dc5756bb