### PR TITLE
Add default operation summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,3 +236,4 @@ second time they speak in a chapter to help clarify who is talking.
   5000 operations respectively.
 - Jest setup now suppresses console output for quieter test runs.
 - Operation logs are now kept per team with an expandable section in each card.
+- Starting an operation now displays the default summary text "Setting out through Warp Gate".

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -15,6 +15,8 @@ const operationEvents = [
   { name: 'Combat challenge', type: 'combat', weight: 1 }
 ];
 
+const operationStartText = 'Setting out through Warp Gate';
+
 class WarpGateCommand extends EffectableEntity {
   constructor() {
     super({ description: 'Warp Gate Command manager' });
@@ -221,7 +223,7 @@ class WarpGateCommand extends EffectableEntity {
     op.timer = 0;
     op.artifacts = 0;
     op.successes = 0;
-    op.summary = '';
+    op.summary = operationStartText;
     return true;
   }
 

--- a/tests/wgcOperationSummary.test.js
+++ b/tests/wgcOperationSummary.test.js
@@ -1,0 +1,15 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC operation summary', () => {
+  test('startOperation sets default summary text', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A'+i, '', 'Soldier', {}));
+    }
+    expect(wgc.startOperation(0)).toBe(true);
+    expect(wgc.operations[0].summary).toBe('Setting out through Warp Gate');
+  });
+});


### PR DESCRIPTION
## Summary
- set default summary text when a WGC team begins an operation
- test that startOperation initializes this text
- document the new behaviour in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab2ad381883279348f34d38887cc9