### PR TITLE
Scale deeper mining cost by completions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,3 +161,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Android project speed multiplier now adds 1 to the calculation and updates active progress bars immediately. The display reads "Deepening speed boost" beside the controls.
 - Deeper mining costs now scale with ore mines built and also increases ore mine construction costs. Android boost scales with built mines instead of deposits.
 - Deeper mining now uses a dedicated class `DeeperMiningProject`.
+- Deeper mining costs also scale with the number of project completions.

--- a/src/js/projects/DeeperMiningProject.js
+++ b/src/js/projects/DeeperMiningProject.js
@@ -3,11 +3,13 @@ class DeeperMiningProject extends AndroidProject {
     let cost = super.getScaledCost();
     if (this.attributes.costOreMineScaling) {
       const oreMines = Math.max((buildings?.oreMine?.count || 0), 1);
+      const completions = this.repeatCount + 1;
+      const multiplier = oreMines * completions;
       const scaledCost = {};
       for (const category in cost) {
         scaledCost[category] = {};
         for (const resource in cost[category]) {
-          scaledCost[category][resource] = cost[category][resource] * oreMines;
+          scaledCost[category][resource] = cost[category][resource] * multiplier;
         }
       }
       return scaledCost;

--- a/tests/deeperMiningCostScaling.test.js
+++ b/tests/deeperMiningCostScaling.test.js
@@ -30,4 +30,32 @@ describe('Deeper mining cost scaling', () => {
     expect(cost.colony.electronics).toBe(50);
     expect(cost.colony.components).toBe(50);
   });
+
+  test('cost also scales with completions', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.buildings = { oreMine: { count: 3 } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const deeperCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'DeeperMiningProject.js'), 'utf8');
+    vm.runInContext(deeperCode + '; this.DeeperMiningProject = DeeperMiningProject;', ctx);
+    const config = {
+      name: 'deeperMining',
+      category: 'infrastructure',
+      cost: { colony: { electronics: 10, components: 10 } },
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { costOreMineScaling: true }
+    };
+    const p = new ctx.DeeperMiningProject(config, 'deeperMining');
+    p.repeatCount = 2;
+    const cost = p.getScaledCost();
+    expect(cost.colony.electronics).toBe(90);
+    expect(cost.colony.components).toBe(90);
+  });
 });


### PR DESCRIPTION
## Summary
- update `DeeperMiningProject` cost scaling to include completions
- document deeper mining completion scaling
- verify deeper mining completion scaling with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cf3cbb87c832786582206e02025e1