### PR TITLE
Fix building subtab alerts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,3 +140,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Project cards can be collapsed via the title to hide details except automation options.
 - Collapsing a project card now keeps its title aligned on the left.
 - Save screen includes a Pause button to stop game updates.
+- Active building subtab alerts clear immediately when unlocking a structure while that subtab is open.

--- a/src/js/buildingUI.js
+++ b/src/js/buildingUI.js
@@ -68,6 +68,16 @@ function registerBuildingUnlockAlert(subtabId) {
     buildingTabAlertNeeded = true;
     buildingSubtabAlerts[subtabId] = true;
     updateBuildingAlert();
+    const activeTab = document.getElementById('buildings');
+    const activeSubtab = document.querySelector('.building-subtab.active');
+    if (
+        activeTab &&
+        activeTab.classList.contains('active') &&
+        activeSubtab &&
+        activeSubtab.dataset.subtab === subtabId
+    ) {
+        markBuildingSubtabViewed(subtabId);
+    }
 }
 
 function updateBuildingAlert() {

--- a/tests/buildingActiveSubtabUnlock.test.js
+++ b/tests/buildingActiveSubtabUnlock.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('active subtab unlock alert clears automatically', () => {
+  test('no alert remains when unlocking while viewing subtab', () => {
+    const html = `<!DOCTYPE html>
+      <div id="buildings" class="tab-content active"></div>
+      <div class="buildings-subtabs">
+        <div id="resource-buildings-tab" class="building-subtab active" data-subtab="resource-buildings">Resources<span id="resource-buildings-alert" class="unlock-alert">!</span></div>
+      </div>
+      <div class="building-subtab-content-wrapper"><div id="resource-buildings" class="building-subtab-content active"></div></div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.gameSettings = { silenceUnlockAlert: false };
+    ctx.buildings = { mine: { category: 'resource', unlocked: true, alertedWhenUnlocked: false } };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.registerBuildingUnlockAlert('resource-buildings');
+    expect(dom.window.document.getElementById('resource-buildings-alert').style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- auto clear building alerts when unlocking a structure while viewing that subtab
- test active building subtab alert clearing
- document the behavior change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68796b9995648327ab96ba87bbf60547