### PR TITLE
Fix operation restart timer

### DIFF
--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -290,6 +290,7 @@ class WarpGateCommand extends EffectableEntity {
           }
           this.totalOperations += loops;
           op.timer -= loops * 600;
+          op.nextEvent = 60;
           op.number = this.teamNextOperationNumber[idx];
           this.teamNextOperationNumber[idx] += 1;
           op.summary = operationStartText;

--- a/tests/wgcOperationRestart.test.js
+++ b/tests/wgcOperationRestart.test.js
@@ -1,0 +1,17 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC operation restart', () => {
+  test('next event resets after completing an operation', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+    expect(wgc.startOperation(0)).toBe(true);
+    wgc.update(600000); // complete first operation
+    expect(wgc.operations[0].number).toBe(2);
+    expect(wgc.operations[0].nextEvent).toBe(60);
+  });
+});


### PR DESCRIPTION
## Summary
- fix WGC operation restart timer so new missions get events
- test that nextEvent resets when operations loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ad1e4bb6883278f725299b0d75f5a