### PR TITLE
Display critical success

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Failed Social Science challenges now trigger the next event as a Combat challenge at 25% higher difficulty.
 - Team member dismissal is disabled during ongoing operations.
 - Individual challenges that roll a 20 are now critical successes granting 1 Alien artifact.
+- Critical successes display "Critical Success" in operation logs.
 - Operations include a difficulty setting that adds to all DCs (team DC +4×) and
   increases artifact rewards by 10% per level. Failed individual checks deal
   10HP damage per level to the chosen member while failed team checks damage all

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -134,14 +134,16 @@ class WarpGateCommand extends EffectableEntity {
     }
 
     let artifact = success && Math.random() < 0.1;
-    if (event.type === 'individual' && rollResult.rolls.includes(20)) {
+    const critical = event.type === 'individual' && rollResult.rolls.includes(20);
+    if (critical) {
       success = true;
       artifact = true;
     }
     if (success) op.successes += 1;
     if (artifact) op.artifacts += 1 + (difficulty > 0 ? difficulty * 0.1 : 0);
     const rollsStr = rollResult.rolls.join(',');
-    const summary = `${event.name}: roll [${rollsStr}] + skill ${skillTotal} (total ${rollResult.sum + skillTotal}) vs DC ${dc} => ${success ? 'Success' : 'Fail'}${artifact ? ' +1 Artifact' : ''}`;
+    const outcome = success ? (critical ? 'Critical Success' : 'Success') : 'Fail';
+    const summary = `${event.name}: roll [${rollsStr}] + skill ${skillTotal} (total ${rollResult.sum + skillTotal}) vs DC ${dc} => ${outcome}${artifact ? ' +1 Artifact' : ''}`;
     op.summary = summary;
     this.addLog(teamIndex, `Team ${teamIndex + 1} - ${summary}`);
 

--- a/tests/wgcCriticalSuccess.test.js
+++ b/tests/wgcCriticalSuccess.test.js
@@ -23,6 +23,7 @@ describe('WGC critical success', () => {
     expect(res.success).toBe(true);
     expect(res.artifact).toBe(true);
     expect(wgc.operations[0].artifacts).toBe(1);
+    expect(wgc.operations[0].summary).toMatch(/Critical Success/);
     Math.random.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- show "Critical Success" in WGC operation summaries
- test critical success summary
- document log display update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ab99c15a08327ab872291c5d99544