### PR TITLE
Fix WGC statistics placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,3 +263,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Scientific Artifact Retrieval stance offers Neutral or Careful modes. Careful doubles artifact chance on Natural Science challenges and delays the next event by triple time.
 - Difficulty selector now includes a tooltip explaining that it raises challenge DCs (+4 per level for team, +1 for individual), grants 10% more XP and artifacts per level, and causes failed individual checks to deal 10 HP damage per level while failed team checks damage everyone for 10 HP.
 - WGC Statistics menu now lists total operations completed and artifacts collected.
+- WGC layout stacks the Statistics menu below R&D while keeping Teams on the right.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -5,12 +5,17 @@
   align-items: flex-start;
 }
 
-#wgc-rd-section {
+.wgc-left {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+#wgc-rd-section {
 }
 
 #wgc-stats-section {
-  flex: 1;
 }
 
 #wgc-teams-section {

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -355,14 +355,16 @@ function generateWGCLayout() {
   return `
     <div class="wgc-container">
       <div class="wgc-main">
-        <div id="wgc-rd-section">
-          <h3>R&amp;D</h3>
-          <div id="wgc-rd-menu"></div>
-        </div>
-        <div id="wgc-stats-section">
-          <h3>Statistics</h3>
-          <div id="wgc-stat-operation"></div>
-          <div id="wgc-stat-artifact"></div>
+        <div class="wgc-left">
+          <div id="wgc-rd-section">
+            <h3>R&amp;D</h3>
+            <div id="wgc-rd-menu"></div>
+          </div>
+          <div id="wgc-stats-section">
+            <h3>Statistics</h3>
+            <div id="wgc-stat-operation"></div>
+            <div id="wgc-stat-artifact"></div>
+          </div>
         </div>
         <div id="wgc-teams-section">
           <h3>Teams</h3>


### PR DESCRIPTION
## Summary
- place the WGC Statistics menu under R&D
- keep teams in a right hand column
- note layout change in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688acdd0dc088327acd89402a60b0d55