### PR TITLE
Switch melt rate coverage calc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,3 +119,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Subtab alerts indicate available Solis quests and completable terraforming milestones.
 - Space mirror power per unit area now uses cross-section area for accurate flux.
 - Space mining water shipments now deliver liquid water to zones above freezing or ice if all zones are below 0°C.
+- Melting and freezing rate calculations now use `calculateZonalCoverage` for ice so scale factors are correct.

--- a/src/js/hydrology.js
+++ b/src/js/hydrology.js
@@ -201,7 +201,7 @@ function simulateSurfaceHydrocarbonFlow(zonalHydrocarbonInput, deltaTime, zonalT
 }
 
 // Compute melting and freezing rates for a surface zone based on temperature
-function calculateMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1) {
+function calculateMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1, coverageFn) {
     return meltingFreezingRatesUtil({
         temperature,
         freezingPoint: 273.15,
@@ -209,11 +209,12 @@ function calculateMeltingFreezingRates(temperature, availableIce, availableLiqui
         availableLiquid,
         availableBuriedIce,
         zoneArea,
+        coverageFn,
         estimateCoverageFn
     });
 }
 
-function calculateMethaneMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1) {
+function calculateMethaneMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1, coverageFn) {
     return meltingFreezingRatesUtil({
         temperature,
         freezingPoint: 90.7,
@@ -221,6 +222,7 @@ function calculateMethaneMeltingFreezingRates(temperature, availableIce, availab
         availableLiquid,
         availableBuriedIce,
         zoneArea,
+        coverageFn,
         estimateCoverageFn
     });
 }

--- a/src/js/phase-change-utils.js
+++ b/src/js/phase-change-utils.js
@@ -34,6 +34,7 @@ function meltingFreezingRates({
   availableLiquid = 0,
   availableBuriedIce = 0,
   zoneArea = 1,
+  coverageFn,
   estimateCoverageFn
 }) {
   const meltingRateMultiplier = 0.000001; // per K per second
@@ -45,7 +46,12 @@ function meltingFreezingRates({
   if (temperature > freezingPoint) {
     const diff = temperature - freezingPoint;
 
-    const surfaceIceCoverage = estimateCoverageFn ? estimateCoverageFn(availableIce || 0, zoneArea) : 1;
+    let surfaceIceCoverage = 1;
+    if (coverageFn) {
+      surfaceIceCoverage = coverageFn();
+    } else if (estimateCoverageFn) {
+      surfaceIceCoverage = estimateCoverageFn(availableIce || 0, zoneArea, 0.01);
+    }
     const surfaceMeltCap = zoneArea * surfaceIceCoverage * 0.1;
     const cappedSurfaceIce = Math.min(availableIce || 0, surfaceMeltCap);
     const surfaceMeltRate = cappedSurfaceIce * meltingRateMultiplier * diff;

--- a/src/js/terraforming-utils.js
+++ b/src/js/terraforming-utils.js
@@ -139,7 +139,8 @@ const calculateZonalMeltingFreezingRates = (terraforming, zone, temperature) => 
   const availableBuriedIce = terraforming.zonalWater?.[zone]?.buriedIce || 0;
   const availableLiquid = terraforming.zonalWater?.[zone]?.liquid || 0;
   const zoneArea = terraforming.celestialParameters.surfaceArea * zonePercentage(zone);
-  return baseCalculateMeltFreeze(temperature, availableIce, availableLiquid, availableBuriedIce, zoneArea);
+  const coverageFn = () => calculateZonalCoverage(terraforming, zone, 'ice');
+  return baseCalculateMeltFreeze(temperature, availableIce, availableLiquid, availableBuriedIce, zoneArea, coverageFn);
 };
 
 if (!isNode) {

--- a/tests/hydrology.test.js
+++ b/tests/hydrology.test.js
@@ -1,5 +1,5 @@
 const { calculateMeltingFreezingRates, simulateSurfaceWaterFlow } = require('../src/js/hydrology.js');
-const { calculateMeltingFreezingRates: zonalRates } = require('../src/js/terraforming-utils.js');
+const { calculateMeltingFreezingRates: zonalRates, calculateZonalCoverage } = require('../src/js/terraforming-utils.js');
 const { getZonePercentage, estimateCoverage } = require('../src/js/zones.js');
 
 global.getZonePercentage = getZonePercentage;
@@ -23,10 +23,10 @@ describe('hydrology melting with buried ice', () => {
     const terra = { zonalWater: { polar: { ice: 5, buriedIce: 3, liquid: 1 } }, celestialParameters: { surfaceArea: 1 } };
     const T = 280;
     const zoneArea = terra.celestialParameters.surfaceArea * getZonePercentage('polar');
-    const coverage = estimateCoverage(5, zoneArea);
+    const coverage = calculateZonalCoverage(terra, 'polar', 'ice');
     const meltCap = zoneArea * coverage * 0.1;
     const diff = T - 273.15;
-    const expected = meltCap * 0.00000001 * diff;
+    const expected = meltCap * 0.000001 * diff;
     const res = zonalRates(terra, 'polar', T);
     expect(res.meltingRate).toBeCloseTo(expected);
   });
@@ -38,10 +38,11 @@ describe('hydrology melting with buried ice', () => {
       tropical: { liquid: 0, ice: 0, buriedIce: 0 }
     };
     const temps = { polar: 250, temperate: 274, tropical: 260 };
-    const melt = simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1000, temps, zoneElevations);
+    const terra = makeTerraforming(zonalWater);
+    const melt = simulateSurfaceWaterFlow(terra, 1000, temps, zoneElevations);
     const slopeFactor = 1 + (zoneElevations.polar - zoneElevations.temperate);
     const zoneArea = getZonePercentage('polar');
-    const coverage = estimateCoverage(100, zoneArea);
+    const coverage = calculateZonalCoverage(terra, 'polar', 'ice');
     const meltCap = zoneArea * coverage * 0.1;
     const expectedMelt = meltCap * 0.001 * slopeFactor;
     const surfaceFraction = 100 / (100 + 50);

--- a/tests/phaseChangeUtils.test.js
+++ b/tests/phaseChangeUtils.test.js
@@ -45,9 +45,9 @@ describe('meltingFreezingRates helper', () => {
       availableIce: 5,
       availableLiquid: 1,
       availableBuriedIce: 2,
-      zoneArea: 1,
-      estimateCoverageFn: (amount, area) => amount / area
+      zoneArea: 1
     };
+    params.coverageFn = () => params.availableIce / params.zoneArea;
     const utilRes = utils.meltingFreezingRates(params);
     const hydro = require('../src/js/hydrology.js');
     const hydroRes = hydro.calculateMeltingFreezingRates(
@@ -55,7 +55,8 @@ describe('meltingFreezingRates helper', () => {
       params.availableIce,
       params.availableLiquid,
       params.availableBuriedIce,
-      params.zoneArea
+      params.zoneArea,
+      () => params.availableIce / params.zoneArea
     );
     expect(utilRes.meltingRate).toBeCloseTo(hydroRes.meltingRate);
     expect(utilRes.freezingRate).toBeCloseTo(hydroRes.freezingRate);


### PR DESCRIPTION
## Summary
- use calculateZonalCoverage to determine surface ice exposure
- support optional coverage function in hydrology helpers
- update tests for new coverage logic
- document change in AGENTS instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875d1fb0d9c83279ea8c893ca2f4250