### PR TITLE
Implement pressure-dependent boiling limits for condensation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ calculations from **physics.js**, **hydrology.js**, **water-cycle.js**,
   coverage and 0.1 m when computing melt flow between zones or within a zone.
 - Water and methane melting/freezing calculations now share a helper in
   **phase-change-utils.js** to avoid duplicate logic.
+ - Condensation calculations now taper off near the pressure-dependent boiling
+   point of each substance. `water-cycle.js` uses an Antoine-equation helper
+   `boilingPointWater`. Methane temperatures rely on `boilingPointMethane`, a
+   log-based approximation good for roughly 0.1–10 bar. Both feed into a
+   `boilingPoint` parameter for `condensationRateFactor`.
 
 The hydrocarbon cycle models methane in its liquid, ice and vapor forms.  It
 uses Penman-based equations for evaporation and sublimation alongside flow and

--- a/src/js/condensation-utils.js
+++ b/src/js/condensation-utils.js
@@ -8,7 +8,7 @@ if (isNodeCondensation) {
   // for browser usage nothing to setup
 }
 
-function condensationRateFactor({ zoneArea, vaporPressure, gravity, dayTemp, nightTemp, saturationFn, freezePoint, transitionRange = 2, maxDiff = 10 }) {
+function condensationRateFactor({ zoneArea, vaporPressure, gravity, dayTemp, nightTemp, saturationFn, freezePoint, transitionRange = 2, maxDiff = 10, boilingPoint = Infinity, boilTransitionRange = 2 }) {
   if (typeof saturationFn !== 'function') {
     throw new Error('condensationRateFactor requires saturationFn');
   }
@@ -24,7 +24,12 @@ function condensationRateFactor({ zoneArea, vaporPressure, gravity, dayTemp, nig
         if (!isNaN(baseRate) && baseRate > 0) {
           const diff = freezePoint - temp;
           const intensityScale = temp < freezePoint ? Math.min(diff / maxDiff, 1.0) : 1.0;
-          const rate = baseRate * intensityScale;
+          let rate = baseRate * intensityScale;
+          if (Number.isFinite(boilingPoint)) {
+            const boilMix = Math.min(Math.max((temp - (boilingPoint - boilTransitionRange)) / (2 * boilTransitionRange), 0), 1);
+            const boilingScale = 1 - boilMix;
+            rate *= boilingScale;
+          }
           const mix = Math.min(Math.max((temp - (freezePoint - transitionRange)) / (2 * transitionRange), 0), 1);
           liquid = rate * mix;
           ice = rate - liquid;

--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -226,7 +226,8 @@
         initialWaterPressurePa,
         gravity,
         dayTemp,
-        nightTemp
+        nightTemp,
+        initialTotalPressurePa
       );
       potentialPrecipitationRateFactor +=
         precipRateFactors.rainfallRateFactor + precipRateFactors.snowfallRateFactor;
@@ -256,7 +257,8 @@
         zoneArea,
         methaneVaporPressure: initialMethanePressurePa,
         dayTemperature: dayTemp,
-        nightTemperature: nightTemp
+        nightTemperature: nightTemp,
+        atmPressure: initialTotalPressurePa
       });
       potentialMethaneCondensationRateFactor +=
         methaneCondRateFactors.liquidRateFactor + methaneCondRateFactors.iceRateFactor;

--- a/src/js/terraforming-utils.js
+++ b/src/js/terraforming-utils.js
@@ -122,14 +122,15 @@ function calculateZonalEvaporationSublimationRates(terraforming, zone, dayTemp, 
   });
 }
 
