### PR TITLE
Add per-team operation logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,3 +235,4 @@ second time they speak in a chapter to help clarify who is talking.
   Teams Beta, Gamma, Delta and Epsilon remain locked until 100, 500, 1000 and
   5000 operations respectively.
 - Jest setup now suppresses console output for quieter test runs.
+- Operation logs are now kept per team with an expandable section in each card.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -210,6 +210,21 @@
   margin-top: 2px;
 }
 
+.team-log {
+  max-height: 100px;
+  overflow-y: auto;
+  background-color: #f9f9f9;
+  border: 1px solid #ccc;
+  margin-top: 5px;
+  padding: 3px;
+}
+
+.team-log pre {
+  white-space: pre-wrap;
+  font-size: 0.75em;
+  margin: 0;
+}
+
 #wgc-log-container {
   max-height: 200px;
   overflow-y: auto;

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -21,7 +21,7 @@ class WarpGateCommand extends EffectableEntity {
     this.enabled = false;
     this.teams = Array.from({ length: 5 }, () => Array(4).fill(null));
     this.operations = Array.from({ length: 5 }, () => ({ active: false, progress: 0, timer: 0, artifacts: 0, successes: 0, summary: '' }));
-    this.log = [];
+    this.logs = Array.from({ length: 5 }, () => []);
     this.totalOperations = 0;
     this.rdUpgrades = {
       wgtEquipment: { purchases: 0 },
@@ -32,9 +32,11 @@ class WarpGateCommand extends EffectableEntity {
     };
   }
 
-  addLog(text) {
-    this.log.push(text);
-    if (this.log.length > 100) this.log.shift();
+  addLog(teamIndex, text) {
+    if (!Array.isArray(this.logs[teamIndex])) return;
+    const log = this.logs[teamIndex];
+    log.push(text);
+    if (log.length > 100) log.shift();
   }
 
   chooseEvent() {
@@ -97,7 +99,7 @@ class WarpGateCommand extends EffectableEntity {
     if (artifact) op.artifacts += 1;
     const summary = `${event.name}: ${success ? 'Success' : 'Fail'}${artifact ? ' +1 Artifact' : ''}`;
     op.summary = summary;
-    this.addLog(`Team ${teamIndex + 1} - ${summary}`);
+    this.addLog(teamIndex, `Team ${teamIndex + 1} - ${summary}`);
 
     if (!success && event.escalate) {
       const combatEvent = operationEvents.find(e => e.type === 'combat');
@@ -204,7 +206,7 @@ class WarpGateCommand extends EffectableEntity {
     }
     const summary = `Operation Complete: ${successes} success(es), ${art} artifact(s)`;
     op.summary = summary;
-    this.addLog(`Team ${teamIndex + 1} - ${summary}`);
+    this.addLog(teamIndex, `Team ${teamIndex + 1} - ${summary}`);
     op.artifacts = 0;
     op.successes = 0;
   }
@@ -265,7 +267,7 @@ class WarpGateCommand extends EffectableEntity {
         successes: op.successes,
         summary: op.summary
       })),
-      log: this.log.slice(),
+      logs: this.logs.map(l => l.slice()),
       totalOperations: this.totalOperations
     };
   }
@@ -294,8 +296,8 @@ class WarpGateCommand extends EffectableEntity {
         summary: op.summary || ''
       }));
     }
-    if (Array.isArray(data.log)) {
-      this.log = data.log.slice(-100);
+    if (Array.isArray(data.logs)) {
+      this.logs = data.logs.map(l => l.slice(-100));
     }
     this.totalOperations = data.totalOperations || 0;
   }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -69,12 +69,14 @@ function generateWGCTeamCards() {
           <div class="team-controls">
             <button class="start-button" data-team="${tIdx}">Start</button>
             <button class="recall-button" data-team="${tIdx}">Recall</button>
+            <button class="log-toggle" data-team="${tIdx}">Log</button>
           </div>
         </div>
         <div class="operation-progress${op.active ? '' : ' hidden'}">
           <div class="operation-progress-bar" style="width: ${op.progress * 100}%"></div>
         </div>
         <div class="operation-summary${op.active ? '' : ' hidden'}">${op.summary || ''}</div>
+        <div class="team-log hidden"><pre></pre></div>
         ${lockMarkup}
       </div>`;
   }).join('');
@@ -321,10 +323,6 @@ function generateWGCLayout() {
         <div id="wgc-teams-section">
           <h3>Teams</h3>
           <div id="wgc-team-cards"></div>
-          <div id="wgc-log-container">
-            <h3>Log</h3>
-            <pre id="wgc-log"></pre>
-          </div>
         </div>
       </div>
     </div>
@@ -351,6 +349,13 @@ function initializeWGCUI() {
           const t = parseInt(e.target.dataset.team, 10);
           warpGateCommand.recallTeam(t);
           updateWGCUI();
+          return;
+        }
+        if (e.target.classList.contains('log-toggle')) {
+          const t = parseInt(e.target.dataset.team, 10);
+          const card = e.target.closest('.wgc-team-card');
+          const log = card.querySelector('.team-log');
+          if (log) log.classList.toggle('hidden');
           return;
         }
 
@@ -436,10 +441,12 @@ function updateWGCUI() {
     }
   });
 
-  const logEl = document.getElementById('wgc-log');
-  if (logEl) {
-    logEl.textContent = (warpGateCommand.log || []).join('\n');
-  }
+  teamNames.forEach((_, tIdx) => {
+    const logEl = document.querySelector(`.wgc-team-card[data-team="${tIdx}"] .team-log pre`);
+    if (logEl) {
+      logEl.textContent = (warpGateCommand.logs[tIdx] || []).join('\n');
+    }
+  });
 }
 
 function redrawWGCTeamCards() {

--- a/tests/wgcTeamLogs.test.js
+++ b/tests/wgcTeamLogs.test.js
@@ -1,0 +1,27 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC team logs', () => {
+  test('logs stored per team and trimmed', () => {
+    const wgc = new WarpGateCommand();
+    for(let i=0;i<4;i++){
+      wgc.recruitMember(0, i, WGCTeamMember.create('A'+i,'','Soldier',{}));
+      wgc.recruitMember(1, i, WGCTeamMember.create('B'+i,'','Soldier',{}));
+    }
+    wgc.roll = () => 20;
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    wgc.startOperation(0);
+    wgc.startOperation(1);
+    wgc.update(60000); // one minute
+    expect(wgc.logs[0].length).toBe(1);
+    expect(wgc.logs[1].length).toBe(1);
+    // add many entries to check trimming
+    for(let i=0;i<150;i++){
+      wgc.addLog(0, 'entry');
+    }
+    expect(wgc.logs[0].length).toBeLessThanOrEqual(100);
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- restructure WGC logging to store entries per team
- update save/load logic to persist new logs
- show expandable log area on each team card
- adjust styles for the new per-team log UI
- document feature update in `AGENTS.md`
- add unit test for per-team logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab09c92848327aef96445eb8996c1