### PR TITLE
Add WGC operation progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,3 +229,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Import colonists adds its colonist gain to resource rates when auto-started.
 - Satellite projects show their scaled cost in resource rates when auto-started.
 - WGC team member skill "Stamina" renamed to "Athletics".
+- WGC teams can now start operations when fully staffed. The Start button shows a 10-minute progress bar that loops automatically.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -187,3 +187,19 @@
   margin-top: 5px;
   width: 50%;
 }
+
+.operation-progress {
+  width: 100%;
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  height: 10px;
+  margin-top: 5px;
+  overflow: hidden;
+}
+
+.operation-progress-bar {
+  height: 100%;
+  background-color: #2196f3;
+  width: 0%;
+  transition: width 0.5s linear;
+}

--- a/src/js/team-member.js
+++ b/src/js/team-member.js
@@ -1,6 +1,5 @@
 class WGCTeamMember {
   constructor({ firstName, lastName = '', classType, level = 1, power = 0, athletics = 0, wit = 0, health, maxHealth }) {
-  constructor({ firstName, lastName = '', classType, level = 1, power = 0, athletics = 0, wit = 0 }) {
     this.firstName = firstName;
     this.lastName = lastName;
     this.classType = classType;

--- a/tests/wgcOperationProgress.test.js
+++ b/tests/wgcOperationProgress.test.js
@@ -1,0 +1,20 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC operations', () => {
+  test('operation progresses and restarts', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      const m = WGCTeamMember.create('A'+i, '', 'Soldier', {});
+      wgc.recruitMember(0, i, m);
+    }
+    expect(wgc.startOperation(0)).toBe(true);
+    wgc.update(60000); // 60 seconds
+    expect(wgc.operations[0].progress).toBeCloseTo(0.1, 3);
+    wgc.update(540000); // remaining 9 minutes
+    expect(wgc.operations[0].progress).toBeCloseTo(0, 3);
+    expect(wgc.operations[0].active).toBe(true);
+  });
+});

--- a/tests/wgcStartButton.test.js
+++ b/tests/wgcStartButton.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WarpGateCommand } = require('../src/js/wgc.js');
+const { WGCTeamMember } = require('../src/js/team-member.js');
+
+describe('WGC start button', () => {
+  test('button enabled only when team is full', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = WarpGateCommand;
+    ctx.WGCTeamMember = WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    let btn = dom.window.document.querySelector('.start-button');
+    expect(btn.disabled).toBe(true);
+    for (let i = 0; i < 4; i++) {
+      const m = ctx.WGCTeamMember.create('A'+i, '', 'Soldier', {});
+      ctx.warpGateCommand.recruitMember(0, i, m);
+    }
+    ctx.redrawWGCTeamCards();
+    ctx.updateWGCUI();
+    btn = dom.window.document.querySelector('.start-button');
+    expect(btn.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Warp Gate Command operation timer and controls
- render progress bars on WGC teams
- disable Start button until team is full
- document feature in AGENTS
- style operation progress bar
- test operation progress logic and Start button UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aa1dfbbd083278b521e6ad78d10a1