### PR TITLE
Auto recall WGC team on KO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,3 +247,4 @@ second time they speak in a chapter to help clarify who is talking.
   increases artifact rewards by 10% per level. Failed individual checks deal
   10HP damage per level to the chosen member while failed team checks damage all
   members for 10HP.
+- Operations abort if any member's HP hits 0. Their HP resets to 1, the team is recalled and the journal notes the injury.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -157,6 +157,15 @@ class WarpGateCommand extends EffectableEntity {
         this.resolveEvent(teamIndex, combatEvent);
       }
     }
+
+    const injured = team.find(m => m && m.health <= 0);
+    if (injured) {
+      injured.health = 1;
+      this.recallTeam(teamIndex);
+      if (typeof addJournalEntry === 'function') {
+        addJournalEntry(`Team ${teamIndex + 1} recalled after ${injured.firstName} was injured.`);
+      }
+    }
     return { success, artifact };
   }
 

--- a/tests/wgcRecallOnInjury.test.js
+++ b/tests/wgcRecallOnInjury.test.js
@@ -1,0 +1,29 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC auto recall on injury', () => {
+  beforeEach(() => {
+    global.addJournalEntry = jest.fn();
+  });
+  afterEach(() => {
+    delete global.addJournalEntry;
+  });
+
+  test('operation recalls when member health drops to zero', () => {
+    const wgc = new WarpGateCommand();
+    const member = WGCTeamMember.create('Bob', '', 'Soldier', {});
+    member.health = 10;
+    const others = ['A','B','C'].map(n => WGCTeamMember.create(n, '', 'Soldier', {}));
+    wgc.recruitMember(0, 0, member);
+    others.forEach((m,i)=>wgc.recruitMember(0, i+1, m));
+    wgc.startOperation(0, 1);
+    wgc.roll = () => ({ sum: 1, rolls: [1] });
+    const event = { name: 'Test', type: 'individual', skill: 'power' };
+    wgc.resolveEvent(0, event);
+    expect(member.health).toBe(1);
+    expect(wgc.operations[0].active).toBe(false);
+    expect(addJournalEntry).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- abort operations when a team member hits 0 HP
- journal note on forced recall
- test recall logic for Warp Gate Command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688abb4b369083279d825feccb57a0d6