### PR TITLE
Fix life growth rate when dry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added a "system-pop-up" story event type for instant messages.
 - Added a `setGameSpeed` console command that multiplies time progression for the current session.
 - Bio Factory stops producing if designed life can't survive in any zone.
+- Life growth rate shows 0 when no liquid water is present and its tooltip lists a moisture multiplier.

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -620,11 +620,12 @@ function updateLifeStatusTable() {
                 : (terraforming.calculateZonalSolarPanelMultiplier ? terraforming.calculateZonalSolarPanelMultiplier(zone) : 1);
             const tempMult = growthTempResults[zone]?.multiplier || 0;
             const radMult = terraforming.getMagnetosphereStatus() ? 1 : (0.5 + 0.5 * designToCheck.getRadiationMitigationRatio());
+            const waterMult = (terraforming.zonalWater[zone]?.liquid || 0) > 1e-9 ? 1 : 0;
             const otherMult = (typeof lifeManager !== 'undefined' && lifeManager.getEffectiveLifeGrowthMultiplier) ? lifeManager.getEffectiveLifeGrowthMultiplier() : 1;
-            const finalRate = baseRate * lumMult * tempMult * capacityMult * radMult * otherMult;
+            const finalRate = baseRate * lumMult * tempMult * capacityMult * radMult * waterMult * otherMult;
             if(valueSpan) valueSpan.textContent = formatNumber(finalRate * 100, false, 2);
             if(tooltipSpan) {
-                tooltipSpan.title = `Base: ${(baseRate*100).toFixed(2)}%\nTemp: x${formatNumber(tempMult, false,2)}\nLuminosity: x${formatNumber(lumMult,false,2)}\nCapacity: x${formatNumber(capacityMult,false,2)}\nRadiation: x${formatNumber(radMult,false,2)}\nOther: x${formatNumber(otherMult,false,2)}`;
+                tooltipSpan.title = `Base: ${(baseRate*100).toFixed(2)}%\nTemp: x${formatNumber(tempMult, false,2)}\nLuminosity: x${formatNumber(lumMult,false,2)}\nCapacity: x${formatNumber(capacityMult,false,2)}\nRadiation: x${formatNumber(radMult,false,2)}\nMoisture: x${formatNumber(waterMult,false,2)}\nOther: x${formatNumber(otherMult,false,2)}`;
             }
         }
     });

--- a/tests/lifeGrowthRateDisplay.test.js
+++ b/tests/lifeGrowthRateDisplay.test.js
@@ -51,7 +51,7 @@ describe('life growth rate display', () => {
 
     const valueSpan = dom.window.document.getElementById('growth-rate-tropical-value');
     const tooltip = dom.window.document.getElementById('growth-rate-tropical-tooltip');
-    expect(valueSpan.textContent).toBe('0.80');
-    expect(tooltip.title).toContain('Base:');
+    expect(valueSpan.textContent).toBe('0');
+    expect(tooltip.title).toContain('Moisture: x0');
   });
 });


### PR DESCRIPTION
## Summary
- moisture multiplier sets growth rate to zero when no liquid water
- display moisture multiplier in life tooltips
- add test coverage for zero growth without water
- document update in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875adef25ec83278ec8e0c3f8f8e66a