### PR TITLE
Prevent dismissing WGC members mid-operation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,3 +236,4 @@ second time they speak in a chapter to help clarify who is talking.
   5000 operations respectively.
 - Jest setup now suppresses console output for quieter test runs.
 - Operation logs are now kept per team with an expandable section in each card.
+- Team members cannot be dismissed while their team is on an operation; the recruit dialog disables the Dismiss button.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -241,9 +241,13 @@ class WarpGateCommand extends EffectableEntity {
   }
 
   dismissMember(teamIndex, slotIndex) {
+    const op = this.operations[teamIndex];
+    if (op && op.active) return false;
     if (this.teams[teamIndex]) {
       this.teams[teamIndex][slotIndex] = null;
+      return true;
     }
+    return false;
   }
 
   renameMember(teamIndex, slotIndex, name) {

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -293,6 +293,9 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   if (member) {
     const dismiss = document.createElement('button');
     dismiss.textContent = 'Dismiss';
+    if (warpGateCommand.operations[teamIndex] && warpGateCommand.operations[teamIndex].active) {
+      dismiss.disabled = true;
+    }
     dismiss.addEventListener('click', () => {
       if (dismiss.textContent === 'Dismiss') {
         dismiss.textContent = 'Are You Sure?';

--- a/tests/wgcDismissButtonDisabled.test.js
+++ b/tests/wgcDismissButtonDisabled.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WarpGateCommand } = require('../src/js/wgc.js');
+const { WGCTeamMember } = require('../src/js/team-member.js');
+
+describe('WGC dismiss restrictions', () => {
+  test('dismiss button disabled during active operation', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = WarpGateCommand;
+    ctx.WGCTeamMember = WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.warpGateCommand.enable();
+    for (let i = 0; i < 4; i++) {
+      ctx.warpGateCommand.recruitMember(0, i, ctx.WGCTeamMember.create('A'+i, '', 'Soldier', {}));
+    }
+    ctx.redrawWGCTeamCards();
+    ctx.updateWGCUI();
+    ctx.warpGateCommand.startOperation(0);
+    ctx.updateWGCUI();
+    ctx.openRecruitDialog(0, 0, ctx.warpGateCommand.teams[0][0]);
+    const btn = Array.from(dom.window.document.querySelectorAll('.wgc-popup-window button'))
+      .find(b => b.textContent === 'Dismiss');
+    expect(btn.disabled).toBe(true);
+  });
+
+  test('dismissMember returns false when operation active', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('B'+i, '', 'Soldier', {}));
+    }
+    wgc.startOperation(0);
+    const result = wgc.dismissMember(0, 0);
+    expect(result).toBe(false);
+    expect(wgc.teams[0][0]).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent Warp Gate Command team member dismissals when an operation is active
- disable the Dismiss button while operations run
- test new dismissal restriction
- document the change in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab365d53c83279fb118a9ab151218