### PR TITLE
Update deeper mining scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - Keep imports and exports browser friendly for loading via **index.html**.
 - The game needs to be able to run from a browser-like environment.
 - Place story projects in **progress-data.js** near the chapter where they unlock.
+- Tooltips should use a `<span class="info-tooltip-icon">&#9432;</span>` element with a descriptive `title`.
 
 # Overview of code
 This repository contains a browser-based incremental game written in JavaScript. The
@@ -198,3 +199,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Spin and motion options now include an Invest checkbox. Only one can be active at a time and the selection persists when saving.
 - Photon thruster energy now alters spin or orbit when invested, and moons drift outward toward escape.
 - Escaped moons replace their parent body with "Star" and no longer count as moons.
+- Deeper mining costs now scale 90% with ore mines and 10% with average depth. A tooltip on the project card explains the formula.
+- Android assignment speed tooltip now states "1 + sqrt(androids assigned / ore mines built)".

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -149,7 +149,7 @@ const projectParameters = {
       }
     },
     duration: 120000,
-    description: "Deepens all ore mines to improve production, adding one layer. Each completion improves metal production by an additive 100%. Cost scales with the number of ore mines and their average depth.",
+    description: "Deepens all ore mines to improve production, adding one layer. Each completion improves metal production by an additive 100%. Most of the cost scales with ore mines built while a small portion also scales with their average depth.",
     repeatable: true,
     maxRepeatCount: 10000,
     unlocked : false,

--- a/src/js/projects/AndroidProject.js
+++ b/src/js/projects/AndroidProject.js
@@ -119,7 +119,7 @@ class AndroidProject extends Project {
 
     const speedDisplay = document.createElement('div');
     speedDisplay.id = `${this.name}-android-speed`;
-    speedDisplay.title = '1 + sqrt(androids assigned / ore veins max deposits)';
+    speedDisplay.title = '1 + sqrt(androids assigned / ore mines built)';
     multiplierContainer.appendChild(speedDisplay);
 
     assignmentContainer.append(assignedAndAvailableContainer, buttonsContainer);

--- a/src/js/projects/DeeperMiningProject.js
+++ b/src/js/projects/DeeperMiningProject.js
@@ -26,7 +26,7 @@ class DeeperMiningProject extends AndroidProject {
     if (this.attributes.costOreMineScaling) {
       const oreMines = Math.max(this.oreMineCount, 1);
       const depth = this.averageDepth;
-      const multiplier = oreMines * depth;
+      const multiplier = oreMines * (0.9 + 0.1 * depth);
       const scaledCost = {};
       for (const category in cost) {
         scaledCost[category] = {};
@@ -45,6 +45,18 @@ class DeeperMiningProject extends AndroidProject {
     if (elements?.androidSpeedDisplay) {
       const mult = this.getAndroidSpeedMultiplier();
       elements.androidSpeedDisplay.textContent = `Deepening speed boost x${formatNumber(mult, true)}`;
+    }
+  }
+
+  renderUI(container) {
+    super.renderUI(container);
+    const elements = projectElements[this.name];
+    if (elements?.costElement) {
+      const info = document.createElement('span');
+      info.classList.add('info-tooltip-icon');
+      info.title = '90% of the cost scales with ore mines built. 10% also scales with average depth.';
+      info.innerHTML = '&#9432;';
+      elements.costElement.appendChild(info);
     }
   }
 

--- a/tests/deeperMiningCostScaling.test.js
+++ b/tests/deeperMiningCostScaling.test.js
@@ -32,7 +32,7 @@ describe('Deeper mining cost scaling', () => {
     expect(cost.colony.components).toBe(50);
   });
 
-  test('cost uses average depth not completions', () => {
+  test('cost partially scales with depth', () => {
     const ctx = { console, EffectableEntity };
     ctx.buildings = { oreMine: { count: 3 } };
     vm.createContext(ctx);
@@ -58,7 +58,7 @@ describe('Deeper mining cost scaling', () => {
     p.averageDepth = 4;
     p.repeatCount = 2;
     const cost = p.getScaledCost();
-    expect(cost.colony.electronics).toBe(120);
-    expect(cost.colony.components).toBe(120);
+    expect(cost.colony.electronics).toBeCloseTo(39);
+    expect(cost.colony.components).toBeCloseTo(39);
   });
 });


### PR DESCRIPTION
## Summary
- explain tooltip guidelines
- rebalance Deeper Mining costs (90% scale with ore mines, 10% with depth)
- show cost scaling tooltip on Deeper Mining project
- correct Android speed multiplier tooltip
- adjust test for new cost formula

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688246aaa7748327844cc58d9a394c1d