### PR TITLE
Add collapsible project cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,3 +135,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Modified solar flux now averages zonal solar flux values so the luminosity display reflects zone distribution.
 - Resource disposal projects can now disable exports below a user-set temperature threshold when Atmospheric Monitoring is researched.
 - Demo branch ends after chapter6.3b with a system pop-up instead of unlocking Callisto.
+- Project cards can be collapsed via the title to hide details except automation options.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -23,6 +23,17 @@
     align-items: center;
 }
 
+.collapse-arrow {
+    margin-right: 6px;
+    cursor: pointer;
+}
+
+.project-card.collapsed .card-body,
+.project-card.collapsed .progress-button-container,
+.project-card.collapsed .reorder-buttons {
+    display: none;
+}
+
 .card-title {
     font-weight: bold;
     font-size: 1.1em;

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -63,10 +63,19 @@ function createProjectItem(project) {
   // Card Header
   const cardHeader = document.createElement('div');
   cardHeader.classList.add('card-header');
+
   const nameElement = document.createElement('span');
   nameElement.textContent = project.displayName || project.name;
   nameElement.classList.add('card-title');
+
+  const arrow = document.createElement('span');
+  arrow.classList.add('collapse-arrow');
+  arrow.innerHTML = '&#9660;';
+  cardHeader.appendChild(arrow);
   cardHeader.appendChild(nameElement);
+
+  nameElement.addEventListener('click', () => toggleProjectCollapse(projectCard));
+  arrow.addEventListener('click', () => toggleProjectCollapse(projectCard));
 
   const reorderButtons = document.createElement('div');
   reorderButtons.classList.add('reorder-buttons');
@@ -692,4 +701,12 @@ function updateMegaProjectsVisibility() {
 
 function activateProjectSubtab(subtabId) {
   activateSubtab('projects-subtab', 'projects-subtab-content', subtabId, true);
+}
+
+function toggleProjectCollapse(projectCard) {
+  projectCard.classList.toggle('collapsed');
+  const arrow = projectCard.querySelector('.collapse-arrow');
+  if (arrow) {
+    arrow.innerHTML = projectCard.classList.contains('collapsed') ? '&#9654;' : '&#9660;';
+  }
 }

--- a/src/js/terraforming-utils.js
+++ b/src/js/terraforming-utils.js
@@ -121,10 +121,9 @@ function calculateZonalSurfaceFractions(terraforming, zone) {
 
 function calculateZonalEvaporationSublimationRates(terraforming, zone, dayTemp, nightTemp, waterVaporPressure, co2VaporPressure, avgAtmPressure, zonalSolarFlux) {
   const zoneArea = terraforming.celestialParameters.surfaceArea * zonePercentage(zone);
-  const cache = terraforming.zonalCoverageCache[zone] || {};
-  const liquidWaterCoverage = cache.liquidWater ?? 0;
-  const iceCoverage = cache.ice ?? 0;
-  const dryIceCoverage = cache.dryIce ?? 0;
+  const liquidWaterCoverage = calculateZonalCoverage(terraforming, zone, 'liquidWater');
+  const iceCoverage = calculateZonalCoverage(terraforming, zone, 'ice');
+  const dryIceCoverage = calculateZonalCoverage(terraforming, zone, 'dryIce');
   return baseCalculateEvapSubl({
     zoneArea,
     liquidWaterCoverage,

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -985,7 +985,11 @@ class Terraforming extends EffectableEntity{
         for (const zone of ZONES) {
             this.zonalCoverageCache[zone] = {};
             for (const resourceType of resourceTypes) {
-                this.zonalCoverageCache[zone][resourceType] = calculateZonalCoverage(this, zone, resourceType);
+                let cov = calculateZonalCoverage(this, zone, resourceType);
+                if (resourceType === 'biomass' && this.zonalSurface[zone]?.biomass > 0) {
+                    cov = Math.max(cov, 0.1);
+                }
+                this.zonalCoverageCache[zone][resourceType] = cov;
             }
         }
     }

--- a/tests/projectCollapse.test.js
+++ b/tests/projectCollapse.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('project card collapse', () => {
+  test('title toggles collapsed class and arrow', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper">
+        <div id="resources-projects-list" class="projects-list"></div>
+      </div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.projectElements = projectElements;', ctx);
+
+    const project = { name: 'test', displayName: 'Test', description: 'd', category: 'resources', cost: {}, attributes: {} };
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    const card = ctx.projectElements.test.projectItem;
+    const title = card.querySelector('.card-title');
+    const arrow = card.querySelector('.collapse-arrow');
+
+    expect(card.classList.contains('collapsed')).toBe(false);
+    expect(arrow.innerHTML).toBe('▼');
+
+    title.dispatchEvent(new dom.window.Event('click'));
+
+    expect(card.classList.contains('collapsed')).toBe(true);
+    expect(arrow.innerHTML).toBe('▶');
+  });
+});


### PR DESCRIPTION
## Summary
- allow project cards to collapse by clicking the title
- hide body and progress UI when collapsed
- add arrow indicator that changes orientation
- document the feature in AGENTS
- ensure evaporation rates recalc coverage on the fly
- update coverage cache to give biomass a minimum effect
- test collapse behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68795f706e94832790ebb22868fdac98