### PR TITLE
Fix AndroidProject not initialized

### DIFF
--- a/src/js/projects/AndroidProject.js
+++ b/src/js/projects/AndroidProject.js
@@ -170,6 +170,11 @@ class AndroidProject extends Project {
   }
 }
 
+// Expose constructor globally for browser usage
+if (typeof globalThis !== 'undefined') {
+  globalThis.AndroidProject = AndroidProject;
+}
+
 if (typeof module !== 'undefined') {
   module.exports = AndroidProject;
 }


### PR DESCRIPTION
## Summary
- expose `AndroidProject` constructor globally so the ProjectManager
  can instantiate Deeper mining with the correct subclass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cebde8dd48327a24fdcf3f1184c75