### PR TITLE
Fix WGC team card lock overlay

### DIFF
--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -221,7 +221,8 @@
 #wgc-log {
   white-space: pre-wrap;
   font-size: 0.8em;
-=======
+}
+
 .wgc-team-locked {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- restore missing CSS for the Warp Gate Command team lock overlay

## Testing
- `npm test --silent` *(fails: Test Suites: 4 failed, 298 passed, 302 total)*

------
https://chatgpt.com/codex/tasks/task_b_688aadf7c9348327ba57713b12141e88