### PR TITLE
Fix short duration project progress bar

### DIFF
--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -456,7 +456,12 @@ function updateProjectUI(projectName) {
           const timeRemaining = Math.max(0, project.remainingTime / 1000).toFixed(2);
           const progressPercent = project.getProgress();
           elements.progressButton.textContent = `In Progress: ${timeRemaining} seconds remaining (${progressPercent}%)`;
-          elements.progressButton.style.background = `linear-gradient(to right, #4caf50 ${progressPercent}%, #ccc ${progressPercent}%)`;
+          if (project.startingDuration < 1000) {
+            // Avoid flashy gradients for instant projects
+            elements.progressButton.style.background = '#4caf50';
+          } else {
+            elements.progressButton.style.background = `linear-gradient(to right, #4caf50 ${progressPercent}%, #ccc ${progressPercent}%)`;
+          }
         } else if (project.isCompleted) {
           elements.progressButton.textContent = `Completed: ${project.displayName}`;
           elements.progressButton.style.background = '#4caf50';

--- a/tests/projectProgressBarShortDuration.test.js
+++ b/tests/projectProgressBarShortDuration.test.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+// Ensure progress bars with very short durations don't show a flashing gradient
+
+describe('short duration progress bar', () => {
+  test('active project under one second uses solid color', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper">
+        <div id="resources-projects-list" class="projects-list"></div>
+      </div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = () => '';
+    ctx.formatBigInteger = () => '';
+    ctx.projectElements = {};
+    ctx.resources = { colony: {}, special: {} };
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.SpaceMiningProject = function(){};
+    ctx.SpaceExportBaseProject = function(){};
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    const config = {
+      name: 'test',
+      category: 'resources',
+      cost: {},
+      duration: 500,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: {}
+    };
+    const project = new ctx.Project(config, 'test');
+    ctx.projectManager.projects.test = project;
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.isActive = true;
+    project.startingDuration = 500;
+    project.remainingTime = 250;
+
+    ctx.updateProjectUI('test');
+    const btn = ctx.projectElements.test.progressButton;
+    expect(btn.style.background.includes('linear-gradient')).toBe(false);
+    expect(btn.style.background).toBe('rgb(76, 175, 80)');
+  });
+});


### PR DESCRIPTION
## Summary
- keep special project progress bars solid when duration is under one second
- add regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cee16fefc83278f7cd00bb3dc2140