### PR TITLE
Allow autobuild to use remaining land

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,3 +275,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Bio Factory renamed to Biodome, and Life Designer UI now shows a Biodomes section displaying points from biodomes.
 - Added TerraformedDurationProject base class; Space Storage and Dyson Swarm now scale duration with terraformed planets. Space Storage is repeatable with 1 trillion tons capacity per completion.
 - Biodomes now require 100 land each, and the Life Designer UI separates controls from biodomes with a new divider.
+- Auto build now constructs as many buildings as available land allows when targets exceed land.

--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -97,7 +97,12 @@ function autoBuild(buildings, delta = 0) {
         if (canBuildFull) {
             buildCount = requiredAmount;
         } else {
-            const maxBuildable = building.maxBuildable();
+            let maxBuildable = building.maxBuildable();
+
+            if (building.requiresLand && typeof building.landAffordCount === 'function') {
+                maxBuildable = Math.min(maxBuildable, building.landAffordCount());
+            }
+
             if (maxBuildable > 0) {
                 buildCount = maxBuildable;
             }

--- a/tests/autobuildLandPartial.test.js
+++ b/tests/autobuildLandPartial.test.js
@@ -1,0 +1,28 @@
+const { autoBuild, autobuildCostTracker } = require('../src/js/autobuild.js');
+
+describe('autoBuild limited by land', () => {
+  test('builds as much as land allows when target exceeds land', () => {
+    const building = {
+      displayName: 'Test Colony',
+      autoBuildEnabled: true,
+      autoBuildPercent: 10,
+      autoBuildPriority: false,
+      count: 0,
+      requiresLand: 1,
+      canAfford: () => false,
+      maxBuildable: () => 10,
+      landAffordCount: () => 5,
+      build: jest.fn(() => true),
+    };
+
+    global.resources = {
+      colony: { colonists: { value: 100 } },
+      surface: { land: { value: 5, reserved: 0 } },
+    };
+
+    autobuildCostTracker.currentCosts = {};
+    autoBuild({ c: building });
+
+    expect(building.build).toHaveBeenCalledWith(5);
+  });
+});


### PR DESCRIPTION
## Summary
- limit auto-build counts by available land so some buildings go up even when target exceeds land
- document new auto-build land logic in AGENTS.md
- test auto-build constructs partial amount with limited land

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d6e75d3248327a773f5241efe83a5