### PR TITLE
Silence test console output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,3 +234,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC tracks total operations completed, displaying the count under the R&D menu.
   Teams Beta, Gamma, Delta and Epsilon remain locked until 100, 500, 1000 and
   5000 operations respectively.
+- Jest setup now suppresses console output for quieter test runs.

--- a/tests/jestSetup.js
+++ b/tests/jestSetup.js
@@ -16,3 +16,8 @@ if (typeof global.window !== 'undefined') {
     global.window.cancelAnimationFrame = global.cancelAnimationFrame;
   }
 }
+
+// Silence noisy console output during tests
+['log', 'info', 'warn', 'error'].forEach(method => {
+  jest.spyOn(console, method).mockImplementation(() => {});
+});


### PR DESCRIPTION
## Summary
- quiet the Jest output by mocking console methods in `jestSetup`
- document the new test behavior in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aafab0ce88327b43531d0e778ced1