### PR TITLE
Fix research button state when new tech becomes visible

### DIFF
--- a/src/js/researchUI.js
+++ b/src/js/researchUI.js
@@ -71,6 +71,7 @@ function updateResearchButtonText(button, researchItem, visible) {
         button.style.color = 'red';
     } else {
         // Otherwise, set to default color
+        button.disabled = false;
         button.style.color = 'inherit';
     }
 


### PR DESCRIPTION
## Summary
- ensure research buttons become clickable when they are revealed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687af4e843448327b65df982acc0eaa1