### PR TITLE
Fix research button enabling

### DIFF
--- a/src/js/researchUI.js
+++ b/src/js/researchUI.js
@@ -67,7 +67,8 @@ function updateResearchButtonText(button, researchItem, visible) {
         button.disabled = true;
         button.style.color = 'inherit';
     } else if (!canAffordResearch(researchItem)) {
-        // If research can't be afforded, set color to red
+        // If research can't be afforded, keep the button enabled but show red
+        button.disabled = false;
         button.style.color = 'red';
     } else {
         // Otherwise, set to default color

--- a/tests/researchVisibilityButtonEnabled.test.js
+++ b/tests/researchVisibilityButtonEnabled.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research.js'), 'utf8');
+const researchUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'researchUI.js'), 'utf8');
+
+describe('research button enabling when revealed', () => {
+  test('button is enabled once visible even if unaffordable', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="energy-research-buttons"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = () => '';
+    ctx.canAffordResearch = () => false;
+    ctx.resources = { colony: { research: { value: 0 }, advancedResearch: { value: 0 } } };
+    ctx.globalGameIsLoadingFromSave = false;
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + researchUICode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.loadResearchCategory = loadResearchCategory; this.updateResearchUI = updateResearchUI;', ctx);
+
+    const params = {
+      energy: [
+        { id: 'a', name: 'A', description: 'A', cost: { research: 100 }, prerequisites: [], effects: [] },
+        { id: 'b', name: 'B', description: 'B', cost: { research: 200 }, prerequisites: [], effects: [] },
+        { id: 'c', name: 'C', description: 'C', cost: { research: 300 }, prerequisites: [], effects: [] },
+        { id: 'd', name: 'D', description: 'D', cost: { research: 400 }, prerequisites: [], effects: [] }
+      ],
+      industry: [],
+      colonization: [],
+      terraforming: [],
+      advanced: []
+    };
+
+    ctx.researchManager = new ctx.ResearchManager(params);
+    ctx.loadResearchCategory('energy');
+
+    const buttons = dom.window.document.querySelectorAll('.research-button');
+    expect(buttons[3].textContent).toBe('???');
+    expect(buttons[3].disabled).toBe(true);
+
+    ctx.canAffordResearch = () => true;
+    ctx.researchManager.completeResearch('a');
+    ctx.canAffordResearch = () => false;
+    ctx.updateResearchUI();
+    const buttonsAfter = dom.window.document.querySelectorAll('.research-button');
+
+    expect(buttonsAfter[3].textContent).toBe('D');
+    expect(buttonsAfter[3].disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent disabled state from lingering on newly revealed research
- verify research button becomes enabled when revealed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688cd48fc0108327931424550e4ed89c