### PR TITLE
Fix android assignment UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,3 +157,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Time to cap/empty tooltips now display 0s when a resource is already full or empty.
 - Story project journal entries now include a separator line and prefix showing progress.
 - Deeper mining supports android assignments for massive speed boosts.
+- Android assignment UI initializes hidden and shows once the upgrade is researched.

--- a/src/js/projects/AndroidProject.js
+++ b/src/js/projects/AndroidProject.js
@@ -112,25 +112,29 @@ class AndroidProject extends Project {
 
     assignmentContainer.append(assignedAndAvailableContainer, buttonsContainer);
     sectionContainer.appendChild(assignmentContainer);
+    sectionContainer.id = `${this.name}-android-assignment`;
+    sectionContainer.style.display = this.isBooleanFlagSet('androidAssist') ? 'block' : 'none';
     container.appendChild(sectionContainer);
 
     projectElements[this.name] = {
       ...projectElements[this.name],
       assignedAndroidsDisplay: assignedDisplay,
       availableAndroidsDisplay: availableDisplay,
+      androidAssignmentContainer: sectionContainer,
       androidSpeedDisplay: speedDisplay,
     };
   }
 
   renderUI(container) {
-    if (this.isBooleanFlagSet('androidAssist')) {
-      this.createAndroidAssignmentUI(container);
-    }
+    this.createAndroidAssignmentUI(container);
   }
 
   updateUI() {
     const elements = projectElements[this.name];
     if (!elements) return;
+    if (elements.androidAssignmentContainer) {
+      elements.androidAssignmentContainer.style.display = this.isBooleanFlagSet('androidAssist') ? 'block' : 'none';
+    }
     if (elements.assignedAndroidsDisplay) {
       elements.assignedAndroidsDisplay.textContent = formatBigInteger(this.assignedAndroids);
     }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -510,7 +510,6 @@ function updateProjectUI(projectName) {
 
   if (typeof AndroidProject !== 'undefined' &&
       project instanceof AndroidProject &&
-      project.isBooleanFlagSet('androidAssist') &&
       !elements.assignedAndroidsDisplay &&
       elements.cardBody) {
     project.createAndroidAssignmentUI(elements.cardBody);

--- a/tests/androidAssignmentUI.test.js
+++ b/tests/androidAssignmentUI.test.js
@@ -6,7 +6,7 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 const numbers = require('../src/js/numbers.js');
 
 describe('AndroidProject UI', () => {
-  test('assignment UI appears when androidAssist flag set', () => {
+  test('assignment UI hides until androidAssist flag set', () => {
   const dom = new JSDOM(`<!DOCTYPE html>
       <div class="projects-subtab-content-wrapper">
         <div id="infrastructure-projects-list" class="projects-list"></div>
@@ -37,14 +37,17 @@ describe('AndroidProject UI', () => {
 
     ctx.initializeProjectsUI();
     ctx.createProjectItem(project);
+    ctx.updateProjectUI('deeperMining');
     ctx.projectElements = vm.runInContext('projectElements', ctx);
 
-    expect(ctx.projectElements.deeperMining.assignedAndroidsDisplay).toBeUndefined();
+    expect(ctx.projectElements.deeperMining.assignedAndroidsDisplay).toBeDefined();
+    const section = ctx.projectElements.deeperMining.androidAssignmentContainer;
+    expect(section.style.display).toBe('none');
 
     project.booleanFlags.add('androidAssist');
     ctx.updateProjectUI('deeperMining');
     ctx.projectElements = vm.runInContext('projectElements', ctx);
 
-    expect(ctx.projectElements.deeperMining.assignedAndroidsDisplay).toBeDefined();
+    expect(ctx.projectElements.deeperMining.androidAssignmentContainer.style.display).toBe('block');
   });
 });


### PR DESCRIPTION
## Summary
- always generate android assignment UI at project init
- toggle the section's display depending on the android assist flag
- adjust projects UI to create the elements on initialization
- update android assignment UI test
- document change in AGENTS

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687ce43b77bc832789ed4f7af721c20e