### PR TITLE
Improve WGC R&D display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,3 +263,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Scientific Artifact Retrieval stance offers Neutral or Careful modes. Careful doubles artifact chance on Natural Science challenges and delays the next event by triple time.
 - Difficulty selector now includes a tooltip explaining that it raises challenge DCs (+4 per level for team, +1 for individual), grants 10% more XP and artifacts per level, and causes failed individual checks to deal 10 HP damage per level while failed team checks damage everyone for 10 HP.
 - WGC Statistics menu now lists total operations completed and artifacts collected.
+- WGC R&D buttons now display their cost directly and equipment upgrades show a +x% artifact chance. Multipliers are aligned vertically.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -134,14 +134,20 @@
 }
 
 .wgc-rd-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 60px auto;
   gap: 10px;
   align-items: center;
   margin-bottom: 5px;
 }
 
 .wgc-rd-item button {
-  margin-left: auto;
+  width: 100%;
+}
+
+.wgc-rd-mult {
+  text-align: right;
+  width: 60px;
 }
 
 .wgc-rd-header {

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -122,6 +122,7 @@ function createRDItem(key, label) {
   div.appendChild(nameSpan);
 
   const multSpan = document.createElement('span');
+  multSpan.classList.add('wgc-rd-mult');
   multSpan.id = `wgc-${key}-mult`;
   div.appendChild(multSpan);
 
@@ -134,15 +135,7 @@ function createRDItem(key, label) {
   });
   div.appendChild(button);
 
-  const costSpan = document.createElement('span');
-  costSpan.id = `wgc-${key}-cost`;
-  div.appendChild(costSpan);
-
-  const countSpan = document.createElement('span');
-  countSpan.id = `wgc-${key}-count`;
-  div.appendChild(countSpan);
-
-  rdElements[key] = { button, cost: costSpan, count: countSpan, mult: multSpan };
+  rdElements[key] = { button, mult: multSpan };
   return div;
 }
 
@@ -155,17 +148,13 @@ function createRDHeader() {
   label.textContent = 'Upgrade';
   div.appendChild(label);
 
-  div.appendChild(document.createElement('span'));
-
-  const spacer = document.createElement('span');
-  spacer.style.marginLeft = 'auto';
-  div.appendChild(spacer);
+  const effect = document.createElement('span');
+  effect.classList.add('wgc-rd-mult');
+  div.appendChild(effect);
 
   const cost = document.createElement('span');
   cost.textContent = 'Cost (Alien Artifacts)';
   div.appendChild(cost);
-
-  div.appendChild(document.createElement('span'));
 
   return div;
 }
@@ -450,17 +439,20 @@ function updateWGCUI() {
   for (const key in rdElements) {
     const el = rdElements[key];
     if (!el) continue;
-    if (el.cost) el.cost.textContent = warpGateCommand.getUpgradeCost(key);
-    if (el.count) el.count.textContent = warpGateCommand.rdUpgrades[key].purchases;
-    if (el.mult && key !== 'wgtEquipment') {
-      el.mult.textContent = `x${warpGateCommand.getMultiplier(key).toFixed(2)}`;
-    } else if (el.mult) {
-      el.mult.textContent = '';
-    }
+    const cost = warpGateCommand.getUpgradeCost(key);
     if (el.button) {
+      el.button.textContent = `Buy (${cost})`;
       const art = (typeof resources !== 'undefined' && resources.special && resources.special.alienArtifact) ? resources.special.alienArtifact.value : 0;
-      el.button.disabled = warpGateCommand.getUpgradeCost(key) > art ||
+      el.button.disabled = cost > art ||
         (warpGateCommand.rdUpgrades[key].max && warpGateCommand.rdUpgrades[key].purchases >= warpGateCommand.rdUpgrades[key].max);
+    }
+    if (el.mult) {
+      if (key === 'wgtEquipment') {
+        const bonus = warpGateCommand.rdUpgrades[key].purchases * 0.1;
+        el.mult.textContent = `+${bonus.toFixed(1)}%`;
+      } else {
+        el.mult.textContent = `x${warpGateCommand.getMultiplier(key).toFixed(2)}`;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- clean up Warp Gate Command R&D menu
- show upgrade cost in the buy button
- display +x% bonus for Equipment upgrade
- align multipliers vertically
- document update in AGENTS log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ace4606f88327b9b6dab56225c02b