### PR TITLE
Add water consumption to adapted fission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Pause button now sets game speed to 0 so time does not advance when paused.
 - Building subtab alerts now clear when switching subtabs.
 - A grey "PAUSED" alert appears in the warning area whenever the game is paused.
+- Adapted fission power now doubles reactor water usage.

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -120,6 +120,14 @@ const researchParameters = {
             targetId: 'nuclearPowerPlant',
             type: 'productionMultiplier',
             value: 2
+          },
+          {
+            target: 'building',
+            targetId: 'nuclearPowerPlant',
+            type: 'resourceConsumptionMultiplier',
+            resourceCategory: 'colony',
+            resourceTarget: 'water',
+            value: 2
           }
         ],
       },

--- a/tests/adaptedFissionPowerResearch.test.js
+++ b/tests/adaptedFissionPowerResearch.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Adapted fission power research', () => {
+  test('exists in energy research with proper cost and effects', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const energy = ctx.researchParameters.energy;
+    const research = energy.find(r => r.id === 'fission_plant1_upgrade2');
+    expect(research).toBeDefined();
+    expect(research.cost.research).toBe(500000);
+    const prod = research.effects.find(e => e.target === 'building' && e.targetId === 'nuclearPowerPlant' && e.type === 'productionMultiplier');
+    expect(prod).toBeDefined();
+    const water = research.effects.find(e => e.target === 'building' && e.targetId === 'nuclearPowerPlant' && e.type === 'resourceConsumptionMultiplier');
+    expect(water).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- increase water usage when Adapted Fission Power is researched
- test for Adapted Fission Power research effects
- document water consumption change in AGENTS log

## Testing
- `npm test` *(fails: 8 failed, 366 passed)*

------
https://chatgpt.com/codex/tasks/task_b_687aa7aca0b483279f0ab3a74956bbbe