### PR TITLE
Implement quadratic XP leveling for WGC members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,3 +247,4 @@ second time they speak in a chapter to help clarify who is talking.
   increases artifact rewards by 10% per level. Failed individual checks deal
   10HP damage per level to the chosen member while failed team checks damage all
   members for 10HP.
+- Team members gain levels after earning XP: 10 XP for level 2 with requirements scaling quadratically. Level ups increase Max Health and add one stat point.

--- a/src/js/team-member.js
+++ b/src/js/team-member.js
@@ -39,8 +39,25 @@ class WGCTeamMember {
     if (this.level < 1) return 0;
     const base = WGCTeamMember.getBaseStats(this.classType);
     const allocated = (this.power - base.power) + (this.athletics - base.athletics) + (this.wit - base.wit);
-    const totalPoints = 5 + ((this.level - 1) * 2);
+    const totalPoints = 5 + (this.level - 1);
     return totalPoints - allocated;
+  }
+
+  getXpForNextLevel() {
+    return 10 * this.level * this.level;
+  }
+
+  addXP(amount = 0) {
+    if (amount <= 0) return;
+    this.xp += amount;
+    let needed = this.getXpForNextLevel();
+    while (this.xp >= needed) {
+      this.xp -= needed;
+      this.level += 1;
+      this.maxHealth = 100 + this.level - 1;
+      if (this.health > this.maxHealth) this.health = this.maxHealth;
+      needed = this.getXpForNextLevel();
+    }
   }
 
   allocatePoints(allocation) {

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -257,7 +257,7 @@ class WarpGateCommand extends EffectableEntity {
     }
     const team = this.teams[teamIndex];
     if (team) {
-      team.forEach(m => { if (m) m.xp = (m.xp || 0) + successes; });
+      team.forEach(m => { if (m && typeof m.addXP === 'function') m.addXP(successes); });
     }
     const summary = `Operation ${op.number} Complete: ${successes} success(es), ${art} artifact(s)`;
     op.summary = summary;

--- a/tests/wgcTeamMemberLevelUp.test.js
+++ b/tests/wgcTeamMemberLevelUp.test.js
@@ -1,0 +1,26 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC team member XP and leveling', () => {
+  test('addXP levels up using quadratic requirement', () => {
+    const m = WGCTeamMember.create('Bob', '', 'Soldier', {});
+    m.addXP(10);
+    expect(m.level).toBe(2);
+    expect(m.xp).toBe(0);
+    m.addXP(50); // 40 needed for level 3, 10 leftover
+    expect(m.level).toBe(3);
+    expect(m.xp).toBe(10);
+  });
+
+  test('operations grant XP and trigger level ups', () => {
+    const wgc = new WarpGateCommand();
+    const member = WGCTeamMember.create('Alice', '', 'Soldier', {});
+    wgc.recruitMember(0, 0, member);
+    wgc.operations[0].successes = 10;
+    wgc.finishOperation(0);
+    expect(member.level).toBe(2);
+    expect(member.xp).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- scale team member stat points by level
- add quadratic XP requirements and leveling logic
- grant XP from operations via new method
- test WGC member leveling
- document leveling feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688abaec50448327aa65c915a1efa853