### PR TITLE
Fix atm status icons for optional gases

### DIFF
--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -258,13 +258,16 @@ function createTemperatureBox(row) {
   
     // Iterate through gases defined in the global resources to build the table structure
     for (const gas in resources.atmospheric) {
+        const hasTarget = terraformingGasTargets.hasOwnProperty(gas);
+        const statusClass = hasTarget ? 'status-cross' : '';
+        const statusIcon = hasTarget ? '✗' : '';
         innerHTML += `
           <tr>
             <td>${resources.atmospheric[gas].displayName}</td>
             <td><span id="${gas}-pressure">0.00</span></td>
             <td><span id="${gas}-delta">N/A</span></td>
             <td><span class='gas-range'>${getGasRangeString(gas)}</span></td>
-            <td><span id="${gas}-status" class="status-cross">✗</span></td>
+            <td><span id="${gas}-status" class="${statusClass}">${statusIcon}</span></td>
           </tr>
         `;
     }
@@ -341,7 +344,10 @@ function createTemperatureBox(row) {
         const statusElement = document.getElementById(`${gas}-status`);
         if (statusElement) {
             const target = terraformingGasTargets[gas];
-            if (target && currentGlobalPressurePa >= target.min && currentGlobalPressurePa <= target.max) {
+            if (!target) {
+                statusElement.textContent = '';
+                statusElement.classList.remove('status-check', 'status-cross');
+            } else if (currentGlobalPressurePa >= target.min && currentGlobalPressurePa <= target.max) {
                 statusElement.textContent = '✓';
                 statusElement.classList.add('status-check');
                 statusElement.classList.remove('status-cross');

--- a/tests/atmosphereGasStatus.test.js
+++ b/tests/atmosphereGasStatus.test.js
@@ -17,8 +17,8 @@ describe('atmosphere gas status icons', () => {
     ctx.DEFAULT_SURFACE_ALBEDO = physics.DEFAULT_SURFACE_ALBEDO;
     ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
 
-    ctx.resources = { atmospheric: { o2: { displayName: 'O2', value: 0 } } };
-    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.resources = { atmospheric: { o2: { displayName: 'O2', value: 0 }, atmosphericWater: { displayName: 'H2O', value: 0 } } };
+    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 }, atmosphericWater: { initialValue: 0 } } } };
     ctx.terraformingGasTargets = { o2: { min: 0, max: 0 } };
     ctx.projectManager = { isBooleanFlagSet: () => false };
 
@@ -55,5 +55,10 @@ describe('atmosphere gas status icons', () => {
     ctx.updateAtmosphereBox();
     expect(statusEl.textContent).toBe('✗');
     expect(statusEl.classList.contains('status-cross')).toBe(true);
+
+    const waterStatus = dom.window.document.getElementById('atmosphericWater-status');
+    expect(waterStatus.textContent).toBe('');
+    expect(waterStatus.classList.contains('status-check')).toBe(false);
+    expect(waterStatus.classList.contains('status-cross')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- hide atmosphere status icon when a gas has no target range
- test that non-required gases show no icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cdfa908f88327a8d5ae88f46e55bd