### PR TITLE
Display paused alert

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,3 +141,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Collapsing a project card now keeps its title aligned on the left.
 - Save screen includes a Pause button to stop game updates.
 - Pause button now sets game speed to 0 so time does not advance when paused.
+- A grey "PAUSED" alert appears in the warning area whenever the game is paused.

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <!-- Add CSS for the new HOPE tab -->
     <link rel="stylesheet" href="src/css/skillsUI.css">
     <link rel="stylesheet" href="src/css/solis.css">
+    <link rel="stylesheet" href="src/css/pause.css">
 
     <!-- Parameter Scripts -->
     <script src="src/js/planet-parameters.js"></script>
@@ -145,6 +146,7 @@
       <div class="resource-wrapper">
         <div id = "special-messages">
           <div id="warning-container"></div>
+          <div id="pause-container"></div>
           <div id="festival-container"></div>
           <div id="gold-asteroid-container"></div>
         </div>

--- a/src/css/pause.css
+++ b/src/css/pause.css
@@ -1,0 +1,18 @@
+#pause-container {
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+}
+
+.pause-message {
+  background-color: #888;
+  color: #fff;
+  padding: 10px;
+  border-radius: 5px;
+  font-weight: bold;
+  text-align: center;
+  font-size: 20px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}

--- a/src/js/pause.js
+++ b/src/js/pause.js
@@ -5,6 +5,7 @@
     paused = !paused;
     globalThis.manualPause = paused;
     const btn = typeof document !== 'undefined' ? document.getElementById('pause-button') : null;
+    const alertBox = typeof document !== 'undefined' ? document.getElementById('pause-container') : null;
     if(typeof setGameSpeed === 'function'){
       setGameSpeed(paused ? 0 : 1);
     }
@@ -13,11 +14,13 @@
         game.scene.pause('mainScene');
       }
       if(btn){ btn.textContent = 'Resume'; }
+      if(alertBox){ alertBox.innerHTML = '<div class="pause-message">PAUSED</div>'; }
     } else {
       if(globalThis.game && game.scene){
         game.scene.resume('mainScene');
       }
       if(btn){ btn.textContent = 'Pause'; }
+      if(alertBox){ alertBox.innerHTML = ''; }
     }
   }
 

--- a/tests/pauseAlert.test.js
+++ b/tests/pauseAlert.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('pause alert message', () => {
+  test('appears and disappears with pause state', () => {
+    const dom = new JSDOM('<!DOCTYPE html><button id="pause-button">Pause</button><div id="pause-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.game = { scene: { pause: () => {}, resume: () => {} } };
+    ctx.gameSpeed = 1;
+    ctx.setGameSpeed = s => { ctx.gameSpeed = s; };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'pause.js'), 'utf8');
+    vm.runInContext(code + '; this.togglePause = togglePause;', ctx);
+
+    const box = dom.window.document.getElementById('pause-container');
+
+    ctx.togglePause();
+    expect(box.textContent).toBe('PAUSED');
+
+    ctx.togglePause();
+    expect(box.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- show a new `PAUSED` alert when the game is paused
- style pause alert with a grey box
- add pause alert test
- document the pause alert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68796c0a61b483278c450f677baae426