### PR TITLE
Fix WGC tests after rework

### DIFF
--- a/tests/scannerProjectBuildCount.test.js
+++ b/tests/scannerProjectBuildCount.test.js
@@ -50,7 +50,8 @@ describe('ScannerProject build count', () => {
     expect(ctx.resources.colony.metal.value).toBe(750);
     project.complete();
     expect(project.repeatCount).toBe(5);
-    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledTimes(5);
+    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledTimes(1);
+    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledWith('ore', 0.5);
   });
 
   test('build count cropped by colonists and remaining repeats', () => {

--- a/tests/wgcTeamMember.test.js
+++ b/tests/wgcTeamMember.test.js
@@ -5,7 +5,7 @@ const { WarpGateCommand } = require('../src/js/wgc.js');
 
 describe('WGC team members', () => {
   test('creation applies base stats', () => {
-    const m = WGCTeamMember.create('Bob', 'Soldier', { power: 2, stamina: 1, wit: 1 });
+    const m = WGCTeamMember.create('Bob', '', 'Soldier', { power: 2, stamina: 1, wit: 1 });
     expect(m.level).toBe(1);
     expect(m.power).toBe(3);
     expect(m.stamina).toBe(2);
@@ -14,12 +14,12 @@ describe('WGC team members', () => {
 
   test('save and load preserves members', () => {
     const wgc = new WarpGateCommand();
-    const member = WGCTeamMember.create('Alice', 'Team Leader', { power: 1, stamina: 0, wit: 0 });
+    const member = WGCTeamMember.create('Alice', '', 'Team Leader', { power: 1, stamina: 0, wit: 0 });
     wgc.recruitMember(0, 0, member);
     const data = wgc.saveState();
     const wgc2 = new WarpGateCommand();
     wgc2.loadState(data);
-    expect(wgc2.teams[0][0].name).toBe('Alice');
+    expect(wgc2.teams[0][0].firstName).toBe('Alice');
     expect(wgc2.teams[0][0].power).toBe(member.power);
   });
 });


### PR DESCRIPTION
## Summary
- update WGC team member tests for new API
- update scanner project build count test for aggregated scanning effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688451da45248327a0f09ff930887e3f