### PR TITLE
Add WGC team recruitment system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC R&D menu lets players spend Alien artifacts on team equipment and factory efficiency upgrades.
 - Quantity selector buttons display their effect: "+" and "-" show the current step (e.g. +1, -1, +10, -10). The x10 and /10 buttons multiply or divide the step, never dropping below 1, and the 0 button resets the count.
 - Ore satellite build quantity now caps at the project's maximum repeat count.
+- WGC team slots now open a recruit dialog for custom-named members with class and skill allocation.
 - Added Space Storage advanced research unlocking a SpaceStorageProject mega project.
 - Androids produce research once Hive Mind Androids advanced research is completed.
 - Added a new special resource "Alien artifact" which starts locked.

--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
     <script src="src/js/hopeUI.js"></script>
     <script src="src/js/solis.js"></script>
     <script src="src/js/solisUI.js"></script>
+    <script src="src/js/team-member.js"></script>
     <script src="src/js/wgc.js"></script>
     <script src="src/js/wgcUI.js"></script>
     <script src="src/js/globals.js"></script>

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -52,6 +52,25 @@
   font-size: 1.5em;
 }
 
+.team-slot {
+  position: relative;
+}
+
+.team-slot .team-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.team-slot .edit-icon {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  font-size: 0.8em;
+  background: rgba(255,255,255,0.7);
+  cursor: pointer;
+}
+
 .team-controls {
   margin-left: auto;
   display: flex;

--- a/src/js/team-member.js
+++ b/src/js/team-member.js
@@ -1,0 +1,47 @@
+class WGCTeamMember {
+  constructor({ name, classType, level = 1, power = 0, stamina = 0, wit = 0 }) {
+    this.name = name;
+    this.classType = classType;
+    this.level = level;
+    this.power = power;
+    this.stamina = stamina;
+    this.wit = wit;
+  }
+
+  static getBaseStats(classType) {
+    const map = {
+      'Team Leader': { power: 1, stamina: 1, wit: 1 },
+      'Soldier': { power: 1, stamina: 1, wit: 0 },
+      'Natural Scientist': { power: 0, stamina: 0, wit: 2 },
+      'Social Scientist': { power: 0, stamina: 0, wit: 2 }
+    };
+    return map[classType] || { power: 0, stamina: 0, wit: 0 };
+  }
+
+  static create(name, classType, allocation) {
+    const base = WGCTeamMember.getBaseStats(classType);
+    return new WGCTeamMember({
+      name,
+      classType,
+      level: 1,
+      power: base.power + (allocation.power || 0),
+      stamina: base.stamina + (allocation.stamina || 0),
+      wit: base.wit + (allocation.wit || 0)
+    });
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      classType: this.classType,
+      level: this.level,
+      power: this.power,
+      stamina: this.stamina,
+      wit: this.wit
+    };
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { WGCTeamMember };
+}

--- a/tests/wgcTeamMember.test.js
+++ b/tests/wgcTeamMember.test.js
@@ -1,0 +1,25 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC team members', () => {
+  test('creation applies base stats', () => {
+    const m = WGCTeamMember.create('Bob', 'Soldier', { power: 2, stamina: 1, wit: 1 });
+    expect(m.level).toBe(1);
+    expect(m.power).toBe(3);
+    expect(m.stamina).toBe(2);
+    expect(m.wit).toBe(1);
+  });
+
+  test('save and load preserves members', () => {
+    const wgc = new WarpGateCommand();
+    const member = WGCTeamMember.create('Alice', 'Team Leader', { power: 1, stamina: 0, wit: 0 });
+    wgc.recruitMember(0, 0, member);
+    const data = wgc.saveState();
+    const wgc2 = new WarpGateCommand();
+    wgc2.loadState(data);
+    expect(wgc2.teams[0][0].name).toBe('Alice');
+    expect(wgc2.teams[0][0].power).toBe(member.power);
+  });
+});


### PR DESCRIPTION
## Summary
- implement WGCTeamMember class for WGC
- allow saving/loading recruited teams
- add team member recruitment UI with skill allocation
- display new class icons and edit option
- document update in AGENTS.md
- add unit tests for team members

## Testing
- `npm test` *(fails: SyntaxError in research-parameters.js and other suites)*

------
https://chatgpt.com/codex/tasks/task_b_688443d69bb48327930f038fae8ceac1