### PR TITLE
Fix luminosity albedo display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ The Dyson Swarm project begins with research into a large orbital array. An adva
 - **ore-scanning.js** searches for underground resource deposits using adjustable scanning strength.
 - **warning.js** displays urgent alerts like colonist deaths or extreme greenhouse conditions.
 - Sustain costs for active projects now register as 'project' consumption in resource rate tooltips.
+- The luminosity box now shows both ground albedo (base plus black dust) and surface albedo derived from physics.js.
 
 # Effectable Entities Design
 

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -210,6 +210,11 @@ class Project extends EffectableEntity {
 
     this.deductSustainResources(deltaTime);
 
+    if (!this.hasSustainResources()) {
+      this.isActive = false;
+      this.isPaused = true;
+    }
+
     this.remainingTime -= deltaTime;
 
     if (this.remainingTime <= 0) {

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -637,9 +637,14 @@ function updateLifeBox() {
         </thead>
         <tbody>
           <tr>
-            <td>Albedo <span class="info-tooltip-icon" title="Albedo is the measure of reflectivity. Key values:\n- Rock (Base): Varies by planet\n- Ocean: 0.06\n- Water Ice: 0.6\n- Dry Ice: 0.6\n- Biomass: 0.20\n- Black Dust: 0.05\n- Methane Ocean: 0.1">&#9432;</span></td>
-            <td><span id="effective-albedo">${terraforming.luminosity.albedo.toFixed(2)}</span></td>
-            <td><span id="albedo-delta"></span></td>
+            <td>Ground Albedo <span class="info-tooltip-icon" title="Base albedo blended with black dust upgrades.">&#9432;</span></td>
+            <td><span id="ground-albedo">${(terraforming.luminosity.groundAlbedo ?? 0).toFixed(2)}</span></td>
+            <td><span id="ground-albedo-delta"></span></td>
+          </tr>
+          <tr>
+            <td>Surface Albedo <span class="info-tooltip-icon" title="Includes oceans, ice and biomass coverage.">&#9432;</span></td>
+            <td><span id="surface-albedo">${(terraforming.luminosity.surfaceAlbedo ?? 0).toFixed(2)}</span></td>
+            <td><span id="surface-albedo-delta"></span></td>
           </tr>
           <tr>
             <td>Solar Flux (W/m²)</td>
@@ -671,15 +676,26 @@ function updateLifeBox() {
       luminosityBox.style.borderColor = 'red';
     }
 
-    const effectiveAlbedo = document.getElementById('effective-albedo');
-    if (effectiveAlbedo) {
-      effectiveAlbedo.textContent = terraforming.luminosity.albedo.toFixed(2);
+    const groundAlbEl = document.getElementById('ground-albedo');
+    if (groundAlbEl) {
+      groundAlbEl.textContent = terraforming.luminosity.groundAlbedo.toFixed(2);
     }
 
-    const albedoDeltaEl = document.getElementById('albedo-delta');
-    if (albedoDeltaEl) {
-      const deltaA = terraforming.luminosity.albedo - terraforming.celestialParameters.albedo;
-      albedoDeltaEl.textContent = `${deltaA >= 0 ? '+' : ''}${formatNumber(deltaA, false, 2)}`;
+    const groundDeltaEl = document.getElementById('ground-albedo-delta');
+    if (groundDeltaEl) {
+      const d = terraforming.luminosity.groundAlbedo - terraforming.celestialParameters.albedo;
+      groundDeltaEl.textContent = `${d >= 0 ? '+' : ''}${formatNumber(d, false, 2)}`;
+    }
+
+    const surfAlbEl = document.getElementById('surface-albedo');
+    if (surfAlbEl) {
+      surfAlbEl.textContent = terraforming.luminosity.surfaceAlbedo.toFixed(2);
+    }
+
+    const surfDeltaEl = document.getElementById('surface-albedo-delta');
+    if (surfDeltaEl) {
+      const d = terraforming.luminosity.surfaceAlbedo - terraforming.celestialParameters.albedo;
+      surfDeltaEl.textContent = `${d >= 0 ? '+' : ''}${formatNumber(d, false, 2)}`;
     }
 
     const modifiedSolarFlux = document.getElementById('modified-solar-flux');

--- a/tests/initialTemperature.test.js
+++ b/tests/initialTemperature.test.js
@@ -36,7 +36,7 @@ function expectedTemperature(terra, params, resources) {
   const AU_METER = 149597870700;
   const distanceMeters = params.celestialParameters.distanceFromSun * AU_METER;
   const modifiedFlux = terra.calculateModifiedSolarFlux(distanceMeters);
-  const groundAlbedo = terra.calculateEffectiveAlbedo();
+  const groundAlbedo = terra.calculateGroundAlbedo();
   const rotation = params.celestialParameters.rotationPeriod || 24;
   const g = params.celestialParameters.gravity;
 

--- a/tests/luminosityDeltaUpdate.test.js
+++ b/tests/luminosityDeltaUpdate.test.js
@@ -14,7 +14,7 @@ describe('updateLuminosityBox', () => {
     ctx.formatNumber = numbers.formatNumber;
 
     ctx.terraforming = {
-      luminosity: { name: 'Luminosity', albedo: 0.3, solarFlux: 1000, modifiedSolarFlux: 1000 },
+      luminosity: { name: 'Luminosity', groundAlbedo: 0.3, surfaceAlbedo: 0.3, albedo: 0.3, solarFlux: 1000, modifiedSolarFlux: 1000 },
       celestialParameters: { albedo: 0.3 },
       getLuminosityStatus: () => true,
       calculateSolarPanelMultiplier: () => 1
@@ -26,11 +26,12 @@ describe('updateLuminosityBox', () => {
     const row = dom.window.document.querySelector('.row');
     ctx.createLuminosityBox(row);
 
+    ctx.terraforming.luminosity.surfaceAlbedo = 0.35;
     ctx.terraforming.luminosity.albedo = 0.35;
     ctx.terraforming.luminosity.modifiedSolarFlux = 1100;
     ctx.updateLuminosityBox();
 
-    const albedoDelta = dom.window.document.getElementById('albedo-delta').textContent;
+    const albedoDelta = dom.window.document.getElementById('surface-albedo-delta').textContent;
     expect(albedoDelta).toBe('+0.05');
 
     const fluxDelta = dom.window.document.getElementById('solar-flux-delta').textContent;


### PR DESCRIPTION
## Summary
- import physics helpers when running under Node
- compute and expose both ground and surface albedo in Terraforming
- display ground and surface albedo with deltas in the luminosity box
- keep project sustain cost pausing after resources are consumed
- document new albedo display behavior in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872fa0ce2208327acb557484a859f39