### PR TITLE
Show auto-start project rate effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,3 +225,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Scanning stops and the progress display hides once deposits reach their planetary cap.
 
 - D_current now initializes from the matching deposit resource value.
+- Import colonists adds its colonist gain to resource rates when auto-started.
+- Satellite projects show their scaled cost in resource rates when auto-started.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -325,7 +325,37 @@ class Project extends EffectableEntity {
 
 
   estimateProjectCostAndGain() {
-    // Default implementation intentionally left blank
+    if (this.isActive && this.autoStart) {
+      const rate = 1000 / this.getEffectiveDuration();
+
+      const cost = this.getScaledCost();
+      for (const category in cost) {
+        for (const resource in cost[category]) {
+          resources[category][resource].modifyRate(
+            -cost[category][resource] * rate,
+            this.displayName,
+            'project'
+          );
+        }
+      }
+
+      if (this.attributes && this.attributes.resourceGain) {
+        const gain = this.getEffectiveResourceGain();
+        for (const category in gain) {
+          for (const resource in gain[category]) {
+            resources[category][resource].modifyRate(
+              gain[category][resource] * rate,
+              this.displayName,
+              'project'
+            );
+          }
+        }
+      }
+    }
+  }
+
+  estimateCostAndGain() {
+    this.estimateProjectCostAndGain();
   }
 
   saveState() {

--- a/tests/importColonistsRate.test.js
+++ b/tests/importColonistsRate.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Import colonists auto-start rate', () => {
+  test('adds colonist rate while active', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projCode + '; this.Project = Project;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.resources = {
+      colony: {
+        colonists: { value: 0, modifyRate: jest.fn(), decrease(){}, updateStorageCap(){} }
+      }
+    };
+    global.resources = ctx.resources;
+
+    const config = ctx.projectParameters.import_colonists_1;
+    const project = new ctx.Project(config, 'import');
+    project.start(ctx.resources);
+    project.autoStart = true;
+
+    project.estimateCostAndGain();
+
+    const expected = (1000 * config.attributes.resourceGain.colony.colonists) / config.duration;
+    expect(ctx.resources.colony.colonists.modifyRate).toHaveBeenCalled();
+    const call = ctx.resources.colony.colonists.modifyRate.mock.calls[0];
+    expect(call[0]).toBeCloseTo(expected);
+    expect(call[1]).toBe('Import colonists');
+    expect(call[2]).toBe('project');
+  });
+});

--- a/tests/scannerProjectRate.test.js
+++ b/tests/scannerProjectRate.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('ScannerProject auto-start cost rate', () => {
+  test('cost scales with build count', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projCode + '; this.Project = Project;', ctx);
+    const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
+    vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.resources = {
+      colony: {
+        metal: { value: 1000, modifyRate: jest.fn(), decrease(){}, updateStorageCap(){} },
+        electronics: { value: 1000, modifyRate: jest.fn(), decrease(){}, updateStorageCap(){} },
+        energy: { value: 3000000, modifyRate: jest.fn(), decrease(){}, updateStorageCap(){} },
+        colonists: { value: 100000 }
+      }
+    };
+    global.resources = ctx.resources;
+
+    const config = ctx.projectParameters.satellite;
+    const project = new ctx.ScannerProject(config, 'sat');
+    project.buildCount = 5;
+    project.start(ctx.resources);
+    project.autoStart = true;
+
+    project.estimateCostAndGain();
+
+    const rate = 1000 / config.duration;
+    const expectedMetal = -50 * 5 * rate;
+    const expectedElectronics = -10 * 5 * rate;
+    const expectedEnergy = -500000 * 5 * rate;
+    expect(ctx.resources.colony.metal.modifyRate).toHaveBeenCalled();
+    expect(ctx.resources.colony.electronics.modifyRate).toHaveBeenCalled();
+    expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalled();
+    const mArgs = ctx.resources.colony.metal.modifyRate.mock.calls[0];
+    const eArgs = ctx.resources.colony.electronics.modifyRate.mock.calls[0];
+    const enArgs = ctx.resources.colony.energy.modifyRate.mock.calls[0];
+    expect(mArgs[0]).toBeCloseTo(expectedMetal);
+    expect(eArgs[0]).toBeCloseTo(expectedElectronics);
+    expect(enArgs[0]).toBeCloseTo(expectedEnergy);
+    expect(mArgs[1]).toBe('Ore satellite');
+    expect(eArgs[1]).toBe('Ore satellite');
+    expect(enArgs[1]).toBe('Ore satellite');
+    expect(mArgs[2]).toBe('project');
+    expect(eArgs[2]).toBe('project');
+    expect(enArgs[2]).toBe('project');
+  });
+});


### PR DESCRIPTION
## Summary
- display resource gain and cost for auto-started projects
- track colonist gain from Import colonists when auto-starting
- account for scaled cost on satellite projects
- add regression tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688a9c0eff5083279e8385492bccbbcd