### PR TITLE
Fix scanning display for underground resources

### DIFF
--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -179,8 +179,19 @@ function updateResourceDisplay(resources) {
           totalElement.textContent = formatNumber(Math.floor(resourceObj.value), true);
         }
 
-        // Update scanning progress if there is scanning strength
-        const scanData = oreScanner.scanData[resourceName];
+        // Update scanning progress if there is scanning strength using ScannerProject instance
+        let scanData;
+        if (typeof projectManager !== 'undefined') {
+          const projName = resourceName === 'geothermal' ? 'geo_satellite' : 'satellite';
+          const scanner = projectManager.projects?.[projName];
+          if (scanner && scanner.scanData) {
+            scanData = scanner.scanData[resourceName];
+          }
+        } else if (typeof oreScanner !== 'undefined') {
+          // Fallback for older saves
+          scanData = oreScanner.scanData[resourceName];
+        }
+
         if (scanData && scanData.currentScanningStrength > 0 && scanningProgressElement) {
           scanningProgressElement.style.display = 'block';
           scanningProgressElement.textContent = `Scanning Progress: ${(scanData.currentScanProgress * 100).toFixed(2)}%`;

--- a/tests/scannerProject.test.js
+++ b/tests/scannerProject.test.js
@@ -21,13 +21,7 @@ describe('ScannerProject scanning effect', () => {
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
     vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
 
-    ctx.oreScanner = {
-      scanData: { ore: { currentScanningStrength: 0 } },
-      adjustScanningStrength: jest.fn((type, val) => {
-        ctx.oreScanner.scanData[type].currentScanningStrength = val;
-      }),
-      startScan: jest.fn()
-    };
+
 
     const config = {
       name: 'scan',
@@ -41,9 +35,10 @@ describe('ScannerProject scanning effect', () => {
     };
 
     const project = new ctx.ScannerProject(config, 'scan');
+    project.initializeScanner({ resources: { underground: { ore: { initialValue: 0, maxDeposits: 1, areaTotal: 100 } } } });
     project.complete();
 
-    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledWith('ore', 0.5);
-    expect(ctx.oreScanner.startScan).toHaveBeenCalledWith('ore');
+    expect(project.scanData.ore.currentScanningStrength).toBeCloseTo(0.5);
+    expect(project.scanData.ore.remainingTime).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- display ore and geothermal scanning progress via corresponding `ScannerProject`
- update scanner project tests to reflect internal scanning logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68845c815e8c83278f4375c203bd53ff