### PR TITLE
Add difficulty label to WGC UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,4 @@ second time they speak in a chapter to help clarify who is talking.
   increases artifact rewards by 10% per level. Failed individual checks deal
   10HP damage per level to the chosen member while failed team checks damage all
   members for 10HP.
+- WGC team cards now label the difficulty selector with "Difficulty" displayed above the input.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -98,6 +98,12 @@
   gap: 5px;
 }
 
+.difficulty-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .team-controls .difficulty-input {
   width: 60px;
 }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -70,7 +70,10 @@ function generateWGCTeamCards() {
         <div class="wgc-team-body">
           <div class="team-slots">${slotMarkup}</div>
           <div class="team-controls">
-            <input type="number" class="difficulty-input" data-team="${tIdx}" value="${op.difficulty || 0}" min="0" />
+            <div class="difficulty-container">
+              <span>Difficulty</span>
+              <input type="number" class="difficulty-input" data-team="${tIdx}" value="${op.difficulty || 0}" min="0" />
+            </div>
             <button class="start-button" data-team="${tIdx}">Start</button>
             <button class="recall-button" data-team="${tIdx}">Recall</button>
             <button class="log-toggle" data-team="${tIdx}">Log</button>

--- a/tests/wgcDifficultyLabel.test.js
+++ b/tests/wgcDifficultyLabel.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC difficulty label', () => {
+  test('label displayed above selector', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    ctx.WGCTeamMember = require('../src/js/team-member.js').WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    const container = dom.window.document.querySelector('.difficulty-container');
+    expect(container).not.toBeNull();
+    const label = container.querySelector('span');
+    const input = container.querySelector('input.difficulty-input');
+    expect(label).not.toBeNull();
+    expect(label.textContent).toBe('Difficulty');
+    expect(container.firstElementChild).toBe(label);
+    expect(container.lastElementChild).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- show label above the Warp Gate Command difficulty selector
- style new difficulty container
- document WGC UI tweak in AGENTS notes
- test for difficulty label element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aba856794832794ef655789cc5e8a