### PR TITLE
Fix thruster UI default calculations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,3 +205,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Deeper mining effects now reapply when average depth changes and old saves default depth to completions.
 - Added Warp Gate Command manager with a WGC subtab (wgc.js and wgcUI.js). The subtab remains hidden until unlocked and the manager persists across planets.
 - Planetary Thrusters now use continuous power with internal element references and save/load their investment state.
+- Planetary Thrusters UI now calculates delta-v and energy using the entered targets and hides spiral Δv until moons escape.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -89,7 +89,7 @@ class PlanetaryThrustersProject extends Project{
         </div>
         <div><span class="stat-label">Target:</span>
              <input id="distTarget" type="number" min="0.1" step="0.1" value="1"><span>AU</span></div>
-        <div><span class="stat-label">Spiral Δv:</span><span id="distDv" class="stat-value">—</span></div>
+        <div id="spiralRow"><span class="stat-label">Spiral Δv:</span><span id="distDv" class="stat-value">—</span></div>
         <div id="escapeRow" style="display:none;">
              <span class="stat-label">Escape Δv:</span><span id="escDv" class="stat-value">—</span>
         </div>
@@ -115,7 +115,7 @@ class PlanetaryThrustersProject extends Project{
       rotDv:g('#rotDv',spinCard),rotE:g('#rotE',spinCard),rotCb:g('#rotInvest',spinCard),
       distNow:g('#distNow',motCard),distTarget:g('#distTarget',motCard),
       distDv:g('#distDv',motCard),distE:g('#distE',motCard),distCb:g('#distInvest',motCard),
-      escRow:g('#escapeRow',motCard),escDv:g('#escDv',motCard),
+      spiralRow:g('#spiralRow',motCard),escRow:g('#escapeRow',motCard),escDv:g('#escDv',motCard),
       parentRow:g('#parentRow',motCard),parentName:g('#parentName',motCard),
       parentRad:g('#parentRad',motCard),moonWarn:g('#moonWarn',motCard),
       pwrVal:g('#pwrVal',pwrCard),pPlus:g('#pPlus',pwrCard),pMinus:g('#pMinus',pwrCard),
@@ -162,12 +162,14 @@ class PlanetaryThrustersProject extends Project{
       this.el.escDv.textContent=fmt(esc,false,3)+" m/s";
       this.el.escRow.style.display="block";
       this.el.parentRow.style.display="block";this.el.moonWarn.style.display="block";
+      this.el.spiralRow.style.display="none";
       this.el.parentName.textContent=parent.name||"Parent";
       this.el.parentRad.textContent=fmt(parent.orbitRadius,false,0)+" km";
       this.el.distDv.textContent="—";
       this.el.distE.textContent=formatEnergy(0.5*p.mass*FUSION_VE*esc);
     }else{
       this.el.escRow.style.display=this.el.parentRow.style.display=this.el.moonWarn.style.display="none";
+      this.el.spiralRow.style.display="block";
       const dv=spiralDeltaV(p.distanceFromSun||this.tgtAU,this.tgtAU);
       this.el.distDv.textContent=fmt(dv,false,3)+" m/s";
       this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dv));
@@ -209,8 +211,14 @@ class PlanetaryThrustersProject extends Project{
     this.el.pPlus.textContent="+"+fmt(this.step,true);
     this.el.pMinus.textContent="-"+fmt(this.step,true);
 
-    /* live energy cost refresh */
-    if(p && !p.parentBody){
+    /* default cost display based on current targets */
+    if(this.el.rotTarget && typeof this.el.rotTarget.value==='string' && !this.spinInvest)
+      this.calcSpinCost();
+    if(this.el.distTarget && typeof this.el.distTarget.value==='string' && !this.motionInvest)
+      this.calcMotionCost();
+
+    /* update remaining energy when investing */
+    if(p && this.motionInvest){
       const dvRem=Math.max(0,this.dVreq-this.dVdone);
       this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dvRem));
     }

--- a/tests/planetaryThrustersUIDefault.test.js
+++ b/tests/planetaryThrustersUIDefault.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+const thrusterCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'PlanetaryThrustersProject.js'), 'utf8');
+const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+
+describe('Planetary Thrusters UI', () => {
+  test('shows default delta v and energy', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.terraforming = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
+
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(thrusterCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.planetaryThruster;
+    const project = new ctx.PlanetaryThrustersProject(config, 'thruster');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    project.updateUI();
+
+    expect(project.el.rotDv.textContent).not.toBe('—');
+    expect(project.el.rotE.textContent).not.toBe('—');
+    expect(project.el.distDv.textContent).not.toBe('—');
+    expect(project.el.distE.textContent).not.toBe('—');
+  });
+
+  test('hides spiral delta v when moon bound', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.terraforming = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 10, parentBody: { name: 'Planet', mass: 5e24, orbitRadius: 50000, distanceFromSun: 1 } } };
+    ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
+
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(thrusterCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.planetaryThruster;
+    const project = new ctx.PlanetaryThrustersProject(config, 'thrusterMoon');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    project.updateUI();
+
+    expect(project.el.spiralRow.style.display).toBe('none');
+    expect(project.el.escRow.style.display).toBe('block');
+  });
+});


### PR DESCRIPTION
## Summary
- update Planetary Thrusters project UI to compute costs from inputs
- hide spiral delta-V until moons escape
- add tests for default values and moon visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6883e1329f2083278d74e612db050045