### PR TITLE
Fix Solis subtab state persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,3 +167,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Restored the yellow/blue animation by re-linking the day-night cycle stylesheet.
 - Day-night setting checkbox now updates when starting a new game or loading a save.
 - Solis tab remains hidden in HTML until chapter 5.2 unlocks it.
+- Solis subtab visibility now checks a saved enabled flag so loading earlier saves hides it again.

--- a/src/js/hopeUI.js
+++ b/src/js/hopeUI.js
@@ -43,6 +43,9 @@ function updateHopeAlert() {
 }
 
 function updateHopeUI() {
+    if (typeof updateSolisVisibility === 'function') {
+        updateSolisVisibility();
+    }
     if (typeof updateSkillTreeUI === 'function') {
         updateSkillTreeUI();
     }

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -208,6 +208,9 @@ function loadGame(slotOrCustomString) {
       if (typeof solisManager.reapplyEffects === 'function') {
         solisManager.reapplyEffects();
       }
+      if (typeof updateSolisVisibility === 'function') {
+        updateSolisVisibility();
+      }
     }
 
     if(gameState.lifeDesigner){

--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -11,6 +11,7 @@ const RESOURCE_UPGRADE_AMOUNTS = {
 class SolisManager extends EffectableEntity {
   constructor(resourceValues = {}) {
     super({ description: 'Solis Manager' });
+    this.enabled = false;
     this.resourceValues = Object.assign({
       metal: 1,
       components: 10,
@@ -226,6 +227,7 @@ class SolisManager extends EffectableEntity {
 
   saveState() {
     return {
+      enabled: this.enabled,
       solisPoints: this.solisPoints,
       rewardMultiplier: this.rewardMultiplier,
       currentQuest: this.currentQuest,
@@ -240,6 +242,7 @@ class SolisManager extends EffectableEntity {
   }
 
   loadState(data) {
+    this.enabled = data.enabled || false;
     this.solisPoints = data.solisPoints || 0;
     this.rewardMultiplier = data.rewardMultiplier || 1;
     this.currentQuest = data.currentQuest;
@@ -256,6 +259,7 @@ class SolisManager extends EffectableEntity {
   }
 
   enable() {
+    this.enabled = true;
     if (typeof showSolisTab === 'function') {
       showSolisTab();
     }

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -29,6 +29,17 @@ function hideSolisTab() {
   if (content) content.classList.add('hidden');
 }
 
+function updateSolisVisibility() {
+  if (typeof solisManager === 'undefined') return;
+  if (solisManager.enabled) {
+    if (!solisTabVisible) {
+      showSolisTab();
+    }
+  } else if (solisTabVisible) {
+    hideSolisTab();
+  }
+}
+
 function createShopItem(key) {
   const item = document.createElement('div');
   item.classList.add('solis-shop-item');
@@ -208,5 +219,5 @@ function updateSolisUI() {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { hideSolisTab, showSolisTab };
+  module.exports = { hideSolisTab, showSolisTab, updateSolisVisibility };
 }

--- a/tests/solisTabDynamicVisibility.test.js
+++ b/tests/solisTabDynamicVisibility.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis subtab visibility reflects enabled flag', () => {
+  test('updateHopeUI shows and hides the tab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="hope-subtab hidden" data-subtab="solis-hope"></div>
+      <div id="solis-hope" class="hope-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.SolisManager = SolisManager;
+    vm.createContext(ctx);
+    const solisUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'solisUI.js'), 'utf8');
+    const hopeUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'hopeUI.js'), 'utf8');
+    vm.runInContext(`${solisUICode}\n${hopeUICode}`, ctx);
+    ctx.solisManager = new ctx.SolisManager();
+    ctx.initializeSolisUI();
+    ctx.updateHopeUI();
+
+    let tab = dom.window.document.querySelector('[data-subtab="solis-hope"]');
+    let content = dom.window.document.getElementById('solis-hope');
+    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+
+    ctx.solisManager.enable();
+    ctx.updateHopeUI();
+    expect(tab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+
+    ctx.solisManager.enabled = false;
+    ctx.updateHopeUI();
+    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- track whether Solis has been enabled via a new flag
- hide or show the Hope subtab based on that flag
- reapply Solis tab visibility after loading a save
- test dynamic visibility of the Solis subtab
- document feature in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e4c58172483279567392f5999fe84