### PR TITLE
Limit visible research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,3 +147,5 @@ second time they speak in a chapter to help clarify who is talking.
 - A grey "PAUSED" alert appears in the warning area whenever the game is paused.
 - Adapted fission power now doubles reactor water usage.
 - Resource tooltips show remaining time until cap or depletion based on current rates.
+- Research lists only reveal the three cheapest available items per category. Others show ??? until unlocked.
+- Terraforming calculations preserve provided surface and cross-section area values.

--- a/src/js/research.js
+++ b/src/js/research.js
@@ -99,6 +99,20 @@ class Research {
       return this.researches[category] || [];
     }
 
+    // Return the IDs of researches that should be visible for a category.
+    // All completed researches stay visible along with the cheapest
+    // `limit` incomplete ones.
+    getVisibleResearchIdsByCategory(category, limit = 3) {
+      const researches = this.getResearchesByCategory(category);
+      const visible = new Set();
+      const unresearched = researches.filter(r => !r.isResearched);
+      unresearched.slice(0, limit).forEach(r => visible.add(r.id));
+      researches.forEach(r => {
+        if (r.isResearched) visible.add(r.id);
+      });
+      return visible;
+    }
+
     calculateResearchTotalCost(research) {
       return Object.values(research.cost || {}).reduce((sum, val) => sum + val, 0);
     }

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -80,8 +80,12 @@ class Terraforming extends EffectableEntity{
     this.resources = resources;
     this.celestialParameters = celestialParameters;
     const radiusMeters = this.celestialParameters.radius * 1000;
-    this.celestialParameters.surfaceArea = 4 * Math.PI * Math.pow(radiusMeters, 2);
-    this.celestialParameters.crossSectionArea = Math.PI * Math.pow(radiusMeters, 2);
+    if (!this.celestialParameters.surfaceArea) {
+        this.celestialParameters.surfaceArea = 4 * Math.PI * Math.pow(radiusMeters, 2);
+    }
+    if (!this.celestialParameters.crossSectionArea) {
+        this.celestialParameters.crossSectionArea = Math.PI * Math.pow(radiusMeters, 2);
+    }
 
     this.lifeParameters = lifeParameters; // Load external life parameters
     this.zonalCoverageCache = {};

--- a/tests/researchVisibilityLimit.test.js
+++ b/tests/researchVisibilityLimit.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research.js'), 'utf8');
+const researchUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'researchUI.js'), 'utf8');
+
+describe('research visibility limited to three', () => {
+  test('hides more expensive researches', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="energy-research-buttons"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.canAffordResearch = () => true;
+    ctx.formatNumber = () => '';
+    ctx.resources = { colony: { research: { value: 1000 }, advancedResearch: { value: 0 } } };
+    ctx.globalGameIsLoadingFromSave = false;
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + researchUICode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.loadResearchCategory = loadResearchCategory; this.updateResearchUI = updateResearchUI;', ctx);
+
+    const params = {
+      energy: [
+        { id: 'a', name: 'A', description: 'A desc', cost: { research: 100 }, prerequisites: [], effects: [] },
+        { id: 'b', name: 'B', description: 'B desc', cost: { research: 200 }, prerequisites: [], effects: [] },
+        { id: 'c', name: 'C', description: 'C desc', cost: { research: 300 }, prerequisites: [], effects: [] },
+        { id: 'd', name: 'D', description: 'D desc', cost: { research: 400 }, prerequisites: [], effects: [] }
+      ],
+      industry: [],
+      colonization: [],
+      terraforming: [],
+      advanced: []
+    };
+
+    ctx.researchManager = new ctx.ResearchManager(params);
+    ctx.loadResearchCategory('energy');
+
+    let buttons = dom.window.document.querySelectorAll('.research-button');
+    let costs = dom.window.document.querySelectorAll('.research-cost');
+    let descs = dom.window.document.querySelectorAll('.research-description');
+
+    expect(buttons.length).toBe(4);
+    expect(buttons[3].textContent).toBe('???');
+    expect(costs[3].textContent).toBe('Cost: ???');
+    expect(descs[3].textContent).toBe('???');
+
+    ctx.researchManager.completeResearch('a');
+    ctx.updateResearchUI();
+    buttons = dom.window.document.querySelectorAll('.research-button');
+    costs = dom.window.document.querySelectorAll('.research-cost');
+    descs = dom.window.document.querySelectorAll('.research-description');
+
+    expect(buttons[0].textContent).toBe('A - Researched');
+    expect(buttons[3].textContent).toBe('D');
+    expect(costs[3].textContent).toBe('Cost:  Research Points');
+    expect(descs[3].textContent).toBe('D desc');
+  });
+});


### PR DESCRIPTION
## Summary
- only show cheapest three research items by category
- hide details for more expensive research items
- preserve provided surface area in terraforming
- refresh research list after each purchase
- add regression test for research visibility limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687af0a04ea88327857320e7cecf4b66