### PR TITLE
Move project save/load into each class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,4 @@ second time they speak in a chapter to help clarify who is talking.
 - The luminosity box shows ground and surface albedo separately.
 - Surface albedo deltas compare against initial values, listing black dust, water,
   ice and biomass percentages.
+- Projects now save and load themselves with dedicated methods overridden by subclasses.

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -123,6 +123,20 @@ class SpaceMiningProject extends SpaceshipProject {
 
     return true;
   }
+
+  saveState() {
+    return {
+      ...super.saveState(),
+      disableAbovePressure: this.disableAbovePressure,
+      disablePressureThreshold: this.disablePressureThreshold,
+    };
+  }
+
+  loadState(state) {
+    super.loadState(state);
+    this.disableAbovePressure = state.disableAbovePressure || false;
+    this.disablePressureThreshold = state.disablePressureThreshold || 0;
+  }
 }
 
 // Expose constructor globally for browser usage

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -488,6 +488,26 @@ class SpaceshipProject extends Project {
   estimateCostAndGain() {
     this.estimateProjectCostAndGain();
   }
+
+  saveState() {
+    return {
+      ...super.saveState(),
+      assignedSpaceships: this.assignedSpaceships,
+      autoAssignSpaceships: this.autoAssignSpaceships,
+      selectedDisposalResource: this.selectedDisposalResource,
+      waitForCapacity: this.waitForCapacity,
+    };
+  }
+
+  loadState(state) {
+    super.loadState(state);
+    this.assignedSpaceships = state.assignedSpaceships;
+    this.autoAssignSpaceships = state.autoAssignSpaceships;
+    this.selectedDisposalResource = state.selectedDisposalResource || this.attributes.defaultDisposal;
+    if (state.waitForCapacity !== undefined) {
+      this.waitForCapacity = state.waitForCapacity;
+    }
+  }
 }
 
 if (typeof globalThis !== 'undefined') {

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -73,6 +73,22 @@ class DysonSwarmReceiverProject extends Project {
       resources.colony.energy.modifyRate(rate, 'Dyson Swarm', 'project');
     }
   }
+
+  saveState() {
+    return {
+      ...super.saveState(),
+      collectors: this.collectors,
+      collectorProgress: this.collectorProgress,
+      autoDeployCollectors: this.autoDeployCollectors,
+    };
+  }
+
+  loadState(state) {
+    super.loadState(state);
+    this.collectors = state.collectors || 0;
+    this.collectorProgress = state.collectorProgress || 0;
+    this.autoDeployCollectors = state.autoDeployCollectors || false;
+  }
 }
 
 if (typeof globalThis !== 'undefined') {

--- a/tests/projectSaveLoadMethods.test.js
+++ b/tests/projectSaveLoadMethods.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Project save/load methods on subclasses', () => {
+  test('SpaceMiningProject saves and loads custom fields', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+
+    const config = { name: 'Mine', category: 'resources', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: { spaceMining: true } };
+    const project = new ctx.SpaceMiningProject(config, 'mine');
+    project.disableAbovePressure = true;
+    project.disablePressureThreshold = 50;
+
+    const saved = project.saveState();
+    const loaded = new ctx.SpaceMiningProject(config, 'mine');
+    loaded.loadState(saved);
+
+    expect(loaded.disableAbovePressure).toBe(true);
+    expect(loaded.disablePressureThreshold).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary
- add per-project `saveState`/`loadState` methods
- call project methods from `ProjectManager`
- override in `SpaceshipProject`, `SpaceMiningProject` and Dyson Swarm receiver
- document change in `AGENTS.md`
- test individual project save/load logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68744ef7513c83278111a4c6b6c26138