### PR TITLE
Update aggressive stance behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,5 +258,6 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC Equipment upgrade now adds 0.1% artifact chance per purchase up to a +90% bonus (100% total) and is limited to 900 buys.
 - Team member class selection becomes locked once recruited.
 - Added Hazardous Biomass stance control with Negotiation and Aggressive options adjusting combat and social event weights.
+- Aggressive stance now removes Social Science challenges entirely while doubling combat weight.
 - Scientific Artifact Retrieval stance offers Neutral or Careful modes. Careful doubles artifact chance on Natural Science challenges and delays the next event by triple time.
 - Difficulty selector now includes a tooltip explaining that it raises challenge DCs (+4 per level for team, +1 for individual), grants 10% more XP and artifacts per level, and causes failed individual checks to deal 10 HP damage per level while failed team checks damage everyone for 10 HP.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -60,7 +60,7 @@ class WarpGateCommand extends EffectableEntity {
       const stance = this.stances && this.stances[teamIndex] ? this.stances[teamIndex].hazardousBiomass : 'Neutral';
       if (e.name === 'Social Science challenge') {
         if (stance === 'Negotiation') e.weight *= 2;
-        if (stance === 'Aggressive') e.weight *= 0.5;
+        if (stance === 'Aggressive') e.weight = 0;
       }
       if (e.type === 'combat') {
         if (stance === 'Negotiation') e.weight *= 0.5;

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -74,7 +74,7 @@ function generateWGCTeamCards() {
           <div class="team-slots">${slotMarkup}</div>
           <div class="team-stances">
             <div class="team-stance">
-              <label>Hazardous Biomass Interactions <span class="info-tooltip-icon" title="Negotiation halves combat challenge weight and doubles social science weight. Aggressive does the opposite.">&#9432;</span></label>
+              <label>Hazardous Biomass Interactions <span class="info-tooltip-icon" title="Negotiation halves combat challenge weight and doubles social science weight. Aggressive removes social science challenges and doubles combat weight.">&#9432;</span></label>
               <select class="hbi-select" data-team="${tIdx}">
                 <option value="Neutral"${stanceVal === 'Neutral' ? ' selected' : ''}>Neutral</option>
                 <option value="Negotiation"${stanceVal === 'Negotiation' ? ' selected' : ''}>Negotiation</option>

--- a/tests/wgcStanceWeights.test.js
+++ b/tests/wgcStanceWeights.test.js
@@ -20,4 +20,18 @@ describe('WGC stance weighting', () => {
     expect(ev.name).toBe('Combat challenge');
     Math.random.mockRestore();
   });
+
+  test('aggressive stance eliminates social science events', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('B'+i, '', 'Soldier', {}));
+    }
+    jest.spyOn(Math, 'random').mockReturnValue(0.8);
+    let ev = wgc.chooseEvent(0);
+    expect(ev.name).toBe('Social Science challenge');
+    wgc.setStance(0, 'Aggressive');
+    ev = wgc.chooseEvent(0);
+    expect(ev.name).not.toBe('Social Science challenge');
+    Math.random.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- aggressive stance now removes social science challenges entirely
- update tooltip describing stance effects
- test that aggressive stance eliminates social science event chance
- note new behavior in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688acbb884488327b482fac524ea0840