-function calculateZonalPrecipitationRateFactor(terraforming, zone, waterVaporPressure, gravity, dayTemp, nightTemp) {
+function calculateZonalPrecipitationRateFactor(terraforming, zone, waterVaporPressure, gravity, dayTemp, nightTemp, atmPressure) {
   const zoneArea = terraforming.celestialParameters.surfaceArea * zonePercentage(zone);
   return baseCalculatePrecipFactor({
     zoneArea,
     waterVaporPressure,
     gravity,
     dayTemperature: dayTemp,
-    nightTemperature: nightTemp
+    nightTemperature: nightTemp,
+    atmPressure
   });
 }
 

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -472,7 +472,8 @@ class Terraforming extends EffectableEntity{
                 globalWaterPressurePa,
                 gravity,
                 dayTemp,
-                nightTemp
+                nightTemp,
+                globalTotalPressurePa
             );
             // Calculate potential amounts based on zonal conditions (before global limits)
             zonalChanges[zone].potentialRainfall = precipRateFactors.rainfallRateFactor * precipitationMultiplier * durationSeconds;
@@ -550,7 +551,8 @@ class Terraforming extends EffectableEntity{
                 zoneArea,
                 methaneVaporPressure: globalMethanePressurePa,
                 dayTemperature: dayTemp,
-                nightTemperature: nightTemp
+                nightTemperature: nightTemp,
+                atmPressure: globalTotalPressurePa
             });
             // Methane Condensation
             const methaneCondensationAmount = methaneCondRateFactors.liquidRateFactor * methaneCondensationParameter * durationSeconds;

--- a/tests/condensationBoiling.test.js
+++ b/tests/condensationBoiling.test.js
@@ -1,0 +1,33 @@
+const { calculatePrecipitationRateFactor, boilingPointWater } = require('../src/js/water-cycle.js');
+const { calculateMethaneCondensationRateFactor, boilingPointMethane } = require('../src/js/hydrocarbon-cycle.js');
+
+describe('condensation stops above boiling point', () => {
+  test('water precipitation zero when above boiling', () => {
+    const atmPressure = 101325; // Pa
+    const boil = boilingPointWater(atmPressure);
+    const res = calculatePrecipitationRateFactor({
+      zoneArea: 1e6,
+      waterVaporPressure: 150000,
+      gravity: 9.81,
+      dayTemperature: boil + 6,
+      nightTemperature: boil + 6,
+      atmPressure
+    });
+    expect(res.rainfallRateFactor).toBe(0);
+    expect(res.snowfallRateFactor).toBe(0);
+  });
+
+  test('methane condensation zero when above boiling', () => {
+    const atmPressure = 101325;
+    const boil = boilingPointMethane(atmPressure);
+    const res = calculateMethaneCondensationRateFactor({
+      zoneArea: 1e6,
+      methaneVaporPressure: 100000,
+      dayTemperature: boil + 6,
+      nightTemperature: boil + 6,
+      atmPressure
+    });
+    expect(res.liquidRateFactor).toBe(0);
+    expect(res.iceRateFactor).toBe(0);
+  });
+});

