### PR TITLE
Add temperature threshold to disposal projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,3 +133,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Overflowed colony water now pools as liquid only in warm zones, or as ice across all zones when none are above freezing.
 - Overflow water splits proportionally among warm zones instead of using their global percentages.
 - Modified solar flux now averages zonal solar flux values so the luminosity display reflects zone distribution.
+- Resource disposal projects can now disable exports below a user-set temperature threshold when Atmospheric Monitoring is researched.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -399,6 +399,16 @@
     width: 60px;
 }
 
+.temperature-control {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.temperature-control .temperature-input {
+    width: 60px;
+}
+
 .resource-selection-input {
     width: 80px;
     text-align: center;

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -494,6 +494,10 @@ function updateProjectUI(projectName) {
       const waitCapacityCheckboxContainer = project.createWaitForCapacityCheckbox();
       elements.automationSettingsContainer.appendChild(waitCapacityCheckboxContainer);
     }
+    if (project instanceof SpaceExportBaseProject && !elements.temperatureControl) {
+      const tempControl = project.createTemperatureControl();
+      elements.automationSettingsContainer.appendChild(tempControl);
+    }
   }
 
 

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -774,6 +774,13 @@ const researchParameters = {
             type: 'booleanFlag',
             flagId: 'atmosphericMonitoring',
             value: true
+          },
+          {
+            target: 'project',
+            targetId: 'disposeResources',
+            type: 'booleanFlag',
+            flagId: 'atmosphericMonitoring',
+            value: true
           }
         ],
       },

--- a/tests/spaceDisposalTemperatureDisable.test.js
+++ b/tests/spaceDisposalTemperatureDisable.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceDisposalProject temperature disable', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const disposalSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceDisposalProject.js'), 'utf8');
+    vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+
+    ctx.resources = { colony:{}, atmospheric:{}, surface:{}, underground:{}, special: { spaceships: { value: 1 } } };
+    ctx.terraforming = { temperature: { value: 300 } };
+    global.resources = ctx.resources;
+    global.terraforming = ctx.terraforming;
+    global.projectManager = { isBooleanFlagSet: () => false };
+  });
+
+  test('cannot start when below threshold', () => {
+    const config = { name:'Dispose', category:'resources', cost:{}, duration:1, description:'', repeatable:true, maxRepeatCount:Infinity, unlocked:true, attributes:{ spaceExport:true, disposalAmount:1 } };
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    project.assignedSpaceships = 1;
+    project.disableBelowTemperature = true;
+    project.disableTemperatureThreshold = 303.15;
+    expect(project.canStart()).toBe(false);
+  });
+
+  test('can start when above threshold', () => {
+    const config = { name:'Dispose', category:'resources', cost:{}, duration:1, description:'', repeatable:true, maxRepeatCount:Infinity, unlocked:true, attributes:{ spaceExport:true, disposalAmount:1 } };
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    project.assignedSpaceships = 1;
+    project.disableBelowTemperature = true;
+    project.disableTemperatureThreshold = 295;
+    expect(project.canStart()).toBe(true);
+  });
+});

--- a/tests/spaceDisposalTemperatureInput.test.js
+++ b/tests/spaceDisposalTemperatureInput.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceDisposalProject temperature control', () => {
+  test('input value respects Celsius setting', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectElements = {};
+    const numbersCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'numbers.js'), 'utf8');
+    vm.runInContext(numbersCode + '; this.toDisplayTemperature = toDisplayTemperature; this.getTemperatureUnit = getTemperatureUnit;', ctx);
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.gameSettings = { useCelsius: true };
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const disposalSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceDisposalProject.js'), 'utf8');
+    vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+
+    const config = { name:'Dispose', category:'resources', cost:{}, duration:1, description:'', repeatable:true, maxRepeatCount:Infinity, unlocked:true, attributes:{ spaceExport:true, disposalAmount:1 } };
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    const control = project.createTemperatureControl();
+    const input = control.querySelector('.temperature-input');
+    expect(parseFloat(input.value)).toBeCloseTo(30);
+  });
+});

--- a/tests/spaceDisposalTemperatureSettings.test.js
+++ b/tests/spaceDisposalTemperatureSettings.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceDisposalProject temperature settings persistence', () => {
+  test('saveState and loadState preserve fields', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const disposalSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceDisposalProject.js'), 'utf8');
+    vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+
+    const config = { name:'Dispose', category:'resources', cost:{}, duration:1, description:'', repeatable:true, maxRepeatCount:Infinity, unlocked:true, attributes:{ spaceExport:true, disposalAmount:1 } };
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    project.disableBelowTemperature = true;
+    project.disableTemperatureThreshold = 290;
+
+    const saved = project.saveState();
+    const loaded = new ctx.SpaceDisposalProject(config, 'dispose');
+    loaded.loadState(saved);
+
+    expect(loaded.disableBelowTemperature).toBe(true);
+    expect(loaded.disableTemperatureThreshold).toBe(290);
+  });
+});


### PR DESCRIPTION
## Summary
- allow Atmospheric Monitoring to control space disposal
- implement temperature limit for SpaceExportBaseProject
- show temperature control in UI
- style temperature control like pressure control
- test temperature disable logic, persistence and UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687845d3886083279fd5dc43ccc82b4d