### PR TITLE
Add WGC facility tooltips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,3 +268,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC R&D buttons now display their cost directly and equipment upgrades show a +x% artifact chance. Multipliers are aligned vertically.
 - WGC layout stacks the Statistics menu below R&D while keeping Teams on the right.
 - Added a Facilities menu to WGC offering hourly upgrades that boost recovery, XP and skills.
+- WGC Facilities menu now displays tooltips describing each upgrade's effect.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -15,6 +15,13 @@ const facilityItems = {
   obstacleCourse: 'Obstacle Course',
   library: 'Library'
 };
+const facilityDescriptions = {
+  infirmary: 'Increases team healing rate by 1% per level.',
+  barracks: 'Increases XP gained from operations by 1% per level.',
+  shootingRange: 'Boosts Power for challenges by 1% per level.',
+  obstacleCourse: 'Boosts Athletics for challenges by 1% per level.',
+  library: 'Boosts Wit for challenges by 1% per level.'
+};
 const facilityElements = {};
 const teamNames = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'];
 const teamUnlocks = [0, 100, 500, 1000, 5000];
@@ -184,6 +191,11 @@ function createFacilityItem(key, label) {
   const name = document.createElement('span');
   name.classList.add('wgc-rd-label');
   name.textContent = label;
+  const info = document.createElement('span');
+  info.classList.add('info-tooltip-icon');
+  info.innerHTML = '&#9432;';
+  info.title = facilityDescriptions[key];
+  name.appendChild(info);
   div.appendChild(name);
 
   const level = document.createElement('span');

--- a/tests/wgcFacilityTooltips.test.js
+++ b/tests/wgcFacilityTooltips.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC facility tooltips', () => {
+  test('each facility has a descriptive tooltip', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    ctx.WGCTeamMember = require('../src/js/team-member.js').WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    const items = dom.window.document.querySelectorAll('#wgc-facilities-menu .wgc-rd-item');
+    expect(items.length).toBeGreaterThan(0);
+    items.forEach(item => {
+      const label = item.querySelector('.wgc-rd-label');
+      const icon = label.querySelector('.info-tooltip-icon');
+      expect(icon).not.toBeNull();
+      const title = icon.getAttribute('title');
+      expect(title).toMatch(/% per level/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- describe facility upgrades in AGENTS
- add descriptions for WGC facilities
- show info tooltip icons in the Facilities menu
- test that every facility lists a tooltip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ad47edd308327a193de2ad0a3b38d