### PR TITLE
Update WGC stance layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,5 +258,5 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC Equipment upgrade now adds 0.1% artifact chance per purchase up to a +90% bonus (100% total) and is limited to 900 buys.
 - Team member class selection becomes locked once recruited.
 - Added Hazardous Biomass stance control with Negotiation and Aggressive options adjusting combat and social event weights.
-- Artifact Retrieval stance offers Neutral or Careful modes. Careful doubles artifact chance on Natural Science challenges and delays the next event by triple time.
+- Scientific Artifact Retrieval stance offers Neutral or Careful modes. Careful doubles artifact chance on Natural Science challenges and delays the next event by triple time.
 - Difficulty selector now includes a tooltip explaining that it raises challenge DCs (+4 per level for team, +1 for individual), grants 10% more XP and artifacts per level, and causes failed individual checks to deal 10 HP damage per level while failed team checks damage everyone for 10 HP.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -38,6 +38,12 @@
   gap: 5px;
 }
 
+.team-stances {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
 .team-slot {
   width: 90px;
   height: 120px;

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -72,20 +72,22 @@ function generateWGCTeamCards() {
         <div class="team-header">Team ${name}</div>
         <div class="wgc-team-body">
           <div class="team-slots">${slotMarkup}</div>
-          <div class="team-stance">
-            <label>Hazardous Biomass Interactions <span class="info-tooltip-icon" title="Negotiation halves combat challenge weight and doubles social science weight. Aggressive does the opposite.">&#9432;</span></label>
-            <select class="hbi-select" data-team="${tIdx}">
-              <option value="Neutral"${stanceVal === 'Neutral' ? ' selected' : ''}>Neutral</option>
-              <option value="Negotiation"${stanceVal === 'Negotiation' ? ' selected' : ''}>Negotiation</option>
-              <option value="Aggressive"${stanceVal === 'Aggressive' ? ' selected' : ''}>Aggressive</option>
-            </select>
-          </div>
-          <div class="team-stance">
-            <label>Artifact Retrieval <span class="info-tooltip-icon" title="Careful doubles artifact chance on Natural Science challenges but delays the next event by triple the time.">&#9432;</span></label>
-            <select class="artifact-select" data-team="${tIdx}">
-              <option value="Neutral"${artVal === 'Neutral' ? ' selected' : ''}>Neutral</option>
-              <option value="Careful"${artVal === 'Careful' ? ' selected' : ''}>Careful</option>
-            </select>
+          <div class="team-stances">
+            <div class="team-stance">
+              <label>Hazardous Biomass Interactions <span class="info-tooltip-icon" title="Negotiation halves combat challenge weight and doubles social science weight. Aggressive does the opposite.">&#9432;</span></label>
+              <select class="hbi-select" data-team="${tIdx}">
+                <option value="Neutral"${stanceVal === 'Neutral' ? ' selected' : ''}>Neutral</option>
+                <option value="Negotiation"${stanceVal === 'Negotiation' ? ' selected' : ''}>Negotiation</option>
+                <option value="Aggressive"${stanceVal === 'Aggressive' ? ' selected' : ''}>Aggressive</option>
+              </select>
+            </div>
+            <div class="team-stance">
+              <label>Scientific Artifact Retrieval <span class="info-tooltip-icon" title="Careful doubles artifact chance on Natural Science challenges but delays the next event by triple the time.">&#9432;</span></label>
+              <select class="artifact-select" data-team="${tIdx}">
+                <option value="Neutral"${artVal === 'Neutral' ? ' selected' : ''}>Neutral</option>
+                <option value="Careful"${artVal === 'Careful' ? ' selected' : ''}>Careful</option>
+              </select>
+            </div>
           </div>
           <div class="team-controls">
             <div class="difficulty-container">


### PR DESCRIPTION
## Summary
- wrap stance selectors in a column container so Artifact Retrieval sits below Hazardous Biomass
- rename Artifact Retrieval stance to Scientific Artifact Retrieval
- note stance rename in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ac9c3a82c8327a7ac0454b07b169c