### PR TITLE
Add alerts for WGC unlock and injuries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,3 +250,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Recalling a team mid-operation now increments the next operation number.
 - Operations abort if any member's HP hits 0. Their HP resets to 1, the team is recalled and the journal notes the injury.
 - WGC team cards now label the difficulty selector with "Difficulty" displayed above the input.
+- Unlocking Warp Gate Command or injuring a team member shows an alert on the HOPE tab and WGC subtab until viewed.

--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
             <div class="hope-subtabs">
                 <div class="hope-subtab active" data-subtab="awakening-hope">Awakening</div>
                 <div class="hope-subtab hidden" data-subtab="solis-hope">Solis<span id="solis-subtab-alert" class="hope-alert">!</span></div>
-                <div class="hope-subtab hidden" data-subtab="wgc-hope">WGC</div>
+                <div class="hope-subtab hidden" data-subtab="wgc-hope">WGC<span id="wgc-subtab-alert" class="hope-alert">!</span></div>
             </div>
             <div class="hope-subtab-content-wrapper">
                 <div id="awakening-hope" class="hope-subtab-content active">

--- a/src/js/hopeUI.js
+++ b/src/js/hopeUI.js
@@ -6,12 +6,18 @@ function initializeHopeTabs() {
             tab.classList.add('active');
             const id = tab.dataset.subtab;
             document.getElementById(id).classList.add('active');
+            if (id === 'wgc-hope' && typeof markWGCViewed === 'function') {
+                markWGCViewed();
+            }
         });
     });
 }
 
 function activateHopeSubtab(subtabId) {
     activateSubtab('hope-subtab', 'hope-subtab-content', subtabId, true);
+    if (subtabId === 'wgc-hope' && typeof markWGCViewed === 'function') {
+        markWGCViewed();
+    }
 }
 
 function initializeHopeUI() {
@@ -29,20 +35,14 @@ function initializeHopeUI() {
 
 function updateHopeAlert() {
     const alertEl = document.getElementById('hope-alert');
-    const subtabEl = document.getElementById('solis-subtab-alert');
-    if (!alertEl && !subtabEl) return;
-    if (typeof gameSettings !== 'undefined' && gameSettings.silenceSolisAlert) {
-        if (alertEl) alertEl.style.display = 'none';
-        if (subtabEl) subtabEl.style.display = 'none';
-        return;
-    }
-    if (typeof solisManager !== 'undefined' && solisManager && solisManager.currentQuest && solisTabVisible) {
-        if (alertEl) alertEl.style.display = 'inline';
-        if (subtabEl) subtabEl.style.display = 'inline';
-    } else {
-        if (alertEl) alertEl.style.display = 'none';
-        if (subtabEl) subtabEl.style.display = 'none';
-    }
+    const solisEl = document.getElementById('solis-subtab-alert');
+    const wgcEl = document.getElementById('wgc-subtab-alert');
+    if (!alertEl && !solisEl && !wgcEl) return;
+    const solisAlert = typeof solisManager !== 'undefined' && solisManager && solisManager.currentQuest && solisTabVisible && !(typeof gameSettings !== 'undefined' && gameSettings.silenceSolisAlert);
+    const wgcAlert = typeof wgcAlertNeeded !== 'undefined' && wgcAlertNeeded && (typeof wgcTabVisible === 'undefined' || wgcTabVisible);
+    if (alertEl) alertEl.style.display = (solisAlert || wgcAlert) ? 'inline' : 'none';
+    if (solisEl) solisEl.style.display = solisAlert ? 'inline' : 'none';
+    if (wgcEl) wgcEl.style.display = wgcAlert ? 'inline' : 'none';
 }
 
 function updateHopeUI() {

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -166,6 +166,7 @@ class WarpGateCommand extends EffectableEntity {
       if (typeof addJournalEntry === 'function') {
         addJournalEntry(`Team ${teamIndex + 1} recalled after ${injured.firstName} was injured.`);
       }
+      if (typeof registerWGCAlert === 'function') registerWGCAlert();
     }
     return { success, artifact };
   }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -1,4 +1,5 @@
 let wgcTabVisible = false;
+let wgcAlertNeeded = false;
 let wgcUIInitialized = false;
 const rdItems = {
   wgtEquipment: 'Warpgate Teams Equipment',
@@ -24,6 +25,7 @@ function showWGCTab() {
   const content = document.getElementById('wgc-hope');
   if (tab) tab.classList.remove('hidden');
   if (content) content.classList.remove('hidden');
+  if (typeof registerWGCAlert === 'function') registerWGCAlert();
 }
 
 function hideWGCTab() {
@@ -486,6 +488,16 @@ function redrawWGCTeamCards() {
   updateWGCUI();
 }
 
+function registerWGCAlert() {
+  wgcAlertNeeded = true;
+  if (typeof updateHopeAlert === 'function') updateHopeAlert();
+}
+
+function markWGCViewed() {
+  wgcAlertNeeded = false;
+  if (typeof updateHopeAlert === 'function') updateHopeAlert();
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     hideWGCTab,
@@ -497,5 +509,8 @@ if (typeof module !== 'undefined' && module.exports) {
     populateRDMenu,
     generateWGCTeamCards,
     generateWGCLayout,
+    registerWGCAlert,
+    markWGCViewed,
+    get wgcAlertNeeded() { return wgcAlertNeeded; }
   };
 }

--- a/tests/wgcAlert.test.js
+++ b/tests/wgcAlert.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC alerts', () => {
+  test('unlock and injury trigger alerts', () => {
+    const html = `<!DOCTYPE html>
+      <div id="hope-tab"><span id="hope-alert" class="hope-alert">!</span></div>
+      <div class="hope-subtab" data-subtab="wgc-hope">WGC<span id="wgc-subtab-alert" class="hope-alert">!</span></div>
+      <div id="wgc-hope" class="hope-subtab-content"></div>`;
+  const dom = new JSDOM(html, { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.EffectableEntity = EffectableEntity;
+  ctx.gameSettings = {};
+    ctx.solisTabVisible = false;
+    ctx.solisManager = null;
+    ctx.initializeSkillsUI = () => {};
+    ctx.initializeSolisUI = () => {};
+    ctx.updateSkillTreeUI = () => {};
+    ctx.updateSolisUI = () => {};
+    ctx.addJournalEntry = () => {};
+    const hopeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'hopeUI.js'), 'utf8');
+    vm.runInContext(hopeCode, ctx);
+    const wgcUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(wgcUICode, ctx);
+    const { WGCTeamMember } = require('../src/js/team-member.js');
+    ctx.WGCTeamMember = WGCTeamMember;
+    ctx.module = { exports: {} };
+    ctx.require = require;
+    const wgcCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgc.js'), 'utf8');
+    vm.runInContext(wgcCode, ctx);
+    ctx.WarpGateCommand = ctx.module.exports.WarpGateCommand;
+
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.showWGCTab();
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('inline');
+    expect(dom.window.document.getElementById('wgc-subtab-alert').style.display).toBe('inline');
+
+    ctx.markWGCViewed();
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('none');
+    expect(dom.window.document.getElementById('wgc-subtab-alert').style.display).toBe('none');
+
+    const member = ctx.WGCTeamMember.create('Bob', '', 'Soldier', {});
+    ctx.warpGateCommand.recruitMember(0, 0, member);
+    ctx.warpGateCommand.operations[0].difficulty = 10;
+    ctx.warpGateCommand.roll = () => ({ sum: 1, rolls: [1] });
+    ctx.wgcTabVisible = true;
+    const event = { name: 'Test', type: 'individual', skill: 'power' };
+    ctx.warpGateCommand.resolveEvent(0, event);
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('inline');
+    expect(dom.window.document.getElementById('wgc-subtab-alert').style.display).toBe('inline');
+  });
+});

--- a/tests/wgcRecallOnInjury.test.js
+++ b/tests/wgcRecallOnInjury.test.js
@@ -20,8 +20,10 @@ describe('WGC auto recall on injury', () => {
     others.forEach((m,i)=>wgc.recruitMember(0, i+1, m));
     wgc.startOperation(0, 1);
     wgc.roll = () => ({ sum: 1, rolls: [1] });
+    jest.spyOn(Math, 'random').mockReturnValue(0);
     const event = { name: 'Test', type: 'individual', skill: 'power' };
     wgc.resolveEvent(0, event);
+    Math.random.mockRestore();
     expect(member.health).toBe(1);
     expect(wgc.operations[0].active).toBe(false);
     expect(addJournalEntry).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add alert indicator to WGC subtab
- show HOPE/WGC alerts when Warp Gate Command unlocks or a team member is injured
- mark WGC viewed when opening the subtab
- expose alert helpers and document the feature
- test new alert behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688abd10781c83279b28e61d880aa6fd