### PR TITLE
Fix scanner D_current sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,3 +222,5 @@ second time they speak in a chapter to help clarify who is talking.
 - ProjectManager automatically initializes scanner projects and assigns the ore scanner instance.
 - Scanner projects now set scanning strength based on total satellites built rather than incrementing per completion.
 - Scanning stops and the progress display hides once deposits reach their planetary cap.
+
+- D_current now initializes from the matching deposit resource value.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -13,8 +13,14 @@ class ScannerProject extends Project {
     this.scanData = {};
     for (const depositType in this.underground) {
       const depositParams = this.underground[depositType];
+      const existing =
+        typeof resources !== 'undefined' &&
+        resources.underground &&
+        resources.underground[depositType]
+          ? resources.underground[depositType].value
+          : undefined;
       this.scanData[depositType] = {
-        D_current: depositParams.initialValue,
+        D_current: existing ?? depositParams.initialValue,
         currentScanProgress: 0,
         currentScanningStrength: 0,
         remainingTime: 0,

--- a/tests/scannerDepositSync.test.js
+++ b/tests/scannerDepositSync.test.js
@@ -1,0 +1,14 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+global.Project = class extends EffectableEntity {};
+const ScannerProject = require('../src/js/projects/ScannerProject.js');
+
+describe('ScannerProject initializes D_current from resource value', () => {
+  test('uses current deposit count when available', () => {
+    const params = { resources: { underground: { ore: { initialValue: 5, maxDeposits: 20, areaTotal: 100 } } } };
+    global.resources = { underground: { ore: { value: 7, addDeposit: jest.fn() } } };
+    const scanner = new ScannerProject({}, 'scan');
+    scanner.initializeScanner(params);
+    expect(scanner.scanData.ore.D_current).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- sync ScannerProject D_current with existing deposit resource values
- add regression test for D_current initialization
- document fix in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68846647cc7c8327bad3b6ed5df3c2d9