### PR TITLE
Cap ore satellite build count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Thruster power display now uses `formatNumber` and energy consumption registers in resource rates.
 - Scanner projects can build multiple satellites at once using a quantity selector with 0, ±, x10 and /10 controls.
 - Quantity selector buttons display their effect: "+" and "-" show the current step (e.g. +1, -1, +10, -10). The x10 and /10 buttons multiply or divide the step, never dropping below 1, and the 0 button resets the count.
+- Ore satellite build quantity now caps at the project's maximum repeat count.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -8,7 +8,11 @@ class ScannerProject extends Project {
   }
 
   getColonistLimit() {
-    return Math.ceil((resources?.colony?.colonists?.value || 0) / 10000);
+    const colonistCap = Math.ceil((resources?.colony?.colonists?.value || 0) / 10000);
+    if (this.maxRepeatCount === Infinity) {
+      return colonistCap;
+    }
+    return Math.min(colonistCap, this.maxRepeatCount);
   }
 
   getEffectiveBuildCount(count = this.buildCount) {

--- a/tests/scannerProjectBuildCount.test.js
+++ b/tests/scannerProjectBuildCount.test.js
@@ -76,4 +76,22 @@ describe('ScannerProject build count', () => {
     expect(project.repeatCount).toBe(3);
     expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledTimes(1);
   });
+
+  test('colonist limit capped by max repeat count', () => {
+    const ctx = createContext();
+    ctx.resources.colony.colonists.value = 20000000; // would allow 2000
+    const config = {
+      name: 'scan',
+      category: 'infra',
+      cost: { colony: { metal: 50 } },
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: 1000,
+      unlocked: true,
+      attributes: { scanner: { canSearchForDeposits: true, searchValue: 0.1, depositType: 'ore' } }
+    };
+    const project = new ctx.ScannerProject(config, 'scan');
+    expect(project.getColonistLimit()).toBe(1000);
+  });
 });


### PR DESCRIPTION
## Summary
- limit ore satellite build count to project max
- test build limit cap
- note change in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6884391b8c6c832798134888af24b5b1