### PR TITLE
Add WGC operation difficulty option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,3 +239,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Operation logs list dice rolls, DC and skill totals.
 - Starting an operation now displays the default summary text "Setting out through Warp Gate".
 - Failed Social Science challenges now trigger the next event as a Combat challenge at 25% higher difficulty.
+- Operations include a difficulty setting that adds to all DCs (team DC +4×) and
+  increases artifact rewards by 10% per level. Failed individual checks deal
+  10HP damage per level to the chosen member while failed team checks damage all
+  members for 10HP.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -98,6 +98,10 @@
   gap: 5px;
 }
 
+.team-controls .difficulty-input {
+  width: 60px;
+}
+
 .wgc-rd-item {
   display: flex;
   gap: 10px;

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -67,6 +67,7 @@ function generateWGCTeamCards() {
         <div class="wgc-team-body">
           <div class="team-slots">${slotMarkup}</div>
           <div class="team-controls">
+            <input type="number" class="difficulty-input" data-team="${tIdx}" value="${op.difficulty || 0}" min="0" />
             <button class="start-button" data-team="${tIdx}">Start</button>
             <button class="recall-button" data-team="${tIdx}">Recall</button>
             <button class="log-toggle" data-team="${tIdx}">Log</button>
@@ -341,7 +342,9 @@ function initializeWGCUI() {
       teamContainer.addEventListener('click', e => {
         if (e.target.classList.contains('start-button')) {
           const t = parseInt(e.target.dataset.team, 10);
-          warpGateCommand.startOperation(t);
+          const input = e.target.closest('.wgc-team-card').querySelector('.difficulty-input');
+          const diff = input ? Math.floor(Math.max(0, parseInt(input.value, 10) || 0)) : 0;
+          warpGateCommand.startOperation(t, diff);
           updateWGCUI();
           return;
         }
@@ -408,6 +411,7 @@ function updateWGCUI() {
     if (!card) return;
     const startBtn = card.querySelector('.start-button');
     const recallBtn = card.querySelector('.recall-button');
+    const diffInput = card.querySelector('.difficulty-input');
     const progressContainer = card.querySelector('.operation-progress');
     const progressBar = card.querySelector('.operation-progress-bar');
     const summaryEl = card.querySelector('.operation-summary');
@@ -422,6 +426,10 @@ function updateWGCUI() {
     }
     if (startBtn) startBtn.disabled = !unlocked || !full || op.active;
     if (recallBtn) recallBtn.disabled = !unlocked || !op.active;
+    if (diffInput) {
+      diffInput.value = op.difficulty || 0;
+      diffInput.disabled = op.active;
+    }
     if (progressContainer && progressBar) {
       if (op.active) {
         progressContainer.classList.remove('hidden');

--- a/tests/wgcOperationDifficulty.test.js
+++ b/tests/wgcOperationDifficulty.test.js
@@ -1,0 +1,45 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC operation difficulty', () => {
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: { increase: jest.fn(), value: 0 } } };
+  });
+
+  test('difficulty modifies DC and artifact rewards', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      const m = WGCTeamMember.create('A' + i, '', 'Soldier', {});
+      m.power = 10; m.athletics = 10; m.wit = 10;
+      wgc.recruitMember(0, i, m);
+    }
+    wgc.roll = () => ({ sum: 20, rolls: [20] });
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    wgc.startOperation(0, 2);
+    const ev = { name: 'Team Power Challenge', type: 'team', skill: 'power' };
+    wgc.resolveEvent(0, ev);
+    expect(wgc.operations[0].summary).toMatch(/DC 48/);
+    expect(wgc.operations[0].artifacts).toBeCloseTo(1.2);
+    Math.random.mockRestore();
+  });
+
+  test('failing challenges cause health loss', () => {
+    const wgc = new WarpGateCommand();
+    const member = WGCTeamMember.create('Bob', '', 'Soldier', {});
+    wgc.recruitMember(0, 0, member);
+    wgc.operations[0].difficulty = 3;
+    wgc.roll = () => ({ sum: 1, rolls: [1] });
+    const indEvent = { name: 'Ind', type: 'individual', skill: 'power' };
+    const teamEvent = { name: 'Team', type: 'team', skill: 'power' };
+    wgc.resolveEvent(0, indEvent);
+    expect(member.health).toBe(70);
+    wgc.recruitMember(0, 1, WGCTeamMember.create('C', '', 'Soldier', {}));
+    wgc.recruitMember(0, 2, WGCTeamMember.create('D', '', 'Soldier', {}));
+    wgc.recruitMember(0, 3, WGCTeamMember.create('E', '', 'Soldier', {}));
+    wgc.resolveEvent(0, teamEvent);
+    expect(wgc.teams[0][0].health).toBe(60);
+    wgc.teams[0].slice(1).forEach(m => { if (m) expect(m.health).toBe(90); });
+  });
+});


### PR DESCRIPTION
## Summary
- allow selecting difficulty when starting Warp Gate Command operations
- adjust DCs, artifact rewards, and health loss based on difficulty
- show difficulty input in team cards and disable it mid-operation
- document the new feature
- test operation difficulty mechanics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab6e4e2988327a8b62655b2b0fd46