### PR TITLE
Fix building subtab alert clearing

### DIFF
--- a/src/js/buildingUI.js
+++ b/src/js/buildingUI.js
@@ -86,6 +86,10 @@ function updateBuildingAlert() {
 }
 
 function markBuildingsViewed() {
+    const active = document.querySelector('.building-subtab.active');
+    if (active && typeof markBuildingSubtabViewed === 'function') {
+        markBuildingSubtabViewed(active.dataset.subtab);
+    }
     buildingTabAlertNeeded = false;
     updateBuildingAlert();
 }

--- a/tests/buildingTabClearsSubtabAlert.test.js
+++ b/tests/buildingTabClearsSubtabAlert.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('building subtab alert clears on tab view', () => {
+  test('clears active subtab alert when viewing buildings tab', () => {
+    const html = `<!DOCTYPE html>
+      <div id="buildings-tab"><span id="buildings-alert" class="unlock-alert">!</span></div>
+      <div class="buildings-subtabs">
+        <div id="resource-buildings-tab" class="building-subtab active" data-subtab="resource-buildings">Resources<span id="resource-buildings-alert" class="unlock-alert">!</span></div>
+      </div>
+      <div class="building-subtab-content-wrapper"><div id="resource-buildings" class="building-subtab-content active"></div></div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.gameSettings = { silenceUnlockAlert: false };
+    ctx.buildings = { mine: { category: 'resource', unlocked: true, alertedWhenUnlocked: false } };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.registerBuildingUnlockAlert('resource-buildings');
+    expect(dom.window.document.getElementById('resource-buildings-alert').style.display).toBe('inline');
+
+    ctx.markBuildingsViewed();
+    expect(dom.window.document.getElementById('resource-buildings-alert').style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- clear building subtab alerts whenever the building tab is opened
- test building subtab alert clears when viewing the tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68796a50ce188327a447633b451efe3a