### PR TITLE
Fix WGC difficulty selector

### DIFF
--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -484,6 +484,15 @@ function initializeWGCUI() {
           updateWGCUI();
         }
       });
+      teamContainer.addEventListener('input', e => {
+        if (e.target.classList.contains('difficulty-input')) {
+          const t = parseInt(e.target.dataset.team, 10);
+          const val = Math.max(0, Math.floor(parseInt(e.target.value, 10) || 0));
+          if (warpGateCommand.operations && warpGateCommand.operations[t]) {
+            warpGateCommand.operations[t].difficulty = val;
+          }
+        }
+      });
     }
     populateRDMenu();
     populateFacilityMenu();

--- a/tests/wgcDifficultyInput.test.js
+++ b/tests/wgcDifficultyInput.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC difficulty input', () => {
+  test('changing the selector stores difficulty value', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = WarpGateCommand;
+    ctx.WGCTeamMember = WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    const input = dom.window.document.querySelector('.difficulty-input');
+    input.value = '2';
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    ctx.updateWGCUI();
+    expect(ctx.warpGateCommand.operations[0].difficulty).toBe(2);
+    expect(dom.window.document.querySelector('.difficulty-input').value).toBe('2');
+  });
+});

--- a/tests/wgcTeamHPBar.test.js
+++ b/tests/wgcTeamHPBar.test.js
@@ -30,8 +30,9 @@ describe('WGC team HP bar', () => {
     const fills = dom.window.document.querySelectorAll('.team-hp-bar-fill');
     expect(fills.length).toBe(2);
     expect(fills[0].style.height).toBe('100%');
-    expect(fills[0].style.backgroundColor).toBe('green');
+    expect(fills[0].classList.contains('low-hp')).toBe(false);
+    expect(fills[0].classList.contains('critical-hp')).toBe(false);
     expect(fills[1].style.height).toBe('20%');
-    expect(fills[1].style.backgroundColor).toBe('red');
+    expect(fills[1].classList.contains('critical-hp')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- persist difficulty input on Warp Gate teams
- adjust HP bar test for class-based colors
- add regression test for difficulty selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688adae9f46c8327a11cb6d8d83b0f77