### PR TITLE
Align WGC difficulty tooltip

### DIFF
--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -104,6 +104,12 @@
   align-items: center;
 }
 
+.difficulty-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .team-controls .difficulty-input {
   width: 60px;
 }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -89,8 +89,10 @@ function generateWGCTeamCards() {
           </div>
           <div class="team-controls">
             <div class="difficulty-container">
-              <span>Difficulty</span>
-              <span class="info-tooltip-icon" title="Raises all challenge DCs (team +4 per level, individual +1 per level). Artifact and XP rewards increase by 10% per level. Failed individual checks deal 10 HP per level to the selected member while failed team checks damage all members for 10 HP.">&#9432;</span>
+              <div class="difficulty-label">
+                <span>Difficulty</span>
+                <span class="info-tooltip-icon" title="Raises all challenge DCs (team +4 per level, individual +1 per level). Artifact and XP rewards increase by 10% per level. Failed individual checks deal 10 HP per level to the selected member while failed team checks damage all members for 10 HP.">&#9432;</span>
+              </div>
               <input type="number" class="difficulty-input" data-team="${tIdx}" value="${op.difficulty || 0}" min="0" />
             </div>
             <button class="start-button" data-team="${tIdx}">Start</button>

--- a/tests/wgcDifficultyLabel.test.js
+++ b/tests/wgcDifficultyLabel.test.js
@@ -23,11 +23,12 @@ describe('WGC difficulty label', () => {
     ctx.updateWGCUI();
     const container = dom.window.document.querySelector('.difficulty-container');
     expect(container).not.toBeNull();
-    const label = container.querySelector('span');
+    const labelWrapper = container.querySelector('.difficulty-label');
     const input = container.querySelector('input.difficulty-input');
-    expect(label).not.toBeNull();
+    expect(labelWrapper).not.toBeNull();
+    const label = labelWrapper.querySelector('span');
     expect(label.textContent).toBe('Difficulty');
-    expect(container.firstElementChild).toBe(label);
+    expect(container.firstElementChild).toBe(labelWrapper);
     expect(container.lastElementChild).toBe(input);
   });
 });


### PR DESCRIPTION
## Summary
- keep the operation difficulty tooltip inline with the text
- adjust CSS and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688aca71b6d48327ba5157512c13cc72