### PR TITLE
Bio factory checks life survivability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Day-night cycle duration now derives from each planet's rotation period, treating one Earth day as one minute.
 - Added a "system-pop-up" story event type for instant messages.
 - Added a `setGameSpeed` console command that multiplies time progression for the current session.
+- Bio Factory stops producing if designed life can't survive in any zone.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -430,6 +430,17 @@ class Building extends EffectableEntity {
         }
       }
 
+      // Disable Bio Factory when designed life cannot survive anywhere
+      if(
+        this.name === 'bioFactory' &&
+        typeof lifeDesigner !== 'undefined' &&
+        lifeDesigner.currentDesign &&
+        typeof lifeDesigner.currentDesign.canSurviveAnywhere === 'function' &&
+        !lifeDesigner.currentDesign.canSurviveAnywhere()
+      ){
+        targetProductivity = 0;
+      }
+
       if(Math.abs(targetProductivity - this.productivity) < 0.001){
         this.productivity = targetProductivity;
       }

--- a/tests/bioFactorySurvival.test.js
+++ b/tests/bioFactorySurvival.test.js
@@ -1,0 +1,46 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+// expose globally before requiring Building
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+
+function createBioFactory(){
+  const config = {
+    name: 'Bio Factory',
+    category: 'terraforming',
+    cost: {},
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new Building(config, 'bioFactory');
+}
+
+describe('bio factory productivity requires survivable environment', () => {
+  beforeEach(() => {
+    global.resources = { colony:{}, surface:{}, underground:{}, atmospheric:{} };
+    global.populationModule = { getWorkerAvailabilityRatio: () => 1 };
+  });
+
+  test('productivity zero when life cannot survive anywhere', () => {
+    global.lifeDesigner = { currentDesign: { canSurviveAnywhere: () => false } };
+    const fac = createBioFactory();
+    fac.active = 1;
+    fac.updateProductivity(global.resources, 1000);
+    expect(fac.productivity).toBe(0);
+  });
+
+  test('produces when life can survive somewhere', () => {
+    global.lifeDesigner = { currentDesign: { canSurviveAnywhere: () => true } };
+    const fac = createBioFactory();
+    fac.active = 1;
+    fac.updateProductivity(global.resources, 1000);
+    expect(fac.productivity).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent Bio Factory from producing when life can't survive anywhere
- test Bio Factory productivity conditional on survivability
- document new behavior in `AGENTS.md`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6875abf5685c83279a5f21ab64a90a89