### PR TITLE
Add android assisted mining research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Atmosphere box shows a green check or red X for each gas requirement.
 - Temperature unit preference now persists when traveling to another planet.
 - Metal export projects now cap each export at max(terraformed planets, 1) billion metal.
+- Deeper mining supports android assignments for massive speed boosts.

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
     <script src="src/js/projects/SpaceExportBaseProject.js"></script>
     <script src="src/js/projects/SpaceExportProject.js"></script>
     <script src="src/js/projects/SpaceDisposalProject.js"></script>
+    <script src="src/js/projects/AndroidProject.js"></script>
     <script src="src/js/projects/CargoRocketProject.js"></script>
     <script src="src/js/projects/dysonswarm.js"></script>
     <script src="src/js/projects/dysonswarmUI.js"></script>

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -140,7 +140,7 @@ const projectParameters = {
     }
   },
   deeperMining: {
-    type: 'Project',
+    type: 'AndroidProject',
     name: "Deeper mining",
     category : "infrastructure",
     cost: {
@@ -152,7 +152,7 @@ const projectParameters = {
     duration: 120000,
     description: "Deepens all ore mines to improve production, adding one layer.  Each completion improves metal production by an additive 100%.  This project becomes more expensive each time it is completed.",
     repeatable: true,
-    maxRepeatCount: 1000,
+    maxRepeatCount: 100000,
     unlocked : false,
     attributes : {
       costScaling : true,

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -334,14 +334,30 @@ const researchParameters = {
           {
             target: 'building',
             targetId: 'androidHousing',
-            type: 'enable'
-          },
+        type: 'enable'
+      },
+      {
+        target: 'resource',
+        resourceType : 'colony',
+        targetId: 'androids',
+        type: 'enable'
+      },
+      ],
+      },
+      {
+        id: 'android_assisted_mining',
+        name: 'Android-assisted deeper mining',
+        description: 'Allows assigning androids to the Deeper mining project for massive speed boosts.',
+        cost: { research: 2000000 },
+        prerequisites: ['deep_mine','android_factory'],
+        effects: [
           {
-            target: 'resource',
-            resourceType : 'colony',
-            targetId: 'androids',
-            type: 'enable'
-          },
+            target: 'project',
+            targetId: 'deeperMining',
+            type: 'booleanFlag',
+            flagId: 'androidAssist',
+            value: true
+          }
         ],
       },
       {

--- a/tests/androidAssistedMiningResearch.test.js
+++ b/tests/androidAssistedMiningResearch.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Android-assisted deeper mining research', () => {
+  test('exists in industry category with correct cost and flag effect', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const industry = ctx.researchParameters.industry;
+    const research = industry.find(r => r.id === 'android_assisted_mining');
+    expect(research).toBeDefined();
+    expect(research.cost.research).toBe(2000000);
+    const flagEffect = research.effects.find(e =>
+      e.target === 'project' &&
+      e.targetId === 'deeperMining' &&
+      e.type === 'booleanFlag' &&
+      e.flagId === 'androidAssist' &&
+      e.value === true
+    );
+    expect(flagEffect).toBeDefined();
+  });
+});

--- a/tests/assignAndroidsMethod.test.js
+++ b/tests/assignAndroidsMethod.test.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('AndroidProject.assignAndroids', () => {
+  test('updates assigned androids and resource count', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = { colony: { androids: { value: 5 } } };
+    ctx.currentPlanetParameters = { resources: { underground: { ore: { maxDeposits: 1000 } } } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+
+    global.resources = ctx.resources;
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
+
+    const config = {
+      name: 'Test',
+      category: 'infrastructure',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {}
+    };
+    const project = new ctx.AndroidProject(config, 'test');
+
+    project.assignAndroids(3);
+    expect(project.assignedAndroids).toBe(3);
+    expect(ctx.resources.colony.androids.value).toBe(2);
+
+    project.assignAndroids(-10);
+    expect(project.assignedAndroids).toBe(0);
+    expect(ctx.resources.colony.androids.value).toBe(5);
+  });
+
+  test('calculates speed multiplier based on ore deposits', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = { colony: { androids: { value: 1_000_000_000 } } };
+    ctx.currentPlanetParameters = { resources: { underground: { ore: { maxDeposits: 1000 } } } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+
+    global.resources = ctx.resources;
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
+
+    const config = {
+      name: 'Test',
+      category: 'infrastructure',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {}
+    };
+    const project = new ctx.AndroidProject(config, 'test');
+    project.booleanFlags.add('androidAssist');
+    project.assignAndroids(1_000_000_000);
+    const mult = project.getAndroidSpeedMultiplier();
+    expect(mult).toBeCloseTo(1000);
+    const duration = project.getBaseDuration();
+    expect(duration).toBeCloseTo(0.1);
+  });
+});


### PR DESCRIPTION
## Summary
- create AndroidProject class for assigning androids to a project
- allow Deeper Mining project to assign androids and repeat 100k times
- add research unlocking android-assisted deeper mining
- load new script in the page
- document the feature in AGENTS.md
- test android assignment logic and research parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cdec39f48832793ecc650865d667a