### PR TITLE
Persist scanner build count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC layout is generated dynamically via wgcUI.js instead of hardcoded in index.html.
 - Quantity selector buttons display their effect: "+" and "-" show the current step (e.g. +1, -1, +10, -10). The x10 and /10 buttons multiply or divide the step, never dropping below 1, and the 0 button resets the count.
 - Ore satellite build quantity now caps at the project's maximum repeat count.
+- Satellite parallel build count now persists when saving and loading.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -155,6 +155,28 @@ class ScannerProject extends Project {
       this.el.bMinus.textContent = `-${formatNumber(this.step, true)}`;
     }
   }
+
+  saveState() {
+    return {
+      ...super.saveState(),
+      buildCount: this.buildCount,
+      activeBuildCount: this.activeBuildCount,
+      step: this.step,
+    };
+  }
+
+  loadState(state) {
+    super.loadState(state);
+    if (state.buildCount !== undefined) {
+      this.buildCount = state.buildCount;
+    }
+    if (state.activeBuildCount !== undefined) {
+      this.activeBuildCount = state.activeBuildCount;
+    }
+    if (state.step !== undefined) {
+      this.step = state.step;
+    }
+  }
 }
 
 if (typeof globalThis !== 'undefined') {

--- a/tests/scannerProjectPersistence.test.js
+++ b/tests/scannerProjectPersistence.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('ScannerProject persistence', () => {
+  test('saveState and loadState preserve build count', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
+    vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
+
+    const config = { name: 'scan', category: 'infra', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 100, unlocked: true };
+    const project = new ctx.ScannerProject(config, 'scan');
+    project.buildCount = 5;
+    project.step = 10;
+    project.activeBuildCount = 3;
+
+    const saved = project.saveState();
+    const loaded = new ctx.ScannerProject(config, 'scan');
+    loaded.loadState(saved);
+
+    expect(loaded.buildCount).toBe(5);
+    expect(loaded.step).toBe(10);
+    expect(loaded.activeBuildCount).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure ScannerProject saves and loads build count settings
- test scanner save/load behavior
- document the change in AGENTS log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68843aef46d08327b5c494464d9f821d