### PR TITLE
Rework deeper mining registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,10 @@ second time they speak in a chapter to help clarify who is talking.
 - Deeper mining supports android assignments for massive speed boosts.
 - Android assignment UI initializes hidden and shows once the upgrade is researched.
 - Android project speed multiplier now adds 1 to the calculation and updates active progress bars immediately. The display reads "Deepening speed boost" beside the controls.
-- Deeper mining costs now scale with ore mines built and also increases ore mine construction costs. Android boost scales with built mines instead of deposits.
+- Deeper mining costs now scale with ore mines built. Android boost scales with built mines instead of deposits.
 - Deeper mining now uses a dedicated class `DeeperMiningProject`.
-- Deeper mining costs also scale with the number of project completions.
+- Project completions increase the average depth by one.
+- Deeper mining tracks ore mines built and their average depth. It pulls the count from buildings after each construction, and ore mine costs no longer increase.
 - Settings menu can disable the day-night cycle. Solar panels and Ice Harvesters operate at half strength and the progress bar hides.
 - Day-night toggle also halves maintenance for those structures and skips the penalty on Ice Harvesters once Infrared Vision is researched.
 - Restored the yellow/blue animation by re-linking the day-night cycle stylesheet.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -348,6 +348,12 @@ class Building extends EffectableEntity {
       const oldProductivity = this.productivity;
       this.count += buildCount;
       this.active += buildCount;
+      if (this.name === 'oreMine' && typeof projectManager !== 'undefined') {
+        const dm = projectManager.projects?.deeperMining;
+        if (dm && typeof dm.registerMine === 'function') {
+          dm.registerMine();
+        }
+      }
       if(this.active > 0){
         this.productivity = oldProductivity * (oldActive / this.active);
       } else {

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -149,7 +149,7 @@ const projectParameters = {
       }
     },
     duration: 120000,
-    description: "Deepens all ore mines to improve production, adding one layer.  Each completion improves metal production by an additive 100%.  The price scales with the number of ore mines constructed and the number of project completions.  The price of ore mines is also adjusted with each completion.",
+    description: "Deepens all ore mines to improve production, adding one layer. Each completion improves metal production by an additive 100%. Cost scales with the number of ore mines and their average depth.",
     repeatable: true,
     maxRepeatCount: 10000,
     unlocked : false,
@@ -162,24 +162,6 @@ const projectParameters = {
           targetId: 'oreMine',
           effectId: 'deeper_mining',
           type: 'productionMultiplier',
-          value: 1
-        },
-        {
-          target: 'building',
-          targetId: 'oreMine',
-          effectId: 'deeper_mining_cost_metal',
-          type: 'resourceCostMultiplier',
-          resourceCategory: 'colony',
-          resourceId: 'metal',
-          value: 1
-        },
-        {
-          target: 'building',
-          targetId: 'oreMine',
-          effectId: 'deeper_mining_cost_components',
-          type: 'resourceCostMultiplier',
-          resourceCategory: 'colony',
-          resourceId: 'components',
           value: 1
         }
       ]

--- a/tests/deeperMiningCostScaling.test.js
+++ b/tests/deeperMiningCostScaling.test.js
@@ -26,12 +26,13 @@ describe('Deeper mining cost scaling', () => {
       attributes: { costOreMineScaling: true }
     };
     const p = new ctx.DeeperMiningProject(config, 'deeperMining');
+    p.registerMine();
     const cost = p.getScaledCost();
     expect(cost.colony.electronics).toBe(50);
     expect(cost.colony.components).toBe(50);
   });
 
-  test('cost also scales with completions', () => {
+  test('cost uses average depth not completions', () => {
     const ctx = { console, EffectableEntity };
     ctx.buildings = { oreMine: { count: 3 } };
     vm.createContext(ctx);
@@ -53,9 +54,11 @@ describe('Deeper mining cost scaling', () => {
       attributes: { costOreMineScaling: true }
     };
     const p = new ctx.DeeperMiningProject(config, 'deeperMining');
+    p.registerMine();
+    p.averageDepth = 4;
     p.repeatCount = 2;
     const cost = p.getScaledCost();
-    expect(cost.colony.electronics).toBe(90);
-    expect(cost.colony.components).toBe(90);
+    expect(cost.colony.electronics).toBe(120);
+    expect(cost.colony.components).toBe(120);
   });
 });

--- a/tests/deeperMiningRegisterMine.test.js
+++ b/tests/deeperMiningRegisterMine.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Deeper mining registerMine updates depth', () => {
+  test('average depth updates when mines built', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.buildings = { oreMine: { count: 0 } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const deeperCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'DeeperMiningProject.js'), 'utf8');
+    vm.runInContext(deeperCode + '; this.DeeperMiningProject = DeeperMiningProject;', ctx);
+    const config = { name: 'deeperMining', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: { costOreMineScaling: true }};
+    const p = new ctx.DeeperMiningProject(config, 'deeperMining');
+    ctx.buildings.oreMine.count = 4;
+    p.registerMine();
+    expect(p.oreMineCount).toBe(4);
+    expect(p.averageDepth).toBe(1);
+    p.averageDepth = 2;
+    ctx.buildings.oreMine.count = 6;
+    p.registerMine();
+    expect(p.oreMineCount).toBe(6);
+    expect(p.averageDepth).toBeCloseTo((2 * 4 + 2) / 6);
+  });
+});


### PR DESCRIPTION
## Summary
- clarify deeper mining patch notes for depth scaling
- have DeeperMiningProject read ore mine count when registering
- call `registerMine` with no argument when ore mines built
- adjust deeper mining tests for new registration logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6882423a482c8327b73baa089fff1b73