### PR TITLE
Rename WGC stamina skill to Athletics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,3 +227,4 @@ second time they speak in a chapter to help clarify who is talking.
 - D_current now initializes from the matching deposit resource value.
 - Import colonists adds its colonist gain to resource rates when auto-started.
 - Satellite projects show their scaled cost in resource rates when auto-started.
+- WGC team member skill "Stamina" renamed to "Athletics".

--- a/src/js/team-member.js
+++ b/src/js/team-member.js
@@ -1,22 +1,22 @@
 class WGCTeamMember {
-  constructor({ firstName, lastName = '', classType, level = 1, power = 0, stamina = 0, wit = 0 }) {
+  constructor({ firstName, lastName = '', classType, level = 1, power = 0, athletics = 0, wit = 0 }) {
     this.firstName = firstName;
     this.lastName = lastName;
     this.classType = classType;
     this.level = level;
     this.power = power;
-    this.stamina = stamina;
+    this.athletics = athletics;
     this.wit = wit;
   }
 
   static getBaseStats(classType) {
     const map = {
-      'Team Leader': { power: 1, stamina: 1, wit: 1 },
-      'Soldier': { power: 1, stamina: 1, wit: 0 },
-      'Natural Scientist': { power: 0, stamina: 0, wit: 2 },
-      'Social Scientist': { power: 0, stamina: 0, wit: 2 }
+      'Team Leader': { power: 1, athletics: 1, wit: 1 },
+      'Soldier': { power: 1, athletics: 1, wit: 0 },
+      'Natural Scientist': { power: 0, athletics: 0, wit: 2 },
+      'Social Scientist': { power: 0, athletics: 0, wit: 2 }
     };
-    return map[classType] || { power: 0, stamina: 0, wit: 0 };
+    return map[classType] || { power: 0, athletics: 0, wit: 0 };
   }
 
   static create(firstName, lastName, classType, allocation) {
@@ -27,7 +27,7 @@ class WGCTeamMember {
       classType,
       level: 1,
       power: base.power + (allocation.power || 0),
-      stamina: base.stamina + (allocation.stamina || 0),
+      athletics: base.athletics + (allocation.athletics || 0),
       wit: base.wit + (allocation.wit || 0)
     });
   }
@@ -35,16 +35,16 @@ class WGCTeamMember {
   getPointsToAllocate() {
     if (this.level < 1) return 0;
     const base = WGCTeamMember.getBaseStats(this.classType);
-    const allocated = (this.power - base.power) + (this.stamina - base.stamina) + (this.wit - base.wit);
+    const allocated = (this.power - base.power) + (this.athletics - base.athletics) + (this.wit - base.wit);
     const totalPoints = 5 + ((this.level - 1) * 2);
     return totalPoints - allocated;
   }
 
   allocatePoints(allocation) {
-    const toSpend = (allocation.power || 0) + (allocation.stamina || 0) + (allocation.wit || 0);
+    const toSpend = (allocation.power || 0) + (allocation.athletics || 0) + (allocation.wit || 0);
     if (toSpend > this.getPointsToAllocate()) return false;
     this.power += (allocation.power || 0);
-    this.stamina += (allocation.stamina || 0);
+    this.athletics += (allocation.athletics || 0);
     this.wit += (allocation.wit || 0);
     return true;
   }
@@ -56,7 +56,7 @@ class WGCTeamMember {
       classType: this.classType,
       level: this.level,
       power: this.power,
-      stamina: this.stamina,
+      athletics: this.athletics,
       wit: this.wit
     };
   }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -195,7 +195,7 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   win.appendChild(level);
 
   const pointsToSpend = member ? member.getPointsToAllocate() : 5;
-  const alloc = { power: 0, stamina: 0, wit: 0 };
+  const alloc = { power: 0, athletics: 0, wit: 0 };
   const remainingSpan = document.createElement('div');
   remainingSpan.textContent = `Points left: ${pointsToSpend}`;
 
@@ -205,11 +205,11 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   const baseStats = member ? WGCTeamMember.getBaseStats(member.classType) : WGCTeamMember.getBaseStats(classSelect.value);
   const statValues = {
     power: member ? member.power : baseStats.power,
-    stamina: member ? member.stamina : baseStats.stamina,
+    athletics: member ? member.athletics : baseStats.athletics,
     wit: member ? member.wit : baseStats.wit
   };
 
-  ['power','stamina','wit'].forEach(stat => {
+  ['power','athletics','wit'].forEach(stat => {
     const statContainer = document.createElement('div');
     statContainer.classList.add('wgc-stat-container');
 
@@ -224,7 +224,7 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
     const addButton = document.createElement('button');
     addButton.textContent = '+';
     addButton.addEventListener('click', () => {
-      const totalAllocated = alloc.power + alloc.stamina + alloc.wit;
+      const totalAllocated = alloc.power + alloc.athletics + alloc.wit;
       if (totalAllocated < pointsToSpend) {
         alloc[stat]++;
         valueSpan.textContent = statValues[stat] + alloc[stat];
@@ -238,11 +238,11 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   classSelect.addEventListener('change', () => {
     const newBaseStats = WGCTeamMember.getBaseStats(classSelect.value);
     statValues.power = newBaseStats.power;
-    statValues.stamina = newBaseStats.stamina;
+    statValues.athletics = newBaseStats.athletics;
     statValues.wit = newBaseStats.wit;
     const statContainers = statsDiv.querySelectorAll('.wgc-stat-container');
     statContainers.forEach((container, index) => {
-      const statName = ['power', 'stamina', 'wit'][index];
+      const statName = ['power', 'athletics', 'wit'][index];
       container.querySelector('span:nth-child(2)').textContent = statValues[statName];
     });
   });

--- a/tests/wgcTeamMember.test.js
+++ b/tests/wgcTeamMember.test.js
@@ -5,16 +5,16 @@ const { WarpGateCommand } = require('../src/js/wgc.js');
 
 describe('WGC team members', () => {
   test('creation applies base stats', () => {
-    const m = WGCTeamMember.create('Bob', '', 'Soldier', { power: 2, stamina: 1, wit: 1 });
+    const m = WGCTeamMember.create('Bob', '', 'Soldier', { power: 2, athletics: 1, wit: 1 });
     expect(m.level).toBe(1);
     expect(m.power).toBe(3);
-    expect(m.stamina).toBe(2);
+    expect(m.athletics).toBe(2);
     expect(m.wit).toBe(1);
   });
 
   test('save and load preserves members', () => {
     const wgc = new WarpGateCommand();
-    const member = WGCTeamMember.create('Alice', '', 'Team Leader', { power: 1, stamina: 0, wit: 0 });
+    const member = WGCTeamMember.create('Alice', '', 'Team Leader', { power: 1, athletics: 0, wit: 0 });
     wgc.recruitMember(0, 0, member);
     const data = wgc.saveState();
     const wgc2 = new WarpGateCommand();


### PR DESCRIPTION
## Summary
- rename WGCTeamMember `stamina` skill to `athletics`
- update recruitment UI for new skill name
- adjust WGC team member tests
- document change in AGENTS log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aa1325a0c8327a79028dcec4ba489