### PR TITLE
Enable leader bonus on solo challenges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Team members with the lowest total XP gain a 1.5× catch-up bonus until they match their highest teammate.
 - Team members regenerate 1 HP per step or 5 HP per step when recalled.
 - Individual challenge summaries now include the rolling member's name.
+- Team leaders now add half of their relevant skill to all individual and science challenges.
 - Natural Science challenges now grant double artifact rewards, configurable via the `artifactMultiplier` event field.
 - WGC Equipment upgrade now adds 0.1% artifact chance per purchase up to a +90% bonus (100% total) and is limited to 900 buys.
 - Team member class selection becomes locked once recruited.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -111,7 +111,11 @@ class WarpGateCommand extends EffectableEntity {
         if (members.length === 0) return { success: false, artifact: false };
         const member = members[Math.floor(Math.random() * members.length)];
         roller = member;
+        const leader = team[0];
         skillTotal = member[event.skill];
+        if (leader) {
+          skillTotal += Math.floor(leader[event.skill] / 2);
+        }
         rollResult = this.roll(1);
         dc = 10 + difficulty;
         success = rollResult.sum + skillTotal >= dc;
@@ -121,13 +125,17 @@ class WarpGateCommand extends EffectableEntity {
         break;
       }
       case 'science': {
+        const leader = team[0];
         let m = team.find(t => t && t.classType === event.specialty);
         if (!m) {
-          m = team[0];
+          m = leader;
           if (!m) return { success: false, artifact: false };
           skillTotal = Math.floor(m.wit / 2);
         } else {
           skillTotal = m.wit;
+        }
+        if (leader) {
+          skillTotal += Math.floor(leader.wit / 2);
         }
         roller = m;
         rollResult = this.roll(1);

--- a/tests/wgcLeaderHalfBonus.test.js
+++ b/tests/wgcLeaderHalfBonus.test.js
@@ -1,0 +1,53 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC team leader bonus', () => {
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: { increase: jest.fn(), value: 0 } } };
+  });
+
+  test('leader adds half skill on own individual challenges', () => {
+    const wgc = new WarpGateCommand();
+    const leader = WGCTeamMember.create('Lead', '', 'Team Leader', {});
+    leader.athletics = 10;
+    wgc.recruitMember(0, 0, leader);
+    wgc.roll = () => ({ sum: 1, rolls: [1] });
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const event = { name: 'Test', type: 'individual', skill: 'athletics' };
+    wgc.resolveEvent(0, event);
+    expect(wgc.operations[0].summary).toMatch(/skill 15/);
+    Math.random.mockRestore();
+  });
+
+  test('leader adds half skill to other member individual challenge', () => {
+    const wgc = new WarpGateCommand();
+    const leader = WGCTeamMember.create('Lead', '', 'Team Leader', {});
+    leader.athletics = 10;
+    const member = WGCTeamMember.create('Bob', '', 'Soldier', {});
+    member.athletics = 5;
+    wgc.recruitMember(0, 0, leader);
+    wgc.recruitMember(0, 1, member);
+    wgc.roll = () => ({ sum: 1, rolls: [1] });
+    jest.spyOn(Math, 'random').mockReturnValue(0.6);
+    const event = { name: 'Test', type: 'individual', skill: 'athletics' };
+    wgc.resolveEvent(0, event);
+    expect(wgc.operations[0].summary).toMatch(/skill 10/);
+    Math.random.mockRestore();
+  });
+
+  test('leader adds half wit on science challenges', () => {
+    const wgc = new WarpGateCommand();
+    const leader = WGCTeamMember.create('Lead', '', 'Team Leader', {});
+    leader.wit = 8;
+    const scientist = WGCTeamMember.create('Nat', '', 'Natural Scientist', {});
+    scientist.wit = 6;
+    wgc.recruitMember(0, 0, leader);
+    wgc.recruitMember(0, 1, scientist);
+    wgc.roll = () => ({ sum: 2, rolls: [2] });
+    const event = { name: 'Natural Science challenge', type: 'science', specialty: 'Natural Scientist' };
+    wgc.resolveEvent(0, event);
+    expect(wgc.operations[0].summary).toMatch(/skill 10/);
+  });
+});


### PR DESCRIPTION
## Summary
- boost team leader performance on individual checks
- document leader individual challenge bonus
- add regression test to ensure leader half-skill bonus works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ac966f18c8327ad1705d8edcaab25