### PR TITLE
Fix autobuild land check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,3 +128,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Luminosity box now shows actual albedo including cloud fraction with a tooltip explaining the calculation.
 - Actual albedo calculation now resides in physics.js and the luminosity box pulls the value from this helper with an updated tooltip.
 - Actual albedo tooltip now explains cloud and haze contributions in plain language.
+- Autobuild no longer records any cost when a structure can't be built due to missing land.

--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -116,10 +116,13 @@ function autoBuild(buildings, delta = 0) {
                 cost.surface.land = (cost.surface.land || 0) + building.requiresLand * buildCount;
             }
 
+            let built = false;
             if (typeof building.build === 'function') {
-                building.build(buildCount);
+                built = building.build(buildCount);
             }
-            autobuildCostTracker.recordCost(building.displayName, cost);
+            if (built) {
+                autobuildCostTracker.recordCost(building.displayName, cost);
+            }
         }
         // Skip incremental building as it significantly impacts performance
     });

--- a/tests/autobuildLandFail.test.js
+++ b/tests/autobuildLandFail.test.js
@@ -1,0 +1,28 @@
+const { autoBuild, autobuildCostTracker } = require('../src/js/autobuild.js');
+
+describe('autoBuild land availability', () => {
+  test('does not record cost when build fails due to no land', () => {
+    const building = {
+      displayName: 'Test Colony',
+      autoBuildEnabled: true,
+      autoBuildPercent: 1,
+      autoBuildPriority: false,
+      count: 0,
+      requiresLand: 1,
+      canAfford: () => false,
+      maxBuildable: () => 1,
+      build: jest.fn(() => false),
+    };
+
+    global.resources = {
+      colony: { colonists: { value: 10 } },
+      surface: { land: { value: 0, reserved: 0 } },
+    };
+
+    autobuildCostTracker.currentCosts = {};
+    autoBuild({ c: building });
+
+    expect(building.build).toHaveBeenCalledWith(1);
+    expect(Object.keys(autobuildCostTracker.currentCosts).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid tracking autobuild cost if build fails
- test that no cost is recorded when land is missing
- document autobuild fix in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687838ec66308327b9f950701367a8d7