### PR TITLE
Update WGC difficulty rewards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,3 +270,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added a Facilities menu to WGC offering hourly upgrades that boost recovery, XP and skills.
 - WGC Facilities menu now displays tooltips describing each upgrade's effect.
 - Operation logs now show the leader's half skill bonus in individual and science challenges.
+- Operations now record the highest difficulty cleared and grant Alien artifact bonuses equal to each newly conquered difficulty level (e.g. clearing level 4 from 0 grants 1+2+3+4 artifacts).

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -1,5 +1,15 @@
 let wgcTabVisible = false;
 let wgcUIInitialized = false;
+if (typeof globalThis.formatNumber === 'undefined') {
+  try {
+    if (typeof require !== 'undefined') {
+      globalThis.formatNumber = require('./numbers.js').formatNumber;
+    }
+  } catch (e) {}
+  if (typeof globalThis.formatNumber === 'undefined') {
+    globalThis.formatNumber = v => v;
+  }
+}
 const rdItems = {
   wgtEquipment: 'Warpgate Teams Equipment',
   componentsEfficiency: 'Components production efficiency',
@@ -419,6 +429,7 @@ function generateWGCLayout() {
             <h3>Statistics</h3>
             <div id="wgc-stat-operation"></div>
             <div id="wgc-stat-artifact"></div>
+            <div id="wgc-stat-difficulty"></div>
           </div>
         </div>
         <div class="wgc-right">
@@ -515,6 +526,11 @@ function updateWGCUI() {
   const artEl = document.getElementById('wgc-stat-artifact');
   if (artEl) {
     artEl.textContent = `Artifacts Collected: ${warpGateCommand.totalArtifacts}`;
+  }
+  const diffEl = document.getElementById('wgc-stat-difficulty');
+  if (diffEl) {
+    const val = warpGateCommand.highestDifficulty;
+    diffEl.textContent = `Highest Difficulty: ${val < 0 ? 'None' : val}`;
   }
   const cdEl = document.getElementById('wgc-facility-cooldown');
   if (cdEl) {

--- a/tests/wgcDifficultyMilestone.test.js
+++ b/tests/wgcDifficultyMilestone.test.js
@@ -1,0 +1,30 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC difficulty milestone rewards', () => {
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: { value: 0, increase: jest.fn() } } };
+  });
+
+  test('artifacts granted for new highest difficulty', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+
+    wgc.operations[0].difficulty = 0;
+    wgc.finishOperation(0);
+    expect(wgc.highestDifficulty).toBe(0);
+    expect(global.resources.special.alienArtifact.increase).toHaveBeenLastCalledWith(1);
+
+    wgc.operations[0].difficulty = 4;
+    wgc.finishOperation(0);
+    expect(wgc.highestDifficulty).toBe(4);
+    expect(global.resources.special.alienArtifact.increase).toHaveBeenLastCalledWith(10);
+    expect(wgc.totalArtifacts).toBe(11);
+    const hasLog = wgc.logs[0].some(l => l.includes('Highest difficulty 4'));
+    expect(hasLog).toBe(true);
+  });
+});

--- a/tests/wgcOperationEvents.test.js
+++ b/tests/wgcOperationEvents.test.js
@@ -27,7 +27,7 @@ describe('WGC operation events', () => {
     expect(wgc.operations[0].successes).toBe(9);
     expect(wgc.operations[0].artifacts).toBe(9);
     wgc.update(60000); // final minute
-    expect(global.resources.special.alienArtifact.value).toBe(9);
+    expect(global.resources.special.alienArtifact.value).toBe(10);
     wgc.teams[0].forEach(m => expect(m.xp).toBe(9));
     Math.random.mockRestore();
   });

--- a/tests/wgcTotalArtifacts.test.js
+++ b/tests/wgcTotalArtifacts.test.js
@@ -11,9 +11,9 @@ describe('WGC total artifacts', () => {
     }
     wgc.operations[0].artifacts = 3;
     wgc.finishOperation(0);
-    expect(wgc.totalArtifacts).toBe(3);
+    expect(wgc.totalArtifacts).toBe(4);
     wgc.operations[0].artifacts = 2;
     wgc.finishOperation(0);
-    expect(wgc.totalArtifacts).toBe(5);
+    expect(wgc.totalArtifacts).toBe(6);
   });
 });


### PR DESCRIPTION
## Summary
- track highest WGC difficulty completed
- give artifact bonuses for new difficulty milestones
- show highest difficulty in WGC statistics
- adjust tests for milestone artifact rewards
- cover milestone behavior in new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688bfe13a5f08327bebe5e3d28708bb0