### PR TITLE
Fix project text in journal reconstruction

### DIFF
--- a/src/js/journal-reconstruction.js
+++ b/src/js/journal-reconstruction.js
@@ -42,10 +42,15 @@
               const steps = storyProjects[obj.projectId]?.attributes?.storyStepLines || storyProjects[obj.projectId]?.attributes?.storySteps || [];
               const needed = obj.repeatCount || steps.length;
               const count = Math.min(repeat, needed, steps.length);
+              const projName = storyProjects[obj.projectId]?.name;
+              const total = storyProjects[obj.projectId]?.attributes?.storySteps?.length || steps.length;
               for (let i = 0; i < count; i++) {
                 const stepText = steps[i];
                 if (stepText != null) {
-                  const textStr = joinLines(stepText);
+                  let textStr = joinLines(stepText);
+                  if (projName) {
+                    textStr = `${projName} ${i + 1}/${total}: ${textStr}`;
+                  }
                   entries.push(textStr);
                   sources.push({ type: 'project', id: obj.projectId, step: i });
                   historyEntries.push(textStr);

--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -344,7 +344,13 @@ function getJournalTextFromSource(source) {
     const proj = progressData && progressData.storyProjects && progressData.storyProjects[source.id];
     const steps = proj && proj.attributes && (proj.attributes.storyStepLines || proj.attributes.storySteps);
     if (steps && steps[source.step] !== undefined) {
-      return joinLines(steps[source.step]);
+      let text = joinLines(steps[source.step]);
+      if (proj && proj.name) {
+        const total = Array.isArray(proj.attributes?.storySteps) ? proj.attributes.storySteps.length : (Array.isArray(proj.attributes?.storyStepLines) ? proj.attributes.storyStepLines.length : steps.length);
+        const stepNum = (typeof source.step === 'number') ? source.step + 1 : 1;
+        text = `${proj.name} ${stepNum}/${total}: ${text}`;
+      }
+      return text;
     }
   }
   return '';

--- a/tests/journalReconstruction.test.js
+++ b/tests/journalReconstruction.test.js
@@ -12,11 +12,11 @@ describe('journal reconstruction from sources', () => {
     const ctx = dom.getInternalVMContext();
     ctx.progressData = {
       chapters: [ { id: 'c1', type: 'journal', narrative: 'alpha' } ],
-      storyProjects: { p1: { attributes: { storySteps: ['step1'] } } }
+      storyProjects: { p1: { name: 'P1', attributes: { storySteps: ['step1'] } } }
     };
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
     vm.runInContext(code, ctx);
     const res = ctx.mapSourcesToText([{type:'chapter', id:'c1'}, {type:'project', id:'p1', step:0}]);
-    expect(res).toEqual(['alpha', 'step1']);
+    expect(res).toEqual(['alpha', 'P1 1/1: step1']);
   });
 });

--- a/tests/reconstructJournalState.test.js
+++ b/tests/reconstructJournalState.test.js
@@ -8,19 +8,19 @@ describe('reconstructJournalState', () => {
         { id: 'c1', type: 'journal', narrative: 'intro' },
         { id: 'c2', type: 'journal', narrative: 'quest', objectives: [{ type: 'project', projectId: 'p1', repeatCount: 3 }] }
       ],
-      storyProjects: { p1: { attributes: { storySteps: ['s1','s2','s3'] } } }
+      storyProjects: { p1: { name: 'P1', attributes: { storySteps: ['s1','s2','s3'] } } }
     };
     const sm = { completedEventIds: new Set(['c1','c2']), activeEventIds: new Set() };
     const pm = { projects: { p1: { repeatCount: 2 } } };
     const res = debugTools.reconstructJournalState(sm, pm, data);
-    expect(res.entries).toEqual(['intro','quest','s1','s2']);
+    expect(res.entries).toEqual(['intro','quest','P1 1/3: s1','P1 2/3: s2']);
     expect(res.sources).toEqual([
       { type:'chapter', id:'c1' },
       { type:'chapter', id:'c2' },
       { type:'project', id:'p1', step:0 },
       { type:'project', id:'p1', step:1 }
     ]);
-    expect(res.historyEntries).toEqual(['intro','quest','s1','s2']);
+    expect(res.historyEntries).toEqual(['intro','quest','P1 1/3: s1','P1 2/3: s2']);
     expect(res.historySources).toEqual([
       { type:'chapter', id:'c1' },
       { type:'chapter', id:'c2' },

--- a/tests/reconstructJournalStateClear.test.js
+++ b/tests/reconstructJournalStateClear.test.js
@@ -8,18 +8,18 @@ describe('reconstructJournalState chapter handling', () => {
         { id: 'c2', type: 'journal', chapter: 2, narrative: 'reset' },
         { id: 'c3', type: 'journal', chapter: 2, narrative: 'after', objectives: [ { type: 'project', projectId: 'p1', repeatCount: 2 } ] }
       ],
-      storyProjects: { p1: { attributes: { storySteps: [null, 'step2'] } } }
+      storyProjects: { p1: { name: 'P1', attributes: { storySteps: [null, 'step2'] } } }
     };
     const sm = { completedEventIds: new Set(['c1','c2','c3']), activeEventIds: new Set() };
     const pm = { projects: { p1: { repeatCount: 2 } } };
     const res = debugTools.reconstructJournalState(sm, pm, data);
-    expect(res.entries).toEqual(['reset','after','step2']);
+    expect(res.entries).toEqual(['reset','after','P1 2/2: step2']);
     expect(res.sources).toEqual([
       { type: 'chapter', id: 'c2' },
       { type: 'chapter', id: 'c3' },
       { type: 'project', id: 'p1', step: 1 }
     ]);
-    expect(res.historyEntries).toEqual(['first','reset','after','step2']);
+    expect(res.historyEntries).toEqual(['first','reset','after','P1 2/2: step2']);
     expect(res.historySources).toEqual([
       { type: 'chapter', id: 'c1' },
       { type: 'chapter', id: 'c2' },


### PR DESCRIPTION
## Summary
- prefix project names when reconstructing journal state
- include project step titles when mapping journal entry sources
- update tests for journal reconstruction logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ce2626ad483279cf4f129b768774d