### PR TITLE
Add WGC statistics display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,3 +260,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Hazardous Biomass stance control with Negotiation and Aggressive options adjusting combat and social event weights.
 - Artifact Retrieval stance offers Neutral or Careful modes. Careful doubles artifact chance on Natural Science challenges and delays the next event by triple time.
 - Difficulty selector now includes a tooltip explaining that it raises challenge DCs (+4 per level for team, +1 for individual), grants 10% more XP and artifacts per level, and causes failed individual checks to deal 10 HP damage per level while failed team checks damage everyone for 10 HP.
+- WGC Statistics menu now lists total operations completed and artifacts collected.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -9,6 +9,10 @@
   flex: 1;
 }
 
+#wgc-stats-section {
+  flex: 1;
+}
+
 #wgc-teams-section {
   flex: 2;
 }

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -28,6 +28,7 @@ class WarpGateCommand extends EffectableEntity {
     this.logs = Array.from({ length: 5 }, () => []);
     this.stances = Array.from({ length: 5 }, () => ({ hazardousBiomass: 'Neutral', artifact: 'Neutral' }));
     this.totalOperations = 0;
+    this.totalArtifacts = 0;
     this.pendingCombat = false;
     this.combatDifficulty = 1;
     this.rdUpgrades = {
@@ -309,6 +310,7 @@ class WarpGateCommand extends EffectableEntity {
     if (art > 0 && typeof resources !== 'undefined' && resources.special && resources.special.alienArtifact) {
       resources.special.alienArtifact.increase(art);
     }
+    this.totalArtifacts += art;
     const team = this.teams[teamIndex];
     if (team) {
       const xpGain = successes * (1 + 0.1 * (op.difficulty || 0));
@@ -413,6 +415,7 @@ class WarpGateCommand extends EffectableEntity {
       teamNextOperationNumber: this.teamNextOperationNumber.slice(),
       logs: this.logs.map(l => l.slice()),
       totalOperations: this.totalOperations,
+      totalArtifacts: this.totalArtifacts,
       pendingCombat: this.pendingCombat,
       combatDifficulty: this.combatDifficulty,
       stances: this.stances.map(s => ({ hazardousBiomass: s.hazardousBiomass, artifact: s.artifact }))
@@ -462,6 +465,7 @@ class WarpGateCommand extends EffectableEntity {
       }));
     }
     this.totalOperations = data.totalOperations || 0;
+    this.totalArtifacts = data.totalArtifacts || 0;
     this.pendingCombat = data.pendingCombat || false;
     this.combatDifficulty = data.combatDifficulty || 1;
   }

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -354,7 +354,11 @@ function generateWGCLayout() {
         <div id="wgc-rd-section">
           <h3>R&amp;D</h3>
           <div id="wgc-rd-menu"></div>
-          <div id="wgc-operation-count"></div>
+        </div>
+        <div id="wgc-stats-section">
+          <h3>Statistics</h3>
+          <div id="wgc-stat-operation"></div>
+          <div id="wgc-stat-artifact"></div>
         </div>
         <div id="wgc-teams-section">
           <h3>Teams</h3>
@@ -431,9 +435,13 @@ function initializeWGCUI() {
 }
 
 function updateWGCUI() {
-  const countEl = document.getElementById('wgc-operation-count');
-  if (countEl) {
-    countEl.textContent = `Operations Completed: ${warpGateCommand.totalOperations}`;
+  const opEl = document.getElementById('wgc-stat-operation');
+  if (opEl) {
+    opEl.textContent = `Operations Completed: ${warpGateCommand.totalOperations}`;
+  }
+  const artEl = document.getElementById('wgc-stat-artifact');
+  if (artEl) {
+    artEl.textContent = `Artifacts Collected: ${warpGateCommand.totalArtifacts}`;
   }
   for (const key in rdElements) {
     const el = rdElements[key];

--- a/tests/wgcTotalArtifacts.test.js
+++ b/tests/wgcTotalArtifacts.test.js
@@ -1,0 +1,19 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC total artifacts', () => {
+  test('finishOperation adds to totalArtifacts', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+    wgc.operations[0].artifacts = 3;
+    wgc.finishOperation(0);
+    expect(wgc.totalArtifacts).toBe(3);
+    wgc.operations[0].artifacts = 2;
+    wgc.finishOperation(0);
+    expect(wgc.totalArtifacts).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- track total artifacts in WarpGateCommand
- show Operations Completed and Artifacts Collected under a new Statistics section
- style statistics section and update AGENTS log
- store/reload total artifacts during saves
- test tracking of collected artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688acac292b48327ac0c3dac2dd41f7d