### PR TITLE
Skip any-chapter events during journal reconstruction

### DIFF
--- a/src/js/journal-reconstruction.js
+++ b/src/js/journal-reconstruction.js
@@ -20,6 +20,7 @@
     let currentChapter = null;
     data.chapters.forEach(ch => {
       if (completed.has(ch.id)) {
+        if (ch.chapter === -1) return; // Skip any-chapter events
         if (currentChapter === null || ch.chapter !== currentChapter) {
           currentChapter = ch.chapter;
           entries.length = 0;

--- a/tests/reconstructJournalStateSkipAnyChapter.test.js
+++ b/tests/reconstructJournalStateSkipAnyChapter.test.js
@@ -1,0 +1,24 @@
+const debugTools = require('../src/js/debug-tools.js');
+
+describe('reconstructJournalState skips chapter -1 events', () => {
+  test('events with chapter -1 are ignored', () => {
+    const data = {
+      chapters: [
+        { id: 'c1', type: 'journal', chapter: 1, narrative: 'first' },
+        { id: 'cX', type: 'journal', chapter: -1, narrative: 'skip' },
+        { id: 'c2', type: 'journal', chapter: 2, narrative: 'second' }
+      ],
+      storyProjects: {}
+    };
+    const sm = { completedEventIds: new Set(['c1','cX','c2']), activeEventIds: new Set() };
+    const pm = {};
+    const res = debugTools.reconstructJournalState(sm, pm, data);
+    expect(res.entries).toEqual(['second']);
+    expect(res.sources).toEqual([{ type: 'chapter', id: 'c2' }]);
+    expect(res.historyEntries).toEqual(['first','second']);
+    expect(res.historySources).toEqual([
+      { type: 'chapter', id: 'c1' },
+      { type: 'chapter', id: 'c2' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore events with `chapter: -1` in `reconstructJournalState`
- test that these events are not included in the journal history

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6874fa06f8688327ae51d51c2f3490d4