### PR TITLE
Fix WGC class select after recruitment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,3 +253,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Operation XP rewards now scale with difficulty as `1 + 0.1×difficulty`.
 - Team members regenerate 1 HP per step or 5 HP per step when recalled.
 - Individual challenge summaries now include the rolling member's name.
+- Team member class selection becomes locked once recruited.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -200,9 +200,10 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
     classSelect.appendChild(opt);
   });
 
-  if (member) classSelect.value = member.classType;
-
-  if (slotIndex === 0 || (member && member.classType === 'Team Leader')) {
+  if (member) {
+    classSelect.value = member.classType;
+    classSelect.disabled = true;
+  } else if (slotIndex === 0) {
     classSelect.value = 'Team Leader';
     classSelect.disabled = true;
   }

--- a/tests/wgcClassLock.test.js
+++ b/tests/wgcClassLock.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC member class locking', () => {
+  test('class dropdown disabled after recruitment', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WGCTeamMember = WGCTeamMember;
+    ctx.WarpGateCommand = WarpGateCommand;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    const member = ctx.WGCTeamMember.create('Bob', '', 'Soldier', {});
+    ctx.warpGateCommand.recruitMember(0, 0, member);
+    ctx.redrawWGCTeamCards();
+    ctx.openRecruitDialog(0, 0, member);
+
+    const select = dom.window.document.querySelector('.wgc-popup-window select');
+    expect(select.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- lock a team member's class after they're recruited
- add regression test for the locked class dropdown
- document the change in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ac121dc988327954012ed87ab5bee