### PR TITLE
Display team max HP in recruit dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,3 +247,4 @@ second time they speak in a chapter to help clarify who is talking.
   increases artifact rewards by 10% per level. Failed individual checks deal
   10HP damage per level to the chosen member while failed team checks damage all
   members for 10HP.
+- Team member cards in the recruit dialog now show Max Health beside XP.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -209,6 +209,12 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   level.textContent = 'Level: 1';
   win.appendChild(level);
 
+  const xpHealth = document.createElement('div');
+  const xpValue = member ? (member.xp || 0) : 0;
+  const maxHPValue = member ? member.maxHealth : 100;
+  xpHealth.textContent = `XP: ${xpValue} | Max HP: ${maxHPValue}`;
+  win.appendChild(xpHealth);
+
   const pointsToSpend = member ? member.getPointsToAllocate() : 5;
   const alloc = { power: 0, athletics: 0, wit: 0 };
   const remainingSpan = document.createElement('div');

--- a/tests/wgcMemberCardHPDisplay.test.js
+++ b/tests/wgcMemberCardHPDisplay.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC member card display', () => {
+  test('shows XP and max health', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WGCTeamMember = WGCTeamMember;
+    ctx.WarpGateCommand = WarpGateCommand;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    const member = new ctx.WGCTeamMember({ firstName: 'Bob', classType: 'Soldier', xp: 5, maxHealth: 120, health: 120 });
+    ctx.warpGateCommand.recruitMember(0, 0, member);
+    ctx.redrawWGCTeamCards();
+    ctx.updateWGCUI();
+    ctx.openRecruitDialog(0, 0, member);
+    const text = dom.window.document.querySelector('.wgc-popup-window').textContent;
+    expect(text).toMatch(/XP:\s*5/);
+    expect(text).toMatch(/Max HP:\s*120/);
+  });
+});


### PR DESCRIPTION
## Summary
- show XP and max health in recruit dialog
- note change in AGENTS docs
- test for recruit dialog HP display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688abb202d288327adc3b99d9d37c7b5