### PR TITLE
Fix unlocking event for atmospheric collector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,3 +180,4 @@ This section outlines the personalities of the main characters in the story.
 
 *   **Elias Kane:** The charismatic and fanatical leader of the Cult of Three Wounds. He believes the aliens are saviors and that humanity's attempts to terraform are a blasphemy against a grand cosmic design. His dialogue is prophetic, manipulative, and aimed at undermining H.O.P.E.'s mission at every turn, as he is secretly following the aliens' orders.
 \n- Atmospheric Water Collector building unlocks via a condition-based story trigger when the planet is hot and dry.
+- Story events with a chapter value of `-1` do not change the current chapter when activated; their journal text appears in whichever chapter is active.

--- a/src/js/progress-data.js
+++ b/src/js/progress-data.js
@@ -974,7 +974,7 @@ progressData.chapters.push(
   {
     id: "any.awCollector",
     type: "journal",
-    chapter: 0,
+    chapter: -1,
     narrative: "Blueprint retrieved: Atmospheric Water Collector now constructible.",
     prerequisites: [],
     objectives: [

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -158,12 +158,16 @@ class StoryManager {
         }
         const eventChapter = event.chapter;
         let chapterChanged = false;
-        if (this.currentChapter === null) {
-            this.currentChapter = eventChapter;
-        } else if (eventChapter !== this.currentChapter) {
-            clearJournal();
-            this.currentChapter = eventChapter;
-            chapterChanged = true;
+
+        // Chapter -1 indicates the event should not change the current chapter
+        if (eventChapter !== -1) {
+            if (this.currentChapter === null) {
+                this.currentChapter = eventChapter;
+            } else if (eventChapter !== this.currentChapter) {
+                clearJournal();
+                this.currentChapter = eventChapter;
+                chapterChanged = true;
+            }
         }
         console.log(`Activating event: ${event.id}`);
         if (!event.activePlanet && typeof spaceManager !== 'undefined' && typeof spaceManager.getCurrentPlanetKey === 'function') {

--- a/tests/anyChapterEvent.test.js
+++ b/tests/anyChapterEvent.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Chapter -1 events do not change current chapter', () => {
+  test('activating event keeps currentChapter', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress.js'), 'utf8');
+    const dataCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress-data.js'), 'utf8');
+    const atmoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'atmo-collector-trigger.js'), 'utf8');
+
+    const ctx = {
+      resources: { surface: { ice: { value: 0 }, liquidWater: { value: 0 } } },
+      terraforming: { calculateTotalPressure: () => 1, temperature: { zones: { tropical: { value: 400 } } } },
+      boilingPointWater: () => 373,
+      addJournalEntry: () => {},
+      clearJournal: () => {},
+      document: { addEventListener: () => {}, removeEventListener: () => {}, getElementById: () => null },
+    };
+    vm.createContext(ctx);
+    vm.runInContext(atmoCode, ctx);
+    vm.runInContext(dataCode, ctx);
+    const event = ctx.progressData.chapters.find(c => c.id === 'any.awCollector');
+    ctx.progressData = { chapters: [event] };
+    vm.runInContext(code + '; this.StoryManager = StoryManager;', ctx);
+    const manager = new ctx.StoryManager(ctx.progressData);
+    manager.currentChapter = 5;
+    manager.update();
+    expect(manager.currentChapter).toBe(5);
+  });
+});

--- a/tests/atmosphericCollectorUnlock.test.js
+++ b/tests/atmosphericCollectorUnlock.test.js
@@ -16,5 +16,6 @@ describe('Atmospheric Water Collector unlock trigger', () => {
     expect(obj.conditionId).toBe('shouldUnlockAtmosphericWaterCollector');
     const reward = ev.reward.find(r => r.targetId === 'atmosphericWaterCollector');
     expect(reward).toBeDefined();
+    expect(ev.chapter).toBe(-1);
   });
 });


### PR DESCRIPTION
## Summary
- prevent chapter switch for events with `chapter: -1`
- mark atmospheric water collector event with `chapter: -1`
- document special chapter behaviour in AGENTS.md
- adjust tests for atmospheric collector event
- add regression test ensuring chapter `-1` events keep current chapter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6874259320488327927151eb7a96486b