### PR TITLE
Add operation difficulty system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,3 +237,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Jest setup now suppresses console output for quieter test runs.
 - Operation logs are now kept per team with an expandable section in each card.
 - Starting an operation now displays the default summary text "Setting out through Warp Gate".
+- Operations now have a difficulty setting. Higher difficulties raise DCs and artifact rewards, and failed challenges deal HP damage.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -67,6 +67,8 @@ function generateWGCTeamCards() {
         <div class="wgc-team-body">
           <div class="team-slots">${slotMarkup}</div>
           <div class="team-controls">
+            <label>Diff:</label>
+            <input type="number" class="difficulty-input" data-team="${tIdx}" value="${op.difficulty || 0}" min="0">
             <button class="start-button" data-team="${tIdx}">Start</button>
             <button class="recall-button" data-team="${tIdx}">Recall</button>
             <button class="log-toggle" data-team="${tIdx}">Log</button>
@@ -341,7 +343,10 @@ function initializeWGCUI() {
       teamContainer.addEventListener('click', e => {
         if (e.target.classList.contains('start-button')) {
           const t = parseInt(e.target.dataset.team, 10);
-          warpGateCommand.startOperation(t);
+          const card = e.target.closest('.wgc-team-card');
+          const input = card ? card.querySelector('.difficulty-input') : null;
+          const diff = input ? Math.floor(Math.max(0, parseInt(input.value, 10) || 0)) : 0;
+          warpGateCommand.startOperation(t, diff);
           updateWGCUI();
           return;
         }
@@ -408,6 +413,7 @@ function updateWGCUI() {
     if (!card) return;
     const startBtn = card.querySelector('.start-button');
     const recallBtn = card.querySelector('.recall-button');
+    const diffInput = card.querySelector('.difficulty-input');
     const progressContainer = card.querySelector('.operation-progress');
     const progressBar = card.querySelector('.operation-progress-bar');
     const summaryEl = card.querySelector('.operation-summary');
@@ -422,6 +428,7 @@ function updateWGCUI() {
     }
     if (startBtn) startBtn.disabled = !unlocked || !full || op.active;
     if (recallBtn) recallBtn.disabled = !unlocked || !op.active;
+    if (diffInput) diffInput.value = op.difficulty || 0;
     if (progressContainer && progressBar) {
       if (op.active) {
         progressContainer.classList.remove('hidden');

--- a/tests/wgcOperationDifficulty.test.js
+++ b/tests/wgcOperationDifficulty.test.js
@@ -1,0 +1,54 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC operation difficulty', () => {
+  test('difficulty scales artifact chance', () => {
+    const event = { name: 'Indiv', type: 'individual', skill: 'athletics' };
+    const wgc0 = new WarpGateCommand();
+    for (let i=0;i<4;i++) {
+      const m = WGCTeamMember.create('A'+i,'','Soldier',{});
+      m.athletics = 10;
+      wgc0.recruitMember(0,i,m);
+    }
+    wgc0.roll = () => 10;
+    jest.spyOn(Math, 'random').mockReturnValue(0.11);
+    wgc0.startOperation(0,0);
+    wgc0.resolveEvent(0,event);
+    expect(wgc0.operations[0].artifacts).toBe(0);
+
+    const wgc2 = new WarpGateCommand();
+    for (let i=0;i<4;i++) {
+      const m = WGCTeamMember.create('B'+i,'','Soldier',{});
+      m.athletics = 10;
+      wgc2.recruitMember(0,i,m);
+    }
+    wgc2.roll = () => 10;
+    Math.random.mockReturnValue(0.11);
+    wgc2.startOperation(0,2);
+    wgc2.resolveEvent(0,event);
+    expect(wgc2.operations[0].artifacts).toBe(1);
+    Math.random.mockRestore();
+  });
+
+  test('failed challenges deal damage', () => {
+    const eventInd = { name: 'Indiv', type: 'individual', skill: 'athletics' };
+    const eventTeam = { name: 'Team', type: 'team', skill: 'power' };
+    const wgc = new WarpGateCommand();
+    for (let i=0;i<4;i++) {
+      const m = WGCTeamMember.create('C'+i,'','Soldier',{});
+      wgc.recruitMember(0,i,m);
+    }
+    wgc.roll = () => 1;
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    wgc.startOperation(0,3);
+    const member = wgc.teams[0][0];
+    wgc.resolveEvent(0,eventInd);
+    expect(member.health).toBe(70);
+    wgc.resolveEvent(0,eventTeam);
+    expect(wgc.teams[0][0].health).toBe(60);
+    wgc.teams[0].slice(1).forEach(m => expect(m.health).toBe(90));
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- allow setting team operation difficulty in Warp Gate Command
- scale DCs, artifact chance and health damage from the new difficulty
- show difficulty inputs on team cards
- persist difficulty level in saves
- add tests for difficulty behavior
- document update in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab4743338832795ef3908de7ed10d