### PR TITLE
Add Dyson Swarm collector feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,8 @@ scripts implement the tabs, pop-ups and other interface elements.
 - The ResearchManager now persists between planets. Only advanced researches remain completed after travel; regular researches reset on each new planet.
 
 ## Dyson Swarm Receiver
-The Dyson Swarm project begins with research into a large orbital array. An advanced research unlocks the concept and a follow-up energy research enables the **Dyson Swarm Receiver** special project. The receiver currently costs massive resources (10M metal, 1M components, 100k electronics) and takes five minutes to build but provides no effect yet.
+The Dyson Swarm project begins with research into a large orbital array. An advanced research unlocks the concept and a follow-up energy research enables the **Dyson Swarm Receiver** special project. The receiver initially costs massive resources (10M metal, 1M components, 100k electronics) and takes five minutes to build.
+Once complete, players may deploy orbital solar collectors from a dedicated UI. Collectors require glass, electronics and components and build over time with optional automation. The total collectors persist when travelling between planets and each provides additional energy production labelled as **Dyson Swarm** in the resource rates.
 - **save.js** manages localStorage save slots and autosaving of resources, structures, research and story progress.
 - **projects.js** and **projectsUI.js** handle special missions such as asteroid mining, cargo exports and other repeatable tasks.
 - Story project progress now stores which narrative steps have already been shown so repeating or reloading a project will never reprint earlier text.

--- a/index.html
+++ b/index.html
@@ -65,6 +65,8 @@
     <script src="src/js/projects/SpaceExportProject.js"></script>
     <script src="src/js/projects/SpaceDisposalProject.js"></script>
     <script src="src/js/projects/CargoRocketProject.js"></script>
+    <script src="src/js/dysonswarm.js"></script>
+    <script src="src/js/dysonswarmUI.js"></script>
     <script src="src/js/projectsUI.js"></script>
     <script src="src/js/research.js"></script>
     <script src="src/js/skills.js"></script>

--- a/src/js/dysonswarm.js
+++ b/src/js/dysonswarm.js
@@ -1,0 +1,83 @@
+class DysonSwarmReceiverProject extends Project {
+  constructor(config, name) {
+    super(config, name);
+    this.collectors = 0;
+    this.collectorDuration = 60000;
+    this.collectorProgress = 0;
+    this.autoDeployCollectors = false;
+    this.collectorCost = {
+      colony: { glass: 1000, electronics: 1000, components: 1000 }
+    };
+    this.energyPerCollector = 1000000;
+  }
+
+  renderUI(container) {
+    if (typeof renderDysonSwarmUI === 'function') {
+      renderDysonSwarmUI(this, container);
+    }
+  }
+
+  updateUI() {
+    if (typeof updateDysonSwarmUI === 'function') {
+      updateDysonSwarmUI(this);
+    }
+  }
+
+  canStartCollector() {
+    if (this.collectorProgress > 0) return false;
+    for (const cat in this.collectorCost) {
+      for (const res in this.collectorCost[cat]) {
+        if (resources[cat][res].value < this.collectorCost[cat][res]) return false;
+      }
+    }
+    return true;
+  }
+
+  deductCollectorResources() {
+    for (const cat in this.collectorCost) {
+      for (const res in this.collectorCost[cat]) {
+        resources[cat][res].decrease(this.collectorCost[cat][res]);
+      }
+    }
+  }
+
+  startCollector() {
+    if (this.canStartCollector()) {
+      this.deductCollectorResources();
+      this.collectorProgress = this.collectorDuration;
+      return true;
+    }
+    return false;
+  }
+
+  update(delta) {
+    super.update(delta);
+    if (this.isCompleted) {
+      if (this.collectorProgress > 0) {
+        this.collectorProgress -= delta;
+        if (this.collectorProgress <= 0) {
+          this.collectorProgress = 0;
+          this.collectors += 1;
+          if (this.autoDeployCollectors) this.startCollector();
+        }
+      } else if (this.autoDeployCollectors) {
+        this.startCollector();
+      }
+    }
+  }
+
+  estimateCostAndGain() {
+    if (this.isCompleted && this.collectors > 0) {
+      const rate = this.collectors * this.energyPerCollector;
+      resources.colony.energy.modifyRate(rate, 'Dyson Swarm', 'project');
+    }
+  }
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.DysonSwarmReceiverProject = DysonSwarmReceiverProject;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = DysonSwarmReceiverProject;
+}

