### PR TITLE
Ignore chapter -1 journal entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ This section outlines the personalities of the main characters in the story.
 - Atmospheric Water Collector building unlocks via a condition-based story trigger when the planet is hot and dry. The trigger is now treated as a prerequisite so the journal entry only appears once conditions are met.
 - Prerequisites can include condition checks like objectives. StoryManager evaluates these when determining if an event should activate.
 - Story events with a chapter value of `-1` do not change the current chapter when activated; their journal text appears in whichever chapter is active.
+- Journal entries from chapter `-1` events are excluded when loading a save or reconstructing the journal.
 
 # Changelogs
 Insert changes here.  Keep it organized.
@@ -190,3 +191,4 @@ Insert changes here.  Keep it organized.
 - Projects requiring ongoing resources check if enough supplies exist for the next second rather than just the current frame.
 - The luminosity box now shows both ground albedo (base plus black dust) and surface albedo derived from physics.js.
 - Surface albedo deltas compare against the initial surface value on game start, defaulting to ground albedo if unavailable. Tooltip breakdowns list black dust, water, ice and biomass percentages.
+- Loading a save now filters out journal entries from chapter `-1` events so they do not persist between sessions.

--- a/src/js/journal-reconstruction.js
+++ b/src/js/journal-reconstruction.js
@@ -20,6 +20,7 @@
     let currentChapter = null;
     data.chapters.forEach(ch => {
       if (completed.has(ch.id)) {
+        if (ch.chapter === -1) return;
         if (currentChapter === null || ch.chapter !== currentChapter) {
           currentChapter = ch.chapter;
           entries.length = 0;

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -28,6 +28,16 @@ function getGameState() {
   };
 }
 
+function filterChapterMinusOneSources(arr) {
+  return (arr || []).filter(src => {
+    if (src && src.type === 'chapter') {
+      const ch = (progressData && progressData.chapters || []).find(c => c.id === src.id);
+      return !(ch && ch.chapter === -1);
+    }
+    return true;
+  });
+}
+
 // Load game state from a specific slot or custom string
 function loadGame(slotOrCustomString) {
   if (slotOrCustomString === undefined) {
@@ -168,10 +178,11 @@ function loadGame(slotOrCustomString) {
     }
 
       if (gameState.journalEntrySources) {
-        const entries = mapSourcesToText(gameState.journalEntrySources);
-        const historySources = gameState.journalHistorySources || gameState.journalEntrySources;
+        const entrySources = filterChapterMinusOneSources(gameState.journalEntrySources);
+        const historySources = filterChapterMinusOneSources(gameState.journalHistorySources || gameState.journalEntrySources);
+        const entries = mapSourcesToText(entrySources);
         const history = mapSourcesToText(historySources);
-        loadJournalEntries(entries, history, gameState.journalEntrySources, historySources);
+        loadJournalEntries(entries, history, entrySources, historySources);
       } else if (gameState.journalEntries) {
         const history = gameState.journalHistory || gameState.journalEntries;
         loadJournalEntries(gameState.journalEntries, history);

--- a/tests/filterChapterMinusOneSources.test.js
+++ b/tests/filterChapterMinusOneSources.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('filterChapterMinusOneSources utility', () => {
+  test('removes sources for chapter -1 events', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'save.js'), 'utf8');
+    const ctx = {
+      progressData: { chapters: [ { id:'a', chapter:-1 }, { id:'b', chapter:0 } ] },
+      document: { addEventListener: () => {}, getElementById: () => null, querySelectorAll: () => [], getElementsByClassName: () => [] },
+      window: {}
+    };
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.filterChapterMinusOneSources = filterChapterMinusOneSources;', ctx);
+    const sources = [{ type:'chapter', id:'a' }, { type:'chapter', id:'b' }];
+    const res = ctx.filterChapterMinusOneSources(sources);
+    expect(res).toEqual([{ type:'chapter', id:'b' }]);
+  });
+});

--- a/tests/reconstructJournalStateMinusOne.test.js
+++ b/tests/reconstructJournalStateMinusOne.test.js
@@ -1,0 +1,18 @@
+const debugTools = require('../src/js/debug-tools.js');
+
+describe('reconstructJournalState ignores chapter -1 entries', () => {
+  test('entries with chapter -1 are omitted', () => {
+    const data = {
+      chapters: [
+        { id: 'c1', type: 'journal', chapter: 0, narrative: 'keep' },
+        { id: 'c2', type: 'journal', chapter: -1, narrative: 'skip' }
+      ]
+    };
+    const sm = { completedEventIds: new Set(['c1','c2']), activeEventIds: new Set() };
+    const res = debugTools.reconstructJournalState(sm, null, data);
+    expect(res.entries).toEqual(['keep']);
+    expect(res.sources).toEqual([{ type: 'chapter', id: 'c1' }]);
+    expect(res.historyEntries).toEqual(['keep']);
+    expect(res.historySources).toEqual([{ type: 'chapter', id: 'c1' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- skip chapter -1 entries while reconstructing the journal
- filter chapter -1 sources during game load
- note chapter -1 filtering in documentation
- test reconstruction and filtering functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68742d98a8bc83278226cfe83075ef4c