### PR TITLE
Fix pause button effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,3 +140,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Project cards can be collapsed via the title to hide details except automation options.
 - Collapsing a project card now keeps its title aligned on the left.
 - Save screen includes a Pause button to stop game updates.
+- Pause button now sets game speed to 0 so time does not advance when paused.

--- a/src/js/game-speed.js
+++ b/src/js/game-speed.js
@@ -1,8 +1,8 @@
 (function(){
   function setGameSpeed(speed){
     const value = Number(speed);
-    if(isNaN(value) || value <= 0){
-      console.warn('setGameSpeed expects a positive number');
+    if(isNaN(value) || value < 0){
+      console.warn('setGameSpeed expects a non-negative number');
       return;
     }
     if(typeof gameSpeed !== 'undefined'){

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -17,6 +17,9 @@ const config = {
 };
 
 const game = new Phaser.Game(config);
+if (typeof globalThis !== 'undefined') {
+  globalThis.game = game;
+}
 
 function preload() {
   // Load assets (images, sounds, etc.) here

--- a/src/js/pause.js
+++ b/src/js/pause.js
@@ -5,6 +5,9 @@
     paused = !paused;
     globalThis.manualPause = paused;
     const btn = typeof document !== 'undefined' ? document.getElementById('pause-button') : null;
+    if(typeof setGameSpeed === 'function'){
+      setGameSpeed(paused ? 0 : 1);
+    }
     if(paused){
       if(globalThis.game && game.scene){
         game.scene.pause('mainScene');

--- a/tests/gameSpeed.test.js
+++ b/tests/gameSpeed.test.js
@@ -26,4 +26,28 @@ describe('setGameSpeed command', () => {
 
     expect(result).toBe(2);
   });
+
+  test('speed 0 prevents progression', () => {
+    const ctx = { console, Phaser: { AUTO: 'AUTO', Game: function(){} } };
+    ctx.EffectableEntity = class {};
+    ctx.planetParameters = { mars: { celestialParameters: { rotationPeriod: 24 }, resources: {}, buildingParameters: { maintenanceFraction: 0 }, populationParameters: {} } };
+    vm.createContext(ctx);
+
+    const globalsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'globals.js'), 'utf8');
+    const speedCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'game-speed.js'), 'utf8');
+    const gameCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'game.js'), 'utf8');
+
+    vm.runInContext(globalsCode, ctx);
+    vm.runInContext(speedCode, ctx);
+    vm.runInContext(gameCode, ctx);
+
+    vm.runInContext('updateLogic = function(d){ playTimeSeconds += d/1000; }; updateRender = ()=>{}; autosave = ()=>{};', ctx);
+
+    vm.runInContext('setGameSpeed(0);', ctx);
+    vm.runInContext('playTimeSeconds = 0;', ctx);
+    vm.runInContext('update(0, 1000);', ctx);
+    const result = vm.runInContext('playTimeSeconds', ctx);
+
+    expect(result).toBe(0);
+  });
 });

--- a/tests/pauseButton.test.js
+++ b/tests/pauseButton.test.js
@@ -11,6 +11,8 @@ describe('pause button', () => {
     ctx.document = dom.window.document;
     const calls = [];
     ctx.game = { scene: { pause: () => calls.push('pause'), resume: () => calls.push('resume') } };
+    ctx.gameSpeed = 1;
+    ctx.setGameSpeed = (s) => { ctx.gameSpeed = s; };
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'pause.js'), 'utf8');
     vm.runInContext(code + '; this.togglePause = togglePause; this.isGamePaused = isGamePaused;', ctx);
 
@@ -20,10 +22,12 @@ describe('pause button', () => {
     expect(calls[0]).toBe('pause');
     expect(btn.textContent).toBe('Resume');
     expect(ctx.isGamePaused()).toBe(true);
+    expect(ctx.gameSpeed).toBe(0);
 
     ctx.togglePause();
     expect(calls[1]).toBe('resume');
     expect(btn.textContent).toBe('Pause');
     expect(ctx.isGamePaused()).toBe(false);
+    expect(ctx.gameSpeed).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- expose Phaser game object globally
- allow setGameSpeed to accept 0
- pause button sets game speed to 0 when paused
- test pause speed and 0 speed behaviour
- document pause button behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68796a6f7e3083279783ab4ccafecf40