### PR TITLE
Add pause button to settings screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Demo branch ends after chapter6.3b with a system pop-up instead of unlocking Callisto.
 - Project cards can be collapsed via the title to hide details except automation options.
 - Collapsing a project card now keeps its title aligned on the left.
+- Save screen includes a Pause button to stop game updates.

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
     <script src="src/js/spaceUI.js"></script>
     <script src="src/js/warning.js"></script>
     <script src="src/js/game.js"></script>
+    <script src="src/js/pause.js"></script>
     <script src="src/js/debug-tools.js"></script>
 </head>
 
@@ -485,6 +486,11 @@
                           <button id="load-from-file-button">Load from File</button>
                         </td>
                       </tr>
+                        <tr>
+                          <td colspan="3">
+                            <button id="pause-button">Pause</button>
+                          </td>
+                        </tr>
                   </tbody>
               </table>
           </div>
@@ -592,6 +598,10 @@
         });
     }
 
+    const pauseButton = document.getElementById("pause-button");
+    if (pauseButton) {
+        pauseButton.addEventListener("click", togglePause);
+    }
      // Ensure the initially active tab content is displayed on load
      // (The 'settings' tab has 'active' class in HTML, so this might be redundant
      // unless dynamically changing the default)

--- a/src/js/pause.js
+++ b/src/js/pause.js
@@ -1,0 +1,31 @@
+(function(){
+  let paused = false;
+
+  function togglePause(){
+    paused = !paused;
+    globalThis.manualPause = paused;
+    const btn = typeof document !== 'undefined' ? document.getElementById('pause-button') : null;
+    if(paused){
+      if(globalThis.game && game.scene){
+        game.scene.pause('mainScene');
+      }
+      if(btn){ btn.textContent = 'Resume'; }
+    } else {
+      if(globalThis.game && game.scene){
+        game.scene.resume('mainScene');
+      }
+      if(btn){ btn.textContent = 'Pause'; }
+    }
+  }
+
+  function isGamePaused(){
+    return paused;
+  }
+
+  if(typeof module !== 'undefined' && module.exports){
+    module.exports = { togglePause, isGamePaused };
+  } else {
+    globalThis.togglePause = togglePause;
+    globalThis.isGamePaused = isGamePaused;
+  }
+})();

--- a/src/js/pop-up.js
+++ b/src/js/pop-up.js
@@ -32,7 +32,7 @@ function createPopup(title, text, buttonText) {
   closeButton.addEventListener('click', () => {
     document.body.removeChild(overlay); // Remove the pop-up
     window.popupActive = false; // Clear popup flag
-    game.scene.resume('mainScene');  // Resume the 'mainScene' scene
+    if(!globalThis.manualPause){ game.scene.resume('mainScene'); }  // Resume the 'mainScene' scene
   });
 
   // Append the text and button to the text container
@@ -103,7 +103,7 @@ function createSystemPopup(title, text, buttonText) {
   closeButton.addEventListener('click', () => {
     document.body.removeChild(overlay);
     window.popupActive = false;
-    game.scene.resume('mainScene');
+    if(!globalThis.manualPause){ game.scene.resume('mainScene'); }
   });
 
   popupWindow.appendChild(closeButton);

--- a/tests/pauseButton.test.js
+++ b/tests/pauseButton.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('pause button', () => {
+  test('toggles scene and button text', () => {
+    const dom = new JSDOM('<!DOCTYPE html><button id="pause-button">Pause</button>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    const calls = [];
+    ctx.game = { scene: { pause: () => calls.push('pause'), resume: () => calls.push('resume') } };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'pause.js'), 'utf8');
+    vm.runInContext(code + '; this.togglePause = togglePause; this.isGamePaused = isGamePaused;', ctx);
+
+    const btn = dom.window.document.getElementById('pause-button');
+
+    ctx.togglePause();
+    expect(calls[0]).toBe('pause');
+    expect(btn.textContent).toBe('Resume');
+    expect(ctx.isGamePaused()).toBe(true);
+
+    ctx.togglePause();
+    expect(calls[1]).toBe('resume');
+    expect(btn.textContent).toBe('Pause');
+    expect(ctx.isGamePaused()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `pause.js` and wire to index.html
- allow popups to respect manual pause state
- add pause button UI and event handler
- document pause button in `AGENTS.md`
- test pause button behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879653286e0832783fdc0d5c240ef01