### PR TITLE
Implement WGC XP catch‑up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Operations abort if any member's HP hits 0. Their HP resets to 1, the team is recalled and the journal notes the injury.
 - WGC team cards now label the difficulty selector with "Difficulty" displayed above the input.
 - Operation XP rewards now scale with difficulty as `1 + 0.1×difficulty`.
+- Team members with the lowest total XP gain a 1.5× catch-up bonus until they match their highest teammate.
 - Team members regenerate 1 HP per step or 5 HP per step when recalled.
 - Individual challenge summaries now include the rolling member's name.
 - WGC Equipment upgrade now adds 0.1% artifact chance per purchase up to a +90% bonus (100% total) and is limited to 900 buys.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -285,7 +285,14 @@ class WarpGateCommand extends EffectableEntity {
     const team = this.teams[teamIndex];
     if (team) {
       const xpGain = successes * (1 + 0.1 * (op.difficulty || 0));
-      team.forEach(m => { if (m) m.xp = (m.xp || 0) + xpGain; });
+      const currentMax = team.reduce((mx, m) => m && m.xp > mx ? m.xp : mx, 0);
+      const newMax = currentMax + xpGain;
+      team.forEach(m => {
+        if (!m) return;
+        let gain = xpGain;
+        if (m.xp < currentMax) gain *= 1.5;
+        m.xp = Math.min(m.xp + gain, newMax);
+      });
     }
     const summary = `Operation ${op.number} Complete: ${successes} success(es), ${art} artifact(s)`;
     op.summary = summary;

--- a/tests/wgcXPCatchup.test.js
+++ b/tests/wgcXPCatchup.test.js
@@ -1,0 +1,30 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC XP catch-up bonus', () => {
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: { increase: jest.fn(), value: 0 } } };
+  });
+
+  test('lowest member gains 1.5x XP until caught up', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A'+i, '', 'Soldier', {}));
+    }
+    wgc.teams[0][0].xp = 10;
+    wgc.teams[0][1].xp = 30;
+    wgc.teams[0][2].xp = 30;
+    wgc.teams[0][3].xp = 30;
+
+    const op = wgc.operations[0];
+    op.successes = 50;
+    op.difficulty = 0;
+    op.artifacts = 0;
+
+    wgc.finishOperation(0);
+
+    wgc.teams[0].forEach(m => expect(m.xp).toBe(80));
+  });
+});


### PR DESCRIPTION
## Summary
- adjust `finishOperation` XP awards so the lowest team members gain a 1.5× catch-up bonus
- document the new mechanic in `AGENTS.md`
- add a unit test covering the catch-up logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ac50c36ac8327b35e5723e239d816