### PR TITLE
Add Hazardous Biomass stance controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,3 +254,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Team members regenerate 1 HP per step or 5 HP per step when recalled.
 - Individual challenge summaries now include the rolling member's name.
 - Team member class selection becomes locked once recruited.
+- Added Hazardous Biomass stance control with Negotiation and Aggressive options adjusting combat and social event weights.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -65,11 +65,20 @@ function generateWGCTeamCards() {
     const unlocked = (typeof warpGateCommand !== 'undefined' && warpGateCommand.totalOperations >= teamUnlocks[tIdx]);
     const lockMarkup = unlocked ? '' :
       `<div class="wgc-team-locked" data-team="${tIdx}">LOCKED<br>${teamUnlocks[tIdx]} Operations</div>`;
+    const stanceVal = (typeof warpGateCommand !== 'undefined' && warpGateCommand.stances && warpGateCommand.stances[tIdx]) ? warpGateCommand.stances[tIdx].hazardousBiomass : 'Neutral';
     return `
       <div class="wgc-team-card" data-team="${tIdx}">
         <div class="team-header">Team ${name}</div>
         <div class="wgc-team-body">
           <div class="team-slots">${slotMarkup}</div>
+          <div class="team-stance">
+            <label>Hazardous Biomass Interactions <span class="info-tooltip-icon" title="Negotiation halves combat challenge weight and doubles social science weight. Aggressive does the opposite.">&#9432;</span></label>
+            <select class="hbi-select" data-team="${tIdx}">
+              <option value="Neutral"${stanceVal === 'Neutral' ? ' selected' : ''}>Neutral</option>
+              <option value="Negotiation"${stanceVal === 'Negotiation' ? ' selected' : ''}>Negotiation</option>
+              <option value="Aggressive"${stanceVal === 'Aggressive' ? ' selected' : ''}>Aggressive</option>
+            </select>
+          </div>
           <div class="team-controls">
             <div class="difficulty-container">
               <span>Difficulty</span>
@@ -392,6 +401,13 @@ function initializeWGCUI() {
           openRecruitDialog(t, s, null);
         }
       });
+      teamContainer.addEventListener('change', e => {
+        if (e.target.classList.contains('hbi-select')) {
+          const t = parseInt(e.target.dataset.team, 10);
+          warpGateCommand.setStance(t, e.target.value);
+          updateWGCUI();
+        }
+      });
     }
     populateRDMenu();
   }
@@ -429,6 +445,7 @@ function updateWGCUI() {
     const startBtn = card.querySelector('.start-button');
     const recallBtn = card.querySelector('.recall-button');
     const diffInput = card.querySelector('.difficulty-input');
+    const stanceSelect = card.querySelector('.hbi-select');
     const progressContainer = card.querySelector('.operation-progress');
     const progressBar = card.querySelector('.operation-progress-bar');
     const summaryEl = card.querySelector('.operation-summary');
@@ -446,6 +463,10 @@ function updateWGCUI() {
     if (diffInput) {
       diffInput.value = op.difficulty || 0;
       diffInput.disabled = op.active;
+    }
+    if (stanceSelect) {
+      const val = warpGateCommand.stances && warpGateCommand.stances[tIdx] ? warpGateCommand.stances[tIdx].hazardousBiomass : 'Neutral';
+      stanceSelect.value = val;
     }
     if (progressContainer && progressBar) {
       if (op.active) {

--- a/tests/wgcHealthRegen.test.js
+++ b/tests/wgcHealthRegen.test.js
@@ -19,6 +19,7 @@ describe('WGC team health regeneration', () => {
       const mem = WGCTeamMember.create('A'+i, '', 'Soldier', {});
       wgc.recruitMember(0, i, mem);
     }
+    wgc.roll = () => ({ sum: 80, rolls: [20, 20, 20, 20] });
     const member = wgc.teams[0][0];
     member.health = 90;
     wgc.startOperation(0);

--- a/tests/wgcSocialScienceEscalation.test.js
+++ b/tests/wgcSocialScienceEscalation.test.js
@@ -14,7 +14,7 @@ describe('WGC social science escalation', () => {
     const res = wgc.resolveEvent(0, socialEvent);
     expect(res.success).toBe(false);
     expect(wgc.logs[0].length).toBe(1);
-    const next = wgc.chooseEvent();
+    const next = wgc.chooseEvent(0);
     expect(next.type).toBe('combat');
     expect(next.difficultyMultiplier).toBeCloseTo(1.25);
   });

--- a/tests/wgcStanceWeights.test.js
+++ b/tests/wgcStanceWeights.test.js
@@ -1,0 +1,23 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC stance weighting', () => {
+  test('negotiation stance favors social science events', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A'+i, '', 'Soldier', {}));
+    }
+    jest.spyOn(Math, 'random').mockReturnValue(0.89);
+    let ev = wgc.chooseEvent(0);
+    expect(ev.name).toBe('Combat challenge');
+    wgc.setStance(0, 'Negotiation');
+    ev = wgc.chooseEvent(0);
+    expect(ev.name).toBe('Social Science challenge');
+    wgc.setStance(0, 'Aggressive');
+    ev = wgc.chooseEvent(0);
+    expect(ev.name).toBe('Combat challenge');
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce stance dropdowns for Warp Gate Command teams
- adjust event weighting based on the selected stance
- save/load stance data and expose setStance
- document the new stance system
- test stance effects and update health regen test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ac3f5253883279e7aea669ad1b355