### PR TITLE
Add time remaining in resource tooltips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,3 +146,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Building subtab alerts now clear when switching subtabs.
 - A grey "PAUSED" alert appears in the warning area whenever the game is paused.
 - Adapted fission power now doubles reactor water usage.
+- Resource tooltips show remaining time until cap or depletion based on current rates.

--- a/src/js/numbers.js
+++ b/src/js/numbers.js
@@ -59,6 +59,28 @@ function getTemperatureUnit() {
     return parts.join(' ');
   }
 
+function formatDuration(seconds) {
+  if (seconds >= 365 * 24 * 3600) {
+    return '>1 year';
+  }
+  if (seconds >= 24 * 3600) {
+    const days = Math.floor(seconds / (24 * 3600));
+    const hours = Math.floor((seconds % (24 * 3600)) / 3600);
+    return `${days}d ${hours}h`;
+  }
+  if (seconds >= 3600) {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    return `${hours}h ${minutes}m`;
+  }
+  if (seconds >= 60) {
+    const minutes = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${minutes}m ${secs}s`;
+  }
+  return `${Math.floor(seconds)}s`;
+}
+
 function formatBuildingCount(value) {
   if (Math.abs(value) > 1e6) {
     return formatNumber(value, false, 3);
@@ -74,5 +96,6 @@ function formatBuildingCount(value) {
       toDisplayTemperature,
       getTemperatureUnit,
       formatPlayTime,
+      formatDuration,
     };
   }

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -245,6 +245,18 @@ function updateResourceRateDisplay(resource){
   if (tooltipElement) {
     let tooltipContent = '';
     tooltipContent += `<div>Value ${formatNumber(resource.value, false, 3)}${resource.unit ? ' ' + resource.unit : ''}</div>`;
+    const netRate = resource.productionRate - resource.consumptionRate;
+    if (netRate > 0 && resource.hasCap) {
+      const time = (resource.cap - resource.value) / netRate;
+      if (time > 0) {
+        tooltipContent += `<div>Time to cap: ${formatDuration(time)}</div>`;
+      }
+    } else if (netRate < 0) {
+      const time = resource.value / Math.abs(netRate);
+      if (time > 0) {
+        tooltipContent += `<div>Time to empty: ${formatDuration(time)}</div>`;
+      }
+    }
 
     if (resource.name === 'workers' && typeof populationModule !== 'undefined') {
       const ratioPercent = (populationModule.getEffectiveWorkerRatio() * 100).toFixed(0);

--- a/tests/resourceHideWhenSmall.test.js
+++ b/tests/resourceHideWhenSmall.test.js
@@ -9,6 +9,7 @@ describe('resource hideWhenSmall display', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
     vm.runInContext(code, ctx);

--- a/tests/resourceTooltipAutobuildCost.test.js
+++ b/tests/resourceTooltipAutobuildCost.test.js
@@ -11,6 +11,7 @@ describe('resource tooltip autobuild cost', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
 
     let code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'autobuild.js'), 'utf8');

--- a/tests/resourceTooltipTime.test.js
+++ b/tests/resourceTooltipTime.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('resource tooltip time remaining', () => {
+  function setup() {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.oreScanner = { scanData: {} };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    return { dom, ctx };
+  }
+
+  test('shows time to cap for positive rate', () => {
+    const { dom, ctx } = setup();
+    const resource = {
+      name: 'metal', displayName: 'Metal', category: 'colony',
+      value: 50, cap: 100, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 2, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton'
+    };
+    ctx.createResourceDisplay({ colony: { metal: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('metal-tooltip').innerHTML;
+    expect(html).toContain('Time to cap');
+    const expected = numbers.formatDuration((100 - 50) / 2);
+    expect(html).toContain(expected);
+  });
+
+  test('shows time to empty for negative rate', () => {
+    const { dom, ctx } = setup();
+    const resource = {
+      name: 'water', displayName: 'Water', category: 'colony',
+      value: 40, cap: 100, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 4,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'ton'
+    };
+    ctx.createResourceDisplay({ colony: { water: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('water-tooltip').innerHTML;
+    expect(html).toContain('Time to empty');
+    const expected = numbers.formatDuration(40 / 4);
+    expect(html).toContain(expected);
+  });
+});

--- a/tests/resourceTooltipUnits.test.js
+++ b/tests/resourceTooltipUnits.test.js
@@ -11,6 +11,7 @@ describe('resource tooltip units', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
@@ -43,6 +44,7 @@ describe('resource tooltip units', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
@@ -75,6 +77,7 @@ describe('resource tooltip units', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');

--- a/tests/resourceTooltipZones.test.js
+++ b/tests/resourceTooltipZones.test.js
@@ -10,6 +10,7 @@ describe('resource tooltip zonal values', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
       ctx.terraforming = {
         zonalWater: {

--- a/tests/waterOverflowTooltip.test.js
+++ b/tests/waterOverflowTooltip.test.js
@@ -10,6 +10,7 @@ describe('overflow rate appears in tooltip', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
     vm.runInContext(code, ctx);

--- a/tests/workerTooltip.test.js
+++ b/tests/workerTooltip.test.js
@@ -10,6 +10,7 @@ describe('worker resource tooltip', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
     ctx.populationModule = { getEffectiveWorkerRatio: () => 0.6 };
     ctx.resources = { colony: { androids: { value: 5 } } };


### PR DESCRIPTION
## Summary
- show time to cap or empty in resource tooltips
- add duration formatter
- test tooltip time behavior
- document the feature in `AGENTS.md`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687ae0d9dbe08327a2de32dd30aecddc