### PR TITLE
Fix WGC recruit button

### DIFF
--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -243,7 +243,8 @@ function initializeWGCUI() {
     if (teamContainer) {
       teamContainer.innerHTML = generateWGCTeamCards();
       teamContainer.addEventListener('click', e => {
-        const btn = e.target.closest('button');
+        const target = e.target instanceof Element ? e.target : e.target.parentElement;
+        const btn = target && target.closest ? target.closest('button') : null;
         const edit = e.target.classList.contains('edit-icon');
         if (btn && btn.parentElement.classList.contains('team-slot')) {
           const slot = btn.parentElement;


### PR DESCRIPTION
## Summary
- fix clicking team slot in WGC when event target isn't an Element

## Testing
- `npm test --silent` *(fails: researchParameters is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_688446b1be90832782da0bdc6744535a