### PR TITLE
Fix celestial parameter save logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,3 +186,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Loading a save now merges any new projects into the order so updates aren't skipped.
 - Photon Thrusters spin card includes a default 'Target : 1 day' field.
 - The motion card warns moons to leave their parent's gravity well before altering solar distance.
+- Celestial parameters now track their original values and reload from configuration when saving or loading games.

--- a/tests/celestialParametersPersistence.test.js
+++ b/tests/celestialParametersPersistence.test.js
@@ -1,0 +1,38 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const lifeParameters = require('../src/js/life-parameters.js');
+
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+const Terraforming = require('../src/js/terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+Terraforming.prototype.synchronizeGlobalResources = function(){};
+Terraforming.prototype._updateZonalCoverageCache = function(){};
+
+describe('celestial parameter persistence', () => {
+  test('saveState includes current and initial parameters', () => {
+    const terra = new Terraforming({}, { radius: 1, distanceFromSun: 1, gravity: 1 });
+    terra.celestialParameters.distanceFromSun = 2;
+    const saved = terra.saveState();
+    expect(saved.celestialParameters.distanceFromSun).toBe(2);
+    expect(saved.initialCelestialParameters.distanceFromSun).toBe(1);
+  });
+
+  test('loadState merges config and derives missing initial', () => {
+    const terra = new Terraforming({}, { radius: 1, distanceFromSun: 1, gravity: 1 });
+    const state = { celestialParameters: { distanceFromSun: 3 } };
+    global.currentPlanetParameters = {
+      celestialParameters: { radius: 1, distanceFromSun: 1, gravity: 1 },
+      resources: { surface: {}, atmospheric: {} }
+    };
+    global.resources = { surface: {}, atmospheric: {}, colony: {}, special: {} };
+    global.getZonePercentage = () => 0.33;
+    global.ZONES = ['tropical','temperate','polar'];
+    terra.calculateInitialValues = function(){};
+    terra.loadState(state);
+    expect(terra.celestialParameters.distanceFromSun).toBe(3);
+    expect(terra.celestialParameters.gravity).toBe(1);
+    expect(terra.initialCelestialParameters.distanceFromSun).toBe(3);
+    expect(terra.initialCelestialParameters.gravity).toBe(1);
+  });
+});

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -67,7 +67,7 @@ describe('Photon Thrusters project', () => {
       expect(moonWarning.textContent.trim()).toBe("Moons must first their parent's gravity well before distance to the sun can be changed");
     expect(spinCard.style.display).toBe('block');
     expect(motionCard.style.display).toBe('block');
-    expect(spin.orbitalPeriod.textContent).toContain('365.25');
+    expect(spin.rotationPeriod.textContent).toBe('1.00 days');
     expect(spin.target.textContent).toBe('1 day');
     expect(motion.distanceSun.textContent).toBe('1.00 AU');
     expect(motion.parentContainer.style.display).toBe('block');


### PR DESCRIPTION
## Summary
- track initial and current celestial parameters in `Terraforming`
- load parameters from config when saving/loading and keep starting values
- update Photon Thrusters tests
- add regression tests for celestial parameter persistence
- document feature in AGENTS.md

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6881a3842030832785dd97ac0c2d5bd8