### PR TITLE
Add header for WGC R&D menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,3 +218,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Space Storage advanced research unlocking a SpaceStorageProject mega project.
 - Androids produce research once Hive Mind Androids advanced research is completed.
 - Added a new special resource "Alien artifact" which starts locked.
+- WGC R&D shop displays a header row labelled "Upgrade" and "Cost (Alien Artifacts)".

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -88,3 +88,7 @@
 .wgc-rd-item button {
   margin-left: auto;
 }
+
+.wgc-rd-header {
+  font-weight: bold;
+}

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -103,10 +103,35 @@ function createRDItem(key, label) {
   return div;
 }
 
+function createRDHeader() {
+  const div = document.createElement('div');
+  div.classList.add('wgc-rd-item', 'wgc-rd-header');
+
+  const label = document.createElement('span');
+  label.classList.add('wgc-rd-label');
+  label.textContent = 'Upgrade';
+  div.appendChild(label);
+
+  div.appendChild(document.createElement('span'));
+
+  const spacer = document.createElement('span');
+  spacer.style.marginLeft = 'auto';
+  div.appendChild(spacer);
+
+  const cost = document.createElement('span');
+  cost.textContent = 'Cost (Alien Artifacts)';
+  div.appendChild(cost);
+
+  div.appendChild(document.createElement('span'));
+
+  return div;
+}
+
 function populateRDMenu() {
   const menu = document.getElementById('wgc-rd-menu');
   if (!menu) return;
   menu.innerHTML = '';
+  menu.appendChild(createRDHeader());
   for (const key in rdItems) {
     menu.appendChild(createRDItem(key, rdItems[key]));
   }

--- a/tests/wgcRDHeader.test.js
+++ b/tests/wgcRDHeader.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('WGC R&D menu header', () => {
+  test('populateRDMenu adds header row', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-rd-menu"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.populateRDMenu();
+    const menu = dom.window.document.getElementById('wgc-rd-menu');
+    const header = menu.firstElementChild;
+    expect(header.classList.contains('wgc-rd-header')).toBe(true);
+    expect(header.textContent).toContain('Upgrade');
+    expect(header.textContent).toContain('Cost (Alien Artifacts)');
+  });
+});


### PR DESCRIPTION
## Summary
- add a header row for the WGC R&D shop
- style header row
- document the change in AGENTS.md
- test header row creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68844728ce8483279d07e1cf2ef2aaf3