### PR TITLE
Improve WGC operation logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,3 +236,4 @@ second time they speak in a chapter to help clarify who is talking.
   5000 operations respectively.
 - Jest setup now suppresses console output for quieter test runs.
 - Operation logs are now kept per team with an expandable section in each card.
+- Operation logs list dice rolls, DC and skill totals.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -50,54 +50,71 @@ class WarpGateCommand extends EffectableEntity {
   }
 
   roll(dice) {
-    let sum = 0;
+    const rolls = [];
     for (let i = 0; i < dice; i++) {
-      sum += Math.floor(Math.random() * 20) + 1;
+      rolls.push(Math.floor(Math.random() * 20) + 1);
     }
-    return sum;
+    return { sum: rolls.reduce((s, v) => s + v, 0), rolls };
   }
 
   resolveEvent(teamIndex, event) {
     const team = this.teams[teamIndex];
     if (!team) return { success: false, artifact: false };
     let success = false;
+    let rollResult = { sum: 0, rolls: [] };
+    let dc = 0;
+    let skillTotal = 0;
     switch (event.type) {
-      case 'team':
-        const skillSum = team.reduce((s, m) => s + (m ? m[event.skill] : 0), 0);
-        success = this.roll(4) + skillSum >= 40;
+      case 'team': {
+        skillTotal = team.reduce((s, m) => s + (m ? m[event.skill] : 0), 0);
+        rollResult = this.roll(4);
+        dc = 40;
+        success = rollResult.sum + skillTotal >= dc;
         break;
-      case 'individual':
+      }
+      case 'individual': {
         const members = team.filter(m => m);
         if (members.length === 0) return { success: false, artifact: false };
         const member = members[Math.floor(Math.random() * members.length)];
-        success = this.roll(1) + member[event.skill] >= 10;
+        skillTotal = member[event.skill];
+        rollResult = this.roll(1);
+        dc = 10;
+        success = rollResult.sum + skillTotal >= dc;
         break;
-      case 'science':
+      }
+      case 'science': {
         let m = team.find(t => t && t.classType === event.specialty);
         if (!m) {
           m = team[0];
           if (!m) return { success: false, artifact: false };
-          const wit = Math.floor(m.wit / 2);
-          success = this.roll(1) + wit >= 10;
+          skillTotal = Math.floor(m.wit / 2);
         } else {
-          success = this.roll(1) + m.wit >= 10;
+          skillTotal = m.wit;
         }
+        rollResult = this.roll(1);
+        dc = 10;
+        success = rollResult.sum + skillTotal >= dc;
         break;
-      case 'combat':
-        const combatSkill = team.reduce((s, mem) => {
+      }
+      case 'combat': {
+        skillTotal = team.reduce((s, mem) => {
           if (!mem) return s;
           const mult = mem.classType === 'Soldier' ? 2 : 1;
-          return s + (mem.power * mult);
+          return s + mem.power * mult;
         }, 0);
-        success = this.roll(4) + combatSkill >= 40;
+        rollResult = this.roll(4);
+        dc = 40;
+        success = rollResult.sum + skillTotal >= dc;
         break;
+      }
     }
 
     const artifact = success && Math.random() < 0.1;
     const op = this.operations[teamIndex];
     if (success) op.successes += 1;
     if (artifact) op.artifacts += 1;
-    const summary = `${event.name}: ${success ? 'Success' : 'Fail'}${artifact ? ' +1 Artifact' : ''}`;
+    const rollsStr = rollResult.rolls.join(',');
+    const summary = `${event.name}: roll [${rollsStr}] + skill ${skillTotal} (total ${rollResult.sum + skillTotal}) vs DC ${dc} => ${success ? 'Success' : 'Fail'}${artifact ? ' +1 Artifact' : ''}`;
     op.summary = summary;
     this.addLog(teamIndex, `Team ${teamIndex + 1} - ${summary}`);
 

--- a/tests/wgcOperationEvents.test.js
+++ b/tests/wgcOperationEvents.test.js
@@ -20,7 +20,7 @@ describe('WGC operation events', () => {
       m.power = 10; m.athletics = 10; m.wit = 10;
       wgc.recruitMember(0,i,m);
     }
-    wgc.roll = () => 20;
+    wgc.roll = () => ({ sum: 20, rolls: [20] });
     jest.spyOn(Math, 'random').mockReturnValue(0);
     expect(wgc.startOperation(0)).toBe(true);
     wgc.update(540000); // 9 minutes

--- a/tests/wgcOperationLogDetails.test.js
+++ b/tests/wgcOperationLogDetails.test.js
@@ -1,0 +1,22 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC operation log details', () => {
+  test('log includes roll results and DC', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      const m = WGCTeamMember.create('A'+i, '', 'Soldier', {});
+      wgc.recruitMember(0, i, m);
+    }
+    wgc.roll = () => ({ sum: 20, rolls: [20] });
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    wgc.startOperation(0);
+    wgc.update(60000);
+    const entry = wgc.logs[0][0];
+    expect(entry).toMatch(/roll \[/i);
+    expect(entry).toMatch(/DC 40/);
+    Math.random.mockRestore();
+  });
+});

--- a/tests/wgcTeamLogs.test.js
+++ b/tests/wgcTeamLogs.test.js
@@ -10,7 +10,7 @@ describe('WGC team logs', () => {
       wgc.recruitMember(0, i, WGCTeamMember.create('A'+i,'','Soldier',{}));
       wgc.recruitMember(1, i, WGCTeamMember.create('B'+i,'','Soldier',{}));
     }
-    wgc.roll = () => 20;
+    wgc.roll = () => ({ sum: 20, rolls: [20] });
     jest.spyOn(Math, 'random').mockReturnValue(0);
     wgc.startOperation(0);
     wgc.startOperation(1);


### PR DESCRIPTION
## Summary
- include dice rolls, DC and skill totals in WGC operation logs
- update tests for new roll object
- cover new log details with a unit test
- document the operation log enhancement in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab329a548832788db6db84bb94f8c