### PR TITLE
Add health stat to WGC team members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Quantity selector buttons display their effect: "+" and "-" show the current step (e.g. +1, -1, +10, -10). The x10 and /10 buttons multiply or divide the step, never dropping below 1, and the 0 button resets the count.
 - Ore satellite build quantity now caps at the project's maximum repeat count.
 - WGC team slots now open a recruit dialog for custom-named members with class and skill allocation.
+- WGC team members now track Health and Max Health, both starting at 100. Max Health scales with level.
 - Added Space Storage advanced research unlocking a SpaceStorageProject mega project.
 - Androids produce research once Hive Mind Androids advanced research is completed.
 - Added a new special resource "Alien artifact" which starts locked.

--- a/src/js/team-member.js
+++ b/src/js/team-member.js
@@ -1,5 +1,5 @@
 class WGCTeamMember {
-  constructor({ firstName, lastName = '', classType, level = 1, power = 0, stamina = 0, wit = 0 }) {
+  constructor({ firstName, lastName = '', classType, level = 1, power = 0, stamina = 0, wit = 0, health, maxHealth }) {
     this.firstName = firstName;
     this.lastName = lastName;
     this.classType = classType;
@@ -7,6 +7,8 @@ class WGCTeamMember {
     this.power = power;
     this.stamina = stamina;
     this.wit = wit;
+    this.maxHealth = typeof maxHealth === 'number' ? maxHealth : 100 + this.level - 1;
+    this.health = typeof health === 'number' ? health : this.maxHealth;
   }
 
   static getBaseStats(classType) {
@@ -57,7 +59,9 @@ class WGCTeamMember {
       level: this.level,
       power: this.power,
       stamina: this.stamina,
-      wit: this.wit
+      wit: this.wit,
+      health: this.health,
+      maxHealth: this.maxHealth
     };
   }
 }

--- a/tests/wgcTeamMember.test.js
+++ b/tests/wgcTeamMember.test.js
@@ -10,6 +10,14 @@ describe('WGC team members', () => {
     expect(m.power).toBe(3);
     expect(m.stamina).toBe(2);
     expect(m.wit).toBe(1);
+    expect(m.health).toBe(100);
+    expect(m.maxHealth).toBe(100);
+  });
+
+  test('max health scales with level', () => {
+    const m = new WGCTeamMember({ firstName: 'Eve', classType: 'Soldier', level: 5 });
+    expect(m.maxHealth).toBe(104);
+    expect(m.health).toBe(104);
   });
 
   test('save and load preserves members', () => {
@@ -21,5 +29,7 @@ describe('WGC team members', () => {
     wgc2.loadState(data);
     expect(wgc2.teams[0][0].firstName).toBe('Alice');
     expect(wgc2.teams[0][0].power).toBe(member.power);
+    expect(wgc2.teams[0][0].health).toBe(member.health);
+    expect(wgc2.teams[0][0].maxHealth).toBe(member.maxHealth);
   });
 });


### PR DESCRIPTION
## Summary
- track health for WGC team members
- update tests for new health property
- document WGC health stat in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aa16a3e8483279c7e6ee2d61cd32f