### PR TITLE
Add Photon Thrusters UI cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,5 +180,6 @@ second time they speak in a chapter to help clarify who is talking.
 - Removed unused Dyson Swarm JS files and updated tests to use the project versions.
 - Added Photon Thrusters special project placeholder.
 - Photon Thrusters script now loads in index.html so the hidden project is generated correctly.
+- Photon Thrusters project now shows spin and motion subcards with orbital and distance info.
 - Moons now include parent body name, mass and orbit radius in planet-parameters.
 - Loading a save now merges any new projects into the order so updates aren't skipped.

--- a/src/js/projects/PhotonThrustersProject.js
+++ b/src/js/projects/PhotonThrustersProject.js
@@ -1,5 +1,89 @@
+function calculateOrbitalPeriodDays(distanceAU) {
+  if (typeof distanceAU !== 'number' || distanceAU <= 0) return 0;
+  const years = Math.sqrt(Math.pow(distanceAU, 3));
+  return years * 365.25;
+}
+
 class PhotonThrustersProject extends Project {
-  // Placeholder for photon thruster logic
+  renderUI(container) {
+    const spinCard = document.createElement('div');
+    spinCard.classList.add('spin-details-card');
+    spinCard.innerHTML = `
+      <div class="card-header">
+        <span class="card-title">Spin</span>
+      </div>
+      <div class="card-body">
+        <div class="stats-grid">
+          <div class="stat-item">
+            <span class="stat-label">Orbital Period:</span>
+            <span id="spin-orbital-period" class="stat-value">0</span>
+          </div>
+        </div>
+      </div>
+    `;
+    container.appendChild(spinCard);
+
+    const motionCard = document.createElement('div');
+    motionCard.classList.add('motion-details-card');
+    motionCard.innerHTML = `
+      <div class="card-header">
+        <span class="card-title">Motion</span>
+      </div>
+      <div class="card-body">
+        <div class="stats-grid">
+          <div class="stat-item">
+            <span class="stat-label">Distance from Sun:</span>
+            <span id="motion-distance-sun" class="stat-value">0</span>
+          </div>
+          <div id="motion-parent-container" class="stat-item" style="display:none;">
+            <span class="stat-label">Parent:</span>
+            <span id="motion-parent-name" class="stat-value"></span>
+            <span class="stat-label">at</span>
+            <span id="motion-parent-distance" class="stat-value"></span>
+          </div>
+        </div>
+      </div>
+    `;
+    container.appendChild(motionCard);
+
+    projectElements[this.name] = {
+      ...projectElements[this.name],
+      spin: {
+        orbitalPeriod: spinCard.querySelector('#spin-orbital-period'),
+      },
+      motion: {
+        distanceSun: motionCard.querySelector('#motion-distance-sun'),
+        parentContainer: motionCard.querySelector('#motion-parent-container'),
+        parentName: motionCard.querySelector('#motion-parent-name'),
+        parentDistance: motionCard.querySelector('#motion-parent-distance'),
+      },
+    };
+  }
+
+  updateUI() {
+    const params = terraforming.celestialParameters || {};
+    const elements = projectElements[this.name];
+    if (!elements) return;
+
+    if (elements.spin && elements.spin.orbitalPeriod) {
+      const period = calculateOrbitalPeriodDays(params.distanceFromSun);
+      elements.spin.orbitalPeriod.textContent = `${formatNumber(period, false, 2)} days`;
+    }
+
+    if (elements.motion) {
+      if (elements.motion.distanceSun) {
+        elements.motion.distanceSun.textContent = `${formatNumber(params.distanceFromSun || 0, false, 2)} AU`;
+      }
+      const parent = params.parentBody;
+      if (parent && elements.motion.parentContainer) {
+        elements.motion.parentContainer.style.display = 'block';
+        elements.motion.parentName.textContent = parent.name || '';
+        elements.motion.parentDistance.textContent = `${formatNumber(parent.orbitRadius || 0, false, 2)} km`;
+      } else if (elements.motion.parentContainer) {
+        elements.motion.parentContainer.style.display = 'none';
+      }
+    }
+  }
 }
 
 if (typeof globalThis !== 'undefined') {


### PR DESCRIPTION
## Summary
- expand `PhotonThrustersProject` with spin and motion subcards
- compute and display orbital period and distance data
- test UI rendering and parent body handling
- document new feature in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68819698d2348327947a1f7389bb83ef