### PR TITLE
Update WGC difficulty damage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,4 +259,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Team member class selection becomes locked once recruited.
 - Added Hazardous Biomass stance control with Negotiation and Aggressive options adjusting combat and social event weights.
 - Artifact Retrieval stance offers Neutral or Careful modes. Careful doubles artifact chance on Natural Science challenges and delays the next event by triple time.
-- Difficulty selector now includes a tooltip explaining that it raises challenge DCs (+4 per level for team, +1 for individual), grants 10% more XP and artifacts per level, and causes failed individual checks to deal 10 HP damage per level while failed team checks damage everyone for 10 HP.
+- Difficulty selector tooltip updated: challenge DCs rise (team +4 per level, individual +1 per level) and rewards increase by 10% per level. Failed individual checks now deal 5 HP per level, failed team checks damage everyone for 2 HP per level and failed combat checks hit everyone for 5 HP per level.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -102,7 +102,7 @@ class WarpGateCommand extends EffectableEntity {
         dc = 40 + difficulty * 4;
         success = rollResult.sum + skillTotal >= dc;
         if (!success) {
-          team.forEach(m => { if (m) m.health = Math.max(m.health - 10, 0); });
+          team.forEach(m => { if (m) m.health = Math.max(m.health - 2 * difficulty, 0); });
         }
         break;
       }
@@ -116,7 +116,7 @@ class WarpGateCommand extends EffectableEntity {
         dc = 10 + difficulty;
         success = rollResult.sum + skillTotal >= dc;
         if (!success) {
-          member.health = Math.max(member.health - 10 * difficulty, 0);
+          member.health = Math.max(member.health - 5 * difficulty, 0);
         }
         break;
       }
@@ -148,6 +148,9 @@ class WarpGateCommand extends EffectableEntity {
         rollResult = this.roll(4);
         dc = 40 * (event.difficultyMultiplier || 1) + difficulty;
         success = rollResult.sum + skillTotal >= dc;
+        if (!success) {
+          team.forEach(m => { if (m) m.health = Math.max(m.health - 5 * difficulty, 0); });
+        }
         break;
       }
     }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -90,7 +90,7 @@ function generateWGCTeamCards() {
           <div class="team-controls">
             <div class="difficulty-container">
               <span>Difficulty</span>
-              <span class="info-tooltip-icon" title="Raises all challenge DCs (team +4 per level, individual +1 per level). Artifact and XP rewards increase by 10% per level. Failed individual checks deal 10 HP per level to the selected member while failed team checks damage all members for 10 HP.">&#9432;</span>
+              <span class="info-tooltip-icon" title="Raises all challenge DCs (team +4 per level, individual +1 per level). Artifact and XP rewards increase by 10% per level. Failed individual checks deal 5 HP per level to the selected member while failed team checks damage all members for 2 HP per level. Failed combat checks damage all members for 5 HP per level.">&#9432;</span>
               <input type="number" class="difficulty-input" data-team="${tIdx}" value="${op.difficulty || 0}" min="0" />
             </div>
             <button class="start-button" data-team="${tIdx}">Start</button>

--- a/tests/wgcDifficultyTooltip.test.js
+++ b/tests/wgcDifficultyTooltip.test.js
@@ -27,6 +27,7 @@ describe('WGC difficulty tooltip', () => {
     const title = icon.getAttribute('title');
     expect(title).toContain('challenge DCs');
     expect(title).toContain('10%');
-    expect(title).toContain('10 HP');
+    expect(title).toContain('5 HP');
+    expect(title).toContain('2 HP');
   });
 });

--- a/tests/wgcOperationDifficulty.test.js
+++ b/tests/wgcOperationDifficulty.test.js
@@ -34,12 +34,12 @@ describe('WGC operation difficulty', () => {
     const indEvent = { name: 'Ind', type: 'individual', skill: 'power' };
     const teamEvent = { name: 'Team', type: 'team', skill: 'power' };
     wgc.resolveEvent(0, indEvent);
-    expect(member.health).toBe(70);
+    expect(member.health).toBe(85);
     wgc.recruitMember(0, 1, WGCTeamMember.create('C', '', 'Soldier', {}));
     wgc.recruitMember(0, 2, WGCTeamMember.create('D', '', 'Soldier', {}));
     wgc.recruitMember(0, 3, WGCTeamMember.create('E', '', 'Soldier', {}));
     wgc.resolveEvent(0, teamEvent);
-    expect(wgc.teams[0][0].health).toBe(60);
-    wgc.teams[0].slice(1).forEach(m => { if (m) expect(m.health).toBe(90); });
+    expect(wgc.teams[0][0].health).toBe(79);
+    wgc.teams[0].slice(1).forEach(m => { if (m) expect(m.health).toBe(94); });
   });
 });

--- a/tests/wgcRecallOnInjury.test.js
+++ b/tests/wgcRecallOnInjury.test.js
@@ -16,7 +16,7 @@ describe('WGC auto recall on injury', () => {
   test('operation recalls when member health drops to zero', () => {
     const wgc = new WarpGateCommand();
     const member = WGCTeamMember.create('Bob', '', 'Soldier', {});
-    member.health = 10;
+    member.health = 4;
     const others = ['A','B','C'].map(n => WGCTeamMember.create(n, '', 'Soldier', {}));
     wgc.recruitMember(0, 0, member);
     others.forEach((m,i)=>wgc.recruitMember(0, i+1, m));


### PR DESCRIPTION
## Summary
- lower health loss from WGC difficulties
- document new behavior
- update tooltip
- adjust tests for new numbers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_688aca403b188327aa422b575a45fb4c