### PR TITLE
Improve ice tooltip display

### DIFF
--- a/tests/resourceTooltipZones.test.js
+++ b/tests/resourceTooltipZones.test.js
@@ -11,19 +11,23 @@ describe('resource tooltip zonal values', () => {
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
     ctx.oreScanner = { scanData: {} };
-    ctx.terraforming = {
-      zonalWater: {
-        tropical: { liquid: 10, ice: 5, buriedIce: 15 },
-        temperate: { liquid: 20, ice: 10, buriedIce: 25 },
-        polar: { liquid: 30, ice: 15, buriedIce: 35 }
-      },
-      zonalSurface: {
-        tropical: { dryIce: 1 },
-        temperate: { dryIce: 2 },
-        polar: { dryIce: 3 }
-      },
-      zonalHydrocarbons: { tropical: {}, temperate: {}, polar: {} }
-    };
+      ctx.terraforming = {
+        zonalWater: {
+          tropical: { liquid: 10, ice: 5, buriedIce: 15 },
+          temperate: { liquid: 20, ice: 10, buriedIce: 25 },
+          polar: { liquid: 30, ice: 15, buriedIce: 35 }
+        },
+        zonalSurface: {
+          tropical: { dryIce: 1 },
+          temperate: { dryIce: 2 },
+          polar: { dryIce: 3 }
+        },
+        zonalHydrocarbons: {
+          tropical: { ice: 2, buriedIce: 4 },
+          temperate: { ice: 3, buriedIce: 6 },
+          polar: { ice: 4, buriedIce: 8 }
+        }
+      };
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
     vm.runInContext(code, ctx);
@@ -46,7 +50,7 @@ describe('resource tooltip zonal values', () => {
     expect(html).toContain('Polar: ' + numbers.formatNumber(30, false, 3));
   });
 
-  test('ice tooltip sums surface and buried ice', () => {
+  test('ice tooltip shows total and buried amounts', () => {
     const { dom, ctx } = setupContext();
     const resource = {
       name: 'ice', displayName: 'Ice', category: 'surface',
@@ -57,12 +61,15 @@ describe('resource tooltip zonal values', () => {
     ctx.createResourceDisplay({ surface: { ice: resource } });
     ctx.updateResourceRateDisplay(resource);
     const html = dom.window.document.getElementById('ice-tooltip').innerHTML;
-    const trop = numbers.formatNumber(5 + 15, false, 3);
-    const temp = numbers.formatNumber(10 + 25, false, 3);
-    const pol = numbers.formatNumber(15 + 35, false, 3);
-    expect(html).toContain('Tropical: ' + trop);
-    expect(html).toContain('Temperate: ' + temp);
-    expect(html).toContain('Polar: ' + pol);
+    const tropTotal = numbers.formatNumber(5 + 15, false, 3);
+    const tempTotal = numbers.formatNumber(10 + 25, false, 3);
+    const polTotal = numbers.formatNumber(15 + 35, false, 3);
+    const tropBuried = numbers.formatNumber(15, false, 3);
+    const tempBuried = numbers.formatNumber(25, false, 3);
+    const polBuried = numbers.formatNumber(35, false, 3);
+    expect(html).toContain(`Tropical: ${tropTotal} / ${tropBuried} (buried)`);
+    expect(html).toContain(`Temperate: ${tempTotal} / ${tempBuried} (buried)`);
+    expect(html).toContain(`Polar: ${polTotal} / ${polBuried} (buried)`);
   });
 
   test('dry ice tooltip shows zonal amounts', () => {
@@ -79,5 +86,27 @@ describe('resource tooltip zonal values', () => {
     expect(html).toContain('Tropical: ' + numbers.formatNumber(1, false, 3));
     expect(html).toContain('Temperate: ' + numbers.formatNumber(2, false, 3));
     expect(html).toContain('Polar: ' + numbers.formatNumber(3, false, 3));
+  });
+
+  test('methane ice tooltip shows total and buried amounts', () => {
+    const { dom, ctx } = setupContext();
+    const resource = {
+      name: 'hydrocarbonIce', displayName: 'Methane Ice', category: 'surface',
+      value: 0, hasCap: false, cap: 0, unlocked: true, reserved: 0,
+      productionRate: 0, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton'
+    };
+    ctx.createResourceDisplay({ surface: { hydrocarbonIce: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('hydrocarbonIce-tooltip').innerHTML;
+    const tTotal = numbers.formatNumber(2 + 4, false, 3);
+    const mTotal = numbers.formatNumber(3 + 6, false, 3);
+    const pTotal = numbers.formatNumber(4 + 8, false, 3);
+    const tBuried = numbers.formatNumber(4, false, 3);
+    const mBuried = numbers.formatNumber(6, false, 3);
+    const pBuried = numbers.formatNumber(8, false, 3);
+    expect(html).toContain(`Tropical: ${tTotal} / ${tBuried} (buried)`);
+    expect(html).toContain(`Temperate: ${mTotal} / ${mBuried} (buried)`);
+    expect(html).toContain(`Polar: ${pTotal} / ${pBuried} (buried)`);
   });
 });


### PR DESCRIPTION
## Summary
- show buried amounts for ice and methane ice in the resource tooltip
- add corresponding tests for buried amounts

## Testing
- `npm test` *(fails: calculateEffectiveTemperatureNoAtm is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6875d7c394908327a5dd7e603077bc4b