### PR TITLE
Add Warp Gate Command subtab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,3 +203,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Android assignment speed tooltip now states "1 + sqrt(androids assigned / ore mines built)".
 - Deeper mining projects track maximum depth instead of repeat count and display average depth in the UI.
 - Deeper mining effects now reapply when average depth changes and old saves default depth to completions.
+- Added Warp Gate Command manager with a WGC subtab (wgc.js and wgcUI.js). The subtab remains hidden until unlocked and the manager persists across planets.

--- a/index.html
+++ b/index.html
@@ -106,6 +106,8 @@
     <script src="src/js/hopeUI.js"></script>
     <script src="src/js/solis.js"></script>
     <script src="src/js/solisUI.js"></script>
+    <script src="src/js/wgc.js"></script>
+    <script src="src/js/wgcUI.js"></script>
     <script src="src/js/globals.js"></script>
     <script src="src/js/game-speed.js"></script>
     <script src="src/js/autobuild.js"></script>
@@ -369,6 +371,7 @@
             <div class="hope-subtabs">
                 <div class="hope-subtab active" data-subtab="awakening-hope">Awakening</div>
                 <div class="hope-subtab hidden" data-subtab="solis-hope">Solis<span id="solis-subtab-alert" class="hope-alert">!</span></div>
+                <div class="hope-subtab hidden" data-subtab="wgc-hope">WGC</div>
             </div>
             <div class="hope-subtab-content-wrapper">
                 <div id="awakening-hope" class="hope-subtab-content active">
@@ -404,6 +407,11 @@
                         <div class="solis-shop">
                             <div id="solis-shop-items"></div>
                         </div>
