### PR TITLE
Add WGC operation counter and team locks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,3 +230,6 @@ second time they speak in a chapter to help clarify who is talking.
 - Satellite projects show their scaled cost in resource rates when auto-started.
 - WGC team member skill "Stamina" renamed to "Athletics".
 - WGC teams can now start operations when fully staffed. The Start button shows a 10-minute progress bar that loops automatically.
+- WGC tracks total operations completed, displaying the count under the R&D menu.
+  Teams Beta, Gamma, Delta and Epsilon remain locked until 100, 500, 1000 and
+  5000 operations respectively.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -19,6 +19,7 @@
   border-radius: 5px;
   padding: 10px;
   margin-bottom: 10px;
+  position: relative;
 }
 
 .wgc-team-card .team-header {
@@ -202,4 +203,22 @@
   background-color: #2196f3;
   width: 0%;
   transition: width 0.5s linear;
+}
+
+.wgc-team-locked {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 1.5em;
+  font-weight: bold;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  z-index: 1;
 }

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -11,6 +11,7 @@ class WarpGateCommand extends EffectableEntity {
     this.enabled = false;
     this.teams = Array.from({ length: 5 }, () => Array(4).fill(null));
     this.operations = Array.from({ length: 5 }, () => ({ active: false, progress: 0, timer: 0 }));
+    this.totalOperations = 0;
     this.rdUpgrades = {
       wgtEquipment: { purchases: 0 },
       componentsEfficiency: { purchases: 0, max: 400 },
@@ -85,11 +86,12 @@ class WarpGateCommand extends EffectableEntity {
     this.operations.forEach(op => {
       if (op.active) {
         op.timer += seconds;
-        op.progress = op.timer / 600;
-        if (op.progress >= 1) {
-          op.timer = 0;
-          op.progress = 0;
+        const loops = Math.floor(op.timer / 600);
+        if (loops > 0) {
+          this.totalOperations += loops;
+          op.timer -= loops * 600;
         }
+        op.progress = op.timer / 600;
       }
     });
   }
@@ -143,7 +145,8 @@ class WarpGateCommand extends EffectableEntity {
         active: op.active,
         progress: op.progress,
         timer: op.timer
-      }))
+      })),
+      totalOperations: this.totalOperations
     };
   }
 
@@ -168,6 +171,7 @@ class WarpGateCommand extends EffectableEntity {
         timer: op.timer || 0
       }));
     }
+    this.totalOperations = data.totalOperations || 0;
   }
 }
 

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -9,6 +9,7 @@ const rdItems = {
 };
 const rdElements = {};
 const teamNames = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'];
+const teamUnlocks = [0, 100, 500, 1000, 5000];
 const classImages = {
   'Team Leader': 'assets/images/team_leader.png',
   'Soldier': 'assets/images/soldier.png',
@@ -58,6 +59,8 @@ function generateWGCTeamCards() {
       }
       return `<div class="team-slot" data-team="${tIdx}" data-slot="${sIdx}"><button>+</button></div>`;
     }).join('');
+    const unlocked = (typeof warpGateCommand !== 'undefined' && warpGateCommand.totalOperations >= teamUnlocks[tIdx]);
+    const lockMarkup = unlocked ? '' : `<div class="wgc-team-locked" data-team="${tIdx}">LOCKED<br>Unlocks at ${teamUnlocks[tIdx]}</div>`;
     return `
       <div class="wgc-team-card" data-team="${tIdx}">
         <div class="team-header">Team ${name}</div>
@@ -71,6 +74,7 @@ function generateWGCTeamCards() {
         <div class="operation-progress${op.active ? '' : ' hidden'}">
           <div class="operation-progress-bar" style="width: ${op.progress * 100}%"></div>
         </div>
+        ${lockMarkup}
       </div>`;
   }).join('');
 }
@@ -311,6 +315,7 @@ function generateWGCLayout() {
         <div id="wgc-rd-section">
           <h3>R&amp;D</h3>
           <div id="wgc-rd-menu"></div>
+          <div id="wgc-operation-count"></div>
         </div>
         <div id="wgc-teams-section">
           <h3>Teams</h3>
@@ -364,6 +369,10 @@ function initializeWGCUI() {
 }
 
 function updateWGCUI() {
+  const countEl = document.getElementById('wgc-operation-count');
+  if (countEl) {
+    countEl.textContent = `Operations Completed: ${warpGateCommand.totalOperations}`;
+  }
   for (const key in rdElements) {
     const el = rdElements[key];
     if (!el) continue;
@@ -388,11 +397,17 @@ function updateWGCUI() {
     const recallBtn = card.querySelector('.recall-button');
     const progressContainer = card.querySelector('.operation-progress');
     const progressBar = card.querySelector('.operation-progress-bar');
+    const lockOverlay = card.querySelector('.wgc-team-locked');
     const team = warpGateCommand.teams[tIdx] || [];
     const full = team.every(m => m);
     const op = warpGateCommand.operations[tIdx];
-    if (startBtn) startBtn.disabled = !full || op.active;
-    if (recallBtn) recallBtn.disabled = !op.active;
+    const unlocked = warpGateCommand.totalOperations >= teamUnlocks[tIdx];
+    if (lockOverlay) {
+      if (unlocked) lockOverlay.classList.add('hidden');
+      else lockOverlay.classList.remove('hidden');
+    }
+    if (startBtn) startBtn.disabled = !unlocked || !full || op.active;
+    if (recallBtn) recallBtn.disabled = !unlocked || !op.active;
     if (progressContainer && progressBar) {
       if (op.active) {
         progressContainer.classList.remove('hidden');

--- a/tests/wgcTeamLockOverlay.test.js
+++ b/tests/wgcTeamLockOverlay.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC team lock overlay', () => {
+  test('beta team locked until 100 operations', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    ctx.WGCTeamMember = require('../src/js/team-member.js').WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    const card = dom.window.document.querySelector('.wgc-team-card[data-team="1"]');
+    const overlay = card.querySelector('.wgc-team-locked');
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toContain('100');
+    ctx.warpGateCommand.totalOperations = 100;
+    ctx.updateWGCUI();
+    expect(overlay.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/tests/wgcTotalOperations.test.js
+++ b/tests/wgcTotalOperations.test.js
@@ -1,0 +1,18 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC total operations', () => {
+  test('operations completed counter increments', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A'+i, '', 'Soldier', {}));
+    }
+    wgc.startOperation(0);
+    wgc.update(600000); // 10 minutes
+    expect(wgc.totalOperations).toBe(1);
+    wgc.update(600000);
+    expect(wgc.totalOperations).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- track total Warp Gate Command (WGC) operations
- show total operations under the WGC R&D menu
- lock later teams behind operation thresholds
- style locked team overlay
- test operation counter and lock behaviour
- document new feature in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aa67b835883279656467702a888af