### PR TITLE
Inline moon thruster warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,3 +191,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Photon Thrusters spin target is now an editable field that displays the energy required to change rotation.
 - Photon Thrusters motion card shows escape energy for moons or an orbital target field for planets.
 - Loading a save now takes initial celestial parameters from configuration and fills missing current values from them.
+- Moon thruster warning moved from the global warning box to a small notice within the Photon Thrusters card.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -519,3 +519,18 @@
     color: #6c757d;
     text-align: left;
 }
+
+/* Simple warning shown in Photon Thrusters */
+.moon-warning {
+    color: #cc6600;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: bold;
+    margin-top: 4px;
+    font-size: 0.9em;
+}
+
+.moon-warning .icon {
+    font-size: 1.1em;
+}

--- a/src/js/projects/PhotonThrustersProject.js
+++ b/src/js/projects/PhotonThrustersProject.js
@@ -135,8 +135,9 @@ class PhotonThrustersProject extends Project {
             <span id="motion-escape-energy" class="stat-value">0</span>
           </div>
         </div>
-        <div id="motion-moon-warning" class="warning-message" style="display:none;">
-          Moons must first their parent's gravity well before distance to the sun can be changed
+        <div id="motion-moon-warning" class="moon-warning" style="display:none;">
+          <span class="icon">\u26A0</span>
+          <span>Escape parent body before adjusting solar distance</span>
         </div>
       </div>
     `;

--- a/src/js/warning.js
+++ b/src/js/warning.js
@@ -8,8 +8,6 @@ function updateWarnings() {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Colonists are dying!</div>';
     } else if (tau > 10 && tempK > 313.15) {
       warningContainer.innerHTML = '<div class="warning-message">Warning: Runaway Greenhouse Effect!</div>';
-    } else if (terraforming?.celestialParameters?.parentBody) {
-      warningContainer.innerHTML = '<div class="warning-message">Moons must first their parent\'s gravity well before distance to the sun can be changed</div>';
     } else {
       warningContainer.innerHTML = '';
     }

--- a/tests/moonWarning.test.js
+++ b/tests/moonWarning.test.js
@@ -4,7 +4,7 @@ const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_m
 const vm = require('vm');
 
 describe('moon distance warning', () => {
-  test('shows message when current body is a moon', () => {
+  test('does not display global message for moons', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="warning-container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.document = dom.window.document;
@@ -17,6 +17,6 @@ describe('moon distance warning', () => {
     ctx.updateWarnings();
 
     const box = dom.window.document.getElementById('warning-container');
-    expect(box.textContent).toBe("Moons must first their parent's gravity well before distance to the sun can be changed");
+    expect(box.textContent).toBe('');
   });
 });

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -90,9 +90,10 @@ describe('Photon Thrusters project', () => {
     const motion = ctx.projectElements.photonThrusters.motion;
     const spinCard = ctx.projectElements.photonThrusters.spinCard;
     const motionCard = ctx.projectElements.photonThrusters.motionCard;
-      const moonWarning = ctx.projectElements.photonThrusters.motion.moonWarning;
-      expect(moonWarning.style.display).toBe("block");
-      expect(moonWarning.textContent.trim()).toBe("Moons must first their parent's gravity well before distance to the sun can be changed");
+    const moonWarning = ctx.projectElements.photonThrusters.motion.moonWarning;
+    expect(moonWarning.style.display).toBe('block');
+    expect(moonWarning.textContent).toContain('Escape parent body');
+    expect(moonWarning.textContent).toContain('\u26A0');
     expect(spinCard.style.display).toBe('block');
     expect(motionCard.style.display).toBe('block');
     const rotValue = parseFloat(spin.rotationPeriod.textContent);


### PR DESCRIPTION
## Summary
- remove moon distance warning from global alerts
- display a simpler notice with icon inside Photon Thrusters card
- style new inline moon warning
- update tests for new warning location and text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881acb386f48327a204cc9cbab81419