### PR TITLE
Add day-night toggle maintenance effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Deeper mining costs now scale with ore mines built and also increases ore mine construction costs. Android boost scales with built mines instead of deposits.
 - Deeper mining now uses a dedicated class `DeeperMiningProject`.
 - Deeper mining costs also scale with the number of project completions.
+- Settings menu can disable the day-night cycle. Solar panels and Ice Harvesters operate at half strength and the progress bar hides.
+- Day-night toggle also halves maintenance for those structures and skips the penalty on Ice Harvesters once Infrared Vision is researched.

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <script src="src/js/save.js"></script>
     <script src="src/js/structuresUI.js"></script>
     <script src="src/js/day-night-cycle.js"></script>
+    <script src="src/js/day-night-setting.js"></script>
     <script src="src/js/ore-scanning.js"></script>
     <script src="src/js/resource.js"></script>
     <script src="src/js/resourceUI.js"></script>
@@ -505,6 +506,9 @@
           <label style="display:block;margin-bottom:8px;">
             <input type="checkbox" id="unlock-alert-toggle"> Disable unlock alerts
           </label>
+          <label style="display:block;margin-bottom:8px;">
+            <input type="checkbox" id="day-night-toggle" title="Stops time of day changes. Solar Panels and Ice Harvesters run at half efficiency and half maintenance."> Disable day-night cycle
+          </label>
       </div>
     </div>
 
@@ -617,6 +621,19 @@
             gameSettings.silenceUnlockAlert = unlockToggle.checked;
             if (typeof updateBuildingAlert === 'function') updateBuildingAlert();
             if (typeof updateProjectAlert === 'function') updateProjectAlert();
+        });
+    }
+
+    const dayNightToggle = document.getElementById('day-night-toggle');
+    if (dayNightToggle) {
+        dayNightToggle.checked = gameSettings.disableDayNightCycle;
+        dayNightToggle.addEventListener('change', () => {
+            gameSettings.disableDayNightCycle = dayNightToggle.checked;
+            if (typeof applyDayNightSettingEffects === 'function') applyDayNightSettingEffects();
+            updateDayNightDisplay();
+            if (typeof updateBuildingDisplay === 'function') {
+                updateBuildingDisplay(buildings);
+            }
         });
     }
 

--- a/src/js/day-night-cycle.js
+++ b/src/js/day-night-cycle.js
@@ -10,9 +10,12 @@ class DayNightCycle {
       this.dayProgress = (this.elapsedTime % this.dayDuration) / this.dayDuration;
     }
   
