### PR TITLE
Display roller in WGC individual challenges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,3 +252,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC team cards now label the difficulty selector with "Difficulty" displayed above the input.
 - Operation XP rewards now scale with difficulty as `1 + 0.1×difficulty`.
 - Team members regenerate 1 HP per step or 5 HP per step when recalled.
+- Individual challenge summaries now include the rolling member's name.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -78,6 +78,7 @@ class WarpGateCommand extends EffectableEntity {
     let rollResult = { sum: 0, rolls: [] };
     let dc = 0;
     let skillTotal = 0;
+    let roller = null;
     const op = this.operations[teamIndex];
     const difficulty = op ? op.difficulty || 0 : 0;
     switch (event.type) {
@@ -95,6 +96,7 @@ class WarpGateCommand extends EffectableEntity {
         const members = team.filter(m => m);
         if (members.length === 0) return { success: false, artifact: false };
         const member = members[Math.floor(Math.random() * members.length)];
+        roller = member;
         skillTotal = member[event.skill];
         rollResult = this.roll(1);
         dc = 10 + difficulty;
@@ -113,6 +115,7 @@ class WarpGateCommand extends EffectableEntity {
         } else {
           skillTotal = m.wit;
         }
+        roller = m;
         rollResult = this.roll(1);
         dc = 10 + difficulty;
         success = rollResult.sum + skillTotal >= dc;
@@ -145,7 +148,8 @@ class WarpGateCommand extends EffectableEntity {
     if (artifact) op.artifacts += 1 + (difficulty > 0 ? difficulty * 0.1 : 0);
     const rollsStr = rollResult.rolls.join(',');
     const outcome = success ? (critical ? 'Critical Success' : 'Success') : 'Fail';
-    const summary = `${event.name}: roll [${rollsStr}] + skill ${skillTotal} (total ${rollResult.sum + skillTotal}) vs DC ${dc} => ${outcome}${artifact ? ' +1 Artifact' : ''}`;
+    const rollerName = roller ? ` (${roller.firstName})` : '';
+    const summary = `${event.name}${rollerName}: roll [${rollsStr}] + skill ${skillTotal} (total ${rollResult.sum + skillTotal}) vs DC ${dc} => ${outcome}${artifact ? ' +1 Artifact' : ''}`;
     op.summary = summary;
     this.addLog(teamIndex, `Team ${teamIndex + 1} - Op ${op.number} - ${summary}`);
 

--- a/tests/wgcIndividualMemberName.test.js
+++ b/tests/wgcIndividualMemberName.test.js
@@ -1,0 +1,18 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC individual challenge member name', () => {
+  test('summary includes member name', () => {
+    const wgc = new WarpGateCommand();
+    const member = WGCTeamMember.create('Alice', '', 'Soldier', {});
+    wgc.recruitMember(0, 0, member);
+    wgc.roll = () => ({ sum: 10, rolls: [10] });
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const event = { name: 'Ind', type: 'individual', skill: 'athletics' };
+    wgc.resolveEvent(0, event);
+    expect(wgc.operations[0].summary).toMatch(/Alice/);
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- log which team member rolled during individual WGC challenges
- test for member name in individual challenge summaries
- document the feature in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688abf4dab6083278b216f5e9d2f7faf