### PR TITLE
Fix Solis shop resource grant timing

### DIFF
--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -146,7 +146,6 @@ class SolisManager extends EffectableEntity {
                typeof resources.colony[key].increase === 'function') {
       const amount = RESOURCE_UPGRADE_AMOUNTS[key] || 0;
       const res = resources.colony[key];
-      res.increase(amount);
       if (typeof addEffect === 'function' && res.hasCap) {
         addEffect({
           target: 'resource',

--- a/tests/solisResourceUpgrades.test.js
+++ b/tests/solisResourceUpgrades.test.js
@@ -46,13 +46,13 @@ describe('Solis resource upgrades', () => {
   });
 
   for (const key of Object.keys(amounts)) {
-    test(`purchaseUpgrade("${key}") increases resource and storage`, () => {
+    test(`purchaseUpgrade("${key}") only increases storage`, () => {
       const resource = makeResource();
       global.resources = { colony: { [key]: resource } };
       const manager = new SolisManager();
       manager.solisPoints = 20; // sufficient
       expect(manager.purchaseUpgrade(key)).toBe(true);
-      expect(resource.value).toBe(amounts[key]);
+      expect(resource.value).toBe(0);
       expect(resource.baseCap).toBe(0);
       expect(resource.cap).toBe(amounts[key]);
     });


### PR DESCRIPTION
## Summary
- prevent Solis shop upgrades from giving resources right away
- update tests for delayed gain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688cccd0f0e883278cbec011a2a91339