### PR TITLE
Fix skipping new projects on load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,3 +181,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Photon Thrusters special project placeholder.
 - Photon Thrusters script now loads in index.html so the hidden project is generated correctly.
 - Moons now include parent body name, mass and orbit radius in planet-parameters.
+- Loading a save now merges any new projects into the order so updates aren't skipped.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -499,6 +499,13 @@ class ProjectManager extends EffectableEntity {
     const projectState = savedState.projects || savedState;
     this.projectOrder = savedState.order || Object.keys(this.projects);
 
+    // Append any newly added projects that were not present in the saved order
+    Object.keys(this.projects).forEach(name => {
+      if (!this.projectOrder.includes(name)) {
+        this.projectOrder.push(name);
+      }
+    });
+
     for (const projectName in projectState) {
       const savedProject = projectState[projectName];
       const project = this.projects[projectName];

--- a/tests/projectLoadMergeNew.test.js
+++ b/tests/projectLoadMergeNew.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('ProjectManager loadState adds new projects', () => {
+  test('new projects appear after loading old save', () => {
+    const ctx = { console, EffectableEntity, addEffect: () => {}, initializeProjectsUI: () => {}, renderProjects: () => {}, initializeProjectAlerts: () => {} };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+
+    const initialParams = { A: { name: 'A', category: 'resources', cost: {}, duration: 1, description: '', unlocked: true } };
+    const manager1 = new ctx.ProjectManager();
+    manager1.initializeProjects(initialParams);
+    const saved = manager1.saveState();
+
+    const newParams = { ...initialParams, B: { name: 'B', category: 'resources', cost: {}, duration: 1, description: '', unlocked: true } };
+    const manager2 = new ctx.ProjectManager();
+    manager2.initializeProjects(newParams);
+    manager2.loadState(saved);
+
+    expect(manager2.projectOrder).toEqual(['A', 'B']);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure ProjectManager merges newly added projects when loading old saves
- test merging of new projects on load
- document the update in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68819500283c832785d576d3dc5fe5d3