### PR TITLE
Add WGC Facilities upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,3 +265,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC Statistics menu now lists total operations completed and artifacts collected.
 - WGC R&D buttons now display their cost directly and equipment upgrades show a +x% artifact chance. Multipliers are aligned vertically.
 - WGC layout stacks the Statistics menu below R&D while keeping Teams on the right.
+- Added a Facilities menu to WGC offering hourly upgrades that boost recovery, XP and skills.

--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
             <div class="hope-subtabs">
                 <div class="hope-subtab active" data-subtab="awakening-hope">Awakening</div>
                 <div class="hope-subtab hidden" data-subtab="solis-hope">Solis<span id="solis-subtab-alert" class="hope-alert">!</span></div>
-                <div class="hope-subtab hidden" data-subtab="wgc-hope">WGC</div>
+                <div class="hope-subtab hidden" data-subtab="wgc-hope">WGC<span id="wgc-subtab-alert" class="hope-alert">!</span></div>
             </div>
             <div class="hope-subtab-content-wrapper">
                 <div id="awakening-hope" class="hope-subtab-content active">

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -15,6 +15,13 @@
 #wgc-rd-section {
 }
 
+#wgc-facilities-section {
+}
+
+#wgc-facility-cooldown {
+  margin-bottom: 5px;
+}
+
 #wgc-stats-section {
 }
 

--- a/src/js/hopeUI.js
+++ b/src/js/hopeUI.js
@@ -29,20 +29,19 @@ function initializeHopeUI() {
 
 function updateHopeAlert() {
     const alertEl = document.getElementById('hope-alert');
-    const subtabEl = document.getElementById('solis-subtab-alert');
-    if (!alertEl && !subtabEl) return;
+    const solisEl = document.getElementById('solis-subtab-alert');
+    const wgcEl = document.getElementById('wgc-subtab-alert');
+    if (!alertEl && !solisEl && !wgcEl) return;
+    let solisShow = typeof solisManager !== 'undefined' && solisManager && solisManager.currentQuest && solisTabVisible;
+    const wgcShow = typeof warpGateCommand !== 'undefined' && warpGateCommand && wgcTabVisible && warpGateCommand.facilityCooldown <= 0;
     if (typeof gameSettings !== 'undefined' && gameSettings.silenceSolisAlert) {
-        if (alertEl) alertEl.style.display = 'none';
-        if (subtabEl) subtabEl.style.display = 'none';
-        return;
+        solisShow = false;
+        if (solisEl) solisEl.style.display = 'none';
+    } else if (solisEl) {
+        solisEl.style.display = solisShow ? 'inline' : 'none';
     }
-    if (typeof solisManager !== 'undefined' && solisManager && solisManager.currentQuest && solisTabVisible) {
-        if (alertEl) alertEl.style.display = 'inline';
-        if (subtabEl) subtabEl.style.display = 'inline';
-    } else {
-        if (alertEl) alertEl.style.display = 'none';
-        if (subtabEl) subtabEl.style.display = 'none';
-    }
+    if (wgcEl) wgcEl.style.display = wgcShow ? 'inline' : 'none';
+    if (alertEl) alertEl.style.display = (solisShow || wgcShow) ? 'inline' : 'none';
 }
 
 function updateHopeUI() {

--- a/tests/wgcFacilityAlert.test.js
+++ b/tests/wgcFacilityAlert.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC facility alert', () => {
+  test('shows alert when upgrade available', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div id="hope-tab"><span id="hope-alert" class="hope-alert">!</span></div>
+      <div class="hope-subtab" data-subtab="wgc-hope">WGC<span id="wgc-subtab-alert" class="hope-alert">!</span></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.warpGateCommand = new WarpGateCommand();
+    ctx.wgcTabVisible = true;
+    ctx.solisTabVisible = false;
+    ctx.initializeSkillsUI = () => {};
+    ctx.initializeSolisUI = () => {};
+    ctx.initializeWGCUI = () => {};
+    ctx.updateSkillTreeUI = () => {};
+    ctx.updateSolisUI = () => {};
+    ctx.updateWGCVisibility = () => {};
+    ctx.updateWGCUI = () => {};
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'hopeUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.warpGateCommand.facilityCooldown = 0;
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('wgc-subtab-alert').style.display).toBe('inline');
+    expect(dom.window.document.getElementById('hope-alert').style.display).toBe('inline');
+
+    ctx.warpGateCommand.facilityCooldown = 10;
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('wgc-subtab-alert').style.display).toBe('none');
+  });
+});

--- a/tests/wgcFacilityUpgrade.test.js
+++ b/tests/wgcFacilityUpgrade.test.js
@@ -1,0 +1,27 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC facility upgrades', () => {
+  test('upgrade sets cooldown and increases level', () => {
+    const wgc = new WarpGateCommand();
+    expect(wgc.upgradeFacility('infirmary')).toBe(true);
+    expect(wgc.facilities.infirmary).toBe(1);
+    expect(wgc.facilityCooldown).toBe(3600);
+    expect(wgc.upgradeFacility('infirmary')).toBe(false);
+    wgc.update(3600 * 1000);
+    expect(wgc.facilityCooldown).toBe(0);
+    expect(wgc.upgradeFacility('infirmary')).toBe(true);
+  });
+
+  test('infirmary boosts healing rate', () => {
+    const wgc = new WarpGateCommand();
+    const mem = WGCTeamMember.create('A', '', 'Soldier', {});
+    mem.health = 50;
+    wgc.recruitMember(0,0,mem);
+    wgc.facilities.infirmary = 10;
+    wgc.update(60000);
+    expect(mem.health).toBeCloseTo(55.5);
+  });
+});


### PR DESCRIPTION
## Summary
- add Facilities menu to WGC UI
- allow hourly facility upgrades with cooldown
- raise HP regen, XP gain and skill totals from facilities
- alert HOPE tab and WGC subtab when upgrades are ready
- document in `AGENTS.md`
- test facility mechanics and alert behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ad1716ee883279df0eb11084cc4da