### PR TITLE
Show land usage breakdown in tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,3 +275,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Bio Factory renamed to Biodome, and Life Designer UI now shows a Biodomes section displaying points from biodomes.
 - Added TerraformedDurationProject base class; Space Storage and Dyson Swarm now scale duration with terraformed planets. Space Storage is repeatable with 1 trillion tons capacity per completion.
 - Biodomes now require 100 land each, and the Life Designer UI separates controls from biodomes with a new divider.
+- Land resource tooltip lists land usage per building sorted by amount.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -57,6 +57,7 @@ function createResourceElement(category, resourceObj, resourceName) {
         ` : ''}
         <div class="resource-pps"></div>
       </div>
+      ${resourceObj.name === 'land' ? `<div class="resource-tooltip" id="${resourceName}-tooltip"></div>` : ''}
     `;
 
     // Add scanning progress below deposits
@@ -203,6 +204,9 @@ function updateResourceDisplay(resources) {
         } else if (scanningProgressElement) {
           scanningProgressElement.style.display = 'none'; // Hide progress element if scanning inactive
         }
+        if (resourceObj.name === 'land') {
+          updateResourceRateDisplay(resourceObj);
+        }
       } else {
         // Update other resources
         const resourceElement = document.getElementById(`${resourceName}-resources-container`);
@@ -260,14 +264,21 @@ function updateResourceRateDisplay(resource){
   const tooltipElement = document.getElementById(`${resource.name}-tooltip`);
   if (tooltipElement) {
     let tooltipContent = '';
-    tooltipContent += `<div>Value ${formatNumber(resource.value, false, 3)}${resource.unit ? ' ' + resource.unit : ''}</div>`;
+    if (resource.name === 'land') {
+      tooltipContent += `<div>Available ${formatNumber(resource.value - resource.reserved, false, 3)}</div>`;
+      tooltipContent += `<div>Used ${formatNumber(resource.reserved, false, 3)}</div>`;
+    } else {
+      tooltipContent += `<div>Value ${formatNumber(resource.value, false, 3)}${resource.unit ? ' ' + resource.unit : ''}</div>`;
+    }
     const netRate = resource.productionRate - resource.consumptionRate;
-    if (netRate > 0 && resource.hasCap) {
-      const time = (resource.cap - resource.value) / netRate;
-      tooltipContent += `<div>Time to cap: ${formatDuration(Math.max(time, 0))}</div>`;
-    } else if (netRate < 0) {
-      const time = resource.value / Math.abs(netRate);
-      tooltipContent += `<div>Time to empty: ${formatDuration(Math.max(time, 0))}</div>`;
+    if (resource.name !== 'land') {
+      if (netRate > 0 && resource.hasCap) {
+        const time = (resource.cap - resource.value) / netRate;
+        tooltipContent += `<div>Time to cap: ${formatDuration(Math.max(time, 0))}</div>`;
+      } else if (netRate < 0) {
+        const time = resource.value / Math.abs(netRate);
+        tooltipContent += `<div>Time to empty: ${formatDuration(Math.max(time, 0))}</div>`;
+      }
     }
 
     if (resource.name === 'workers' && typeof populationModule !== 'undefined') {
@@ -297,6 +308,25 @@ function updateResourceRateDisplay(resource){
           });
           tooltipContent += '</div>';
         }
+      }
+    } else if (resource.name === 'land' && typeof buildings !== 'undefined') {
+      const assignments = [];
+      for (const name in buildings) {
+        const b = buildings[name];
+        if (b.active > 0 && b.requiresLand) {
+          const used = b.active * b.requiresLand;
+          if (used > 0) {
+            assignments.push([b.displayName || name, used]);
+          }
+        }
+      }
+      if (assignments.length > 0) {
+        assignments.sort((a, b) => b[1] - a[1]);
+        tooltipContent += '<div><strong>Assignments:</strong></div><div style="display: table; width: 100%;">';
+        assignments.forEach(([n, count]) => {
+          tooltipContent += `\n          <div style="display: table-row;">\n            <div style="display: table-cell; text-align: left; padding-right: 10px;">${n}</div>\n            <div style="display: table-cell; text-align: right;">${formatNumber(count, true)}</div>\n          </div>`;
+        });
+        tooltipContent += '</div>';
       }
     }
 

--- a/tests/landTooltip.test.js
+++ b/tests/landTooltip.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('land resource tooltip', () => {
+  function setup() {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.oreScanner = { scanData: {} };
+    ctx.buildings = {
+      factory: { displayName: 'Factory', active: 2, requiresLand: 100 },
+      greenhouse: { displayName: 'Greenhouse', active: 3, requiresLand: 10 }
+    };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    return { dom, ctx };
+  }
+
+  test('breakdown sorted by land usage', () => {
+    const { dom, ctx } = setup();
+    const land = {
+      name: 'land',
+      displayName: 'Land',
+      category: 'surface',
+      value: 1000,
+      reserved: 230,
+      hasCap: true,
+      unlocked: true,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      unit: null
+    };
+    ctx.createResourceDisplay({ surface: { land } });
+    ctx.updateResourceRateDisplay(land);
+    const html = dom.window.document.getElementById('land-tooltip').innerHTML;
+    expect(html).toContain('Factory');
+    expect(html).toContain('Greenhouse');
+    const firstIndex = html.indexOf('Factory');
+    const secondIndex = html.indexOf('Greenhouse');
+    expect(firstIndex).toBeLessThan(secondIndex);
+    expect(html).toContain('200');
+    expect(html).toContain('30');
+  });
+});


### PR DESCRIPTION
## Summary
- Add tooltip for the land resource that lists per-building land usage sorted by amount
- Cover land tooltip ordering with unit tests
- Document land usage tooltip in AGENTS instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d6dd3af3c8327b04590890308470b