### PR TITLE
Fix photon thruster parent info layout

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -129,6 +129,16 @@
     color: #343a40;
 }
 
+/* Display parent orbit text in a single line */
+#motion-parent-container .stat-label {
+    display: inline;
+    margin: 0 4px 0 0;
+}
+#motion-parent-container .stat-value {
+    display: inline;
+    margin-right: 4px;
+}
+
 /* Mirror Oversight Card */
 .mirror-oversight-card .card-body {
     display: flex;


### PR DESCRIPTION
## Summary
- keep the parent body info on one line in Photon Thrusters motion card

## Testing
- `npm test --silent`
- `npx jest --runTestsByPath tests/photonThrustersProject.test.js`

------
https://chatgpt.com/codex/tasks/task_b_6881afb4b97c8327a5ccf046c35faec3