### PR TITLE
Show collector duration in Dyson Swarm UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,3 +110,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Surface albedo deltas compare against initial values, listing black dust, water,
   ice and biomass percentages.
 - Projects now save and load themselves with dedicated methods overridden by subclasses.
+- Dyson Swarm collector duration now scales with the number of terraformed planets using a helper in SpaceManager, and the button shows the time required.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -353,7 +353,7 @@ const projectParameters = {
       }
     },
     duration: 300000,
-    description: 'Construct the receiver array to receive energy from the Dyson Swarm and enables its expansion.',
+    description: 'Construct the receiver array to receive energy from the Dyson Swarm and enables its expansion. All colonies on terraformed worlds can help deploy collectors when materials are provided, shortening the process.',
     repeatable: false,
     unlocked: false,
     attributes: { }

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -2,13 +2,24 @@ class DysonSwarmReceiverProject extends Project {
   constructor(config, name) {
     super(config, name);
     this.collectors = 0;
-    this.collectorDuration = 60000;
+    this.baseCollectorDuration = 60000;
     this.collectorProgress = 0;
     this.autoDeployCollectors = false;
     this.collectorCost = {
       colony: { metal: 250000, electronics: 125000, components: 20000, glass: 4000,  }
     };
     this.energyPerCollector = 1000000000000;
+  }
+
+  get collectorDuration() {
+    if (
+      typeof spaceManager === 'undefined' ||
+      typeof spaceManager.getTerraformedPlanetCount !== 'function'
+    ) {
+      return this.baseCollectorDuration;
+    }
+    const count = spaceManager.getTerraformedPlanetCount();
+    return this.baseCollectorDuration / (count + 1);
   }
 
   renderUI(container) {

--- a/src/js/projects/dysonswarmUI.js
+++ b/src/js/projects/dysonswarmUI.js
@@ -71,7 +71,8 @@ function updateDysonSwarmUI(project) {
     els.startButton.style.background = `linear-gradient(to right, #4caf50 ${pct}%, #ccc ${pct}%)`;
   } else {
     const can = project.canStartCollector();
-    els.startButton.textContent = 'Deploy Collector';
+    const dur = Math.round(project.collectorDuration / 1000);
+    els.startButton.textContent = `Deploy Collector (${dur}s)`;
     els.startButton.style.background = can ? '#4caf50' : '#f44336';
   }
   els.autoCheckbox.checked = project.autoDeployCollectors;

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -62,6 +62,15 @@ class SpaceManager extends EffectableEntity {
     }
 
     /**
+     * Counts how many planets have been fully terraformed.
+     * @returns {number}
+     */
+    getTerraformedPlanetCount() {
+        return Object.values(this.planetStatuses)
+            .filter(status => status.terraformed).length;
+    }
+
+    /**
      * Enable a planet so it appears in the UI.
      * @param {string} planetKey
      * @returns {boolean} True if the planet exists and was enabled.

--- a/tests/dysonSwarmCollectorDuration.test.js
+++ b/tests/dysonSwarmCollectorDuration.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Dyson Swarm collector duration UI', () => {
+  test('button shows adjusted duration', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.resources = { colony: { glass: { displayName: 'Glass' }, electronics: { displayName: 'Electronics' }, components: { displayName: 'Components' } } };
+    ctx.spaceManager = {
+      planetStatuses: { mars: { terraformed: false } },
+      getTerraformedPlanetCount() {
+        return Object.values(this.planetStatuses).filter(p => p.terraformed).length;
+      }
+    };
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'dysonswarmUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.renderDysonSwarmUI = renderDysonSwarmUI; this.updateDysonSwarmUI = updateDysonSwarmUI; this.projectElements = projectElements;', ctx);
+
+    const project = {
+      name: 'dyson',
+      collectorCost: { colony: { glass: 1000, electronics: 1000, components: 1000 } },
+      collectors: 0,
+      energyPerCollector: 0,
+      get collectorDuration() {
+        const count = ctx.spaceManager.getTerraformedPlanetCount ?
+          ctx.spaceManager.getTerraformedPlanetCount() : 0;
+        return 60000 / (count + 1);
+      },
+      collectorProgress: 0,
+      autoDeployCollectors: false,
+      isCompleted: true,
+      canStartCollector: () => true,
+      startCollector: () => {},
+      renderUI(container) { ctx.renderDysonSwarmUI(this, container); },
+      updateUI() { ctx.updateDysonSwarmUI(this); }
+    };
+
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    project.updateUI();
+
+    const text = ctx.projectElements.dyson.startButton.textContent;
+    expect(text).toBe('Deploy Collector (60s)');
+
+    ctx.spaceManager.planetStatuses = {
+      mars: { terraformed: false },
+      titan: { terraformed: true },
+      europa: { terraformed: true }
+    };
+    project.updateUI();
+    const text2 = ctx.projectElements.dyson.startButton.textContent;
+    expect(text2).toBe('Deploy Collector (20s)');
+  });
+});


### PR DESCRIPTION
## Summary
- scale Dyson Swarm collector duration by terraformed planets
- show deployment duration on the deploy button
- clarify Dyson Swarm Receiver description
- document update in AGENTS.md
- update unit test for collector duration display
- add method to SpaceManager to count terraformed planets

## Testing
- `npm test --silent | tail -n 2`


------
https://chatgpt.com/codex/tasks/task_b_6874fa70d6d083279791ef304e4ef502