### PR TITLE
Add Photon Thruster energy investment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,3 +192,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Photon Thrusters motion card shows escape energy for moons or an orbital target field for planets.
 - Loading a save now takes initial celestial parameters from configuration and fills missing current values from them.
 - Numbers above sextillion now format as Sp, Oc and No up to 1e30.
+- Photon Thrusters project gains an energy investment UI with +/- buttons, 0, /10, x10 and Max. Invested energy drains every second and shows in resource rates.


### PR DESCRIPTION
## Summary
- extend Photon Thrusters project with energy investment logic and UI
- record new update in `AGENTS.md`
- test energy consumption from thruster investment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881ad6abb708327a199cc8c5dbe7411