### PR TITLE
Delay Photon Thruster subcards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,5 +181,6 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Photon Thrusters special project placeholder.
 - Photon Thrusters script now loads in index.html so the hidden project is generated correctly.
 - Photon Thrusters project now shows spin and motion subcards with orbital and distance info.
+- Spin and motion subcards only appear once the Photon Thrusters project is completed.
 - Moons now include parent body name, mass and orbit radius in planet-parameters.
 - Loading a save now merges any new projects into the order so updates aren't skipped.

--- a/src/js/projects/PhotonThrustersProject.js
+++ b/src/js/projects/PhotonThrustersProject.js
@@ -8,6 +8,7 @@ class PhotonThrustersProject extends Project {
   renderUI(container) {
     const spinCard = document.createElement('div');
     spinCard.classList.add('spin-details-card');
+    spinCard.style.display = this.isCompleted ? 'block' : 'none';
     spinCard.innerHTML = `
       <div class="card-header">
         <span class="card-title">Spin</span>
@@ -25,6 +26,7 @@ class PhotonThrustersProject extends Project {
 
     const motionCard = document.createElement('div');
     motionCard.classList.add('motion-details-card');
+    motionCard.style.display = this.isCompleted ? 'block' : 'none';
     motionCard.innerHTML = `
       <div class="card-header">
         <span class="card-title">Motion</span>
@@ -48,6 +50,8 @@ class PhotonThrustersProject extends Project {
 
     projectElements[this.name] = {
       ...projectElements[this.name],
+      spinCard,
+      motionCard,
       spin: {
         orbitalPeriod: spinCard.querySelector('#spin-orbital-period'),
       },
@@ -64,6 +68,13 @@ class PhotonThrustersProject extends Project {
     const params = terraforming.celestialParameters || {};
     const elements = projectElements[this.name];
     if (!elements) return;
+
+    if (elements.spinCard) {
+      elements.spinCard.style.display = this.isCompleted ? 'block' : 'none';
+    }
+    if (elements.motionCard) {
+      elements.motionCard.style.display = this.isCompleted ? 'block' : 'none';
+    }
 
     if (elements.spin && elements.spin.orbitalPeriod) {
       const period = calculateOrbitalPeriodDays(params.distanceFromSun);

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -51,6 +51,7 @@ describe('Photon Thrusters project', () => {
 
     const config = ctx.projectParameters.photonThrusters;
     const project = new ctx.PhotonThrustersProject(config, 'photonThrusters');
+    project.isCompleted = true;
     const container = dom.window.document.getElementById('container');
     project.renderUI(container);
     ctx.projectElements = vm.runInContext('projectElements', ctx);
@@ -59,6 +60,10 @@ describe('Photon Thrusters project', () => {
 
     const spin = ctx.projectElements.photonThrusters.spin;
     const motion = ctx.projectElements.photonThrusters.motion;
+    const spinCard = ctx.projectElements.photonThrusters.spinCard;
+    const motionCard = ctx.projectElements.photonThrusters.motionCard;
+    expect(spinCard.style.display).toBe('block');
+    expect(motionCard.style.display).toBe('block');
     expect(spin.orbitalPeriod.textContent).toContain('365.25');
     expect(motion.distanceSun.textContent).toBe('1.00 AU');
     expect(motion.parentContainer.style.display).toBe('block');
@@ -85,6 +90,7 @@ describe('Photon Thrusters project', () => {
 
     const config = ctx.projectParameters.photonThrusters;
     const project = new ctx.PhotonThrustersProject(config, 'photonThrusters');
+    project.isCompleted = true;
     const container = dom.window.document.getElementById('container');
     project.renderUI(container);
     ctx.projectElements = vm.runInContext('projectElements', ctx);
@@ -94,5 +100,42 @@ describe('Photon Thrusters project', () => {
     const motion = ctx.projectElements.photonThrusters.motion;
     expect(motion.distanceSun.textContent).toBe('2.00 AU');
     expect(motion.parentContainer.style.display).toBe('none');
+  });
+
+  test('subcards hidden until project complete', () => {
+    const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = require('../src/js/numbers.js').formatNumber;
+    ctx.projectElements = {};
+    ctx.terraforming = { celestialParameters: { distanceFromSun: 1 } };
+    ctx.EffectableEntity = EffectableEntity;
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const subclassCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'PhotonThrustersProject.js'), 'utf8');
+    vm.runInContext(subclassCode + '; this.PhotonThrustersProject = PhotonThrustersProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.photonThrusters;
+    const project = new ctx.PhotonThrustersProject(config, 'photonThrusters');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.updateUI();
+
+    const spinCard = ctx.projectElements.photonThrusters.spinCard;
+    const motionCard = ctx.projectElements.photonThrusters.motionCard;
+    expect(spinCard.style.display).toBe('none');
+    expect(motionCard.style.display).toBe('none');
+
+    project.isCompleted = true;
+    project.updateUI();
+    expect(spinCard.style.display).toBe('block');
+    expect(motionCard.style.display).toBe('block');
   });
 });


### PR DESCRIPTION
## Summary
- hide Photon Thruster spin and motion cards until the project finishes
- test that the cards remain hidden until completion
- document this update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881986b09508327bcf58962c4e42a20