### PR TITLE
Fix tests and sync day-night toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,3 +165,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Settings menu can disable the day-night cycle. Solar panels and Ice Harvesters operate at half strength and the progress bar hides.
 - Day-night toggle also halves maintenance for those structures and skips the penalty on Ice Harvesters once Infrared Vision is researched.
 - Restored the yellow/blue animation by re-linking the day-night cycle stylesheet.
+- Day-night setting checkbox now updates when starting a new game or loading a save.

--- a/src/js/day-night-setting.js
+++ b/src/js/day-night-setting.js
@@ -47,7 +47,9 @@
         if(typeof removeEffect === 'function') effects.forEach(removeEffect);
       }
     });
-    document.dispatchEvent(new CustomEvent('dayNightCycleToggled'));
+    if (typeof document !== 'undefined') {
+      document.dispatchEvent(new CustomEvent('dayNightCycleToggled'));
+    }
   }
 
   if(typeof module !== 'undefined' && module.exports){

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -130,6 +130,10 @@ function initializeGameState(options = {}) {
   if (!preserveManagers) {
     gameSettings.useCelsius = false;
     gameSettings.disableDayNightCycle = false;
+    const dayNightToggle = typeof document !== 'undefined' ? document.getElementById('day-night-toggle') : null;
+    if (dayNightToggle) {
+      dayNightToggle.checked = gameSettings.disableDayNightCycle;
+    }
   }
   
   globalEffects = new EffectableEntity({description : 'Manages global effects'});

--- a/tests/dayNightDisplayHidden.test.js
+++ b/tests/dayNightDisplayHidden.test.js
@@ -13,6 +13,6 @@ describe('day-night display hidden', () => {
 
     updateDayNightDisplay();
     const container = dom.window.document.querySelector('.day-night-progress-bar-container');
-    expect(container.style.visibility).toBe('hidden');
+    expect(container.style.display).toBe('none');
   });
 });

--- a/tests/journalToggle.test.js
+++ b/tests/journalToggle.test.js
@@ -9,7 +9,7 @@ describe('journal toggle functionality', () => {
     const dom = new JSDOM(`<!DOCTYPE html><html><body>
       <div id="journal" class="journal"><div id="journal-entries"></div></div>
       <button id="toggle-journal-button"></button>
-      <span id="journal-alert" class="journal-alert"></span>
+      <button id="show-journal-button" class="hidden"></button>
     </body></html>`, { runScripts: 'outside-only' });
 
     const ctx = dom.getInternalVMContext();
@@ -26,6 +26,6 @@ describe('journal toggle functionality', () => {
     jest.runAllTimers();
     jest.useRealTimers();
 
-    expect(dom.window.document.getElementById('journal-alert').style.display).toBe('inline');
+    expect(dom.window.document.getElementById('show-journal-button').classList.contains('unread')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- fix failing day-night tests
- update journal toggle test to match UI
- dispatch day-night toggle events safely
- reset day-night checkbox on new game
- note feature in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e36acddbc83278fb76d2fe8ff7030