### PR TITLE
Halve ice harvester usage when day-night disabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,3 +165,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Settings menu can disable the day-night cycle. Solar panels and Ice Harvesters operate at half strength and the progress bar hides.
 - Day-night toggle also halves maintenance for those structures and skips the penalty on Ice Harvesters once Infrared Vision is researched.
 - Restored the yellow/blue animation by re-linking the day-night cycle stylesheet.
+- Disabling the day-night cycle now also halves Ice Harvester consumption unless Infrared Vision is researched.

--- a/src/js/day-night-cycle.js
+++ b/src/js/day-night-cycle.js
@@ -55,10 +55,10 @@ function rotationPeriodToDuration(rotationHours) {
 function updateDayNightDisplay() {
   const container = document.querySelector('.day-night-progress-bar-container');
   if (typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle) {
-    if (container) container.style.display = 'none';
+    if (container) container.style.visibility = 'hidden';
     return;
   }
-  if (container) container.style.display = 'block';
+  if (container) container.style.visibility = 'visible';
 
   const dayNightStatus = dayNightCycle.isDay() ? 'Day' : 'Night';
   const dayProgress = dayNightCycle.getDayProgress() * 100;

--- a/src/js/day-night-setting.js
+++ b/src/js/day-night-setting.js
@@ -17,6 +17,18 @@
       };
       effects.push(prodEffect);
 
+      if (id === 'iceHarvester') {
+        const consEffect = {
+          target: 'building',
+          targetId: id,
+          type: 'consumptionMultiplier',
+          value: 0.5,
+          effectId: `disable-day-night-consumption-${id}`,
+          sourceId: 'settings'
+        };
+        effects.push(consEffect);
+      }
+
       const cost = (building.cost && building.cost.colony) || {};
       for(const resource in cost){
         effects.push({
@@ -37,7 +49,9 @@
         if(typeof removeEffect === 'function') effects.forEach(removeEffect);
       }
     });
-    document.dispatchEvent(new CustomEvent('dayNightCycleToggled'));
+    if (typeof document !== 'undefined') {
+      document.dispatchEvent(new CustomEvent('dayNightCycleToggled'));
+    }
   }
 
   if(typeof module !== 'undefined' && module.exports){

--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -270,6 +270,10 @@ function updateJournalAlert() {
   if (showButton) {
     showButton.classList.toggle('unread', journalUnread);
   }
+  const alert = document.getElementById('journal-alert');
+  if (alert) {
+    alert.style.display = journalUnread ? 'inline' : 'none';
+  }
 }
 
 function updateShowJournalButtonPosition() {
@@ -287,11 +291,11 @@ function toggleJournal() {
   journalCollapsed = !journalCollapsed;
   if (journalCollapsed) {
     journal.classList.add('collapsed');
-    showButton.classList.remove('hidden');
+    if (showButton) showButton.classList.remove('hidden');
     updateShowJournalButtonPosition();
   } else {
     journal.classList.remove('collapsed');
-    showButton.classList.add('hidden');
+    if (showButton) showButton.classList.add('hidden');
     journalUnread = false;
     updateJournalAlert();
     if (showButton) {

--- a/tests/dayNightSettingEffects.test.js
+++ b/tests/dayNightSettingEffects.test.js
@@ -37,10 +37,12 @@ describe('day-night setting effects', () => {
     expect(buildings.solarPanel.activeEffects.some(e => e.effectId === 'disable-day-night-production-solarPanel')).toBe(true);
     expect(buildings.solarPanel.activeEffects.some(e => e.effectId === 'disable-day-night-maintenance-solarPanel-metal')).toBe(true);
     expect(buildings.iceHarvester.activeEffects.some(e => e.effectId === 'disable-day-night-production-iceHarvester')).toBe(true);
+    expect(buildings.iceHarvester.activeEffects.some(e => e.effectId === 'disable-day-night-consumption-iceHarvester')).toBe(true);
 
     buildings.iceHarvester.dayNightActivity = false;
     applyDayNightSettingEffects();
     expect(buildings.iceHarvester.activeEffects.some(e => e.effectId === 'disable-day-night-production-iceHarvester')).toBe(false);
+    expect(buildings.iceHarvester.activeEffects.some(e => e.effectId === 'disable-day-night-consumption-iceHarvester')).toBe(false);
 
     global.gameSettings.disableDayNightCycle = false;
     applyDayNightSettingEffects();


### PR DESCRIPTION
## Summary
- reduce ice harvester consumption when turning off the day-night cycle
- guard DOM access in day-night utilities
- make journal toggle safe without `show-journal-button`
- expose unread journal state via alert span
- test day-night setting effects for consumption penalty removal
- document the new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e324dccfc83279eace344a3c2b366