-    isDay() {
+  isDay() {
+      if (typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle) {
+        return true;
+      }
       return this.dayProgress < 0.5;
-    }
+  }
   
     isNight() {
       return !this.isDay();
@@ -50,8 +53,15 @@ function rotationPeriodToDuration(rotationHours) {
 
 
 function updateDayNightDisplay() {
+  const container = document.querySelector('.day-night-progress-bar-container');
+  if (typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle) {
+    if (container) container.style.display = 'none';
+    return;
+  }
+  if (container) container.style.display = 'block';
+
   const dayNightStatus = dayNightCycle.isDay() ? 'Day' : 'Night';
-  const dayProgress = dayNightCycle.getDayProgress() * 100;  
+  const dayProgress = dayNightCycle.getDayProgress() * 100;
 
   const progressBar = document.getElementById('day-night-progress-bar');
   const progressText = document.getElementById('progress-text');
@@ -61,7 +71,7 @@ function updateDayNightDisplay() {
   // Update text, optionally round to 2 decimal places for display
   progressText.textContent = `Day Progress: ${dayProgress.toFixed(1)}%`;
 
-    // Change color gradually between yellow (day) and dark blue (night)
+  // Change color gradually between yellow (day) and dark blue (night)
   if (dayNightStatus === 'Day') {
     // Transition from yellow (255, 255, 0) to orange (255, 165, 0)
     progressBar.style.backgroundColor = `rgb(255, ${255 - dayProgress * 0.9}, 0)`; // Transitions from yellow to orange

--- a/src/js/day-night-setting.js
+++ b/src/js/day-night-setting.js
@@ -1,0 +1,47 @@
+(function(){
+  function applyDayNightSettingEffects(){
+    if(typeof buildings === 'undefined') return;
+    const targets = ['iceHarvester','solarPanel'];
+    targets.forEach(id => {
+      const building = buildings[id];
+      if(!building) return;
+
+      const effects = [];
+      const prodEffect = {
+        target: 'building',
+        targetId: id,
+        type: 'productionMultiplier',
+        value: 0.5,
+        effectId: `disable-day-night-production-${id}`,
+        sourceId: 'settings'
+      };
+      effects.push(prodEffect);
+
+      const cost = (building.cost && building.cost.colony) || {};
+      for(const resource in cost){
+        effects.push({
+          target: 'building',
+          targetId: id,
+          type: 'maintenanceCostMultiplier',
+          resourceCategory: 'colony',
+          resourceId: resource,
+          value: 0.5,
+          effectId: `disable-day-night-maintenance-${id}-${resource}`,
+          sourceId: 'settings'
+        });
+      }
+
+      if(typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle && building.dayNightActivity){
+        if(typeof addEffect === 'function') effects.forEach(addEffect);
+      } else {
+        if(typeof removeEffect === 'function') effects.forEach(removeEffect);
+      }
+    });
+  }
+
+  if(typeof module !== 'undefined' && module.exports){
+    module.exports = { applyDayNightSettingEffects };
+  } else {
+    globalThis.applyDayNightSettingEffects = applyDayNightSettingEffects;
+  }
+})();

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -459,6 +459,10 @@ class EffectableEntity {
         this.sortAllResearches();
       }
 
+      if (flagId === 'dayNightActivity' && typeof applyDayNightSettingEffects === 'function') {
+        applyDayNightSettingEffects();
+      }
+
       console.log(`Boolean flag "${flagId}" set to ${value} for ${this.name}.`);
     }
 

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -44,6 +44,9 @@ function create() {
   // Initialize buildings
   buildings = initializeBuildings(buildingsParameters);
   createBuildingButtons(buildings);
+  if (typeof applyDayNightSettingEffects === 'function') {
+    applyDayNightSettingEffects();
+  }
   if (typeof initializeBuildingAlerts === 'function') {
     initializeBuildingAlerts();
   }
@@ -198,6 +201,9 @@ function initializeGameState(options = {}) {
   // Regenerate UI elements to bind to new objects
   createResourceDisplay(resources); // Also need to update resource display
   createBuildingButtons(buildings);
+  if (typeof applyDayNightSettingEffects === 'function') {
+    applyDayNightSettingEffects();
+  }
   if (typeof initializeBuildingAlerts === 'function') {
     initializeBuildingAlerts();
   }

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -24,6 +24,7 @@ let gameSettings = {
   silenceSolisAlert: false,
   silenceMilestoneAlert: false,
   silenceUnlockAlert: false,
+  disableDayNightCycle: false,
 };
 
 let colonySliderSettings = {

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -239,6 +239,10 @@ function loadGame(slotOrCustomString) {
       if(unlockToggle){
         unlockToggle.checked = gameSettings.silenceUnlockAlert;
       }
+      const dayNightToggle = document.getElementById('day-night-toggle');
+      if(dayNightToggle){
+        dayNightToggle.checked = gameSettings.disableDayNightCycle;
+      }
       if (typeof completedResearchHidden !== 'undefined') {
         completedResearchHidden = gameSettings.hideCompletedResearch || false;
         if (typeof updateAllResearchButtons === 'function') {
@@ -269,6 +273,16 @@ function loadGame(slotOrCustomString) {
     }
 
     tabManager.activateTab('buildings');
+
+    if(typeof applyDayNightSettingEffects === 'function'){
+      applyDayNightSettingEffects();
+    }
+    if (typeof updateDayNightDisplay === 'function') {
+      updateDayNightDisplay();
+    }
+    if (typeof updateBuildingDisplay === 'function') {
+      updateBuildingDisplay(buildings);
+    }
 
     globalGameIsLoadingFromSave = false;
 

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -202,7 +202,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     productivityValue.textContent = `${Math.round(structure.productivity * 100)}%`;
     productivityContainer.appendChild(productivityValue);
 
-    if (structure.dayNightActivity) {
+    if (structure.dayNightActivity && !(typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle)) {
       const dayNightIcon = document.createElement('span');
       dayNightIcon.id = `${structure.name}-day-night-icon`;
       dayNightIcon.classList.add('day-night-icon');
@@ -611,7 +611,7 @@ function updateDecreaseButtonText(button, buildCount) {
         const productivityValue = Math.round((structure.productivity * 100));
         productivityElement.textContent = `${productivityValue}%`;
 
-        if (structure.dayNightActivity && dayNightCycle.isNight()) {
+        if (structure.dayNightActivity && dayNightCycle.isNight() && !(typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle)) {
           productivityElement.style.color = 'darkblue';
         } else if (productivityValue < 100) {
           productivityElement.style.color = 'red';
@@ -622,7 +622,12 @@ function updateDecreaseButtonText(button, buildCount) {
 
       const iconElement = document.getElementById(`${structureName}-day-night-icon`);
       if (iconElement) {
-        iconElement.textContent = dayNightCycle.isDay() ? '☀️' : '🌙';
+        if (typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle) {
+          iconElement.style.display = 'none';
+        } else {
+          iconElement.style.display = '';
+          iconElement.textContent = dayNightCycle.isDay() ? '☀️' : '🌙';
+        }
       }
   
       const button = document.getElementById(`build-${structureName}`);

--- a/tests/dayNightDisplayHidden.test.js
+++ b/tests/dayNightDisplayHidden.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const { updateDayNightDisplay } = require('../src/js/day-night-cycle.js');
+
+describe('day-night display hidden', () => {
+  test('progress bar hidden when setting disabled', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div class="day-night-progress-bar-container"><span id="progress-text"></span><div id="day-night-progress-bar"></div></div>', { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    global.dayNightCycle = { isDay: () => true, getDayProgress: () => 0 };
+    global.gameSettings = { disableDayNightCycle: true };
+
+    updateDayNightDisplay();
+    const container = dom.window.document.querySelector('.day-night-progress-bar-container');
+    expect(container.style.display).toBe('none');
+  });
+});

--- a/tests/dayNightSettingEffects.test.js
+++ b/tests/dayNightSettingEffects.test.js
@@ -1,0 +1,51 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+const { applyDayNightSettingEffects } = require('../src/js/day-night-setting.js');
+
+describe('day-night setting effects', () => {
+  function createBuilding(name){
+    return new Building({
+      name,
+      category:'energy',
+      cost:{ colony: { metal: 10 } },
+      consumption:{},
+      production:{ colony: { energy: 1 } },
+      storage:{},
+      dayNightActivity:true,
+      canBeToggled:true,
+      requiresMaintenance:true,
+      maintenanceFactor:1,
+      requiresDeposit:null,
+      requiresWorker:0,
+      unlocked:true
+    }, name);
+  }
+
+  test('toggle adds and removes effects and respects research', () => {
+    global.maintenanceFraction = 0.1;
+    global.buildings = {
+      solarPanel: createBuilding('solarPanel'),
+      iceHarvester: createBuilding('iceHarvester')
+    };
+    global.addEffect = effect => buildings[effect.targetId].addAndReplace(effect);
+    global.removeEffect = effect => buildings[effect.targetId].removeEffect(effect);
+    global.gameSettings = { disableDayNightCycle: true };
+
+    applyDayNightSettingEffects();
+
+    expect(buildings.solarPanel.activeEffects.some(e => e.effectId === 'disable-day-night-production-solarPanel')).toBe(true);
+    expect(buildings.solarPanel.activeEffects.some(e => e.effectId === 'disable-day-night-maintenance-solarPanel-metal')).toBe(true);
+    expect(buildings.iceHarvester.activeEffects.some(e => e.effectId === 'disable-day-night-production-iceHarvester')).toBe(true);
+
+    buildings.iceHarvester.dayNightActivity = false;
+    applyDayNightSettingEffects();
+    expect(buildings.iceHarvester.activeEffects.some(e => e.effectId === 'disable-day-night-production-iceHarvester')).toBe(false);
+
+    global.gameSettings.disableDayNightCycle = false;
+    applyDayNightSettingEffects();
+
+    expect(buildings.solarPanel.activeEffects.length).toBe(0);
+    expect(buildings.iceHarvester.activeEffects.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- hide day-night cycle progress bar and icons when disabled
- give solar panels and ice harvesters production and maintenance multipliers when the cycle is off
- ignore the penalty once Infrared Vision removes the day/night restriction
- reapply effects when research toggles day/night activity
- document new behavior in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687da642476c83279b8e7c906c7f98cf