### PR TITLE
Add difficulty tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC Equipment upgrade now adds 0.1% artifact chance per purchase up to a +90% bonus (100% total) and is limited to 900 buys.
 - Team member class selection becomes locked once recruited.
 - Added Hazardous Biomass stance control with Negotiation and Aggressive options adjusting combat and social event weights.
+- Difficulty selector now includes a tooltip explaining that it raises challenge DCs (+4 per level for team, +1 for individual), grants 10% more XP and artifacts per level, and causes failed individual checks to deal 10 HP damage per level while failed team checks damage everyone for 10 HP.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -82,6 +82,7 @@ function generateWGCTeamCards() {
           <div class="team-controls">
             <div class="difficulty-container">
               <span>Difficulty</span>
+              <span class="info-tooltip-icon" title="Raises all challenge DCs (team +4 per level, individual +1 per level). Artifact and XP rewards increase by 10% per level. Failed individual checks deal 10 HP per level to the selected member while failed team checks damage all members for 10 HP.">&#9432;</span>
               <input type="number" class="difficulty-input" data-team="${tIdx}" value="${op.difficulty || 0}" min="0" />
             </div>
             <button class="start-button" data-team="${tIdx}">Start</button>

--- a/tests/wgcDifficultyTooltip.test.js
+++ b/tests/wgcDifficultyTooltip.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC difficulty tooltip', () => {
+  test('tooltip explains effects of difficulty', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    ctx.WGCTeamMember = require('../src/js/team-member.js').WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    const container = dom.window.document.querySelector('.difficulty-container');
+    const icon = container.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    const title = icon.getAttribute('title');
+    expect(title).toContain('challenge DCs');
+    expect(title).toContain('10%');
+    expect(title).toContain('10 HP');
+  });
+});


### PR DESCRIPTION
## Summary
- add tooltip about operation difficulty
- note the tooltip in AGENTS instructions
- test tooltip and effect text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ac74d3188832795f051b841cc2e46