### PR TITLE
Hide Solis tab until unlocked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Day-night toggle also halves maintenance for those structures and skips the penalty on Ice Harvesters once Infrared Vision is researched.
 - Restored the yellow/blue animation by re-linking the day-night cycle stylesheet.
 - Day-night setting checkbox now updates when starting a new game or loading a save.
+- Solis tab remains hidden in HTML until chapter 5.2 unlocks it.

--- a/index.html
+++ b/index.html
@@ -363,14 +363,14 @@
         <div class="container hope-container">
             <div class="hope-subtabs">
                 <div class="hope-subtab active" data-subtab="awakening-hope">Awakening</div>
-                <div class="hope-subtab" data-subtab="solis-hope">Solis<span id="solis-subtab-alert" class="hope-alert">!</span></div>
+                <div class="hope-subtab hidden" data-subtab="solis-hope">Solis<span id="solis-subtab-alert" class="hope-alert">!</span></div>
             </div>
             <div class="hope-subtab-content-wrapper">
                 <div id="awakening-hope" class="hope-subtab-content active">
                     <div id="skill-points-display">Skill Points: <span id="skill-points-value">0</span></div>
                     <div id="skill-tree" class="skill-tree"></div>
                 </div>
-                <div id="solis-hope" class="hope-subtab-content">
+                <div id="solis-hope" class="hope-subtab-content hidden">
                     <div class="solis-container">
                         <div class="solis-header">
                             <h2>Solis Quests</h2>

--- a/tests/solisTabHiddenMarkup.test.js
+++ b/tests/solisTabHiddenMarkup.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Solis subtab markup', () => {
+  test('index.html hides Solis tab by default', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    expect(html).toMatch(/<div class="hope-subtab hidden" data-subtab="solis-hope">/);
+    expect(html).toMatch(/<div id="solis-hope" class="hope-subtab-content hidden">/);
+  });
+});


### PR DESCRIPTION
## Summary
- hide Solis subtab markup by default
- note hidden tab behavior in AGENTS changelog
- test that index.html hides the Solis subtab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e46e462048327b3c646b467fc3d71