### PR TITLE
Add hydrocarbon surfaces to albedo mix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Melting and freezing rate calculations now use `calculateZonalCoverage` for ice so scale factors are correct.
 - Hydrology wrappers no longer pass `estimateCoverage` to the melt/freeze util; they provide a `calculateZonalCoverage` function instead.
 - Surface albedo now averages zonal albedos and the luminosity tooltip lists rock, water, ice and biomass percentages per zone.
+- Hydrocarbon and dry ice coverage now contribute to surface albedo calculations and appear in the luminosity tooltip.

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -714,10 +714,10 @@ function updateLifeBox() {
       const lines = [];
       for (const z of ZONES) {
         const fr = calculateZonalSurfaceFractions(terraforming, z);
-        const rock = Math.max(1 - (fr.ocean + fr.ice + fr.biomass), 0);
+        const rock = Math.max(1 - (fr.ocean + fr.ice + fr.hydrocarbon + fr.hydrocarbonIce + fr.co2_ice + fr.biomass), 0);
         const pct = v => (v * 100).toFixed(1);
         const name = z.charAt(0).toUpperCase() + z.slice(1);
-        lines.push(`${name}: R ${pct(rock)}% W ${pct(fr.ocean)}% I ${pct(fr.ice)}% B ${pct(fr.biomass)}%`);
+        lines.push(`${name}: R ${pct(rock)}% W ${pct(fr.ocean)}% I ${pct(fr.ice)}% HC ${pct(fr.hydrocarbon)}% MI ${pct(fr.hydrocarbonIce)}% D ${pct(fr.co2_ice)}% B ${pct(fr.biomass)}%`);
       }
       surfTooltip.title = lines.join('\n');
     }

--- a/tests/initialTemperature.test.js
+++ b/tests/initialTemperature.test.js
@@ -66,7 +66,10 @@ function expectedTemperature(terra, params, resources) {
     const zoneFractions = calculateSurfaceFractions(
       calculateZonalCoverage(terra, zone, 'liquidWater'),
       calculateZonalCoverage(terra, zone, 'ice'),
-      calculateZonalCoverage(terra, zone, 'biomass')
+      calculateZonalCoverage(terra, zone, 'biomass'),
+      calculateZonalCoverage(terra, zone, 'liquidMethane'),
+      calculateZonalCoverage(terra, zone, 'hydrocarbonIce'),
+      calculateZonalCoverage(terra, zone, 'dryIce')
     );
     const zTemps = physics.dayNightTemperaturesModel({
       groundAlbedo,

--- a/tests/surfaceFractions.test.js
+++ b/tests/surfaceFractions.test.js
@@ -2,15 +2,31 @@ const { calculateSurfaceFractions } = require('../src/js/terraforming-utils.js')
 
 describe('calculateSurfaceFractions', () => {
   test('scales water and ice when they exceed available area', () => {
-    const f = calculateSurfaceFractions(0.8, 0.6, 0.2);
+    const f = calculateSurfaceFractions(0.8, 0.6, 0.2, 0, 0, 0);
     expect(f.biomass).toBeCloseTo(0.2);
     expect(f.ocean + f.ice + f.biomass).toBeCloseTo(1);
     expect(f.ocean).toBeCloseTo(0.45714, 4);
     expect(f.ice).toBeCloseTo(0.34286, 4);
+    expect(f.hydrocarbon).toBeCloseTo(0);
+    expect(f.hydrocarbonIce).toBeCloseTo(0);
+    expect(f.co2_ice).toBeCloseTo(0);
   });
 
   test('returns original values when under capacity', () => {
-    const f = calculateSurfaceFractions(0.3, 0.2, 0.1);
-    expect(f).toEqual({ ocean: 0.3, ice: 0.2, biomass: 0.1 });
+    const f = calculateSurfaceFractions(0.3, 0.2, 0.1, 0, 0, 0);
+    expect(f).toEqual({ ocean: 0.3, ice: 0.2, hydrocarbon: 0, hydrocarbonIce: 0, co2_ice: 0, biomass: 0.1 });
+  });
+
+  test('scales all surfaces proportionally after biomass', () => {
+    const f = calculateSurfaceFractions(0.2, 0.2, 0.3, 0.2, 0.2, 0.2);
+    const share = 0.14;
+    expect(f.biomass).toBeCloseTo(0.3);
+    expect(f.ocean).toBeCloseTo(share);
+    expect(f.ice).toBeCloseTo(share);
+    expect(f.hydrocarbon).toBeCloseTo(share);
+    expect(f.hydrocarbonIce).toBeCloseTo(share);
+    expect(f.co2_ice).toBeCloseTo(share);
+    const total = f.ocean + f.ice + f.hydrocarbon + f.hydrocarbonIce + f.co2_ice + f.biomass;
+    expect(total).toBeCloseTo(1);
   });
 });


### PR DESCRIPTION
## Summary
- expand `calculateSurfaceFractions` to include liquid hydrocarbon, methane ice and dry ice
- include these surfaces in `calculateZonalSurfaceFractions`
- update luminosity tooltip for new surface breakdown
- document the update
- adjust related unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6876beaa026883279f565f7ae096082a