### PR TITLE
Implement team HP regeneration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,3 +251,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Operations abort if any member's HP hits 0. Their HP resets to 1, the team is recalled and the journal notes the injury.
 - WGC team cards now label the difficulty selector with "Difficulty" displayed above the input.
 - Operation XP rewards now scale with difficulty as `1 + 0.1×difficulty`.
+- Team members regenerate 1 HP per step or 5 HP per step when recalled.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -256,6 +256,16 @@ class WarpGateCommand extends EffectableEntity {
         op.progress = op.timer / 600;
       }
     });
+
+    const minuteFraction = seconds / 60;
+    this.teams.forEach((team, idx) => {
+      const op = this.operations[idx];
+      const rate = op && op.active ? 1 : 5;
+      const heal = rate * minuteFraction;
+      team.forEach(m => {
+        if (m) m.health = Math.min(m.health + heal, m.maxHealth);
+      });
+    });
   }
 
   finishOperation(teamIndex) {

--- a/tests/wgcHealthRegen.test.js
+++ b/tests/wgcHealthRegen.test.js
@@ -1,0 +1,28 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC team health regeneration', () => {
+  test('members heal 5 HP per step when not active', () => {
+    const wgc = new WarpGateCommand();
+    const m = WGCTeamMember.create('Bob', '', 'Soldier', {});
+    m.health = 90;
+    wgc.recruitMember(0, 0, m);
+    wgc.update(60000); // one minute
+    expect(m.health).toBeCloseTo(95);
+  });
+
+  test('members heal 1 HP per step during operations', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      const mem = WGCTeamMember.create('A'+i, '', 'Soldier', {});
+      wgc.recruitMember(0, i, mem);
+    }
+    const member = wgc.teams[0][0];
+    member.health = 90;
+    wgc.startOperation(0);
+    wgc.update(60000); // one minute
+    expect(member.health).toBeCloseTo(91);
+  });
+});

--- a/tests/wgcRecallOnInjury.test.js
+++ b/tests/wgcRecallOnInjury.test.js
@@ -6,9 +6,11 @@ const { WarpGateCommand } = require('../src/js/wgc.js');
 describe('WGC auto recall on injury', () => {
   beforeEach(() => {
     global.addJournalEntry = jest.fn();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
   });
   afterEach(() => {
     delete global.addJournalEntry;
+    Math.random.mockRestore();
   });
 
   test('operation recalls when member health drops to zero', () => {


### PR DESCRIPTION
## Summary
- regenerate Warp Gate Command team member HP every update
- document HP regeneration rules in AGENTS guide
- add tests for HP regeneration
- stabilize recall on injury test by fixing `Math.random`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_688abd2d31f08327bfb8f4ab4c07f8b8