### PR TITLE
Add spin target display and moon warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,3 +184,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Spin and motion subcards only appear once the Photon Thrusters project is completed.
 - Moons now include parent body name, mass and orbit radius in planet-parameters.
 - Loading a save now merges any new projects into the order so updates aren't skipped.
+- Photon Thrusters spin card includes a default 'Target : 1 day' field.
+- Moons display a warning about leaving their parent's gravity well before altering distance to the sun.

--- a/src/js/projects/PhotonThrustersProject.js
+++ b/src/js/projects/PhotonThrustersProject.js
@@ -19,6 +19,10 @@ class PhotonThrustersProject extends Project {
             <span class="stat-label">Orbital Period:</span>
             <span id="spin-orbital-period" class="stat-value">0</span>
           </div>
+          <div class="stat-item">
+            <span class="stat-label">Target :</span>
+            <span id="spin-target" class="stat-value">1 day</span>
+          </div>
         </div>
       </div>
     `;
@@ -54,6 +58,7 @@ class PhotonThrustersProject extends Project {
       motionCard,
       spin: {
         orbitalPeriod: spinCard.querySelector('#spin-orbital-period'),
+        target: spinCard.querySelector('#spin-target'),
       },
       motion: {
         distanceSun: motionCard.querySelector('#motion-distance-sun'),

--- a/src/js/warning.js
+++ b/src/js/warning.js
@@ -6,10 +6,19 @@ function updateWarnings() {
 
     if (colonists.consumptionRate > colonists.productionRate) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Colonists are dying!</div>';
-    } else if (tau > 10) {
     } else if (tau > 10 && tempK > 313.15) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Runaway Greenhouse Effect!</div>';
+    } else if (terraforming?.celestialParameters?.parentBody) {
+      warningContainer.innerHTML = '<div class="warning-message">Moons must first their parent\'s gravity well before distance to the sun can be changed</div>';
     } else {
       warningContainer.innerHTML = '';
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = updateWarnings;
+}
+
+if (typeof window !== 'undefined') {
+  window.updateWarnings = updateWarnings;
 }

--- a/tests/moonWarning.test.js
+++ b/tests/moonWarning.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+
+describe('moon distance warning', () => {
+  test('shows message when current body is a moon', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="warning-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.resources = { colony: { colonists: { consumptionRate: 0, productionRate: 1 } } };
+    ctx.terraforming = { temperature: { opticalDepth: 0, value: 0 }, celestialParameters: { parentBody: { name: 'Jupiter' } } };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'warning.js'), 'utf8');
+    vm.runInContext(code + '; this.updateWarnings = updateWarnings;', ctx);
+
+    ctx.updateWarnings();
+
+    const box = dom.window.document.getElementById('warning-container');
+    expect(box.textContent).toBe("Moons must first their parent's gravity well before distance to the sun can be changed");
+  });
+});

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -65,6 +65,7 @@ describe('Photon Thrusters project', () => {
     expect(spinCard.style.display).toBe('block');
     expect(motionCard.style.display).toBe('block');
     expect(spin.orbitalPeriod.textContent).toContain('365.25');
+    expect(spin.target.textContent).toBe('1 day');
     expect(motion.distanceSun.textContent).toBe('1.00 AU');
     expect(motion.parentContainer.style.display).toBe('block');
     expect(motion.parentName.textContent).toBe('Mars');


### PR DESCRIPTION
## Summary
- show spin target field in photon thrusters project
- warn players that moons must leave the parent gravity well before adjusting distance to the sun
- test moon warnings
- update photon thrusters tests
- document changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68819bbd2a60832798c326bb4d22df63