### PR TITLE
Fix progress bar display for short projects

### DIFF
--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -455,11 +455,12 @@ function updateProjectUI(projectName) {
         if (project.isActive) {
           const timeRemaining = Math.max(0, project.remainingTime / 1000).toFixed(2);
           const progressPercent = project.getProgress();
-          elements.progressButton.textContent = `In Progress: ${timeRemaining} seconds remaining (${progressPercent}%)`;
           if (project.startingDuration < 1000) {
+            elements.progressButton.textContent = `In Progress: ${timeRemaining} seconds remaining`;
             // Avoid flashy gradients for instant projects
             elements.progressButton.style.background = '#4caf50';
           } else {
+            elements.progressButton.textContent = `In Progress: ${timeRemaining} seconds remaining (${progressPercent}%)`;
             elements.progressButton.style.background = `linear-gradient(to right, #4caf50 ${progressPercent}%, #ccc ${progressPercent}%)`;
           }
         } else if (project.isCompleted) {

--- a/tests/projectProgressBarShortDuration.test.js
+++ b/tests/projectProgressBarShortDuration.test.js
@@ -60,5 +60,6 @@ describe('short duration progress bar', () => {
     const btn = ctx.projectElements.test.progressButton;
     expect(btn.style.background.includes('linear-gradient')).toBe(false);
     expect(btn.style.background).toBe('rgb(76, 175, 80)');
+    expect(btn.textContent.includes('%')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- keep progress bars solid green for projects under 1 second
- hide the percent complete in those cases
- test that short projects omit the percent text

## Testing
- `npm test --silent -- -i`

------
https://chatgpt.com/codex/tasks/task_b_687cefbe8fe48327a0c206241d85a54e