### PR TITLE
Move parent body info into celestial parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Photon Thrusters project now shows spin and motion subcards with orbital and distance info.
 - Spin and motion subcards only appear once the Photon Thrusters project is completed.
 - Moons now include parent body name, mass and orbit radius in planet-parameters.
+- Parent body info now resides inside each planet's `celestialParameters` object.
 - Loading a save now merges any new projects into the order so updates aren't skipped.
 - Photon Thrusters spin card includes a default 'Target : 1 day' field.
 - The motion card warns moons to leave their parent's gravity well before altering solar distance.

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -256,12 +256,12 @@ const titanOverrides = {
     radius: 2574.7,
     mass: 1.345e23, // kg
     albedo: 0.15,
-  rotationPeriod: 382.7,
-  },
-  parentBody: {
-    name: 'Saturn',
-    mass: 5.683e26,       // kg
-    orbitRadius: 1221870  // km
+    rotationPeriod: 382.7,
+    parentBody: {
+      name: 'Saturn',
+      mass: 5.683e26,       // kg
+      orbitRadius: 1221870  // km
+    }
   }
 };
 
@@ -357,12 +357,12 @@ const callistoOverrides = {
     radius: 2410.3,            // km :contentReference[oaicite:4]{index=4}
     mass: 1.076e23,            // kg
     albedo: 0.17,              // Bond albedo estimate :contentReference[oaicite:5]{index=5}
-    rotationPeriod: 400.8      // hours (16 .7 days tidally‑locked) :contentReference[oaicite:6]{index=6}
-  },
-  parentBody: {
-    name: 'Jupiter',
-    mass: 1.898e27,      // kg
-    orbitRadius: 1882700 // km
+    rotationPeriod: 400.8,     // hours (16 .7 days tidally‑locked) :contentReference[oaicite:6]{index=6}
+    parentBody: {
+      name: 'Jupiter',
+      mass: 1.898e27,      // kg
+      orbitRadius: 1882700 // km
+    }
   }
 };
 
@@ -437,12 +437,12 @@ const ganymedeOverrides = {
     radius: 2634.1,            // km
     mass: 1.482e23,            // kg
     albedo: 0.21,              // Bond albedo estimate
-    rotationPeriod: 171.7      // hours (7.155 days, tidally locked)
-  },
-  parentBody: {
-    name: 'Jupiter',
-    mass: 1.898e27,     // kg
-    orbitRadius: 1070400 // km
+    rotationPeriod: 171.7,     // hours (7.155 days, tidally locked)
+    parentBody: {
+      name: 'Jupiter',
+      mass: 1.898e27,     // kg
+      orbitRadius: 1070400 // km
+    }
   }
 };
 

--- a/tests/planetParameters.test.js
+++ b/tests/planetParameters.test.js
@@ -29,10 +29,11 @@ describe('getPlanetParameters', () => {
     ];
     for (const { key, parent } of moons) {
       const params = getPlanetParameters(key);
-      expect(params.parentBody).toBeDefined();
-      expect(params.parentBody.name).toBe(parent);
-      expect(typeof params.parentBody.mass).toBe('number');
-      expect(typeof params.parentBody.orbitRadius).toBe('number');
+      const body = params.celestialParameters.parentBody;
+      expect(body).toBeDefined();
+      expect(body.name).toBe(parent);
+      expect(typeof body.mass).toBe('number');
+      expect(typeof body.orbitRadius).toBe('number');
     }
   });
 


### PR DESCRIPTION
## Summary
- move `parentBody` into each planet's `celestialParameters`
- adapt test expectations for the new location
- document the change in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881aaf00a608327a8c4aaf8c35f595c