### PR TITLE
Add random WGC operation events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,3 +230,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Satellite projects show their scaled cost in resource rates when auto-started.
 - WGC team member skill "Stamina" renamed to "Athletics".
 - WGC teams can now start operations when fully staffed. The Start button shows a 10-minute progress bar that loops automatically.
+- Operations now feature random weighted challenges each minute. Results are logged, grant XP and may yield Alien artifacts when successful.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -203,3 +203,21 @@
   width: 0%;
   transition: width 0.5s linear;
 }
+
+.operation-summary {
+  font-size: 0.8em;
+  margin-top: 2px;
+}
+
+#wgc-log-container {
+  max-height: 200px;
+  overflow-y: auto;
+  background-color: #f9f9f9;
+  border: 1px solid #ccc;
+  padding: 5px;
+}
+
+#wgc-log {
+  white-space: pre-wrap;
+  font-size: 0.8em;
+}

--- a/src/js/team-member.js
+++ b/src/js/team-member.js
@@ -1,5 +1,5 @@
 class WGCTeamMember {
-  constructor({ firstName, lastName = '', classType, level = 1, power = 0, athletics = 0, wit = 0, health, maxHealth }) {
+  constructor({ firstName, lastName = '', classType, level = 1, power = 0, athletics = 0, wit = 0, health, maxHealth, xp = 0 }) {
     this.firstName = firstName;
     this.lastName = lastName;
     this.classType = classType;
@@ -7,6 +7,7 @@ class WGCTeamMember {
     this.power = power;
     this.athletics = athletics;
     this.wit = wit;
+    this.xp = xp;
     this.maxHealth = typeof maxHealth === 'number' ? maxHealth : 100 + this.level - 1;
     this.health = typeof health === 'number' ? health : this.maxHealth;
   }
@@ -60,6 +61,7 @@ class WGCTeamMember {
       power: this.power,
       athletics: this.athletics,
       wit: this.wit,
+      xp: this.xp,
       health: this.health,
       maxHealth: this.maxHealth
     };

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -5,12 +5,23 @@ if (typeof globalThis.WGCTeamMember === 'undefined' && isNodeWGC) {
   } catch (e) {}
 }
 
+const operationEvents = [
+  { name: 'Team Power Challenge', type: 'team', skill: 'power', weight: 1 },
+  { name: 'Team Athletics Challenge', type: 'team', skill: 'athletics', weight: 1 },
+  { name: 'Team Wits Challenge', type: 'team', skill: 'wit', weight: 1 },
+  { name: 'Individual Athletics Challenge', type: 'individual', skill: 'athletics', weight: 1 },
+  { name: 'Natural Science challenge', type: 'science', specialty: 'Natural Scientist', escalate: true, weight: 1 },
+  { name: 'Social Science challenge', type: 'science', specialty: 'Social Scientist', escalate: true, weight: 1 },
+  { name: 'Combat challenge', type: 'combat', weight: 1 }
+];
+
 class WarpGateCommand extends EffectableEntity {
   constructor() {
     super({ description: 'Warp Gate Command manager' });
     this.enabled = false;
     this.teams = Array.from({ length: 5 }, () => Array(4).fill(null));
-    this.operations = Array.from({ length: 5 }, () => ({ active: false, progress: 0, timer: 0 }));
+    this.operations = Array.from({ length: 5 }, () => ({ active: false, progress: 0, timer: 0, artifacts: 0, successes: 0, summary: '' }));
+    this.log = [];
     this.rdUpgrades = {
       wgtEquipment: { purchases: 0 },
       componentsEfficiency: { purchases: 0, max: 400 },
@@ -18,6 +29,80 @@ class WarpGateCommand extends EffectableEntity {
       superconductorEfficiency: { purchases: 0, max: 400 },
       androidsEfficiency: { purchases: 0, max: 400 },
     };
+  }
+
+  addLog(text) {
+    this.log.push(text);
+    if (this.log.length > 100) this.log.shift();
+  }
+
+  chooseEvent() {
+    const total = operationEvents.reduce((s, e) => s + (e.weight || 1), 0);
+    let r = Math.random() * total;
+    for (const ev of operationEvents) {
+      r -= ev.weight || 1;
+      if (r < 0) return ev;
+    }
+    return operationEvents[0];
+  }
+
+  roll(dice) {
+    let sum = 0;
+    for (let i = 0; i < dice; i++) {
+      sum += Math.floor(Math.random() * 20) + 1;
+    }
+    return sum;
+  }
+
+  resolveEvent(teamIndex, event) {
+    const team = this.teams[teamIndex];
+    if (!team) return { success: false, artifact: false };
+    let success = false;
+    switch (event.type) {
+      case 'team':
+        const skillSum = team.reduce((s, m) => s + (m ? m[event.skill] : 0), 0);
+        success = this.roll(4) + skillSum >= 40;
+        break;
+      case 'individual':
+        const members = team.filter(m => m);
+        if (members.length === 0) return { success: false, artifact: false };
+        const member = members[Math.floor(Math.random() * members.length)];
+        success = this.roll(1) + member[event.skill] >= 10;
+        break;
+      case 'science':
+        let m = team.find(t => t && t.classType === event.specialty);
+        if (!m) {
+          m = team[0];
+          if (!m) return { success: false, artifact: false };
+          const wit = Math.floor(m.wit / 2);
+          success = this.roll(1) + wit >= 10;
+        } else {
+          success = this.roll(1) + m.wit >= 10;
+        }
+        break;
+      case 'combat':
+        const combatSkill = team.reduce((s, mem) => {
+          if (!mem) return s;
+          const mult = mem.classType === 'Soldier' ? 2 : 1;
+          return s + (mem.power * mult);
+        }, 0);
+        success = this.roll(4) + combatSkill >= 40;
+        break;
+    }
+
+    const artifact = success && Math.random() < 0.1;
+    const op = this.operations[teamIndex];
+    if (success) op.successes += 1;
+    if (artifact) op.artifacts += 1;
+    const summary = `${event.name}: ${success ? 'Success' : 'Fail'}${artifact ? ' +1 Artifact' : ''}`;
+    op.summary = summary;
+    this.addLog(`Team ${teamIndex + 1} - ${summary}`);
+
+    if (!success && event.escalate) {
+      const combatEvent = operationEvents.find(e => e.type === 'combat');
+      this.resolveEvent(teamIndex, combatEvent);
+    }
+    return { success, artifact };
   }
 
   enable() {
@@ -82,16 +167,40 @@ class WarpGateCommand extends EffectableEntity {
 
   update(_delta) {
     const seconds = _delta / 1000;
-    this.operations.forEach(op => {
+    this.operations.forEach((op, idx) => {
       if (op.active) {
+        const prev = Math.floor(op.timer / 60);
         op.timer += seconds;
-        op.progress = op.timer / 600;
-        if (op.progress >= 1) {
-          op.timer = 0;
-          op.progress = 0;
+        const curr = Math.floor(op.timer / 60);
+        for (let t = prev; t < curr && t < 9; t++) {
+          this.resolveEvent(idx, this.chooseEvent());
         }
+        if (op.timer >= 600) {
+          this.finishOperation(idx);
+          op.timer -= 600;
+        }
+        op.progress = op.timer / 600;
       }
     });
+  }
+
+  finishOperation(teamIndex) {
+    const op = this.operations[teamIndex];
+    if (!op) return;
+    const art = op.artifacts;
+    const successes = op.successes;
+    if (art > 0 && typeof resources !== 'undefined' && resources.special && resources.special.alienArtifact) {
+      resources.special.alienArtifact.increase(art);
+    }
+    const team = this.teams[teamIndex];
+    if (team) {
+      team.forEach(m => { if (m) m.xp = (m.xp || 0) + successes; });
+    }
+    const summary = `Operation Complete: ${successes} success(es), ${art} artifact(s)`;
+    op.summary = summary;
+    this.addLog(`Team ${teamIndex + 1} - ${summary}`);
+    op.artifacts = 0;
+    op.successes = 0;
   }
 
   startOperation(teamIndex) {
@@ -102,6 +211,9 @@ class WarpGateCommand extends EffectableEntity {
     op.active = true;
     op.progress = 0;
     op.timer = 0;
+    op.artifacts = 0;
+    op.successes = 0;
+    op.summary = '';
     return true;
   }
 
@@ -142,8 +254,12 @@ class WarpGateCommand extends EffectableEntity {
       operations: this.operations.map(op => ({
         active: op.active,
         progress: op.progress,
-        timer: op.timer
-      }))
+        timer: op.timer,
+        artifacts: op.artifacts,
+        successes: op.successes,
+        summary: op.summary
+      })),
+      log: this.log.slice()
     };
   }
 
@@ -165,8 +281,14 @@ class WarpGateCommand extends EffectableEntity {
       this.operations = data.operations.map(op => ({
         active: !!op.active,
         progress: op.progress || 0,
-        timer: op.timer || 0
+        timer: op.timer || 0,
+        artifacts: op.artifacts || 0,
+        successes: op.successes || 0,
+        summary: op.summary || ''
       }));
+    }
+    if (Array.isArray(data.log)) {
+      this.log = data.log.slice(-100);
     }
   }
 }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -45,7 +45,7 @@ function updateWGCVisibility() {
 function generateWGCTeamCards() {
   return teamNames.map((name, tIdx) => {
     const slots = (typeof warpGateCommand !== 'undefined' && warpGateCommand.teams[tIdx]) ? warpGateCommand.teams[tIdx] : [null, null, null, null];
-    const op = (typeof warpGateCommand !== 'undefined' && warpGateCommand.operations[tIdx]) ? warpGateCommand.operations[tIdx] : { active: false, progress: 0 };
+    const op = (typeof warpGateCommand !== 'undefined' && warpGateCommand.operations[tIdx]) ? warpGateCommand.operations[tIdx] : { active: false, progress: 0, summary: '' };
     const slotMarkup = slots.map((m, sIdx) => {
       if (m) {
         const img = classImages[m.classType] || '';
@@ -71,6 +71,7 @@ function generateWGCTeamCards() {
         <div class="operation-progress${op.active ? '' : ' hidden'}">
           <div class="operation-progress-bar" style="width: ${op.progress * 100}%"></div>
         </div>
+        <div class="operation-summary${op.active ? '' : ' hidden'}">${op.summary || ''}</div>
       </div>`;
   }).join('');
 }
@@ -315,6 +316,10 @@ function generateWGCLayout() {
         <div id="wgc-teams-section">
           <h3>Teams</h3>
           <div id="wgc-team-cards"></div>
+          <div id="wgc-log-container">
+            <h3>Log</h3>
+            <pre id="wgc-log"></pre>
+          </div>
         </div>
       </div>
     </div>
@@ -361,6 +366,9 @@ function initializeWGCUI() {
     populateRDMenu();
   }
   wgcUIInitialized = true;
+  if (typeof warpGateCommand !== 'undefined') {
+    updateWGCUI();
+  }
 }
 
 function updateWGCUI() {
@@ -388,6 +396,7 @@ function updateWGCUI() {
     const recallBtn = card.querySelector('.recall-button');
     const progressContainer = card.querySelector('.operation-progress');
     const progressBar = card.querySelector('.operation-progress-bar');
+    const summaryEl = card.querySelector('.operation-summary');
     const team = warpGateCommand.teams[tIdx] || [];
     const full = team.every(m => m);
     const op = warpGateCommand.operations[tIdx];
@@ -397,12 +406,25 @@ function updateWGCUI() {
       if (op.active) {
         progressContainer.classList.remove('hidden');
         progressBar.style.width = `${Math.floor(op.progress * 100)}%`;
+        if (summaryEl) {
+          summaryEl.classList.remove('hidden');
+          summaryEl.textContent = op.summary || '';
+        }
       } else {
         progressContainer.classList.add('hidden');
         progressBar.style.width = '0%';
+        if (summaryEl) {
+          summaryEl.classList.add('hidden');
+          summaryEl.textContent = '';
+        }
       }
     }
   });
+
+  const logEl = document.getElementById('wgc-log');
+  if (logEl) {
+    logEl.textContent = (warpGateCommand.log || []).join('\n');
+  }
 }
 
 function redrawWGCTeamCards() {
@@ -410,6 +432,7 @@ function redrawWGCTeamCards() {
   if (teamContainer) {
     teamContainer.innerHTML = generateWGCTeamCards();
   }
+  updateWGCUI();
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/tests/wgcOperationEvents.test.js
+++ b/tests/wgcOperationEvents.test.js
@@ -1,0 +1,34 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC operation events', () => {
+  class MockResource extends EffectableEntity {
+    constructor(v=0){ super({description:'aa'}); this.value=v; }
+    increase(v){ this.value += v; }
+  }
+
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: new MockResource(0) } };
+  });
+
+  test('events grant xp and artifacts on success', () => {
+    const wgc = new WarpGateCommand();
+    for(let i=0;i<4;i++){
+      const m = WGCTeamMember.create('A'+i,'','Soldier',{});
+      m.power = 10; m.athletics = 10; m.wit = 10;
+      wgc.recruitMember(0,i,m);
+    }
+    wgc.roll = () => 20;
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    expect(wgc.startOperation(0)).toBe(true);
+    wgc.update(540000); // 9 minutes
+    expect(wgc.operations[0].successes).toBe(9);
+    expect(wgc.operations[0].artifacts).toBe(9);
+    wgc.update(60000); // final minute
+    expect(global.resources.special.alienArtifact.value).toBe(9);
+    wgc.teams[0].forEach(m => expect(m.xp).toBe(9));
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- support xp on WGCTeamMembers
- implement weighted challenge events for WGC operations
- reward operations with alien artifacts and xp
- show challenge summaries and a log in the WGC UI
- add tests for new operation event logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aa8c308388327b0e3463b996e7833