+                    </div>
+                </div>
+                <div id="wgc-hope" class="hope-subtab-content hidden">
+                    <div class="wgc-container">
+                        <p>Warp Gate Command coming soon...</p>
                     </div>
                 </div>
             </div>

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -91,6 +91,7 @@ function create() {
   goldenAsteroid = new GoldenAsteroid();
 
   solisManager = new SolisManager();
+  warpGateCommand = new WarpGateCommand();
 
   lifeDesigner = new LifeDesigner();
   lifeManager = new LifeManager();
@@ -190,6 +191,9 @@ function initializeGameState(options = {}) {
   if (!preserveManagers || !solisManager) {
     solisManager = new SolisManager();
   }
+  if (!preserveManagers || !warpGateCommand) {
+    warpGateCommand = new WarpGateCommand();
+  }
 
   lifeDesigner = new LifeDesigner();
   lifeManager = new LifeManager();
@@ -238,6 +242,9 @@ function initializeGameState(options = {}) {
   if (preserveManagers && solisManager && typeof solisManager.reapplyEffects === 'function') {
     solisManager.reapplyEffects();
   }
+  if (preserveManagers && warpGateCommand && typeof warpGateCommand.reapplyEffects === 'function') {
+    warpGateCommand.reapplyEffects();
+  }
 }
 
 function updateLogic(delta) {
@@ -267,6 +274,9 @@ function updateLogic(delta) {
 
   if (solisManager) {
     solisManager.update(delta);
+  }
+  if (warpGateCommand) {
+    warpGateCommand.update(delta);
   }
 
   lifeDesigner.update(delta);

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -47,5 +47,6 @@ let ghgFactorySettings = {
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
 let skillManager;
 let solisManager;
+let warpGateCommand;
 let playTimeSeconds = 0;
 let gameSpeed = 1;

--- a/src/js/hopeUI.js
+++ b/src/js/hopeUI.js
@@ -22,6 +22,9 @@ function initializeHopeUI() {
     if (typeof initializeSolisUI === 'function') {
         initializeSolisUI();
     }
+    if (typeof initializeWGCUI === 'function') {
+        initializeWGCUI();
+    }
 }
 
 function updateHopeAlert() {
@@ -51,6 +54,12 @@ function updateHopeUI() {
     }
     if (typeof updateSolisUI === 'function') {
         updateSolisUI();
+    }
+    if (typeof updateWGCVisibility === 'function') {
+        updateWGCVisibility();
+    }
+    if (typeof updateWGCUI === 'function') {
+        updateWGCUI();
     }
     updateHopeAlert();
 }

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -1,0 +1,29 @@
+class WarpGateCommand extends EffectableEntity {
+  constructor() {
+    super({ description: 'Warp Gate Command manager' });
+    this.enabled = false;
+  }
+
+  enable() {
+    this.enabled = true;
+    if (typeof showWGCTab === 'function') {
+      showWGCTab();
+    }
+  }
+
+  update(_delta) {
+    // placeholder for future behavior
+  }
+
+  saveState() {
+    return { enabled: this.enabled };
+  }
+
+  loadState(data = {}) {
+    this.enabled = data.enabled || false;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { WarpGateCommand };
+}

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -1,0 +1,41 @@
+let wgcTabVisible = false;
+let wgcUIInitialized = false;
+
+function showWGCTab() {
+  wgcTabVisible = true;
+  const tab = document.querySelector('.hope-subtab[data-subtab="wgc-hope"]');
+  const content = document.getElementById('wgc-hope');
+  if (tab) tab.classList.remove('hidden');
+  if (content) content.classList.remove('hidden');
+}
+
+function hideWGCTab() {
+  wgcTabVisible = false;
+  const tab = document.querySelector('.hope-subtab[data-subtab="wgc-hope"]');
+  const content = document.getElementById('wgc-hope');
+  if (tab) tab.classList.add('hidden');
+  if (content) content.classList.add('hidden');
+}
+
+function updateWGCVisibility() {
+  if (typeof warpGateCommand === 'undefined') return;
+  if (warpGateCommand.enabled) {
+    if (!wgcTabVisible) showWGCTab();
+  } else if (wgcTabVisible) {
+    hideWGCTab();
+  }
+}
+
+function initializeWGCUI() {
+  if (wgcUIInitialized) return;
+  hideWGCTab();
+  wgcUIInitialized = true;
+}
+
+function updateWGCUI() {
+  // future UI updates
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { hideWGCTab, showWGCTab, updateWGCVisibility };
+}

--- a/tests/wgcTabDynamicVisibility.test.js
+++ b/tests/wgcTabDynamicVisibility.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC subtab visibility reflects enabled flag', () => {
+  test('updateHopeUI shows and hides the tab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="hope-subtab hidden" data-subtab="wgc-hope"></div>
+      <div id="wgc-hope" class="hope-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = WarpGateCommand;
+    vm.createContext(ctx);
+    const wgcUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    const hopeUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'hopeUI.js'), 'utf8');
+    vm.runInContext(`${wgcUICode}\n${hopeUICode}`, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateHopeUI();
+
+    let tab = dom.window.document.querySelector('[data-subtab="wgc-hope"]');
+    let content = dom.window.document.getElementById('wgc-hope');
+    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+
+    ctx.warpGateCommand.enable();
+    ctx.updateHopeUI();
+    expect(tab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+
+    ctx.warpGateCommand.enabled = false;
+    ctx.updateHopeUI();
+    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/tests/wgcTabHiddenByDefault.test.js
+++ b/tests/wgcTabHiddenByDefault.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('WGC tab hidden by default', () => {
+  test('initializeWGCUI hides tab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="hope-subtab" data-subtab="wgc-hope"></div>
+      <div id="wgc-hope"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+    ctx.initializeWGCUI();
+    const tab = dom.window.document.querySelector('[data-subtab="wgc-hope"]');
+    const content = dom.window.document.getElementById('wgc-hope');
+    const visible = vm.runInContext('wgcTabVisible', ctx);
+    expect(visible).toBe(false);
+    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/tests/wgcTabHiddenMarkup.test.js
+++ b/tests/wgcTabHiddenMarkup.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('WGC subtab markup', () => {
+  test('index.html hides WGC tab by default', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    expect(html).toMatch(/<div class="hope-subtab hidden" data-subtab="wgc-hope">/);
+    expect(html).toMatch(/<div id="wgc-hope" class="hope-subtab-content hidden">/);
+  });
+});

--- a/tests/wgcTravelPersistence.test.js
+++ b/tests/wgcTravelPersistence.test.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('WGC state persists across planet travel', () => {
+  test('traveling does not reset warpGateCommand', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) { this.config = config; },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+
+    vm.runInContext('warpGateCommand.enabled = true;', ctx);
+    const before = vm.runInContext('warpGateCommand', ctx);
+
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const after = vm.runInContext('warpGateCommand', ctx);
+    const flag = vm.runInContext('warpGateCommand.enabled', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(after).toBe(before);
+    expect(flag).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce WGC manager with persistence
- create `wgc.js` and `wgcUI.js` for new Warp Gate Command subtab
- load the WGC scripts in `index.html` and add hidden markup
- expose `warpGateCommand` in globals and hook it into game lifecycle
- update Hope UI to handle the new subtab
- document feature in `AGENTS.md`
- test WGC subtab visibility and persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6882a4e4ed6c83279b2deca038ad08e5