### PR TITLE
Enable zonal distribution for space mirrors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Actual albedo calculation now resides in physics.js and the luminosity box pulls the value from this helper with an updated tooltip.
 - Actual albedo tooltip now explains cloud and haze contributions in plain language.
 - Autobuild no longer records any cost when a structure can't be built due to missing land.
+- Space mirror oversight now distributes mirrors across zones with sliders for each zone and an automatic "any zone" value.

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1160,27 +1160,22 @@ class Terraforming extends EffectableEntity{
         projectManager.projects.spaceMirrorFacility.isBooleanFlagSet('spaceMirrorFacilityOversight') &&
         typeof mirrorOversightSettings !== 'undefined'
       ) {
-        const perc = mirrorOversightSettings.percentage || 0;
-        const targetZone = mirrorOversightSettings.zone;
-    
-        if (perc > 0) {
-          // Split the POWER based on the percentage setting
-          distributedMirrorPower = totalMirrorPower * (1 - perc);
-          focusedMirrorPower = totalMirrorPower * perc;
-    
-          if (mirrorOversightSettings.applyToLantern) {
-            distributedLanternPower = totalLanternPower * (1 - perc);
-            focusedLanternPower = totalLanternPower * perc;
-          }
-    
-          // Calculate focused FLUX for the target zone only
-          if (targetZone === zone) {
-            const targetZoneArea = totalSurfaceArea * getZonePercentage(targetZone);
-            if (targetZoneArea > 0) {
-              focusedMirrorFlux = 4*focusedMirrorPower / targetZoneArea;
-              focusedLanternFlux = 4*focusedLanternPower / targetZoneArea;
-            }
-          }
+        const dist = mirrorOversightSettings.distribution || {};
+        const zonePerc = dist[zone] || 0;
+        const globalPerc = 1 - ((dist.tropical || 0) + (dist.temperate || 0) + (dist.polar || 0));
+
+        distributedMirrorPower = totalMirrorPower * globalPerc;
+        focusedMirrorPower = totalMirrorPower * zonePerc;
+
+        if (mirrorOversightSettings.applyToLantern) {
+          distributedLanternPower = totalLanternPower * globalPerc;
+          focusedLanternPower = totalLanternPower * zonePerc;
+        }
+
+        const zoneArea = totalSurfaceArea * getZonePercentage(zone);
+        if (zoneArea > 0 && zonePerc > 0) {
+          focusedMirrorFlux = 4 * focusedMirrorPower / zoneArea;
+          focusedLanternFlux = 4 * focusedLanternPower / zoneArea;
         }
       }
     

--- a/tests/calculateZoneSolarFlux.test.js
+++ b/tests/calculateZoneSolarFlux.test.js
@@ -19,14 +19,14 @@ function createTerraforming() {
 }
 
 describe('calculateZoneSolarFlux', () => {
-  test('applies mirror oversight percentage to selected zone', () => {
+  test('applies mirror distribution to selected zone', () => {
     const terra = createTerraforming();
     global.buildings = { spaceMirror: { surfaceArea: 500, active: 1 } };
     global.projectManager = {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { percentage: 0.5, zone: 'tropical', applyToLantern: false };
+    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0 }, applyToLantern: false };
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -36,7 +36,7 @@ describe('calculateZoneSolarFlux', () => {
     const baseSolar = terra.luminosity.solarFlux;
     const mirror = terra.calculateMirrorEffect();
     const totalArea = terra.celestialParameters.surfaceArea;
-    const distributedMirror = (4 * mirror.interceptedPower * (1 - 0.5) * buildings.spaceMirror.active) / totalArea;
+    const distributedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / totalArea;
     const focusedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / (totalArea * zonePerc);
     const expected = (baseSolar + distributedMirror + focusedMirror) * ratio;
     const result = terra.calculateZoneSolarFlux('tropical');
@@ -50,7 +50,7 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { percentage: 0.5, zone: 'tropical', applyToLantern: false };
+    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0 }, applyToLantern: false };
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -59,7 +59,7 @@ describe('calculateZoneSolarFlux', () => {
     const baseSolar = terra.luminosity.solarFlux;
     const mirror = terra.calculateMirrorEffect();
     const totalArea = terra.celestialParameters.surfaceArea;
-    const distributedMirror = (4 * mirror.interceptedPower * (1 - 0.5) * buildings.spaceMirror.active) / totalArea;
+    const distributedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / totalArea;
     const expected = (baseSolar + distributedMirror) * ratio;
     const result = terra.calculateZoneSolarFlux('temperate');
     expect(result).toBeCloseTo(expected, 5);
@@ -75,7 +75,7 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { percentage: 0.5, zone: 'tropical', applyToLantern: true };
+    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0 }, applyToLantern: true };
 
     Terraforming.prototype.calculateLanternFlux = function(){
       const lantern = buildings.hyperionLantern;
@@ -96,9 +96,9 @@ describe('calculateZoneSolarFlux', () => {
     const lanternFlux = terra.calculateLanternFlux();
     const totalArea = terra.celestialParameters.surfaceArea;
     const areaFactor = terra.celestialParameters.crossSectionArea / totalArea;
-    const distributedMirror = (4 * mirror.interceptedPower * (1 - 0.5) * buildings.spaceMirror.active) / totalArea;
+    const distributedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / totalArea;
     const focusedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / (totalArea * zonePerc);
-    const distributedLantern = 4 * lanternFlux * areaFactor * (1 - 0.5);
+    const distributedLantern = 4 * lanternFlux * areaFactor * 0.5;
     const focusedLantern = 4 * lanternFlux * areaFactor * 0.5 / zonePerc;
     const expected = (baseSolar + distributedMirror + focusedMirror + distributedLantern + focusedLantern) * ratio;
     const result = terra.calculateZoneSolarFlux('tropical');

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -95,5 +95,5 @@ test('initializeGameState resets colony sliders to defaults', () => {
   }
 
   expect(settings).toEqual({ workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 });
-  expect(oversight).toEqual({ percentage: 0, zone: 'tropical', applyToLantern: false });
+  expect(oversight).toEqual({ distribution: { tropical: 0, temperate: 0, polar: 0 }, applyToLantern: false });
 });

--- a/tests/mirrorOversightSettings.test.js
+++ b/tests/mirrorOversightSettings.test.js
@@ -5,8 +5,7 @@ global.terraforming = { calculateMirrorEffect: () => ({ interceptedPower: 0, pow
 global.formatNumber = () => '';
 
 const {
-  setMirrorFocusZone,
-  setMirrorFocusPercentage,
+  setMirrorDistribution,
   resetMirrorOversightSettings,
   mirrorOversightSettings
 } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
@@ -19,21 +18,21 @@ delete global.formatNumber;
 
 describe('mirror oversight settings', () => {
   test('setters modify settings', () => {
-    setMirrorFocusZone('temperate');
-    setMirrorFocusPercentage(50);
+    setMirrorDistribution('tropical', 40);
+    setMirrorDistribution('temperate', 30);
     mirrorOversightSettings.applyToLantern = true;
-    expect(mirrorOversightSettings.zone).toBe('temperate');
-    expect(mirrorOversightSettings.percentage).toBeCloseTo(0.5);
+    expect(mirrorOversightSettings.distribution.tropical).toBeCloseTo(0.4);
+    expect(mirrorOversightSettings.distribution.temperate).toBeCloseTo(0.3);
     expect(mirrorOversightSettings.applyToLantern).toBe(true);
   });
 
   test('reset restores defaults', () => {
-    mirrorOversightSettings.zone = 'polar';
-    mirrorOversightSettings.percentage = 0.8;
+    mirrorOversightSettings.distribution.tropical = 0.2;
+    mirrorOversightSettings.distribution.temperate = 0.3;
+    mirrorOversightSettings.distribution.polar = 0.4;
     mirrorOversightSettings.applyToLantern = true;
     resetMirrorOversightSettings();
-    expect(mirrorOversightSettings.zone).toBe('tropical');
-    expect(mirrorOversightSettings.percentage).toBe(0);
+    expect(mirrorOversightSettings.distribution).toEqual({ tropical: 0, temperate: 0, polar: 0 });
     expect(mirrorOversightSettings.applyToLantern).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- rework space mirror oversight to control distribution among zones
- update terraforming to apply separate zonal allocations
- adjust UI and tests for new sliders
- document feature in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68783e59a8548327b36350256e9909af