### PR TITLE
Use planetary rotation for day/night cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,4 @@ second time they speak in a chapter to help clarify who is talking.
   ice and biomass percentages.
 - Projects now save and load themselves with dedicated methods overridden by subclasses.
 - Dyson Swarm collector duration now scales with the number of terraformed planets using a helper in SpaceManager, and the button shows the time required.
+- Day-night cycle duration now derives from each planet's rotation period, treating one Earth day as one minute.

--- a/src/js/day-night-cycle.js
+++ b/src/js/day-night-cycle.js
@@ -35,13 +35,19 @@ class DayNightCycle {
     }
 
     // Method to load the state into DayNightCycle
-    loadState(state) {
-      this.dayProgress = state.dayProgress || 0;
-      this.elapsedTime = state.elapsedTime || 0;
-    }
+  loadState(state) {
+    this.dayProgress = state.dayProgress || 0;
+    this.elapsedTime = state.elapsedTime || 0;
+  }
 }
 
-  
+// Convert a rotation period in hours to a day-night cycle duration in
+// milliseconds using one Earth day as one minute.
+function rotationPeriodToDuration(rotationHours) {
+  return (rotationHours / 24) * 60000;
+}
+
+
 
 function updateDayNightDisplay() {
   const dayNightStatus = dayNightCycle.isDay() ? 'Day' : 'Night';
@@ -64,4 +70,8 @@ function updateDayNightDisplay() {
     progressBar.style.backgroundColor = `rgb(0, 0, ${dayProgress * 2.55})`; // Transitions from dark blue to lighter blue as night progresses
     progressBar.classList.add('night');
   }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { DayNightCycle, rotationPeriodToDuration, updateDayNightDisplay };
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -29,7 +29,9 @@ function create() {
   }, tabParameters);
 
   // Set up the game scene, objects, and initial state
-  dayNightCycle = new DayNightCycle(120000); // Day duration of 2 minutes (120000 milliseconds)
+  const rotation = currentPlanetParameters.celestialParameters.rotationPeriod || 24;
+  const dayDuration = rotationPeriodToDuration(rotation);
+  dayNightCycle = new DayNightCycle(dayDuration);
   updateDayNightDisplay();
 
   // Initialize resources
@@ -119,7 +121,9 @@ function initializeGameState(options = {}) {
 
   playTimeSeconds = 0;
 
-  dayNightCycle = new DayNightCycle(120000); // Day duration of 2 minutes (120000 milliseconds)
+  const rotation = currentPlanetParameters.celestialParameters.rotationPeriod || 24;
+  const dayDuration = rotationPeriodToDuration(rotation);
+  dayNightCycle = new DayNightCycle(dayDuration);
   resources = {};
   resources = createResources(currentPlanetParameters.resources);
   if (savedAdvancedResearch) {

--- a/tests/dayNightCycleDuration.test.js
+++ b/tests/dayNightCycleDuration.test.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+const { rotationPeriodToDuration } = require('../src/js/day-night-cycle.js');
+
+describe('day-night cycle duration', () => {
+  test('initializes using planet rotation period', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) {
+        this.config = config;
+      },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+
+    const marsDuration = vm.runInContext('dayNightCycle.dayDuration', ctx);
+    const expectedMars = rotationPeriodToDuration(
+      planetParameters.mars.celestialParameters.rotationPeriod
+    );
+
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const titanDuration = vm.runInContext('dayNightCycle.dayDuration', ctx);
+    const expectedTitan = rotationPeriodToDuration(
+      planetParameters.titan.celestialParameters.rotationPeriod
+    );
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(marsDuration).toBeCloseTo(expectedMars, 5);
+    expect(titanDuration).toBeCloseTo(expectedTitan, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- compute day-night duration from `rotationPeriod` when creating game state
- expose helper `rotationPeriodToDuration`
- export utilities from day-night cycle module
- add regression test for day-night cycle duration
- document feature in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875183f4b888327b40f4a68d1689f7f