### PR TITLE
Ensure android assignment UI always initializes

### DIFF
--- a/tests/androidAssignmentUI.test.js
+++ b/tests/androidAssignmentUI.test.js
@@ -37,12 +37,15 @@ describe('AndroidProject UI', () => {
 
     ctx.initializeProjectsUI();
     ctx.createProjectItem(project);
-    ctx.updateProjectUI('deeperMining');
     ctx.projectElements = vm.runInContext('projectElements', ctx);
 
-    expect(ctx.projectElements.deeperMining.assignedAndroidsDisplay).toBeDefined();
+    // UI should be created immediately but hidden until the research flag is set
     const section = ctx.projectElements.deeperMining.androidAssignmentContainer;
+    expect(section).toBeDefined();
     expect(section.style.display).toBe('none');
+
+    ctx.updateProjectUI('deeperMining');
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
 
     project.booleanFlags.add('androidAssist');
     ctx.updateProjectUI('deeperMining');


### PR DESCRIPTION
## Summary
- verify the android assignment UI is created when project cards are rendered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ce760793c832784fbf1e9a3de66b5