### PR TITLE
Add export cap based on terraformed planets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,3 +153,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Reorder arrows for special projects now ignore locked projects when determining movement limits.
 - Atmosphere box shows a green check or red X for each gas requirement.
 - Temperature unit preference now persists when traveling to another planet.
+- Metal export projects now cap each export at max(terraformed planets, 1) billion metal.

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -83,9 +83,11 @@ class SpaceExportBaseProject extends SpaceshipProject {
     disposalPerShip.id = `${this.name}-disposal-per-ship`;
     const totalDisposal = document.createElement('div');
     totalDisposal.id = `${this.name}-total-disposal`;
+    const maxDisposal = document.createElement('div');
+    maxDisposal.id = `${this.name}-max-disposal`;
     const gainPerResource = document.createElement('div');
     gainPerResource.id = `${this.name}-gain-per-ship`;
-    detailsGrid.append(selectContainer, disposalPerShip, totalDisposal, gainPerResource);
+    detailsGrid.append(selectContainer, disposalPerShip, totalDisposal, maxDisposal, gainPerResource);
   
     disposalContainer.append(detailsGrid);
     sectionContainer.appendChild(disposalContainer);
@@ -95,6 +97,7 @@ class SpaceExportBaseProject extends SpaceshipProject {
       disposalSelect,
       disposalPerShipElement: disposalPerShip,
       totalDisposalElement: totalDisposal,
+      maxDisposalElement: maxDisposal,
       gainPerResourceElement: gainPerResource,
     };
 
@@ -190,6 +193,10 @@ class SpaceExportBaseProject extends SpaceshipProject {
         }
       }
       elements.totalDisposalElement.textContent = `Total Export: ${formatNumber(total, true)}`;
+    }
+
+    if (elements.maxDisposalElement && typeof this.getExportCap === 'function') {
+      elements.maxDisposalElement.textContent = `Max Export: ${formatNumber(this.getExportCap(), true)}`;
     }
     
     if (elements.gainPerResourceElement && this.attributes.fundingGainAmount) {

--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -1,4 +1,34 @@
-class SpaceExportProject extends SpaceExportBaseProject {}
+class SpaceExportProject extends SpaceExportBaseProject {
+  getExportCap() {
+    if (
+      typeof spaceManager !== 'undefined' &&
+      typeof spaceManager.getTerraformedPlanetCount === 'function'
+    ) {
+      const count = spaceManager.getTerraformedPlanetCount();
+      return Math.max(count, 1) * 1000000000;
+    }
+    return 1000000000;
+  }
+
+  getMaxAssignableShips() {
+    const capacity = this.attributes.disposalAmount || 1;
+    return Math.floor(this.getExportCap() / (100 * capacity));
+  }
+
+  assignSpaceships(count) {
+    const maxShips = this.getMaxAssignableShips();
+    const available = Math.floor(resources.special.spaceships.value);
+    const adjusted = Math.max(
+      -this.assignedSpaceships,
+      Math.min(count, available, maxShips - this.assignedSpaceships)
+    );
+    super.assignSpaceships(adjusted);
+  }
+
+  updateUI() {
+    super.updateUI();
+  }
+}
 
 if (typeof globalThis !== 'undefined') {
   globalThis.SpaceExportProject = SpaceExportProject;

--- a/tests/spaceExportProject.test.js
+++ b/tests/spaceExportProject.test.js
@@ -31,4 +31,32 @@ describe('SpaceExportProject', () => {
     expect(totalCost.colony.metal).toBeCloseTo(2 * config.attributes.costPerShip.colony.metal);
     expect(totalCost.colony.energy).toBeCloseTo(2 * config.attributes.costPerShip.colony.energy);
   });
+
+  test('assignSpaceships respects export cap', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    ctx.resources = { special: { spaceships: { value: 100 } }, colony: { metal: {} } };
+    ctx.spaceManager = { getTerraformedPlanetCount: () => 2 };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const exportSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportProject.js'), 'utf8');
+    vm.runInContext(exportSubclass + '; this.SpaceExportProject = SpaceExportProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    global.resources = ctx.resources;
+    global.spaceManager = ctx.spaceManager;
+
+    const config = ctx.projectParameters.exportResources;
+    const project = new ctx.SpaceExportProject(config, 'exportResources');
+    const maxShips = project.getMaxAssignableShips();
+
+    project.assignSpaceships(100);
+    expect(project.assignedSpaceships).toBe(Math.min(100, maxShips));
+  });
 });


### PR DESCRIPTION
## Summary
- cap SpaceExportProject exports to 1B metal per terraformed planet
- show this maximum in project UI
- limit ship assignments to stay under the cap
- test that assignments respect the cap
- document the new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cd68204ec8327a2a791c9f17ba821