### PR TITLE
Fix WGC recruit window visibility

### DIFF
--- a/src/css/pop-up.css
+++ b/src/css/pop-up.css
@@ -19,6 +19,7 @@
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   text-align: center;
+  color: white;
   max-height: 80%; /* Ensure that it doesn't take up too much vertical space */
   overflow-y: auto; /* Add scrolling if needed */
 }


### PR DESCRIPTION
## Summary
- make text in pop-up windows white so WGC recruitment dialog is visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688447fac5588327882c87789b04e425