### PR TITLE
Hide Dyson Swarm UI until receiver complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ scripts implement the tabs, pop-ups and other interface elements.
 The Dyson Swarm project begins with research into a large orbital array. An advanced research unlocks the concept and a follow-up energy research enables the **Dyson Swarm Receiver** special project. The receiver initially costs massive resources (10M metal, 1M components, 100k electronics) and takes five minutes to build.
 Once complete, players may deploy orbital solar collectors from a dedicated UI. Collectors require glass, electronics and components and build over time with optional automation. The total collectors persist when travelling between planets and each provides additional energy production labelled as **Dyson Swarm** in the resource rates.
 - The collector progress bar now updates even after the receiver project is finished, and collector controls remain disabled until the receiver itself is complete.
+- The solar collector UI remains hidden until the receiver project is completed, showing the Dyson Swarm card only when ready.
 - **save.js** manages localStorage save slots and autosaving of resources, structures, research and story progress.
 - **projects.js** and **projectsUI.js** handle special missions such as asteroid mining, cargo exports and other repeatable tasks.
 - Story project progress now stores which narrative steps have already been shown so repeating or reloading a project will never reprint earlier text.

--- a/src/js/dysonswarmUI.js
+++ b/src/js/dysonswarmUI.js
@@ -33,6 +33,9 @@ function renderDysonSwarmUI(project, container) {
 function updateDysonSwarmUI(project) {
   const els = projectElements[project.name];
   if (!els) return;
+  if (els.swarmCard) {
+    els.swarmCard.style.display = project.isCompleted ? 'block' : 'none';
+  }
   els.collectorsDisplay.textContent = formatNumber(project.collectors, false, 0);
   els.powerPerDisplay.textContent = formatNumber(project.energyPerCollector, false, 0);
   const total = project.energyPerCollector * project.collectors;

--- a/tests/dysonSwarmCardVisibility.test.js
+++ b/tests/dysonSwarmCardVisibility.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Dyson Swarm card visibility', () => {
+  test('card hidden until project complete', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.projectElements = {};
+    ctx.formatNumber = n => n;
+    ctx.console = console;
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'dysonswarmUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+
+    const project = {
+      name: 'dyson',
+      collectors: 0,
+      energyPerCollector: 0,
+      collectorDuration: 0,
+      collectorProgress: 0,
+      autoDeployCollectors: false,
+      isCompleted: false,
+      canStartCollector: () => true,
+      startCollector: () => {}
+    };
+
+    const container = dom.window.document.getElementById('container');
+    ctx.renderDysonSwarmUI(project, container);
+
+    ctx.updateDysonSwarmUI(project);
+    const card = ctx.projectElements[project.name].swarmCard;
+    expect(card.style.display).toBe('none');
+
+    project.isCompleted = true;
+    ctx.updateDysonSwarmUI(project);
+    expect(card.style.display).toBe('block');
+  });
+});


### PR DESCRIPTION
## Summary
- hide the Dyson Swarm collector card until the receiver project finishes
- note this behaviour in `AGENTS.md`
- test card visibility logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687427faefc88327a0e0df64c6fbf910