### PR TITLE
Add land cost for biodomes and adjust life UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,3 +274,4 @@ second time they speak in a chapter to help clarify who is talking.
 - ResearchManager now skips hidden entries when revealing the next three researches.
 - Bio Factory renamed to Biodome, and Life Designer UI now shows a Biodomes section displaying points from biodomes.
 - Added TerraformedDurationProject base class; Space Storage and Dyson Swarm now scale duration with terraformed planets. Space Storage is repeatable with 1 trillion tons capacity per completion.
+- Biodomes now require 100 land each, and the Life Designer UI separates controls from biodomes with a new divider.

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -454,6 +454,7 @@ const buildingsParameters = {
     requiresMaintenance: true,
     requiresWorker: 100,
     maintenanceFactor: 1,
-    unlocked: false
+    unlocked: false,
+    requiresLand: 100
   }
 };

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -76,6 +76,7 @@ function initializeLifeTerraformingDesignerUI() {
                  <button id="life-apply-btn">Deploy</button>
                  <div id="life-apply-progress"></div>
                </div>
+               <hr style="margin: 15px 0;">
                <div id="life-biodomes-section" style="margin-top: 10px;">
                  <h4>Biodomes</h4>
                  <p>Points from biodomes : <span id="life-biodome-points">0</span></p>

--- a/tests/biodomeLandCost.test.js
+++ b/tests/biodomeLandCost.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Biodome land cost', () => {
+  test('Biodome requires 100 land', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildings-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.buildingsParameters = buildingsParameters;', ctx);
+    const b = ctx.buildingsParameters.biodome;
+    expect(b.requiresLand).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- charge 100 land per Biodome
- add divider between Controls and Biodomes in Life Designer
- test Biodome land requirement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d6c558f7083278c6779612496ad46