### PR TITLE
Add jest setup and update life growth tooltip test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "devDependencies": {
     "jest": "^29.5.0",
     "jsdom": "^22.1.0"
+  },
+  "jest": {
+    "setupFiles": ["<rootDir>/tests/jestSetup.js"]
   }
 }

--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -12,6 +12,13 @@ let journalCurrentEventId = null; // id of the event whose text is typing
 let journalUserScrolling = false;
 let journalChapterIndex = 0;
 
+if (typeof globalThis.requestAnimationFrame === 'undefined') {
+  globalThis.requestAnimationFrame = cb => setTimeout(cb, 16);
+}
+if (typeof globalThis.cancelAnimationFrame === 'undefined') {
+  globalThis.cancelAnimationFrame = id => clearTimeout(id);
+}
+
 function joinLines(text) {
   return Array.isArray(text) ? text.join('\n') : text;
 }

--- a/tests/jestSetup.js
+++ b/tests/jestSetup.js
@@ -1,0 +1,18 @@
+const realSetTimeout = global.setTimeout;
+const realClearTimeout = global.clearTimeout;
+
+if (typeof global.requestAnimationFrame === 'undefined') {
+  global.requestAnimationFrame = (cb) => realSetTimeout(cb, 0);
+}
+if (typeof global.cancelAnimationFrame === 'undefined') {
+  global.cancelAnimationFrame = (id) => realClearTimeout(id);
+}
+
+if (typeof global.window !== 'undefined') {
+  if (typeof global.window.requestAnimationFrame === 'undefined') {
+    global.window.requestAnimationFrame = global.requestAnimationFrame;
+  }
+  if (typeof global.window.cancelAnimationFrame === 'undefined') {
+    global.window.cancelAnimationFrame = global.cancelAnimationFrame;
+  }
+}

--- a/tests/lifeGrowthRateDisplay.test.js
+++ b/tests/lifeGrowthRateDisplay.test.js
@@ -52,6 +52,6 @@ describe('life growth rate display', () => {
     const valueSpan = dom.window.document.getElementById('growth-rate-tropical-value');
     const tooltip = dom.window.document.getElementById('growth-rate-tropical-tooltip');
     expect(valueSpan.textContent).toBe('0');
-    expect(tooltip.title).toContain('Moisture: x0');
+    expect(tooltip.title).toContain('Liquid Water: x0');
   });
 });


### PR DESCRIPTION
## Summary
- add Jest setup file to define `requestAnimationFrame` and `cancelAnimationFrame`
- reference setup file in `package.json`
- update tooltip expectation in life growth rate test
- provide fallback `requestAnimationFrame` implementation in `journal.js`

## Testing
- `npm test` *(fails: 5 failing, 368 passing)*

------
https://chatgpt.com/codex/tasks/task_b_687aaa2535fc8327a404e40bc5adf854