### PR TITLE
Fix Dyson Swarm research category

### DIFF
--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -189,6 +189,17 @@ const researchParameters = {
           }
         ],
       },
+      {
+        id: 'dyson_swarm_receiver',
+        name: 'Dyson Swarm Receiver',
+        description: 'Enables construction of a receiver for orbital solar collectors.',
+        cost: { research: 10000000000 },
+        prerequisites: [],
+        requiredFlags: ['dysonSwarmUnlocked'],
+        effects: [
+          { target: 'project', targetId: 'dysonSwarmReceiver', type: 'enable' }
+        ]
+      },
     ],
     industry: [
       {
@@ -1041,17 +1052,6 @@ const researchParameters = {
             type: 'enable'
           }
         ],
-      },
-      {
-        id: 'dyson_swarm_receiver',
-        name: 'Dyson Swarm Receiver',
-        description: 'Enables construction of a receiver for orbital solar collectors.',
-        cost: { research: 10000000000 },
-        prerequisites: [],
-        requiredFlags: ['dysonSwarmUnlocked'],
-        effects: [
-          { target: 'project', targetId: 'dysonSwarmReceiver', type: 'enable' }
-        ]
       },
     ],
     advanced: [

--- a/tests/dysonSwarmResearch.test.js
+++ b/tests/dysonSwarmResearch.test.js
@@ -17,10 +17,16 @@ describe('Dyson Swarm research parameters', () => {
   });
 
   test('energy research requires unlock flag', () => {
-    const text = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research-parameters.js'), 'utf8');
-    expect(text).toMatch(/id:\s*'dyson_swarm_receiver'/);
-    expect(text).toMatch(/cost:\s*{\s*research:\s*10000000000\s*}/);
-    expect(text).toMatch(/requiredFlags:\s*\['dysonSwarmUnlocked'\]/);
-    expect(text).toMatch(/targetId:\s*'dysonSwarmReceiver'/);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const energy = ctx.researchParameters.energy;
+    const research = energy.find(r => r.id === 'dyson_swarm_receiver');
+    expect(research).toBeDefined();
+    expect(research.cost.research).toBe(10000000000);
+    expect(research.requiredFlags).toEqual(['dysonSwarmUnlocked']);
+    const effect = research.effects.find(e => e.target === 'project' && e.targetId === 'dysonSwarmReceiver');
+    expect(effect).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- move Dyson Swarm Receiver research definition to the energy list
- update research test to check the energy category

## Testing
- `npx jest tests/dysonSwarmResearch.test.js --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_b_68740f48eae883278a6937bb5f91b398