### PR TITLE
Add leader skill bonus to WGC checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,3 +253,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Operation XP rewards now scale with difficulty as `1 + 0.1×difficulty`.
 - Team members regenerate 1 HP per step or 5 HP per step when recalled.
 - Individual challenge summaries now include the rolling member's name.
+- Team leader grants half their relevant skill to all individual rolls and to science challenges when another member performs them.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -98,6 +98,11 @@ class WarpGateCommand extends EffectableEntity {
         const member = members[Math.floor(Math.random() * members.length)];
         roller = member;
         skillTotal = member[event.skill];
+        const leader = team[0];
+        if (leader && leader !== member) {
+          const leaderBonus = Math.floor(leader[event.skill] / 2);
+          if (leaderBonus > 0) skillTotal += leaderBonus;
+        }
         rollResult = this.roll(1);
         dc = 10 + difficulty;
         success = rollResult.sum + skillTotal >= dc;
@@ -114,6 +119,11 @@ class WarpGateCommand extends EffectableEntity {
           skillTotal = Math.floor(m.wit / 2);
         } else {
           skillTotal = m.wit;
+          const leader = team[0];
+          if (leader && leader !== m) {
+            const leaderBonus = Math.floor(leader.wit / 2);
+            if (leaderBonus > 0) skillTotal += leaderBonus;
+          }
         }
         roller = m;
         rollResult = this.roll(1);

--- a/tests/wgcLeaderBonus.test.js
+++ b/tests/wgcLeaderBonus.test.js
@@ -1,0 +1,38 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC team leader skill bonus', () => {
+  test('leader adds half skill to individual checks', () => {
+    const wgc = new WarpGateCommand();
+    const leader = WGCTeamMember.create('Lead', '', 'Team Leader', {});
+    leader.athletics = 6;
+    const member = WGCTeamMember.create('Bob', '', 'Soldier', {});
+    member.athletics = 2;
+    wgc.recruitMember(0, 0, leader);
+    wgc.recruitMember(0, 1, member);
+    wgc.roll = () => ({ sum: 5, rolls: [5] });
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.6).mockReturnValue(0.99);
+    const event = { name: 'Test', type: 'individual', skill: 'athletics' };
+    wgc.resolveEvent(0, event);
+    expect(wgc.operations[0].summary).toMatch(/skill 5/);
+    Math.random.mockRestore();
+  });
+
+  test('leader adds half wit to science checks when not the scientist', () => {
+    const wgc = new WarpGateCommand();
+    const leader = WGCTeamMember.create('Lead', '', 'Team Leader', {});
+    leader.wit = 6;
+    const scientist = WGCTeamMember.create('Eve', '', 'Natural Scientist', {});
+    scientist.wit = 4;
+    wgc.recruitMember(0, 0, leader);
+    wgc.recruitMember(0, 1, scientist);
+    wgc.roll = () => ({ sum: 5, rolls: [5] });
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+    const event = { name: 'NS', type: 'science', specialty: 'Natural Scientist' };
+    wgc.resolveEvent(0, event);
+    expect(wgc.operations[0].summary).toMatch(/skill 7/);
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- have the team leader contribute half their skill to individual and science rolls
- test the new behavior
- document the feature in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ac296fa84832789f07b6bdd2eb892