### PR TITLE
Keep reorder controls visible on collapsed projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,3 +149,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Resource tooltips show remaining time until cap or depletion based on current rates.
 - Research lists only reveal the three cheapest available items per category. Others show ??? until unlocked.
 - Terraforming calculations preserve provided surface and cross-section area values.
+- Collapsed project cards now keep their reorder arrows visible so special projects can be moved without expanding them.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -29,8 +29,7 @@
 }
 
 .project-card.collapsed .card-body,
-.project-card.collapsed .progress-button-container,
-.project-card.collapsed .reorder-buttons {
+.project-card.collapsed .progress-button-container {
     display: none;
 }
 

--- a/tests/reorderButtonsVisible.test.js
+++ b/tests/reorderButtonsVisible.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('reorder buttons visibility', () => {
+  test('remain visible when project card is collapsed', () => {
+    const css = fs.readFileSync(path.join(__dirname, '..', 'src/css', 'projects.css'), 'utf8');
+    const dom = new JSDOM(`<!DOCTYPE html><style>${css}</style><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.window = dom.window;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.toggleProjectCollapse = toggleProjectCollapse; this.projectElements = projectElements;', ctx);
+
+    const project = { name: 'test', displayName: 'Test', description: 'd', category: 'resources', cost: {}, attributes: {} };
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    const card = ctx.projectElements.test.projectItem;
+    ctx.toggleProjectCollapse(card);
+    const reorder = card.querySelector('.reorder-buttons');
+    const style = dom.window.getComputedStyle(reorder);
+    expect(style.display).not.toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- keep reorder buttons visible when project card collapsed
- test that reorder buttons remain visible when collapsed
- document the change in AGENTS

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687af55852348327941e9c61ea05fb40