### PR TITLE
Fix journal button placement when hiding day-night display

### DIFF
--- a/src/js/day-night-cycle.js
+++ b/src/js/day-night-cycle.js
@@ -55,10 +55,12 @@ function rotationPeriodToDuration(rotationHours) {
 function updateDayNightDisplay() {
   const container = document.querySelector('.day-night-progress-bar-container');
   if (typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle) {
-    if (container) container.style.display = 'none';
+    if (container) {
+      container.style.visibility = 'hidden';
+    }
     return;
   }
-  if (container) container.style.display = 'block';
+  if (container) container.style.visibility = 'visible';
 
   const dayNightStatus = dayNightCycle.isDay() ? 'Day' : 'Night';
   const dayProgress = dayNightCycle.getDayProgress() * 100;

--- a/tests/dayNightDisplayHidden.test.js
+++ b/tests/dayNightDisplayHidden.test.js
@@ -13,6 +13,6 @@ describe('day-night display hidden', () => {
 
     updateDayNightDisplay();
     const container = dom.window.document.querySelector('.day-night-progress-bar-container');
-    expect(container.style.display).toBe('none');
+    expect(container.style.visibility).toBe('hidden');
   });
 });


### PR DESCRIPTION
## Summary
- keep the day-night progress container's width so journal toggle stays right aligned
- update day-night display test for new visibility rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687db8825fa0832786f5704656a2e649