### PR TITLE
Implement game speed console command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Dyson Swarm collector duration now scales with the number of terraformed planets using a helper in SpaceManager, and the button shows the time required.
 - Day-night cycle duration now derives from each planet's rotation period, treating one Earth day as one minute.
 - Added a "system-pop-up" story event type for instant messages.
+- Added a `setGameSpeed` console command that multiplies time progression for the current session.

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
     <script src="src/js/solis.js"></script>
     <script src="src/js/solisUI.js"></script>
     <script src="src/js/globals.js"></script>
+    <script src="src/js/game-speed.js"></script>
     <script src="src/js/autobuild.js"></script>
     <script src="src/js/gold-asteroid.js"></script>
     <script src="src/js/space.js"></script>

--- a/src/js/game-speed.js
+++ b/src/js/game-speed.js
@@ -1,0 +1,23 @@
+(function(){
+  function setGameSpeed(speed){
+    const value = Number(speed);
+    if(isNaN(value) || value <= 0){
+      console.warn('setGameSpeed expects a positive number');
+      return;
+    }
+    if(typeof gameSpeed !== 'undefined'){
+      gameSpeed = value;
+    }
+  }
+
+  function getGameSpeed(){
+    return typeof gameSpeed !== 'undefined' ? gameSpeed : 1;
+  }
+
+  if(typeof module !== 'undefined' && module.exports){
+    module.exports = { setGameSpeed, getGameSpeed };
+  } else {
+    globalThis.setGameSpeed = setGameSpeed;
+    globalThis.getGameSpeed = getGameSpeed;
+  }
+})();

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -273,11 +273,12 @@ function updateRender() {
 }
 
 function update(time, delta) {
+  const speed = (typeof gameSpeed !== 'undefined') ? gameSpeed : 1;
+  const scaledDelta = delta * speed;
+  updateLogic(scaledDelta);   // Update game state
+  updateRender();             // Render updated game state
 
-  updateLogic(delta);   // Update game state
-  updateRender();       // Render updated game state
-
-  autosave(delta);      // Call the autosave function
+  autosave(scaledDelta);      // Call the autosave function
 }
 
 function startNewGame() {

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -44,3 +44,4 @@ let globalEffects = new EffectableEntity({description : 'Manages global effects'
 let skillManager;
 let solisManager;
 let playTimeSeconds = 0;
+let gameSpeed = 1;

--- a/tests/gameSpeed.test.js
+++ b/tests/gameSpeed.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('setGameSpeed command', () => {
+  test('multiplies delta time in update', () => {
+    const ctx = { console, Phaser: { AUTO: 'AUTO', Game: function(){} } };
+    ctx.EffectableEntity = class {};
+    ctx.planetParameters = { mars: { celestialParameters: { rotationPeriod: 24 }, resources: {}, buildingParameters: { maintenanceFraction: 0 }, populationParameters: {} } };
+    vm.createContext(ctx);
+
+    const globalsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'globals.js'), 'utf8');
+    const speedCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'game-speed.js'), 'utf8');
+    const gameCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'game.js'), 'utf8');
+
+    vm.runInContext(globalsCode, ctx);
+    vm.runInContext(speedCode, ctx);
+    vm.runInContext(gameCode, ctx);
+
+    vm.runInContext('updateLogic = function(d){ playTimeSeconds += d/1000; }; updateRender = ()=>{}; autosave = ()=>{};', ctx);
+
+    vm.runInContext('setGameSpeed(2);', ctx);
+    vm.runInContext('playTimeSeconds = 0;', ctx);
+    vm.runInContext('update(0, 1000);', ctx);
+    const result = vm.runInContext('playTimeSeconds', ctx);
+
+    expect(result).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `setGameSpeed` helper
- adjust update loop to scale time by game speed
- expose `game-speed.js` in the page
- document feature in AGENTS
- test `setGameSpeed`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68759ea2e8d88327ad167a279a74947e