### PR TITLE
Add critical success rule for WGC individual rolls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,3 +239,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Operation logs list dice rolls, DC and skill totals.
 - Starting an operation now displays the default summary text "Setting out through Warp Gate".
 - Failed Social Science challenges now trigger the next event as a Combat challenge at 25% higher difficulty.
+- Individual challenges that roll a 20 are now critical successes granting 1 Alien artifact.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -125,7 +125,11 @@ class WarpGateCommand extends EffectableEntity {
       }
     }
 
-    const artifact = success && Math.random() < 0.1;
+    let artifact = success && Math.random() < 0.1;
+    if (event.type === 'individual' && rollResult.rolls.includes(20)) {
+      success = true;
+      artifact = true;
+    }
     const op = this.operations[teamIndex];
     if (success) op.successes += 1;
     if (artifact) op.artifacts += 1;

--- a/tests/wgcCriticalSuccess.test.js
+++ b/tests/wgcCriticalSuccess.test.js
@@ -1,0 +1,28 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC critical success', () => {
+  class MockResource extends EffectableEntity {
+    constructor(v=0){ super({description:'aa'}); this.value=v; }
+    increase(v){ this.value += v; }
+  }
+
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: new MockResource(0) } };
+  });
+
+  test('individual roll of 20 always succeeds and grants an artifact', () => {
+    const wgc = new WarpGateCommand();
+    wgc.recruitMember(0, 0, WGCTeamMember.create('A', '', 'Soldier', {}));
+    const event = { name: 'Test', type: 'individual', skill: 'athletics' };
+    wgc.roll = () => ({ sum: 20, rolls: [20] });
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+    const res = wgc.resolveEvent(0, event);
+    expect(res.success).toBe(true);
+    expect(res.artifact).toBe(true);
+    expect(wgc.operations[0].artifacts).toBe(1);
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- make rolling a 20 on an individual WGC operation a critical success
- test critical success logic for individual events
- note critical successes in AGENTS log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab72810ac832794b56f45edfac3f9