### PR TITLE
Persist temperature unit across planets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Terraforming calculations preserve provided surface and cross-section area values.
 - Collapsed project cards now keep their reorder arrows visible so special projects can be moved without expanding them.
 - Reorder arrows for special projects now ignore locked projects when determining movement limits.
+- Temperature unit preference now persists when traveling to another planet.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -124,7 +124,9 @@ function initializeGameState(options = {}) {
     resetJournal();
   }
 
-  gameSettings.useCelsius = false;
+  if (!preserveManagers) {
+    gameSettings.useCelsius = false;
+  }
   
   globalEffects = new EffectableEntity({description : 'Manages global effects'});
 

--- a/tests/temperatureSettingTravel.test.js
+++ b/tests/temperatureSettingTravel.test.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('temperature setting persists across planet travel', () => {
+  test('traveling does not reset Celsius display', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) { this.config = config; },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['\"]([^'\"]+)['\"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('gameSettings.useCelsius = true;', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const useCelsius = vm.runInContext('gameSettings.useCelsius', ctx);
+    const unit = vm.runInContext('getTemperatureUnit()', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(useCelsius).toBe(true);
+    expect(unit).toBe('\u00B0C');
+  });
+});


### PR DESCRIPTION
## Summary
- keep temperature unit setting when switching planets
- add regression test for Celsius setting persistence
- document persistence in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cd36d0ac48327942c18d5cdf59be5