### PR TITLE
Fix thruster subcard visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,5 +206,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Warp Gate Command manager with a WGC subtab (wgc.js and wgcUI.js). The subtab remains hidden until unlocked and the manager persists across planets.
 - Planetary Thrusters now use continuous power with internal element references and save/load their investment state.
 - Planetary Thrusters UI now calculates delta-v and energy using the entered targets and hides spiral Δv until moons escape.
-- Spin, motion and thruster power cards stay hidden until the project is unlocked.
+- Spin, motion and thruster power cards stay hidden until the project is completed.
 - Thruster power display now uses `formatNumber` and energy consumption registers in resource rates.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -77,7 +77,7 @@ class PlanetaryThrustersProject extends Project{
       <div class="invest-container left"><label><input id="rotInvest" type="checkbox"> Invest</label></div>
     </div>`;
     const spinCard=document.createElement('div');spinCard.className="info-card";spinCard.innerHTML=spinHTML;c.appendChild(spinCard);
-    spinCard.style.display=this.unlocked?"block":"none";
+    spinCard.style.display=this.isCompleted?"block":"none";
 
     /* motion */
     const motHTML=`<div class="card-header"><span class="card-title">Motion</span></div>
@@ -100,7 +100,7 @@ class PlanetaryThrustersProject extends Project{
       <div id="moonWarn" class="moon-warning" style="display:none;">⚠ Escape parent first</div>
     </div>`;
     const motCard=document.createElement('div');motCard.className="info-card";motCard.innerHTML=motHTML;c.appendChild(motCard);
-    motCard.style.display=this.unlocked?"block":"none";
+    motCard.style.display=this.isCompleted?"block":"none";
 
     /* power */
     const pwrHTML=`<div class="card-header"><span class="card-title">Thruster Power</span></div>
@@ -121,7 +121,7 @@ class PlanetaryThrustersProject extends Project{
       </div>
     </div>`;
     const pwrCard=document.createElement('div');pwrCard.className="info-card";pwrCard.innerHTML=pwrHTML;c.appendChild(pwrCard);
-    pwrCard.style.display=this.unlocked?"block":"none";
+    pwrCard.style.display=this.isCompleted?"block":"none";
 
     /* refs */
     const g=(sel,r)=>r.querySelector(sel);
@@ -216,7 +216,7 @@ class PlanetaryThrustersProject extends Project{
 /* ---------- UI refresh ------------------------------------------------ */
   updateUI(){
     if(this.el.spinCard){
-      const vis = this.unlocked ? 'block' : 'none';
+      const vis = this.isCompleted ? 'block' : 'none';
       this.el.spinCard.style.display = vis;
       this.el.motCard.style.display = vis;
       this.el.pwrCard.style.display = vis;

--- a/tests/planetaryThrustersVisibility.test.js
+++ b/tests/planetaryThrustersVisibility.test.js
@@ -37,6 +37,12 @@ describe('Planetary Thrusters visibility', () => {
 
     project.enable();
     project.updateUI();
+    expect(project.el.spinCard.style.display).toBe('none');
+    expect(project.el.motCard.style.display).toBe('none');
+    expect(project.el.pwrCard.style.display).toBe('none');
+
+    project.complete();
+    project.updateUI();
     expect(project.el.spinCard.style.display).toBe('block');
     expect(project.el.motCard.style.display).toBe('block');
     expect(project.el.pwrCard.style.display).toBe('block');


### PR DESCRIPTION
## Summary
- hide Planetary Thrusters spin, motion and power cards until the project is completed
- update visibility test for completion check
- document behaviour change in **AGENTS.md**

## Testing
- `npm test`
- `npx jest tests/planetaryThrustersVisibility.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_6883eb6b8d1883278078876dec49e3b0