### PR TITLE
Add moon warning to motion card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,3 +184,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Spin and motion subcards only appear once the Photon Thrusters project is completed.
 - Moons now include parent body name, mass and orbit radius in planet-parameters.
 - Loading a save now merges any new projects into the order so updates aren't skipped.
+- Photon Thrusters spin card includes a default 'Target : 1 day' field.
+- The motion card warns moons to leave their parent's gravity well before altering solar distance.

--- a/src/js/projects/PhotonThrustersProject.js
+++ b/src/js/projects/PhotonThrustersProject.js
@@ -19,6 +19,10 @@ class PhotonThrustersProject extends Project {
             <span class="stat-label">Orbital Period:</span>
             <span id="spin-orbital-period" class="stat-value">0</span>
           </div>
+          <div class="stat-item">
+            <span class="stat-label">Target :</span>
+            <span id="spin-target" class="stat-value">1 day</span>
+          </div>
         </div>
       </div>
     `;
@@ -44,6 +48,9 @@ class PhotonThrustersProject extends Project {
             <span id="motion-parent-distance" class="stat-value"></span>
           </div>
         </div>
+        <div id="motion-moon-warning" class="warning-message" style="display:none;">
+          Moons must first their parent's gravity well before distance to the sun can be changed
+        </div>
       </div>
     `;
     container.appendChild(motionCard);
@@ -54,12 +61,14 @@ class PhotonThrustersProject extends Project {
       motionCard,
       spin: {
         orbitalPeriod: spinCard.querySelector('#spin-orbital-period'),
+        target: spinCard.querySelector('#spin-target'),
       },
       motion: {
         distanceSun: motionCard.querySelector('#motion-distance-sun'),
         parentContainer: motionCard.querySelector('#motion-parent-container'),
         parentName: motionCard.querySelector('#motion-parent-name'),
         parentDistance: motionCard.querySelector('#motion-parent-distance'),
+        moonWarning: motionCard.querySelector("#motion-moon-warning"),
       },
     };
   }
@@ -93,6 +102,9 @@ class PhotonThrustersProject extends Project {
       } else if (elements.motion.parentContainer) {
         elements.motion.parentContainer.style.display = 'none';
       }
+        if (elements.motion.moonWarning) {
+          elements.motion.moonWarning.style.display = parent ? "block" : "none";
+        }
     }
   }
 }

--- a/src/js/warning.js
+++ b/src/js/warning.js
@@ -6,10 +6,17 @@ function updateWarnings() {
 
     if (colonists.consumptionRate > colonists.productionRate) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Colonists are dying!</div>';
-    } else if (tau > 10) {
     } else if (tau > 10 && tempK > 313.15) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Runaway Greenhouse Effect!</div>';
     } else {
       warningContainer.innerHTML = '';
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = updateWarnings;
+}
+
+if (typeof window !== 'undefined') {
+  window.updateWarnings = updateWarnings;
 }

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -62,9 +62,13 @@ describe('Photon Thrusters project', () => {
     const motion = ctx.projectElements.photonThrusters.motion;
     const spinCard = ctx.projectElements.photonThrusters.spinCard;
     const motionCard = ctx.projectElements.photonThrusters.motionCard;
+      const moonWarning = ctx.projectElements.photonThrusters.motion.moonWarning;
+      expect(moonWarning.style.display).toBe("block");
+      expect(moonWarning.textContent.trim()).toBe("Moons must first their parent's gravity well before distance to the sun can be changed");
     expect(spinCard.style.display).toBe('block');
     expect(motionCard.style.display).toBe('block');
     expect(spin.orbitalPeriod.textContent).toContain('365.25');
+    expect(spin.target.textContent).toBe('1 day');
     expect(motion.distanceSun.textContent).toBe('1.00 AU');
     expect(motion.parentContainer.style.display).toBe('block');
     expect(motion.parentName.textContent).toBe('Mars');
@@ -98,6 +102,8 @@ describe('Photon Thrusters project', () => {
     project.updateUI();
 
     const motion = ctx.projectElements.photonThrusters.motion;
+      const moonWarning = ctx.projectElements.photonThrusters.motion.moonWarning;
+      expect(moonWarning.style.display).toBe("none");
     expect(motion.distanceSun.textContent).toBe('2.00 AU');
     expect(motion.parentContainer.style.display).toBe('none');
   });


### PR DESCRIPTION
## Summary
- show warning inside Photon Thrusters motion card when controlling a moon
- test moon warning visibility
- remove obsolete global warning logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68819bbd2a60832798c326bb4d22df63