--- a/src/js/dysonswarmUI.js
+++ b/src/js/dysonswarmUI.js
@@ -1,0 +1,60 @@
+function renderDysonSwarmUI(project, container) {
+  const card = document.createElement('div');
+  card.classList.add('dyson-swarm-card');
+  card.innerHTML = `
+    <div class="card-header">
+      <span class="card-title">Dyson Swarm</span>
+    </div>
+    <div class="card-body">
+      <div class="stats-grid">
+        <div class="stat-item"><span class="stat-label">Collectors:</span><span id="ds-collectors"></span></div>
+        <div class="stat-item"><span class="stat-label">Power/Collector:</span><span id="ds-power-per"></span></div>
+        <div class="stat-item"><span class="stat-label">Total Power:</span><span id="ds-total-power"></span></div>
+      </div>
+      <div class="progress-button-container"><button id="ds-start" class="progress-button"></button></div>
+      <div class="checkbox-container"><input type="checkbox" id="ds-auto"><label for="ds-auto">Auto start</label></div>
+    </div>`;
+  container.appendChild(card);
+
+  projectElements[project.name] = {
+    ...projectElements[project.name],
+    swarmCard: card,
+    collectorsDisplay: card.querySelector('#ds-collectors'),
+    powerPerDisplay: card.querySelector('#ds-power-per'),
+    totalPowerDisplay: card.querySelector('#ds-total-power'),
+    startButton: card.querySelector('#ds-start'),
+    autoCheckbox: card.querySelector('#ds-auto')
+  };
+
+  card.querySelector('#ds-start').addEventListener('click', () => project.startCollector());
+  card.querySelector('#ds-auto').addEventListener('change', e => { project.autoDeployCollectors = e.target.checked; });
+}
+
+function updateDysonSwarmUI(project) {
+  const els = projectElements[project.name];
+  if (!els) return;
+  els.collectorsDisplay.textContent = formatNumber(project.collectors, false, 0);
+  els.powerPerDisplay.textContent = formatNumber(project.energyPerCollector, false, 0);
+  const total = project.energyPerCollector * project.collectors;
+  els.totalPowerDisplay.textContent = formatNumber(total, false, 0);
+  if (project.collectorProgress > 0) {
+    const pct = ((project.collectorDuration - project.collectorProgress) / project.collectorDuration) * 100;
+    const secs = Math.max(0, project.collectorProgress / 1000).toFixed(2);
+    els.startButton.textContent = `Deploying (${secs}s)`;
+    els.startButton.style.background = `linear-gradient(to right, #4caf50 ${pct}%, #ccc ${pct}%)`;
+  } else {
+    const can = project.canStartCollector();
+    els.startButton.textContent = 'Deploy Collector';
+    els.startButton.style.background = can ? '#4caf50' : '#f44336';
+  }
+  els.autoCheckbox.checked = project.autoDeployCollectors;
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.renderDysonSwarmUI = renderDysonSwarmUI;
+  globalThis.updateDysonSwarmUI = updateDysonSwarmUI;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { renderDysonSwarmUI, updateDysonSwarmUI };
+}

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -465,6 +465,11 @@ class ProjectManager extends EffectableEntity {
           state.disablePressureThreshold = project.disablePressureThreshold;
         }
       }
+      if (typeof DysonSwarmReceiverProject !== 'undefined' && project instanceof DysonSwarmReceiverProject) {
+        state.collectors = project.collectors;
+        state.collectorProgress = project.collectorProgress;
+        state.autoDeployCollectors = project.autoDeployCollectors;
+      }
 
       projectState[projectName] = state;
     }
@@ -507,14 +512,19 @@ class ProjectManager extends EffectableEntity {
           if(savedProject.waitForCapacity !== undefined){
             project.waitForCapacity = savedProject.waitForCapacity;
           }
-          if (typeof SpaceMiningProject !== 'undefined' && project instanceof SpaceMiningProject) {
-            project.disableAbovePressure = savedProject.disableAbovePressure || false;
-            project.disablePressureThreshold = savedProject.disablePressureThreshold || 0;
-          }
+        if (typeof SpaceMiningProject !== 'undefined' && project instanceof SpaceMiningProject) {
+          project.disableAbovePressure = savedProject.disableAbovePressure || false;
+          project.disablePressureThreshold = savedProject.disablePressureThreshold || 0;
         }
-        if(project.attributes.completionEffect && (project.isCompleted || project.repeatCount > 0)){
-          project.applyCompletionEffect();
-        }
+      }
+      if (typeof DysonSwarmReceiverProject !== 'undefined' && project instanceof DysonSwarmReceiverProject) {
+        project.collectors = savedProject.collectors || 0;
+        project.collectorProgress = savedProject.collectorProgress || 0;
+        project.autoDeployCollectors = savedProject.autoDeployCollectors || false;
+      }
+      if(project.attributes.completionEffect && (project.isCompleted || project.repeatCount > 0)){
+        project.applyCompletionEffect();
+      }
       }
     }
 

--- a/tests/dysonSwarmEnergyProduction.test.js
+++ b/tests/dysonSwarmEnergyProduction.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Dyson Swarm energy production', () => {
+  test('completed project adds energy rate based on collectors', () => {
+    const ctx = {
+      console,
+      EffectableEntity,
+      resources: {
+        colony: {
+          energy: { value: 0, modifyRate: jest.fn(), updateStorageCap: () => {} },
+          glass: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
+          electronics: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
+          components: { value: 2000, decrease: () => {}, updateStorageCap: () => {} }
+        }
+      },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const dysonCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'dysonswarm.js'), 'utf8');
+    vm.runInContext(dysonCode + '; this.DysonSwarmReceiverProject = DysonSwarmReceiverProject;', ctx);
+
+    const params = { name: 'Dyson', category: 'mega', cost: {}, duration: 0, description: '', repeatable: false, unlocked: true, attributes: {} };
+    const project = new ctx.DysonSwarmReceiverProject(params, 'dyson');
+    project.isCompleted = true;
+    project.collectors = 3;
+    project.energyPerCollector = 50;
+
+    project.estimateCostAndGain();
+
+    expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalledWith(150, 'Dyson Swarm', 'project');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `DysonSwarmReceiverProject` with collector deployment and energy output
- create companion UI helpers
- save/load collector data in ProjectManager
- expose new scripts through `index.html`
- document Dyson Swarm mechanics
- test energy production from collectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68741dcbfb3c8327a05dd5a20962f01c