### PR TITLE
Fix atmospheric collector unlock sequencing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,4 +181,5 @@ This section outlines the personalities of the main characters in the story.
 
 *   **Elias Kane:** The charismatic and fanatical leader of the Cult of Three Wounds. He believes the aliens are saviors and that humanity's attempts to terraform are a blasphemy against a grand cosmic design. His dialogue is prophetic, manipulative, and aimed at undermining H.O.P.E.'s mission at every turn, as he is secretly following the aliens' orders.
 - Atmospheric Water Collector building unlocks via a condition-based story trigger when the planet is hot and dry. The trigger is now treated as a prerequisite so the journal entry only appears once conditions are met.
+- Prerequisites can include condition checks like objectives. StoryManager evaluates these when determining if an event should activate.
 - Story events with a chapter value of `-1` do not change the current chapter when activated; their journal text appears in whichever chapter is active.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,5 +180,5 @@ This section outlines the personalities of the main characters in the story.
 *   **Dr. Evelyn Hart:** A brilliant and pragmatic scientist, Dr. Hart is the architect of Operation Sidestep. Her dialogue is professional, focused, and driven by the immense scientific and strategic pressures of the unfolding crisis. She is a master of contingency planning and secrecy.
 
 *   **Elias Kane:** The charismatic and fanatical leader of the Cult of Three Wounds. He believes the aliens are saviors and that humanity's attempts to terraform are a blasphemy against a grand cosmic design. His dialogue is prophetic, manipulative, and aimed at undermining H.O.P.E.'s mission at every turn, as he is secretly following the aliens' orders.
-\n- Atmospheric Water Collector building unlocks via a condition-based story trigger when the planet is hot and dry.
+- Atmospheric Water Collector building unlocks via a condition-based story trigger when the planet is hot and dry. The trigger is now treated as a prerequisite so the journal entry only appears once conditions are met.
 - Story events with a chapter value of `-1` do not change the current chapter when activated; their journal text appears in whichever chapter is active.

--- a/src/js/progress-data.js
+++ b/src/js/progress-data.js
@@ -976,10 +976,10 @@ progressData.chapters.push(
     type: "journal",
     chapter: -1,
     narrative: "Blueprint retrieved: Atmospheric Water Collector now constructible.",
-    prerequisites: [],
-    objectives: [
+    prerequisites: [
       { type: 'condition', conditionId: 'shouldUnlockAtmosphericWaterCollector', description: '' }
     ],
+    objectives: [],
     reward: [
       { target: 'building', targetId: 'atmosphericWaterCollector', type: 'enable' }
     ]

--- a/tests/atmosphericCollectorUnlock.test.js
+++ b/tests/atmosphericCollectorUnlock.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const vm = require('vm');
 
 describe('Atmospheric Water Collector unlock trigger', () => {
-  test('story trigger exists with condition objective', () => {
+  test('story trigger exists with condition prerequisite', () => {
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress-data.js'), 'utf8');
     const ctx = {};
     vm.createContext(ctx);
@@ -11,9 +11,10 @@ describe('Atmospheric Water Collector unlock trigger', () => {
     const chapters = ctx.progressData.chapters;
     const ev = chapters.find(c => c.id === 'any.awCollector');
     expect(ev).toBeDefined();
-    const obj = ev.objectives[0];
-    expect(obj.type).toBe('condition');
-    expect(obj.conditionId).toBe('shouldUnlockAtmosphericWaterCollector');
+    expect(ev.objectives.length).toBe(0);
+    const prereq = ev.prerequisites[0];
+    expect(prereq.type).toBe('condition');
+    expect(prereq.conditionId).toBe('shouldUnlockAtmosphericWaterCollector');
     const reward = ev.reward.find(r => r.targetId === 'atmosphericWaterCollector');
     expect(reward).toBeDefined();
     expect(ev.chapter).toBe(-1);

--- a/tests/prerequisiteCondition.test.js
+++ b/tests/prerequisiteCondition.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('StoryManager condition prerequisites', () => {
+  test('event activates only when condition is true', () => {
+    const progressCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress.js'), 'utf8');
+    const context = {
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      document: { addEventListener: () => {}, removeEventListener: () => {}, getElementById: () => null },
+      clearJournal: () => {},
+      addJournalEntry: () => {},
+      addEffect: () => {},
+      removeEffect: () => {},
+      resources: {},
+      buildings: {},
+      colonies: {},
+      terraforming: {}
+    };
+    vm.createContext(context);
+    vm.runInContext(progressCode + '; this.StoryManager = StoryManager;', context);
+
+    context.progressData = { chapters: [
+      {
+        id: 'cond.test',
+        type: 'journal',
+        chapter: -1,
+        narrative: 'x',
+        prerequisites: [{ type: 'condition', conditionId: 'testCondition' }]
+      }
+    ] };
+
+    context.testCondition = () => false;
+
+    const manager = new context.StoryManager(context.progressData);
+    context.window = { popupActive: false, storyManager: manager };
+
+    manager.update();
+    expect(manager.activeEventIds.has('cond.test')).toBe(false);
+
+    context.testCondition = () => true;
+    manager.update();
+    expect(manager.activeEventIds.has('cond.test')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the Atmospheric Water Collector story event waits on its unlock condition by moving it from `objectives` to `prerequisites`
- update tests to expect the new prerequisite
- document the change in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68742874bb888327b724660b0a415e23