### PR TITLE
Update photon thruster spin controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,3 +186,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Loading a save now merges any new projects into the order so updates aren't skipped.
 - Photon Thrusters spin card includes a default 'Target : 1 day' field.
 - The motion card warns moons to leave their parent's gravity well before altering solar distance.
+- Photon Thrusters spin target is now an editable field that displays the energy required to change rotation.

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -3,6 +3,14 @@ const path = require('path');
 const vm = require('vm');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 
+function spinEnergyCost(mass, radius, currentHours, targetHours) {
+  const I = 0.4 * mass * Math.pow(radius * 1000, 2);
+  const w1 = (2 * Math.PI) / (currentHours * 3600);
+  const w2 = (2 * Math.PI) / (targetHours * 3600);
+  const deltaE = 0.5 * I * (w2 * w2 - w1 * w1);
+  return Math.abs(deltaE) / 86400;
+}
+
 describe('Photon Thrusters project', () => {
   test('parameters define correct costs', () => {
     const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
@@ -39,7 +47,7 @@ describe('Photon Thrusters project', () => {
     ctx.console = console;
     ctx.formatNumber = require('../src/js/numbers.js').formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { distanceFromSun: 1, parentBody: { name: 'Mars', orbitRadius: 50000 } } };
+    ctx.terraforming = { celestialParameters: { distanceFromSun: 1, rotationPeriod: 24.6, radius: 3389.5, mass: 6.417e23, parentBody: { name: 'Mars', orbitRadius: 50000 } } };
     ctx.EffectableEntity = EffectableEntity;
 
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -68,7 +76,15 @@ describe('Photon Thrusters project', () => {
     expect(spinCard.style.display).toBe('block');
     expect(motionCard.style.display).toBe('block');
     expect(spin.orbitalPeriod.textContent).toContain('365.25');
-    expect(spin.target.textContent).toBe('1 day');
+    expect(spin.target.value).toBe('1');
+    const expectedCost = ctx.formatNumber(
+      spinEnergyCost(6.417e23, 3389.5, 24.6, 24),
+      false,
+      2
+    ) + ' W-day';
+    expect(spin.energyCost.textContent).toBe(expectedCost);
+    const inputs = container.querySelectorAll('#spin-target');
+    expect(inputs.length).toBe(1);
     expect(motion.distanceSun.textContent).toBe('1.00 AU');
     expect(motion.parentContainer.style.display).toBe('block');
     expect(motion.parentName.textContent).toBe('Mars');
@@ -82,7 +98,7 @@ describe('Photon Thrusters project', () => {
     ctx.console = console;
     ctx.formatNumber = require('../src/js/numbers.js').formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { distanceFromSun: 2 } };
+    ctx.terraforming = { celestialParameters: { distanceFromSun: 2, rotationPeriod: 24.6, radius: 3389.5, mass: 6.417e23 } };
     ctx.EffectableEntity = EffectableEntity;
 
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -106,6 +122,13 @@ describe('Photon Thrusters project', () => {
       expect(moonWarning.style.display).toBe("none");
     expect(motion.distanceSun.textContent).toBe('2.00 AU');
     expect(motion.parentContainer.style.display).toBe('none');
+    const spin = ctx.projectElements.photonThrusters.spin;
+    const expectedCost = ctx.formatNumber(
+      spinEnergyCost(6.417e23, 3389.5, 24.6, 24),
+      false,
+      2
+    ) + ' W-day';
+    expect(spin.energyCost.textContent).toBe(expectedCost);
   });
 
   test('subcards hidden until project complete', () => {
@@ -116,7 +139,7 @@ describe('Photon Thrusters project', () => {
     ctx.console = console;
     ctx.formatNumber = require('../src/js/numbers.js').formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { distanceFromSun: 1 } };
+    ctx.terraforming = { celestialParameters: { distanceFromSun: 1, rotationPeriod: 24.6, radius: 3389.5, mass: 6.417e23 } };
     ctx.EffectableEntity = EffectableEntity;
 
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -153,7 +176,7 @@ describe('Photon Thrusters project', () => {
     ctx.console = console;
     ctx.formatNumber = require('../src/js/numbers.js').formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { rotationPeriod: 400.8 } };
+    ctx.terraforming = { celestialParameters: { rotationPeriod: 400.8, distanceFromSun: 5.2, radius: 2410.3, mass: 1.076e23 } };
     ctx.EffectableEntity = EffectableEntity;
 
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -175,5 +198,11 @@ describe('Photon Thrusters project', () => {
     const spin = ctx.projectElements.photonThrusters.spin;
     const value = parseFloat(spin.rotationPeriod.textContent);
     expect(value).toBeCloseTo(16.7, 1);
+    const expectedCost = ctx.formatNumber(
+      spinEnergyCost(1.076e23, 2410.3, 400.8, 24),
+      false,
+      2
+    ) + ' W-day';
+    expect(spin.energyCost.textContent).toBe(expectedCost);
   });
 });


### PR DESCRIPTION
## Summary
- allow photon thruster spin target to be edited
- display orbital period and energy cost for spin changes
- compute energy cost from planet mass and radius
- update photon thruster tests
- document new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881a2bcedd8832784791e6c652bde57