### PR TITLE
Fix tooltip flicker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Atmosphere box shows a green check or red X for each gas requirement.
 - Temperature unit preference now persists when traveling to another planet.
 - Metal export projects now cap each export at max(terraformed planets, 1) billion metal.
+- Time to cap/empty tooltips now display 0s when a resource is already full or empty.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -248,14 +248,10 @@ function updateResourceRateDisplay(resource){
     const netRate = resource.productionRate - resource.consumptionRate;
     if (netRate > 0 && resource.hasCap) {
       const time = (resource.cap - resource.value) / netRate;
-      if (time > 0) {
-        tooltipContent += `<div>Time to cap: ${formatDuration(time)}</div>`;
-      }
+      tooltipContent += `<div>Time to cap: ${formatDuration(Math.max(time, 0))}</div>`;
     } else if (netRate < 0) {
       const time = resource.value / Math.abs(netRate);
-      if (time > 0) {
-        tooltipContent += `<div>Time to empty: ${formatDuration(time)}</div>`;
-      }
+      tooltipContent += `<div>Time to empty: ${formatDuration(Math.max(time, 0))}</div>`;
     }
 
     if (resource.name === 'workers' && typeof populationModule !== 'undefined') {

--- a/tests/resourceTooltipTime.test.js
+++ b/tests/resourceTooltipTime.test.js
@@ -48,4 +48,34 @@ describe('resource tooltip time remaining', () => {
     const expected = numbers.formatDuration(40 / 4);
     expect(html).toContain(expected);
   });
+
+  test('shows 0 time to cap when already full', () => {
+    const { dom, ctx } = setup();
+    const resource = {
+      name: 'oxygen', displayName: 'O2', category: 'colony',
+      value: 100, cap: 100, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 5, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'kg'
+    };
+    ctx.createResourceDisplay({ colony: { oxygen: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('oxygen-tooltip').innerHTML;
+    expect(html).toContain('Time to cap');
+    expect(html).toContain('0s');
+  });
+
+  test('shows 0 time to empty when already empty', () => {
+    const { dom, ctx } = setup();
+    const resource = {
+      name: 'fuel', displayName: 'Fuel', category: 'colony',
+      value: 0, cap: 50, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 3,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'kg'
+    };
+    ctx.createResourceDisplay({ colony: { fuel: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('fuel-tooltip').innerHTML;
+    expect(html).toContain('Time to empty');
+    expect(html).toContain('0s');
+  });
 });


### PR DESCRIPTION
## Summary
- keep time to cap/empty tooltip visible at 0 seconds
- test tooltip behavior at zero remaining time
- document tooltip improvement

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687ce0f5ace08327aaf845dbaa09dba4