### PR TITLE
Fix day-night setting effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,3 +170,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Day-night setting checkbox now updates when starting a new game or loading a save.
 - Solis tab remains hidden in HTML until chapter 5.2 unlocks it.
 - Solis subtab visibility now checks a saved enabled flag so loading earlier saves hides it again.
+- Day-night effects no longer reapply each frame; they update only when toggling the setting or loading a save.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -280,9 +280,6 @@ function updateLogic(delta) {
 
   recalculateTotalRates();
 
-  if (typeof applyGameEffects === 'function') {
-    applyGameEffects();
-  }
 }
 
 function updateRender() {


### PR DESCRIPTION
## Summary
- prevent `applyGameEffects` from running every update cycle
- update docs about day-night setting effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e4ee71cc083279d1565bad204f020