### PR TITLE
Add parent body data to moons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,3 +178,4 @@ second time they speak in a chapter to help clarify who is talking.
   up to one trillion units.
 - Replication logic now resides in self-replicating-ships.js and is invoked from resource.js.
 - Removed unused Dyson Swarm JS files and updated tests to use the project versions.
+- Moons now include parent body name, mass and orbit radius in planet-parameters.

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -255,6 +255,11 @@ const titanOverrides = {
     radius: 2574.7,
     albedo: 0.15,
   rotationPeriod: 382.7,
+  },
+  parentBody: {
+    name: 'Saturn',
+    mass: 5.683e26,       // kg
+    orbitRadius: 1221870  // km
   }
 };
 
@@ -350,6 +355,11 @@ const callistoOverrides = {
     radius: 2410.3,            // km :contentReference[oaicite:4]{index=4}
     albedo: 0.17,              // Bond albedo estimate :contentReference[oaicite:5]{index=5}
     rotationPeriod: 400.8      // hours (16 .7 days tidally‑locked) :contentReference[oaicite:6]{index=6}
+  },
+  parentBody: {
+    name: 'Jupiter',
+    mass: 1.898e27,      // kg
+    orbitRadius: 1882700 // km
   }
 };
 
@@ -424,6 +434,11 @@ const ganymedeOverrides = {
     radius: 2634.1,            // km
     albedo: 0.21,              // Bond albedo estimate
     rotationPeriod: 171.7      // hours (7.155 days, tidally locked)
+  },
+  parentBody: {
+    name: 'Jupiter',
+    mass: 1.898e27,     // kg
+    orbitRadius: 1070400 // km
   }
 };
 

--- a/tests/planetParameters.test.js
+++ b/tests/planetParameters.test.js
@@ -20,4 +20,19 @@ describe('getPlanetParameters', () => {
     expect(params.resources.colony.advancedResearch.hasCap).toBe(false);
     expect(params.resources.colony.advancedResearch.unlocked).toBe(false);
   });
+
+  test('moons specify their parent body', () => {
+    const moons = [
+      { key: 'titan', parent: 'Saturn' },
+      { key: 'callisto', parent: 'Jupiter' },
+      { key: 'ganymede', parent: 'Jupiter' }
+    ];
+    for (const { key, parent } of moons) {
+      const params = getPlanetParameters(key);
+      expect(params.parentBody).toBeDefined();
+      expect(params.parentBody.name).toBe(parent);
+      expect(typeof params.parentBody.mass).toBe('number');
+      expect(typeof params.parentBody.orbitRadius).toBe('number');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- enrich Titan, Callisto and Ganymede with their parent planet data
- record this update in `AGENTS.md`
- verify moons expose this information via tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688169c1bc208327bd5ac295a94dd1fe