### PR TITLE
Fix ore scanner speed calculation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,3 +220,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added a new special resource "Alien artifact" which starts locked.
 - WGC R&D shop displays a header row labelled "Upgrade" and "Cost (Alien Artifacts)".
 - ProjectManager automatically initializes scanner projects and assigns the ore scanner instance.
+- Scanner projects now set scanning strength based on total satellites built rather than incrementing per completion.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -162,7 +162,34 @@ class ScannerProject extends Project {
   update(deltaTime) {
     super.update(deltaTime);
     if (this.scanData) {
+      if (
+        this.attributes.scanner &&
+        this.attributes.scanner.depositType
+      ) {
+        const depositType = this.attributes.scanner.depositType;
+        const targetStrength =
+          (this.attributes.scanner.searchValue || 0) * this.repeatCount;
+        if (this.scanData[depositType].currentScanningStrength !== targetStrength) {
+          this.adjustScanningStrength(depositType, targetStrength);
+          if (targetStrength > 0) {
+            this.startScan(depositType);
+          }
+        }
+      }
       this.updateScan(deltaTime);
+    } else if (
+      typeof oreScanner !== 'undefined' &&
+      oreScanner.adjustScanningStrength &&
+      this.attributes.scanner &&
+      this.attributes.scanner.depositType
+    ) {
+      const depositType = this.attributes.scanner.depositType;
+      const targetStrength =
+        (this.attributes.scanner.searchValue || 0) * this.repeatCount;
+      oreScanner.adjustScanningStrength(depositType, targetStrength);
+      if (targetStrength > 0 && oreScanner.startScan) {
+        oreScanner.startScan(depositType);
+      }
     }
   }
 
@@ -249,24 +276,22 @@ class ScannerProject extends Project {
       this.attributes.scanner &&
       this.attributes.scanner.canSearchForDeposits
     ) {
-      this.applyScannerEffect(n);
+      this.applyScannerEffect();
     }
     this.activeBuildCount = 1;
   }
 
-  applyScannerEffect(count = 1) {
+  applyScannerEffect() {
     if (
       this.attributes.scanner &&
-      this.attributes.scanner.searchValue &&
       this.attributes.scanner.depositType
     ) {
       const depositType = this.attributes.scanner.depositType;
-      const additionalStrength = this.attributes.scanner.searchValue * count;
-      this.adjustScanningStrength(
-        depositType,
-        this.scanData[depositType].currentScanningStrength + additionalStrength
-      );
-      this.startScan(depositType);
+      if (typeof oreScanner !== 'undefined' && oreScanner.startScan) {
+        oreScanner.startScan(depositType);
+      } else {
+        this.startScan(depositType);
+      }
     }
   }
 

--- a/tests/scannerProject.test.js
+++ b/tests/scannerProject.test.js
@@ -13,7 +13,7 @@ describe('ScannerProject scanning effect', () => {
     expect(ctx.projectParameters.geo_satellite.type).toBe('ScannerProject');
   });
 
-  test('applyScannerEffect increases strength and starts scan', () => {
+  test('update sets scanning strength from repeat count', () => {
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
     const ctx = { console, EffectableEntity };
@@ -40,10 +40,15 @@ describe('ScannerProject scanning effect', () => {
       attributes: { scanner: { canSearchForDeposits: true, searchValue: 0.5, depositType: 'ore' } }
     };
 
-    const project = new ctx.ScannerProject(config, 'scan');
-    project.complete();
+  const project = new ctx.ScannerProject(config, 'scan');
+  project.repeatCount = 1;
+  project.update(0);
 
-    expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledWith('ore', 0.5);
-    expect(ctx.oreScanner.startScan).toHaveBeenCalledWith('ore');
+  expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledWith('ore', 0.5);
+  expect(ctx.oreScanner.startScan).toHaveBeenCalledWith('ore');
+
+  project.repeatCount = 2;
+  project.update(0);
+  expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenLastCalledWith('ore', 1);
   });
 });

--- a/tests/scannerProjectBuildCount.test.js
+++ b/tests/scannerProjectBuildCount.test.js
@@ -49,6 +49,7 @@ describe('ScannerProject build count', () => {
     project.start(ctx.resources);
     expect(ctx.resources.colony.metal.value).toBe(750);
     project.complete();
+    project.update(0);
     expect(project.repeatCount).toBe(5);
     expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledTimes(1);
     expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledWith('ore', 0.5);
@@ -74,6 +75,7 @@ describe('ScannerProject build count', () => {
     expect(project.getScaledCost().colony.metal).toBe(50); // only one allowed
     project.start(ctx.resources);
     project.complete();
+    project.update(0);
     expect(project.repeatCount).toBe(3);
     expect(ctx.oreScanner.adjustScanningStrength).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- tweak `ScannerProject` so scanning strength updates using repeat count each tick
- keep old global fallback in `applyScannerEffect`
- adjust scanner project tests for new behaviour
- document scanner change in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68845cb4aca08327b6e1d213e17b8531