### PR TITLE
Hide planetary thruster controls until unlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,3 +206,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Warp Gate Command manager with a WGC subtab (wgc.js and wgcUI.js). The subtab remains hidden until unlocked and the manager persists across planets.
 - Planetary Thrusters now use continuous power with internal element references and save/load their investment state.
 - Planetary Thrusters UI now calculates delta-v and energy using the entered targets and hides spiral Δv until moons escape.
+- Spin, motion and thruster power cards stay hidden until the project is unlocked.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -77,6 +77,7 @@ class PlanetaryThrustersProject extends Project{
       <div class="invest-container left"><label><input id="rotInvest" type="checkbox"> Invest</label></div>
     </div>`;
     const spinCard=document.createElement('div');spinCard.className="info-card";spinCard.innerHTML=spinHTML;c.appendChild(spinCard);
+    spinCard.style.display=this.unlocked?"block":"none";
 
     /* motion */
     const motHTML=`<div class="card-header"><span class="card-title">Motion</span></div>
@@ -99,6 +100,7 @@ class PlanetaryThrustersProject extends Project{
       <div id="moonWarn" class="moon-warning" style="display:none;">⚠ Escape parent first</div>
     </div>`;
     const motCard=document.createElement('div');motCard.className="info-card";motCard.innerHTML=motHTML;c.appendChild(motCard);
+    motCard.style.display=this.unlocked?"block":"none";
 
     /* power */
     const pwrHTML=`<div class="card-header"><span class="card-title">Thruster Power</span></div>
@@ -108,10 +110,12 @@ class PlanetaryThrustersProject extends Project{
         <button id="pPlus">+</button><button id="pDiv">/10</button><button id="pMul">x10</button></div>
     </div>`;
     const pwrCard=document.createElement('div');pwrCard.className="info-card";pwrCard.innerHTML=pwrHTML;c.appendChild(pwrCard);
+    pwrCard.style.display=this.unlocked?"block":"none";
 
     /* refs */
     const g=(sel,r)=>r.querySelector(sel);
-    this.el={rotNow:g('#rotNow',spinCard),rotTarget:g('#rotTarget',spinCard),
+    this.el={spinCard, motCard, pwrCard,
+      rotNow:g('#rotNow',spinCard),rotTarget:g('#rotTarget',spinCard),
       rotDv:g('#rotDv',spinCard),rotE:g('#rotE',spinCard),rotCb:g('#rotInvest',spinCard),
       distNow:g('#distNow',motCard),distTarget:g('#distTarget',motCard),
       distDv:g('#distDv',motCard),distE:g('#distE',motCard),distCb:g('#distInvest',motCard),
@@ -202,6 +206,12 @@ class PlanetaryThrustersProject extends Project{
 
 /* ---------- UI refresh ------------------------------------------------ */
   updateUI(){
+    if(this.el.spinCard){
+      const vis = this.unlocked ? 'block' : 'none';
+      this.el.spinCard.style.display = vis;
+      this.el.motCard.style.display = vis;
+      this.el.pwrCard.style.display = vis;
+    }
     const p=terraforming.celestialParameters||{};
     this.el.rotNow.textContent = fmt(getRotHours(p)/24,false,3)+" days";
     this.el.distNow.textContent = p.parentBody?

--- a/tests/planetaryThrustersVisibility.test.js
+++ b/tests/planetaryThrustersVisibility.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const numbers = require('../src/js/numbers.js');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+const thrusterCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'PlanetaryThrustersProject.js'), 'utf8');
+const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+
+describe('Planetary Thrusters visibility', () => {
+  test('subcards hidden until unlocked', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.terraforming = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(thrusterCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.planetaryThruster;
+    const project = new ctx.PlanetaryThrustersProject(config, 'thruster');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    project.updateUI();
+
+    expect(project.el.spinCard.style.display).toBe('none');
+    expect(project.el.motCard.style.display).toBe('none');
+    expect(project.el.pwrCard.style.display).toBe('none');
+
+    project.enable();
+    project.updateUI();
+    expect(project.el.spinCard.style.display).toBe('block');
+    expect(project.el.motCard.style.display).toBe('block');
+    expect(project.el.pwrCard.style.display).toBe('block');
+  });
+});


### PR DESCRIPTION
## Summary
- hide planetary thruster spin/motion/power cards when locked
- toggle cards on updateUI when project unlocked
- add test for visibility toggle
- document feature change in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6883e518721c83279553aa96a777dbb4