--- a/tests/condensationUtils.test.js
+++ b/tests/condensationUtils.test.js
@@ -45,7 +45,8 @@ describe('cycle wrappers match helper output', () => {
       waterVaporPressure: 800,
       gravity: 9.81,
       dayTemperature: 276,
-      nightTemperature: 275
+      nightTemperature: 275,
+      atmPressure: 101325
     };
     const expected = condensationRateFactor({
       zoneArea: params.zoneArea,
@@ -54,7 +55,9 @@ describe('cycle wrappers match helper output', () => {
       dayTemp: params.dayTemperature,
       nightTemp: params.nightTemperature,
       saturationFn: water.saturationVaporPressureBuck,
-      freezePoint: 273.15
+      freezePoint: 273.15,
+      boilingPoint: water.boilingPointWater(params.atmPressure),
+      boilTransitionRange: 5
     });
     const res = water.calculatePrecipitationRateFactor(params);
     expect(res.rainfallRateFactor).toBeCloseTo(expected.liquidRate);
@@ -66,7 +69,8 @@ describe('cycle wrappers match helper output', () => {
       zoneArea: 1e6,
       methaneVaporPressure: 30000,
       dayTemperature: 94,
-      nightTemperature: 93
+      nightTemperature: 93,
+      atmPressure: 101325
     };
     const expected = condensationRateFactor({
       zoneArea: params.zoneArea,
@@ -75,7 +79,9 @@ describe('cycle wrappers match helper output', () => {
       dayTemp: params.dayTemperature,
       nightTemp: params.nightTemperature,
       saturationFn: hydrocarbon.calculateSaturationPressureMethane,
-      freezePoint: 90.7
+      freezePoint: 90.7,
+      boilingPoint: hydrocarbon.boilingPointMethane(params.atmPressure),
+      boilTransitionRange: 5
     });
     const res = hydrocarbon.calculateMethaneCondensationRateFactor(params);
     expect(res.liquidRateFactor).toBeCloseTo(expected.liquidRate);

--- a/tests/methaneCondensationSmoothing.test.js
+++ b/tests/methaneCondensationSmoothing.test.js
@@ -3,6 +3,7 @@ const { calculateMethaneCondensationRateFactor } = require('../src/js/hydrocarbo
 describe('methane condensation smoothing around freezing', () => {
   const zoneArea = 1e6; // m^2
   const methaneVaporPressure = 30000; // Pa - ensure above saturation
+  const atmPressure = 101325;
 
   test('above freezing favors liquid', () => {
     const res = calculateMethaneCondensationRateFactor({
@@ -10,6 +11,7 @@ describe('methane condensation smoothing around freezing', () => {
       methaneVaporPressure,
       dayTemperature: 94,
       nightTemperature: 93,
+      atmPressure,
     });
     expect(res.liquidRateFactor).toBeGreaterThan(0);
     expect(res.liquidRateFactor).toBeGreaterThan(res.iceRateFactor);
@@ -21,6 +23,7 @@ describe('methane condensation smoothing around freezing', () => {
       methaneVaporPressure,
       dayTemperature: 88,
       nightTemperature: 89,
+      atmPressure,
     });
     expect(res.iceRateFactor).toBeGreaterThan(res.liquidRateFactor);
     expect(res.iceRateFactor).toBeGreaterThan(0);
@@ -32,6 +35,7 @@ describe('methane condensation smoothing around freezing', () => {
       methaneVaporPressure,
       dayTemperature: 91,
       nightTemperature: 90,
+      atmPressure,
     });
     expect(res.liquidRateFactor).toBeGreaterThan(0);
     expect(res.iceRateFactor).toBeGreaterThan(0);

--- a/tests/precipitationSmoothing.test.js
+++ b/tests/precipitationSmoothing.test.js
@@ -4,6 +4,7 @@ describe('precipitation smoothing around freezing', () => {
   const zoneArea = 1e6; // m^2
   const waterVaporPressure = 800; // Pa
   const gravity = 9.81;
+  const atmPressure = 101325;
 
   test('above freezing gives predominantly rain', () => {
     const res = calculatePrecipitationRateFactor({
@@ -12,6 +13,7 @@ describe('precipitation smoothing around freezing', () => {
       gravity,
       dayTemperature: 276,
       nightTemperature: 275,
+      atmPressure,
     });
     expect(res.rainfallRateFactor).toBeGreaterThan(0);
     expect(res.rainfallRateFactor).toBeGreaterThan(res.snowfallRateFactor);
@@ -24,6 +26,7 @@ describe('precipitation smoothing around freezing', () => {
       gravity,
       dayTemperature: 270,
       nightTemperature: 271,
+      atmPressure,
     });
     expect(res.rainfallRateFactor).toBe(0);
     expect(res.snowfallRateFactor).toBeGreaterThan(0);
@@ -36,6 +39,7 @@ describe('precipitation smoothing around freezing', () => {
       gravity,
       dayTemperature: 274,
       nightTemperature: 272,
+      atmPressure,
     });
     expect(res.rainfallRateFactor).toBeGreaterThan(0);
     expect(res.snowfallRateFactor).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- smooth precipitation and condensation tapering near boiling points
- calculate water and methane boiling points based on pressure
- pass atmospheric pressure through precipitation and condensation calls
- document the new condensation behaviour in AGENTS
- test boiling point edge cases and update existing tests
- replace iterative water boiling calculation with empirical Antoine formula
- replace iterative methane boiling calculation with a log-based approximation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68741649156c83279f834ed5a5633333