### PR TITLE
Add team HP bar

### DIFF
--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -255,3 +255,20 @@
   text-align: center;
   z-index: 1;
 }
+
+.team-hp-bar {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  bottom: 2px;
+  width: 6px;
+  background-color: #555;
+}
+
+.team-hp-bar-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: green;
+}

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -51,7 +51,10 @@ function generateWGCTeamCards() {
       if (m) {
         const img = classImages[m.classType] || '';
         const unspentPoints = m.getPointsToAllocate() > 0 ? '<div class="unspent-points-indicator">!</div>' : '';
+        const hpPercent = Math.floor((m.health / m.maxHealth) * 100);
+        const hpColor = hpPercent < 25 ? 'red' : 'green';
         return `<div class="team-slot filled" data-team="${tIdx}" data-slot="${sIdx}">
+          <div class="team-hp-bar"><div class="team-hp-bar-fill" style="height:${hpPercent}%;background-color:${hpColor};"></div></div>
           <div class="team-member-name">${m.firstName}</div>
           <img src="${img}" class="team-icon">
           ${unspentPoints}
@@ -439,6 +442,17 @@ function updateWGCUI() {
         }
       }
     }
+
+    team.forEach((member, sIdx) => {
+      const slot = card.querySelector(`.team-slot[data-slot="${sIdx}"]`);
+      if (!slot || !member) return;
+      const bar = slot.querySelector('.team-hp-bar-fill');
+      if (bar) {
+        const hpPercent = Math.floor((member.health / member.maxHealth) * 100);
+        bar.style.height = `${hpPercent}%`;
+        bar.style.backgroundColor = hpPercent < 25 ? 'red' : 'green';
+      }
+    });
   });
 
   teamNames.forEach((_, tIdx) => {

--- a/tests/wgcTeamHPBar.test.js
+++ b/tests/wgcTeamHPBar.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC team HP bar', () => {
+  test('hp bar reflects health percent and color', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WGCTeamMember = require('../src/js/team-member.js').WGCTeamMember;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.warpGateCommand.enable();
+    const healthy = new ctx.WGCTeamMember({ firstName: 'A', classType: 'Soldier', health: 100, maxHealth: 100 });
+    const wounded = new ctx.WGCTeamMember({ firstName: 'B', classType: 'Soldier', health: 20, maxHealth: 100 });
+    ctx.warpGateCommand.recruitMember(0, 0, healthy);
+    ctx.warpGateCommand.recruitMember(0, 1, wounded);
+    ctx.redrawWGCTeamCards();
+    ctx.updateWGCUI();
+    const fills = dom.window.document.querySelectorAll('.team-hp-bar-fill');
+    expect(fills.length).toBe(2);
+    expect(fills[0].style.height).toBe('100%');
+    expect(fills[0].style.backgroundColor).toBe('green');
+    expect(fills[1].style.height).toBe('20%');
+    expect(fills[1].style.backgroundColor).toBe('red');
+  });
+});


### PR DESCRIPTION
## Summary
- display WGC team member HP as a vertical bar in each slot
- update the bar each UI refresh
- style the bar in green or red based on HP percent
- cover feature with a new Jest test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab5b0e9148327bd9eec7e84cd2e26