### PR TITLE
Fix celestial parameter initialization when loading saves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,4 @@ second time they speak in a chapter to help clarify who is talking.
 - The motion card warns moons to leave their parent's gravity well before altering solar distance.
 - Celestial parameters now track their original values and reload from configuration when saving or loading games.
 - Photon Thrusters spin target is now an editable field that displays the energy required to change rotation.
+- Loading a save now takes initial celestial parameters from configuration and fills missing current values from them.

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1517,16 +1517,11 @@ synchronizeGlobalResources() {
       if (terraformingState.celestialParameters) {
           Object.assign(this.celestialParameters, terraformingState.celestialParameters);
       }
-      if (terraformingState.initialCelestialParameters) {
-          this.initialCelestialParameters = structuredClone(terraformingState.initialCelestialParameters);
-      } else if (terraformingState.celestialParameters) {
-          this.initialCelestialParameters = structuredClone(terraformingState.celestialParameters);
-      }
 
-      // Ensure every field in current has an initial value
-      for (const key in this.celestialParameters) {
-          if (this.initialCelestialParameters[key] === undefined) {
-              this.initialCelestialParameters[key] = this.celestialParameters[key];
+      // Ensure current has values for all initial parameters
+      for (const key in this.initialCelestialParameters) {
+          if (this.celestialParameters[key] === undefined) {
+              this.celestialParameters[key] = this.initialCelestialParameters[key];
           }
       }
 

--- a/tests/celestialParametersPersistence.test.js
+++ b/tests/celestialParametersPersistence.test.js
@@ -18,7 +18,7 @@ describe('celestial parameter persistence', () => {
     expect(saved.initialCelestialParameters.distanceFromSun).toBe(1);
   });
 
-  test('loadState merges config and derives missing initial', () => {
+  test('loadState merges config and resets initial from planet', () => {
     const terra = new Terraforming({}, { radius: 1, distanceFromSun: 1, gravity: 1 });
     const state = { celestialParameters: { distanceFromSun: 3 } };
     global.currentPlanetParameters = {
@@ -32,7 +32,7 @@ describe('celestial parameter persistence', () => {
     terra.loadState(state);
     expect(terra.celestialParameters.distanceFromSun).toBe(3);
     expect(terra.celestialParameters.gravity).toBe(1);
-    expect(terra.initialCelestialParameters.distanceFromSun).toBe(3);
+    expect(terra.initialCelestialParameters.distanceFromSun).toBe(1);
     expect(terra.initialCelestialParameters.gravity).toBe(1);
   });
 });

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -75,8 +75,8 @@ describe('Photon Thrusters project', () => {
       expect(moonWarning.textContent.trim()).toBe("Moons must first their parent's gravity well before distance to the sun can be changed");
     expect(spinCard.style.display).toBe('block');
     expect(motionCard.style.display).toBe('block');
-    expect(spin.rotationPeriod.textContent).toBe('1.00 days');
-    expect(spin.target.textContent).toBe('1 day');
+    expect(spin.rotationPeriod.textContent).toBe('1.03 days');
+    expect(spin.target.value).toBe('1');
     expect(motion.distanceSun.textContent).toBe('1.00 AU');
     expect(motion.parentContainer.style.display).toBe('block');
     expect(motion.parentName.textContent).toBe('Mars');


### PR DESCRIPTION
## Summary
- load initial celestial values from planet config when loading
- ensure missing values in current parameters use initial ones
- update photon thruster tests for new UI
- adjust celestial parameter persistence test
- document fix in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881a85fc6b08327ad6c8e1b6da1beb8