### PR TITLE
Fix deeper mining effect scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,3 +202,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Deeper mining costs now scale 90% with ore mines and 10% with average depth. A tooltip on the project card explains the formula.
 - Android assignment speed tooltip now states "1 + sqrt(androids assigned / ore mines built)".
 - Deeper mining projects track maximum depth instead of repeat count and display average depth in the UI.
+- Deeper mining effects now reapply when average depth changes and old saves default depth to completions.

--- a/src/js/projects/DeeperMiningProject.js
+++ b/src/js/projects/DeeperMiningProject.js
@@ -19,6 +19,9 @@ class DeeperMiningProject extends AndroidProject {
       const totalDepth = this.averageDepth * current;
       this.oreMineCount = built;
       this.averageDepth = (totalDepth + delta) / this.oreMineCount;
+      if (this.attributes?.completionEffect) {
+        this.applyCompletionEffect();
+      }
     }
   }
 
@@ -107,8 +110,22 @@ class DeeperMiningProject extends AndroidProject {
 
   loadState(state) {
     super.loadState(state);
-    this.oreMineCount = state.oreMineCount || 0;
-    this.averageDepth = state.averageDepth || 1;
+    let built = 0;
+    if (typeof buildings !== 'undefined' && buildings.oreMine) {
+      built = buildings.oreMine.count;
+    } else if (typeof globalThis !== 'undefined' && globalThis.buildings?.oreMine) {
+      built = globalThis.buildings.oreMine.count;
+    }
+    this.oreMineCount =
+      state.oreMineCount !== undefined ? state.oreMineCount : built;
+    if (state.averageDepth !== undefined) {
+      this.averageDepth = state.averageDepth;
+    } else {
+      this.averageDepth = (this.repeatCount || 0) + 1;
+    }
+    if (this.attributes?.completionEffect) {
+      this.applyCompletionEffect();
+    }
   }
 }
 

--- a/tests/deeperMiningEffectUpdate.test.js
+++ b/tests/deeperMiningEffectUpdate.test.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Deeper mining effect updates with depth', () => {
+  test('ore mine multiplier adjusts when average depth changes', () => {
+    const oreMine = new EffectableEntity({ description: 'oreMine' });
+    oreMine.name = 'oreMine';
+    oreMine.count = 2;
+    global.buildings = { oreMine };
+    global.EffectableEntity = EffectableEntity;
+    global.addEffect = (effect) => {
+      if (effect.target === 'building' && effect.targetId === 'oreMine') {
+        oreMine.addAndReplace(effect);
+      }
+    };
+    const ctx = { console, EffectableEntity, buildings: global.buildings, addEffect: global.addEffect };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const deeperCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'DeeperMiningProject.js'), 'utf8');
+    vm.runInContext(deeperCode + '; this.DeeperMiningProject = DeeperMiningProject;', ctx);
+
+    const config = {
+      name: 'deeperMining',
+      category: 'infrastructure',
+      cost: {},
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxDepth: Infinity,
+      unlocked: true,
+      attributes: {
+        effectScaling: true,
+        completionEffect: [{
+          target: 'building',
+          targetId: 'oreMine',
+          effectId: 'deeper_mining',
+          type: 'productionMultiplier',
+          value: 1
+        }]
+      }
+    };
+
+    const project = new ctx.DeeperMiningProject(config, 'deeperMining');
+    project.repeatCount = 1;
+    project.averageDepth = 2;
+    project.applyCompletionEffect();
+    let effect = oreMine.activeEffects.find(e => e.effectId === 'deeper_mining');
+    expect(effect.value).toBe(2);
+
+    oreMine.count = 3;
+    project.registerMine();
+    effect = oreMine.activeEffects.find(e => e.effectId === 'deeper_mining');
+    expect(effect.value).toBeCloseTo(project.averageDepth);
+  });
+});


### PR DESCRIPTION
## Summary
- update deeper mining mines when average depth changes
- load average depth from repeatCount when missing
- describe deeper mining effect update in `AGENTS.md`
- add test for updated effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68825854dc288327acf656c1d9d66114