### PR TITLE
Improve Android mining boost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,3 +158,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Story project journal entries now include a separator line and prefix showing progress.
 - Deeper mining supports android assignments for massive speed boosts.
 - Android assignment UI initializes hidden and shows once the upgrade is researched.
+- Android project speed multiplier now adds 1 to the calculation and updates active progress bars immediately. The display reads "Deepening speed boost" beside the controls.

--- a/tests/assignAndroidsMethod.test.js
+++ b/tests/assignAndroidsMethod.test.js
@@ -67,8 +67,8 @@ describe('AndroidProject.assignAndroids', () => {
     project.booleanFlags.add('androidAssist');
     project.assignAndroids(1_000_000_000);
     const mult = project.getAndroidSpeedMultiplier();
-    expect(mult).toBeCloseTo(1000);
+    expect(mult).toBeCloseTo(1001);
     const duration = project.getBaseDuration();
-    expect(duration).toBeCloseTo(0.1);
+    expect(duration).toBeCloseTo(0.0999);
   });
 });


### PR DESCRIPTION
## Summary
- tweak AndroidProject's speed multiplier to add 1 to the calculation
- adjust active progress bars when android assignments change
- display the multiplier as "Deepening speed boost" beside the controls
- update corresponding unit test
- document the new behavior in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ced7781ec83279f9b1656b75e53a5