### PR TITLE
Fix Dyson Swarm collector UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ scripts implement the tabs, pop-ups and other interface elements.
 ## Dyson Swarm Receiver
 The Dyson Swarm project begins with research into a large orbital array. An advanced research unlocks the concept and a follow-up energy research enables the **Dyson Swarm Receiver** special project. The receiver initially costs massive resources (10M metal, 1M components, 100k electronics) and takes five minutes to build.
 Once complete, players may deploy orbital solar collectors from a dedicated UI. Collectors require glass, electronics and components and build over time with optional automation. The total collectors persist when travelling between planets and each provides additional energy production labelled as **Dyson Swarm** in the resource rates.
+- The collector progress bar now updates even after the receiver project is finished, and collector controls remain disabled until the receiver itself is complete.
 - **save.js** manages localStorage save slots and autosaving of resources, structures, research and story progress.
 - **projects.js** and **projectsUI.js** handle special missions such as asteroid mining, cargo exports and other repeatable tasks.
 - Story project progress now stores which narrative steps have already been shown so repeating or reloading a project will never reprint earlier text.

--- a/src/js/dysonswarm.js
+++ b/src/js/dysonswarm.js
@@ -24,6 +24,7 @@ class DysonSwarmReceiverProject extends Project {
   }
 
   canStartCollector() {
+    if (!this.isCompleted) return false;
     if (this.collectorProgress > 0) return false;
     for (const cat in this.collectorCost) {
       for (const res in this.collectorCost[cat]) {

--- a/src/js/dysonswarmUI.js
+++ b/src/js/dysonswarmUI.js
@@ -37,6 +37,16 @@ function updateDysonSwarmUI(project) {
   els.powerPerDisplay.textContent = formatNumber(project.energyPerCollector, false, 0);
   const total = project.energyPerCollector * project.collectors;
   els.totalPowerDisplay.textContent = formatNumber(total, false, 0);
+  if (!project.isCompleted) {
+    els.startButton.textContent = 'Receiver Incomplete';
+    els.startButton.style.background = '#999';
+    els.startButton.disabled = true;
+    els.autoCheckbox.disabled = true;
+    return;
+  } else {
+    els.startButton.disabled = false;
+    els.autoCheckbox.disabled = false;
+  }
   if (project.collectorProgress > 0) {
     const pct = ((project.collectorDuration - project.collectorProgress) / project.collectorDuration) * 100;
     const secs = Math.max(0, project.collectorProgress / 1000).toFixed(2);

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -376,15 +376,13 @@ class ProjectManager extends EffectableEntity {
   updateProjects(deltaTime) {
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
-  
+
       if (typeof project.autoAssign === 'function') {
         project.autoAssign();
       }
-  
-      // Update each project if it is active
-      if (project.isActive) {
-        project.update(deltaTime);
-      }
+
+      // Always update so subclasses can run logic after completion
+      project.update(deltaTime);
     }
   }
 

--- a/tests/dysonSwarmCollector.test.js
+++ b/tests/dysonSwarmCollector.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Dyson Swarm collector behaviour', () => {
+  test('collector countdown progresses after update', () => {
+    const ctx = {
+      console,
+      EffectableEntity,
+      resources: {
+        colony: {
+          glass: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
+          electronics: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
+          components: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
+          energy: { value: 0, modifyRate: () => {}, updateStorageCap: () => {} }
+        }
+      },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+    const dysonCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'dysonswarm.js'), 'utf8');
+    vm.runInContext(dysonCode + '; this.DysonSwarmReceiverProject = DysonSwarmReceiverProject;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    const params = { name: 'dyson', category: 'mega', cost: {}, duration: 0, description: '', repeatable: false, unlocked: true, attributes: {} };
+    const project = new ctx.DysonSwarmReceiverProject(params, 'dyson');
+    project.isCompleted = true;
+    ctx.projectManager.projects.dyson = project;
+
+    project.startCollector();
+    expect(project.collectorProgress).toBe(project.collectorDuration);
+    ctx.projectManager.updateProjects(1000);
+    expect(project.collectorProgress).toBe(project.collectorDuration - 1000);
+  });
+
+  test('collector cannot start before receiver completion', () => {
+    const ctx = {
+      console,
+      EffectableEntity,
+      resources: {
+        colony: {
+          glass: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
+          electronics: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
+          components: { value: 2000, decrease: () => {}, updateStorageCap: () => {} }
+        }
+      },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const dysonCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'dysonswarm.js'), 'utf8');
+    vm.runInContext(dysonCode + '; this.DysonSwarmReceiverProject = DysonSwarmReceiverProject;', ctx);
+
+    const params = { name: 'dyson', category: 'mega', cost: {}, duration: 0, description: '', repeatable: false, unlocked: true, attributes: {} };
+    const project = new ctx.DysonSwarmReceiverProject(params, 'dyson');
+
+    const started = project.startCollector();
+    expect(started).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- keep projects updating after completion so collectors tick down
- block solar collector start until the receiver is complete
- disable collector UI until the receiver is finished
- document Dyson Swarm collector behaviour
- add unit tests for Dyson Swarm collectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687425d4e2208327b1c8b501bfddaac9