### PR TITLE
Fix luminosity solar flux averaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space mirror oversight now distributes mirrors across zones with sliders for each zone and an automatic "any zone" value.
 - Overflowed colony water now pools as liquid only in warm zones, or as ice across all zones when none are above freezing.
 - Overflow water splits proportionally among warm zones instead of using their global percentages.
+- Modified solar flux now averages zonal solar flux values so the luminosity display reflects zone distribution.

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -893,7 +893,6 @@ class Terraforming extends EffectableEntity{
       this.luminosity.actualAlbedo = this.calculateActualAlbedo();
       this.luminosity.albedo = this.luminosity.surfaceAlbedo;
       this.luminosity.solarFlux = this.calculateSolarFlux(this.celestialParameters.distanceFromSun * AU_METER);
-      this.luminosity.modifiedSolarFlux = this.calculateModifiedSolarFlux(this.celestialParameters.distanceFromSun * AU_METER);
     }
 
     updateSurfaceTemperature() {
@@ -923,6 +922,7 @@ class Terraforming extends EffectableEntity{
 
       this.luminosity.zonalFluxes = {};
       let weightedTemp = 0;
+      let weightedFlux = 0;
       for (const zone in this.temperature.zones) {
         const zoneFlux = this.calculateZoneSolarFlux(zone);
         this.luminosity.zonalFluxes[zone] = zoneFlux;
@@ -933,8 +933,10 @@ class Terraforming extends EffectableEntity{
         this.temperature.zones[zone].night = zoneTemps.night;
         const zonePct = getZonePercentage(zone);
         weightedTemp += zoneTemps.mean * zonePct;
+        weightedFlux += zoneFlux * zonePct;
       }
       this.temperature.value = weightedTemp;
+      this.luminosity.modifiedSolarFlux = weightedFlux;
       this.temperature.effectiveTempNoAtmosphere = effectiveTemp(this.luminosity.surfaceAlbedo, modifiedSolarFlux);
     }
 

--- a/tests/weightedSolarFlux.test.js
+++ b/tests/weightedSolarFlux.test.js
@@ -1,0 +1,38 @@
+const { getZoneRatio, getZonePercentage } = require('../src/js/zones.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const lifeParameters = require('../src/js/life-parameters.js');
+
+// Globals required by terraforming.js
+global.getZoneRatio = getZoneRatio;
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+// Disable project flags
+global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+// No mirror oversight
+global.mirrorOversightSettings = {};
+
+// Stub physics functions used in updateSurfaceTemperature
+global.calculateAtmosphericPressure = () => 0;
+global.calculateEmissivity = () => 0;
+global.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+global.effectiveTemp = () => 0;
+// Used by calculateActualAlbedo via physics.js
+global.calculateActualAlbedoPhysics = () => ({ albedo: 0 });
+// Used by calculateZonalSurfaceFractions
+global.calculateZonalSurfaceFractions = () => ({ ocean: 0, ice: 0, hydrocarbon: 0, hydrocarbonIce: 0, co2_ice: 0, biomass: 0 });
+
+const Terraforming = require('../src/js/terraforming.js');
+
+describe('weighted solar flux', () => {
+  test('modifiedSolarFlux equals zonal weighted average', () => {
+    global.resources = { atmospheric: {}, special: { albedoUpgrades: { value: 0 } } };
+    global.buildings = { spaceMirror: { surfaceArea: 500, active: 1 }, hyperionLantern: { active: 0 } };
+
+    const tf = new Terraforming(global.resources, { radius: 1, distanceFromSun: 1, albedo: 0, gravity: 1 });
+
+    const zones = ['tropical','temperate','polar'];
+    const expected = zones.reduce((sum, z) => sum + tf.luminosity.zonalFluxes[z] * getZonePercentage(z), 0);
+    expect(tf.luminosity.modifiedSolarFlux).toBeCloseTo(expected, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- keep modifiedSolarFlux in sync with zonal flux calculations
- compute weighted flux when updating temperatures
- test that modifiedSolarFlux equals weighted zonal flux
- document the change in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687842e383a08327aa8bdfcf14f160b5