### PR TITLE
Create DeeperMiningProject subclass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,3 +160,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Android assignment UI initializes hidden and shows once the upgrade is researched.
 - Android project speed multiplier now adds 1 to the calculation and updates active progress bars immediately. The display reads "Deepening speed boost" beside the controls.
 - Deeper mining costs now scale with ore mines built and also increases ore mine construction costs. Android boost scales with built mines instead of deposits.
+- Deeper mining now uses a dedicated class `DeeperMiningProject`.

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
     <script src="src/js/projects/SpaceExportProject.js"></script>
     <script src="src/js/projects/SpaceDisposalProject.js"></script>
     <script src="src/js/projects/AndroidProject.js"></script>
+    <script src="src/js/projects/DeeperMiningProject.js"></script>
     <script src="src/js/projects/CargoRocketProject.js"></script>
     <script src="src/js/projects/dysonswarm.js"></script>
     <script src="src/js/projects/dysonswarmUI.js"></script>

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -140,7 +140,7 @@ const projectParameters = {
     }
   },
   deeperMining: {
-    type: 'AndroidProject',
+    type: 'DeeperMiningProject',
     name: "Deeper mining",
     category : "infrastructure",
     cost: {

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -105,17 +105,6 @@ class Project extends EffectableEntity {
 
       return scaledCost;
     }
-    if (this.attributes.costOreMineScaling) {
-      const oreMines = Math.max((buildings?.oreMine?.count || 0), 1);
-      const scaledCost = {};
-      for (const resourceCategory in cost) {
-        scaledCost[resourceCategory] = {};
-        for (const resource in cost[resourceCategory]) {
-          scaledCost[resourceCategory][resource] = cost[resourceCategory][resource] * oreMines;
-        }
-      }
-      return scaledCost;
-    }
     return cost;
   }
 

--- a/src/js/projects/AndroidProject.js
+++ b/src/js/projects/AndroidProject.js
@@ -155,7 +155,7 @@ class AndroidProject extends Project {
     }
     if (elements.androidSpeedDisplay) {
       const mult = this.getAndroidSpeedMultiplier();
-      elements.androidSpeedDisplay.textContent = `Deepening speed boost x${formatNumber(mult, true)}`;
+      elements.androidSpeedDisplay.textContent = `Speed x${formatNumber(mult, true)}`;
     }
   }
 

--- a/src/js/projects/DeeperMiningProject.js
+++ b/src/js/projects/DeeperMiningProject.js
@@ -1,0 +1,34 @@
+class DeeperMiningProject extends AndroidProject {
+  getScaledCost() {
+    let cost = super.getScaledCost();
+    if (this.attributes.costOreMineScaling) {
+      const oreMines = Math.max((buildings?.oreMine?.count || 0), 1);
+      const scaledCost = {};
+      for (const category in cost) {
+        scaledCost[category] = {};
+        for (const resource in cost[category]) {
+          scaledCost[category][resource] = cost[category][resource] * oreMines;
+        }
+      }
+      return scaledCost;
+    }
+    return cost;
+  }
+
+  updateUI() {
+    super.updateUI();
+    const elements = projectElements[this.name];
+    if (elements?.androidSpeedDisplay) {
+      const mult = this.getAndroidSpeedMultiplier();
+      elements.androidSpeedDisplay.textContent = `Deepening speed boost x${formatNumber(mult, true)}`;
+    }
+  }
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.DeeperMiningProject = DeeperMiningProject;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = DeeperMiningProject;
+}

--- a/tests/androidAssignmentUI.test.js
+++ b/tests/androidAssignmentUI.test.js
@@ -27,12 +27,14 @@ describe('AndroidProject UI', () => {
     vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
     const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js'), 'utf8');
     vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const deeperCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'DeeperMiningProject.js'), 'utf8');
+    vm.runInContext(deeperCode + '; this.DeeperMiningProject = DeeperMiningProject;', ctx);
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
     vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
 
     ctx.projectManager = new ctx.ProjectManager();
     const config = { name: 'deeperMining', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: {} };
-    const project = new ctx.AndroidProject(config, 'deeperMining');
+    const project = new ctx.DeeperMiningProject(config, 'deeperMining');
     ctx.projectManager.projects.deeperMining = project;
 
     ctx.initializeProjectsUI();

--- a/tests/deeperMiningCostScaling.test.js
+++ b/tests/deeperMiningCostScaling.test.js
@@ -12,6 +12,8 @@ describe('Deeper mining cost scaling', () => {
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
     const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js'), 'utf8');
     vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const deeperCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'DeeperMiningProject.js'), 'utf8');
+    vm.runInContext(deeperCode + '; this.DeeperMiningProject = DeeperMiningProject;', ctx);
     const config = {
       name: 'deeperMining',
       category: 'infrastructure',
@@ -23,7 +25,7 @@ describe('Deeper mining cost scaling', () => {
       unlocked: true,
       attributes: { costOreMineScaling: true }
     };
-    const p = new ctx.AndroidProject(config, 'deeperMining');
+    const p = new ctx.DeeperMiningProject(config, 'deeperMining');
     const cost = p.getScaledCost();
     expect(cost.colony.electronics).toBe(50);
     expect(cost.colony.components).toBe(50);


### PR DESCRIPTION
## Summary
- add a `DeeperMiningProject` class extending `AndroidProject`
- move ore mine cost scaling into the new class
- show generic speed text in `AndroidProject`
- update project parameters and include new script
- adjust unit tests and changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cf226dc108327a0e9bcff8deb0b16