### PR TITLE
Implement social science failure escalation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,3 +238,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Operation logs are now kept per team with an expandable section in each card.
 - Operation logs list dice rolls, DC and skill totals.
 - Starting an operation now displays the default summary text "Setting out through Warp Gate".
+- Failed Social Science challenges now trigger the next event as a Combat challenge at 25% higher difficulty.

--- a/tests/wgcSocialScienceEscalation.test.js
+++ b/tests/wgcSocialScienceEscalation.test.js
@@ -1,0 +1,21 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC social science escalation', () => {
+  test('failed social science challenge triggers harder combat next', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A'+i, '', 'Soldier', {}));
+    }
+    const socialEvent = { name: 'Social Science challenge', type: 'science', specialty: 'Social Scientist', escalate: true };
+    wgc.roll = () => ({ sum: 1, rolls: [1] });
+    const res = wgc.resolveEvent(0, socialEvent);
+    expect(res.success).toBe(false);
+    expect(wgc.logs[0].length).toBe(1);
+    const next = wgc.chooseEvent();
+    expect(next.type).toBe('combat');
+    expect(next.difficultyMultiplier).toBeCloseTo(1.25);
+  });
+});


### PR DESCRIPTION
## Summary
- escalate failed Social Science challenges to a harder combat challenge on the next event
- persist pending combat difficulty in save data
- test Social Science escalation logic
- document the new escalation rule in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab4f3bda88327839c64f2921d3cf0