### PR TITLE
Fix special project reorder limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Research lists only reveal the three cheapest available items per category. Others show ??? until unlocked.
 - Terraforming calculations preserve provided surface and cross-section area values.
 - Collapsed project cards now keep their reorder arrows visible so special projects can be moved without expanding them.
+- Reorder arrows for special projects now ignore locked projects when determining movement limits.

--- a/tests/projectReorderSkipLocked.test.js
+++ b/tests/projectReorderSkipLocked.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('project reorder ignores locked projects', () => {
+  test('arrows disabled only based on unlocked projects', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.window = dom.window;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = () => '';
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.SpaceMiningProject = function(){};
+    ctx.SpaceExportBaseProject = function(){};
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(projectsCode + uiCode + '; this.EffectableEntity = EffectableEntity; this.ProjectManager = ProjectManager; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.projectElements = projectElements;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    const baseProject = () => ({
+      description: '',
+      category: 'resources',
+      cost: {},
+      attributes: {},
+      isActive: false,
+      isCompleted: false,
+      isPaused: false,
+      duration: 100,
+      getEffectiveDuration() { return this.duration; },
+      canStart() { return true; },
+      getProgress() { return 0; }
+    });
+
+    ctx.projectManager.projects = {
+      A: { name: 'A', displayName: 'A', unlocked: true, ...baseProject() },
+      B: { name: 'B', displayName: 'B', unlocked: false, ...baseProject() },
+      C: { name: 'C', displayName: 'C', unlocked: true, ...baseProject() }
+    };
+    ctx.projectManager.projectOrder = ['A', 'B', 'C'];
+
+    ctx.createProjectItem(ctx.projectManager.projects.A);
+    ctx.createProjectItem(ctx.projectManager.projects.B);
+    ctx.createProjectItem(ctx.projectManager.projects.C);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    ctx.updateProjectUI('A');
+    ctx.updateProjectUI('B');
+    ctx.updateProjectUI('C');
+
+    const upA = ctx.projectElements.A.upButton;
+    const downC = ctx.projectElements.C.downButton;
+
+    expect(upA.classList.contains('disabled')).toBe(true);
+    expect(downC.classList.contains('disabled')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- keep reorder arrows disabled when at the first/last unlocked project
- skip locked projects when reordering special projects
- test special project reorder logic
- document change in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687af6de6b808327be5842f6fdf6229f