### PR TITLE
Update WGC equipment upgrade logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,3 +253,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Operation XP rewards now scale with difficulty as `1 + 0.1×difficulty`.
 - Team members regenerate 1 HP per step or 5 HP per step when recalled.
 - Individual challenge summaries now include the rolling member's name.
+- WGC Equipment upgrade now adds 0.1% artifact chance per purchase up to a +90% bonus (100% total) and is limited to 900 buys.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -30,7 +30,7 @@ class WarpGateCommand extends EffectableEntity {
     this.pendingCombat = false;
     this.combatDifficulty = 1;
     this.rdUpgrades = {
-      wgtEquipment: { purchases: 0 },
+      wgtEquipment: { purchases: 0, max: 900 },
       componentsEfficiency: { purchases: 0, max: 400 },
       electronicsEfficiency: { purchases: 0, max: 400 },
       superconductorEfficiency: { purchases: 0, max: 400 },
@@ -138,7 +138,9 @@ class WarpGateCommand extends EffectableEntity {
       }
     }
 
-    let artifact = success && Math.random() < 0.1;
+    const equip = this.rdUpgrades.wgtEquipment ? this.rdUpgrades.wgtEquipment.purchases : 0;
+    const artifactChance = Math.min(0.1 + equip * 0.001, 1);
+    let artifact = success && Math.random() < artifactChance;
     const critical = event.type === 'individual' && rollResult.rolls.includes(20);
     if (critical) {
       success = true;

--- a/tests/wgcEquipmentArtifactChance.test.js
+++ b/tests/wgcEquipmentArtifactChance.test.js
@@ -1,0 +1,46 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC Equipment artifact chance', () => {
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: { value: 0, increase: jest.fn(), decrease: jest.fn() } } };
+  });
+
+  test('equipment upgrades raise artifact chance to 100% at max', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+    wgc.roll = () => ({ sum: 80, rolls: [20,20,20,20] });
+
+    const event = { name: 'Team Power Challenge', type: 'team', skill: 'power' };
+    const rand = jest.spyOn(Math, 'random');
+    rand.mockReturnValueOnce(0.15);
+    let res = wgc.resolveEvent(0, event);
+    expect(res.artifact).toBe(false);
+
+    wgc.rdUpgrades.wgtEquipment.purchases = 600;
+    rand.mockReturnValueOnce(0.15);
+    res = wgc.resolveEvent(0, event);
+    expect(res.artifact).toBe(true);
+
+    wgc.rdUpgrades.wgtEquipment.purchases = 900;
+    rand.mockReturnValueOnce(0.95);
+    res = wgc.resolveEvent(0, event);
+    expect(res.artifact).toBe(true);
+
+    rand.mockReturnValueOnce(0.5);
+    res = wgc.resolveEvent(0, event);
+    expect(res.artifact).toBe(true);
+
+    rand.mockRestore();
+  });
+
+  test('purchaseUpgrade respects max', () => {
+    const wgc = new WarpGateCommand();
+    wgc.rdUpgrades.wgtEquipment.purchases = 900;
+    expect(wgc.purchaseUpgrade('wgtEquipment')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- cap WGC equipment purchases at 900 with artifact chance bonus up to +90%
- allow 100% artifact chance when fully upgraded
- update tests for the new maximum chance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ac160c1b08327b0fb3b73174f1f63