### PR TITLE
Fix building subtab alert clearing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Save screen includes a Pause button to stop game updates.
 - Active building subtab alerts clear immediately when unlocking a structure while that subtab is open.
 - Pause button now sets game speed to 0 so time does not advance when paused.
+- Building subtab alerts now clear when switching subtabs.

--- a/src/js/buildingUI.js
+++ b/src/js/buildingUI.js
@@ -31,6 +31,9 @@ function activateBuildingSubtab(subtabId) {
     // Activate the clicked subtab and corresponding content
     document.getElementById(subtabId + '-tab').classList.add('active'); // Activate the subtab by concatenating '-tab'
     document.getElementById(subtabId).classList.add('active'); // Activate the corresponding content
+    if (typeof markBuildingSubtabViewed === 'function') {
+        markBuildingSubtabViewed(subtabId);
+    }
 }
 
 function initializeBuildingTabs() {

--- a/tests/buildingSubtabSwitchClearsAlert.test.js
+++ b/tests/buildingSubtabSwitchClearsAlert.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('building subtab alert clears on subtab switch', () => {
+  test('clears alert when activating subtab', () => {
+    const html = `<!DOCTYPE html>
+      <div class="buildings-subtabs">
+        <div id="resource-buildings-tab" class="building-subtab" data-subtab="resource-buildings">Resources<span id="resource-buildings-alert" class="unlock-alert">!</span></div>
+      </div>
+      <div class="building-subtab-content-wrapper"><div id="resource-buildings" class="building-subtab-content"></div></div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.gameSettings = { silenceUnlockAlert: false };
+    ctx.buildings = { mine: { category: 'resource', unlocked: true, alertedWhenUnlocked: false } };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.registerBuildingUnlockAlert('resource-buildings');
+    expect(dom.window.document.getElementById('resource-buildings-alert').style.display).toBe('inline');
+
+    ctx.activateBuildingSubtab('resource-buildings');
+    expect(dom.window.document.getElementById('resource-buildings-alert').style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- clear building subtab alert when switching subtabs
- add regression test for clearing when activating a subtab
- note new behaviour in AGENTS changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68796d3bfe408327812b2616cbe3dd22