### PR TITLE
Fix ore scanner amount display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,3 +209,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Spin, motion and thruster power cards stay hidden until the project is completed.
 - Thruster power display now uses `formatNumber` and energy consumption registers in resource rates.
 - Scanner projects can build multiple satellites at once using a quantity selector with 0, ±, x10 and /10 controls.
+- Quantity selector buttons display their effect: "+" and "-" show the current step (e.g. +1, -1, +10, -10). The x10 and /10 buttons multiply or divide the step, never dropping below 1, and the 0 button resets the count.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -92,7 +92,16 @@ class ScannerProject extends Project {
     const val = document.createElement('span');
     val.id = `${this.name}-count`;
     val.className = 'stat-value';
-    countContainer.append(label, val);
+    const slash = document.createElement('span');
+    slash.textContent = ' / ';
+    const max = document.createElement('span');
+    max.id = `${this.name}-max`;
+    max.className = 'stat-value';
+    const info = document.createElement('span');
+    info.className = 'info-tooltip-icon';
+    info.title = 'Colonists let us build scanners in parallel. One satellite can be produced per 10,000 colonists.';
+    info.innerHTML = '&#9432;';
+    countContainer.append(label, val, slash, max, info);
 
     const controls = document.createElement('div');
     controls.className = 'thruster-power-controls';
@@ -118,7 +127,7 @@ class ScannerProject extends Project {
     wrapper.append(countContainer, controls);
     container.appendChild(wrapper);
 
-    this.el = { val, bPlus, bMinus, bMul, bDiv, b0 };
+    this.el = { val, max, bPlus, bMinus, bMul, bDiv, b0 };
 
     const refresh = () => updateProjectUI(this.name);
     bPlus.onclick = () => { this.adjustBuildCount(this.step); refresh(); };
@@ -129,9 +138,17 @@ class ScannerProject extends Project {
   }
 
   updateUI() {
-    const elements = projectElements[this.name];
-    if (elements && elements.val) {
-      elements.val.textContent = formatNumber(this.buildCount, true);
+    if (this.el.val) {
+      this.el.val.textContent = formatNumber(this.buildCount, true);
+    }
+    if (this.el.max) {
+      this.el.max.textContent = formatNumber(this.getColonistLimit(), true);
+    }
+    if (this.el.bPlus) {
+      this.el.bPlus.textContent = `+${formatNumber(this.step, true)}`;
+    }
+    if (this.el.bMinus) {
+      this.el.bMinus.textContent = `-${formatNumber(this.step, true)}`;
     }
   }
 }

--- a/tests/scannerProjectUIUpdate.test.js
+++ b/tests/scannerProjectUIUpdate.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
+const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+
+describe('ScannerProject UI update', () => {
+  test('shows build count, cap and button steps', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="c"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.resources = { colony: { colonists: { value: 15000, displayName: 'Colonists' }, metal:{value:0,decrease(){},updateStorageCap(){}}, electronics:{value:0,decrease(){},updateStorageCap(){}}, energy:{value:0,decrease(){},updateStorageCap(){}} } };
+    ctx.oreScanner = { scanData:{ ore:{ currentScanningStrength:0 } }, adjustScanningStrength(){}, startScan(){} };
+
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const project = new ctx.ScannerProject(ctx.projectParameters.satellite, 'sat');
+    const container = ctx.document.getElementById('c');
+    project.renderUI(container);
+    project.updateUI();
+
+    expect(project.el.val.textContent).toBe('1');
+    expect(project.el.max.textContent).toBe('2');
+    expect(project.el.bPlus.textContent).toBe('+1');
+    expect(project.el.bMinus.textContent).toBe('-1');
+
+    project.el.bMul.click();
+    project.updateUI();
+    expect(project.el.bPlus.textContent).toBe('+10');
+    expect(project.el.bMinus.textContent).toBe('-10');
+  });
+});


### PR DESCRIPTION
## Summary
- show build amount in ScannerProject UI
- show colonist cap with tooltip
- update + and - buttons to display step size
- document button behaviour in AGENTS
- test ScannerProject UI updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688436fd19448327b7cce188906f0d08