### PR TITLE
Add Warp Gate Command dynamic layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,3 +209,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Spin, motion and thruster power cards stay hidden until the project is completed.
 - Thruster power display now uses `formatNumber` and energy consumption registers in resource rates.
 - Scanner projects can build multiple satellites at once using a quantity selector with 0, ±, x10 and /10 controls.
+- Warp Gate Command UI now features an R&D section and team management cards.
+- WGC layout is generated dynamically via wgcUI.js instead of hardcoded in index.html.

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <link rel="stylesheet" href="src/css/skillsUI.css">
     <link rel="stylesheet" href="src/css/solis.css">
     <link rel="stylesheet" href="src/css/pause.css">
+    <link rel="stylesheet" href="src/css/wgc.css">
 
     <!-- Parameter Scripts -->
     <script src="src/js/planet-parameters.js"></script>
@@ -411,9 +412,7 @@
                     </div>
                 </div>
                 <div id="wgc-hope" class="hope-subtab-content hidden">
-                    <div class="wgc-container">
-                        <p>Warp Gate Command coming soon...</p>
-                    </div>
+                    <!-- UI generated dynamically -->
                 </div>
             </div>
         </div>

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -1,0 +1,60 @@
+/* Styles for Warp Gate Command UI */
+.wgc-main {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+#wgc-rd-section {
+  flex: 1;
+}
+
+#wgc-teams-section {
+  flex: 2;
+}
+
+.wgc-team-card {
+  background-color: #f9f9f9;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.wgc-team-card .team-header {
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
+.wgc-team-body {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.team-slots {
+  display: flex;
+  gap: 5px;
+}
+
+.team-slot {
+  width: 50px;
+  height: 50px;
+  border: 1px dashed #999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.team-slot button {
+  width: 100%;
+  height: 100%;
+  font-size: 1.5em;
+}
+
+.team-controls {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -26,9 +26,55 @@ function updateWGCVisibility() {
   }
 }
 
+function generateWGCTeamCards() {
+  const names = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'];
+  return names.map(name => `
+    <div class="wgc-team-card">
+      <div class="team-header">Team ${name}</div>
+      <div class="wgc-team-body">
+        <div class="team-slots">
+          <div class="team-slot"><button>+</button></div>
+          <div class="team-slot"><button>+</button></div>
+          <div class="team-slot"><button>+</button></div>
+          <div class="team-slot"><button>+</button></div>
+        </div>
+        <div class="team-controls">
+          <button>Start</button>
+          <button>Recall</button>
+        </div>
+      </div>
+    </div>
+  `).join('');
+}
+
+function generateWGCLayout() {
+  return `
+    <div class="wgc-container">
+      <div class="wgc-main">
+        <div id="wgc-rd-section">
+          <h3>R&amp;D</h3>
+          <div id="wgc-rd-menu"></div>
+        </div>
+        <div id="wgc-teams-section">
+          <h3>Teams</h3>
+          <div id="wgc-team-cards"></div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
 function initializeWGCUI() {
   if (wgcUIInitialized) return;
   hideWGCTab();
+  const container = document.getElementById('wgc-hope');
+  if (container) {
+    container.innerHTML = generateWGCLayout();
+    const teamContainer = container.querySelector('#wgc-team-cards');
+    if (teamContainer) {
+      teamContainer.innerHTML = generateWGCTeamCards();
+    }
+  }
   wgcUIInitialized = true;
 }
 
@@ -37,5 +83,13 @@ function updateWGCUI() {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { hideWGCTab, showWGCTab, updateWGCVisibility };
+  module.exports = {
+    hideWGCTab,
+    showWGCTab,
+    updateWGCVisibility,
+    initializeWGCUI,
+    updateWGCUI,
+    generateWGCTeamCards,
+    generateWGCLayout,
+  };
 }


### PR DESCRIPTION
## Summary
- generate WGC layout via JavaScript instead of static markup
- insert team cards after building the layout
- document the change in AGENTS instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688437e628788327852141ac91681397