### PR TITLE
Show android worker count in tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Modified solar flux now averages zonal solar flux values so the luminosity display reflects zone distribution.
 - Resource disposal projects can now disable exports below a user-set temperature threshold when Atmospheric Monitoring is researched.
 - Workers tooltip now shows the colonist worker ratio and lists assignments per building sorted by usage.
+- Workers tooltip also lists android-provided workers.
 - Demo branch ends after chapter6.3b with a system pop-up instead of unlocking Callisto.
 - Buildings and special projects now show an exclamation mark when first unlocked. Alerts clear on visiting the relevant tab or subtab and can be disabled in settings.
 - Project cards can be collapsed via the title to hide details except automation options.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -249,6 +249,10 @@ function updateResourceRateDisplay(resource){
     if (resource.name === 'workers' && typeof populationModule !== 'undefined') {
       const ratioPercent = (populationModule.getEffectiveWorkerRatio() * 100).toFixed(0);
       tooltipContent += `<div>${ratioPercent}% of colonists provide workers</div>`;
+      if (typeof resources !== 'undefined') {
+        const androids = resources.colony?.androids?.value || 0;
+        tooltipContent += `<div>${formatNumber(androids, true)} from androids</div>`;
+      }
 
       if (typeof buildings !== 'undefined') {
         const assignments = [];

--- a/tests/workerTooltip.test.js
+++ b/tests/workerTooltip.test.js
@@ -12,6 +12,7 @@ describe('worker resource tooltip', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.oreScanner = { scanData: {} };
     ctx.populationModule = { getEffectiveWorkerRatio: () => 0.6 };
+    ctx.resources = { colony: { androids: { value: 5 } } };
     ctx.buildings = {
       mine: { displayName: 'Mine', active: 2, getTotalWorkerNeed: () => 5, getEffectiveWorkerMultiplier: () => 1 },
       factory: { displayName: 'Factory', active: 1, getTotalWorkerNeed: () => 20, getEffectiveWorkerMultiplier: () => 1 }
@@ -42,6 +43,7 @@ describe('worker resource tooltip', () => {
     ctx.updateResourceRateDisplay(workers);
     const html = dom.window.document.getElementById('workers-tooltip').innerHTML;
     expect(html).toContain('60%');
+    expect(html).toContain('5 from androids');
   });
 
   test('breakdown sorted by assigned workers', () => {


### PR DESCRIPTION
## Summary
- display android worker count in tooltip
- test worker tooltip for android worker value
- document feature in AGENTS notes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68796c6d673483278c7b133297a6041c