### PR TITLE
Add Photon Thrusters investment toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,3 +194,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Moon thruster warning moved from the global warning box to a small notice within the Photon Thrusters card.
 - Numbers above sextillion now format as Sp, Oc and No up to 1e30.
 - Photon Thrusters project gains an energy investment UI with +/- buttons, 0, /10, x10 and Max. Invested energy drains every second and shows in resource rates.
+- Spin and motion options now include an Invest checkbox. Only one can be active at a time and the selection persists when saving.


### PR DESCRIPTION
## Summary
- add Invest checkboxes on Photon Thrusters spin and motion cards
- persist selected investment mode and energy data in save files
- require a mode to be selected for energy consumption
- test investment checkbox behaviour and save/load
- document new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881b01100648327a516ef9bc00410d1