### PR TITLE
Fix project title alignment when collapsed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Workers tooltip now shows the colonist worker ratio and lists assignments per building sorted by usage.
 - Demo branch ends after chapter6.3b with a system pop-up instead of unlocking Callisto.
 - Project cards can be collapsed via the title to hide details except automation options.
+- Collapsing a project card now keeps its title aligned on the left.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -19,7 +19,7 @@
     padding: 8px 12px;
     border-bottom: 1px solid #dee2e6;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
     align-items: center;
 }
 
@@ -438,6 +438,7 @@
 .reorder-buttons {
     display: flex;
     flex-direction: column;
+    margin-left: auto;
 }
 
 .reorder-buttons button {


### PR DESCRIPTION
## Summary
- prevent card headers from spacing out when reorder buttons are hidden
- keep reorder buttons aligned right with auto margin
- document fix in AGENTS changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687962cb04e4832797605b721b7a5d84