### PR TITLE
Enable batch satellite building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,3 +208,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Planetary Thrusters UI now calculates delta-v and energy using the entered targets and hides spiral Δv until moons escape.
 - Spin, motion and thruster power cards stay hidden until the project is completed.
 - Thruster power display now uses `formatNumber` and energy consumption registers in resource rates.
+- Scanner projects can build multiple satellites at once using a quantity selector with 0, ±, x10 and /10 controls.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -1,4 +1,64 @@
 class ScannerProject extends Project {
+  constructor(config, name) {
+    super(config, name);
+    this.buildCount = 1;
+    this.step = 1;
+    this.activeBuildCount = 1;
+    this.el = {};
+  }
+
+  getColonistLimit() {
+    return Math.ceil((resources?.colony?.colonists?.value || 0) / 10000);
+  }
+
+  getEffectiveBuildCount(count = this.buildCount) {
+    const remaining = this.maxRepeatCount === Infinity ? Infinity : this.maxRepeatCount - this.repeatCount;
+    return Math.max(0, Math.min(count, remaining));
+  }
+
+  getScaledCost() {
+    const base = super.getScaledCost();
+    const count = this.isActive ? (this.activeBuildCount || 1) : this.getEffectiveBuildCount(Math.min(this.buildCount, this.getColonistLimit()));
+    const scaled = {};
+    for (const cat in base) {
+      scaled[cat] = {};
+      for (const res in base[cat]) {
+        scaled[cat][res] = base[cat][res] * count;
+      }
+    }
+    return scaled;
+  }
+
+  adjustBuildCount(delta) {
+    const limit = this.getColonistLimit();
+    this.buildCount = Math.max(0, Math.min(this.buildCount + delta, limit));
+  }
+
+  setBuildCount(val) {
+    const limit = this.getColonistLimit();
+    this.buildCount = Math.max(0, Math.min(val, limit));
+  }
+
+  start(resources) {
+    this.activeBuildCount = this.getEffectiveBuildCount(Math.min(this.buildCount, this.getColonistLimit()));
+    return super.start(resources);
+  }
+
+  complete() {
+    const n = this.activeBuildCount || 1;
+    for (let i = 0; i < n; i++) {
+      super.complete();
+      if (
+        this.attributes &&
+        this.attributes.scanner &&
+        this.attributes.scanner.canSearchForDeposits
+      ) {
+        this.applyScannerEffect();
+      }
+    }
+    this.activeBuildCount = 1;
+  }
+
   applyScannerEffect() {
     if (
       this.attributes.scanner &&
@@ -21,14 +81,57 @@ class ScannerProject extends Project {
     }
   }
 
-  complete() {
-    super.complete();
-    if (
-      this.attributes &&
-      this.attributes.scanner &&
-      this.attributes.scanner.canSearchForDeposits
-    ) {
-      this.applyScannerEffect();
+  renderUI(container) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'power-controls-wrapper';
+    const countContainer = document.createElement('div');
+    countContainer.className = 'invested-container';
+    const label = document.createElement('span');
+    label.className = 'stat-label';
+    label.textContent = 'Amount:';
+    const val = document.createElement('span');
+    val.id = `${this.name}-count`;
+    val.className = 'stat-value';
+    countContainer.append(label, val);
+
+    const controls = document.createElement('div');
+    controls.className = 'thruster-power-controls';
+    const main = document.createElement('div');
+    main.className = 'main-buttons';
+    const b0 = document.createElement('button');
+    b0.textContent = '0';
+    const bMinus = document.createElement('button');
+    bMinus.textContent = '-';
+    const bPlus = document.createElement('button');
+    bPlus.textContent = '+';
+    main.append(b0, bMinus, bPlus);
+
+    const mult = document.createElement('div');
+    mult.className = 'multiplier-container';
+    const bDiv = document.createElement('button');
+    bDiv.textContent = '/10';
+    const bMul = document.createElement('button');
+    bMul.textContent = 'x10';
+    mult.append(bDiv, bMul);
+
+    controls.append(main, mult);
+    wrapper.append(countContainer, controls);
+    container.appendChild(wrapper);
+
+    this.el = { val, bPlus, bMinus, bMul, bDiv, b0 };
+
+    const refresh = () => updateProjectUI(this.name);
+    bPlus.onclick = () => { this.adjustBuildCount(this.step); refresh(); };
+    bMinus.onclick = () => { this.adjustBuildCount(-this.step); refresh(); };
+    bMul.onclick = () => { this.step *= 10; refresh(); };
+    bDiv.onclick = () => { this.step = Math.max(1, this.step / 10); refresh(); };
+    b0.onclick = () => { this.setBuildCount(0); refresh(); };
+  }
+
+  updateUI() {
+    const elements = projectElements[this.name];
+    if (elements && elements.val) {
+      elements.val.textContent = formatNumber(this.buildCount, true);
     }
   }
 }

--- a/tests/scannerProjectBuildCount.test.js
+++ b/tests/scannerProjectBuildCount.test.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('ScannerProject build count', () => {
+  const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
+
+  function createContext() {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = {
+      colony: {
+        metal: { value: 1000, decrease(v){ this.value -= v; }, updateStorageCap(){} },
+        electronics: { value: 1000, decrease(){}, updateStorageCap(){} },
+        energy: { value: 1000000, decrease(){}, updateStorageCap(){} },
+        colonists: { value: 100000 }
+      }
+    };
+    ctx.oreScanner = {
+      scanData: { ore: { currentScanningStrength: 0 } },
+      adjustScanningStrength: jest.fn((t,v)=>{ ctx.oreScanner.scanData[t].currentScanningStrength = v; }),
+      startScan: jest.fn()
+    };
+    vm.createContext(ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
+    global.resources = ctx.resources;
+    global.oreScanner = ctx.oreScanner;
+    return ctx;
+  }
+
+  test('cost scales with build count and completions increase', () => {
+    const ctx = createContext();
+    const config = {
+      name: 'scan',
+      category: 'infra',
+      cost: { colony: { metal: 50 } },
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: 1000,
+      unlocked: true,
+      attributes: { scanner: { canSearchForDeposits: true, searchValue: 0.1, depositType: 'ore' } }
+    };
+    const project = new ctx.ScannerProject(config, 'scan');
+    project.buildCount = 5;
+    expect(project.getScaledCost().colony.metal).toBe(250);
+    project.start(ctx.resources);
+    expect(ctx.resources.colony.metal.value).toBe(750);
+    project.complete();
+    expect(project.repeatCount).toBe(5);
+    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledTimes(5);
+  });
+
+  test('build count cropped by colonists and remaining repeats', () => {
+    const ctx = createContext();
+    ctx.resources.colony.colonists.value = 5000; // limit 1
+    const config = {
+      name: 'scan',
+      category: 'infra',
+      cost: { colony: { metal: 50 } },
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: 3,
+      unlocked: true,
+      attributes: { scanner: { canSearchForDeposits: true, searchValue: 0.1, depositType: 'ore' } }
+    };
+    const project = new ctx.ScannerProject(config, 'scan');
+    project.repeatCount = 2;
+    project.buildCount = 5;
+    expect(project.getScaledCost().colony.metal).toBe(50); // only one allowed
+    project.start(ctx.resources);
+    project.complete();
+    expect(project.repeatCount).toBe(3);
+    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- allow ScannerProjects to build multiple satellites at a time
- add UI with +/-/0/x10/÷10 controls for build amount
- document the new feature in AGENTS
- test build count limits and scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688433878f0c83279e003ddf38e94f4d