### PR TITLE
Add spaceship assignment and resource selection to Space Storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,3 +274,4 @@ second time they speak in a chapter to help clarify who is talking.
 - ResearchManager now skips hidden entries when revealing the next three researches.
 - Bio Factory renamed to Biodome, and Life Designer UI now shows a Biodomes section displaying points from biodomes.
 - Added TerraformedDurationProject base class; Space Storage and Dyson Swarm now scale duration with terraformed planets. Space Storage is repeatable with 1 trillion tons capacity per completion.
+- Space Storage project now offers spaceship assignment with resource checkboxes and always displays storage stats with terraformed duration reduction.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -385,11 +385,15 @@ const projectParameters = {
       }
     },
     duration: 300000,
-    description: 'Construct an orbital facility for massive resource storage.',
+    description: 'Construct an orbital facility for massive resource storage. Each terraformed planet reduces construction time.',
     repeatable: true,
     maxRepeatCount: Infinity,
     unlocked: false,
-    attributes: { }
+    attributes: {
+      spaceStorage: true,
+      costPerShip: { colony: { energy: 1_000_000_000 } },
+      transportPerShip: 1_000_000_000
+    }
   },
   disposeResources : {
     type: 'SpaceDisposalProject',

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -1,9 +1,21 @@
-class SpaceStorageProject extends TerraformingDurationProject {
+class SpaceStorageProject extends SpaceshipProject {
   constructor(config, name) {
     super(config, name);
     this.baseDuration = config.duration;
     this.capacityPerCompletion = 1000000000000;
     this.usedStorage = 0;
+    this.selectedResources = [];
+  }
+
+  getDurationWithTerraformBonus(baseDuration) {
+    if (
+      typeof spaceManager === 'undefined' ||
+      typeof spaceManager.getTerraformedPlanetCount !== 'function'
+    ) {
+      return baseDuration;
+    }
+    const count = spaceManager.getTerraformedPlanetCount();
+    return baseDuration / (count + 1);
   }
 
   get maxStorage() {
@@ -14,13 +26,33 @@ class SpaceStorageProject extends TerraformingDurationProject {
     return this.getDurationWithTerraformBonus(this.baseDuration);
   }
 
-  renderUI(container) {
-    if (typeof renderSpaceStorageUI === 'function') {
-      renderSpaceStorageUI(this, container);
+  toggleResourceSelection(category, resource, isSelected) {
+    const exists = this.selectedResources.some(
+      (r) => r.category === category && r.resource === resource
+    );
+    if (isSelected && !exists) {
+      this.selectedResources.push({ category, resource });
+    } else if (!isSelected && exists) {
+      this.selectedResources = this.selectedResources.filter(
+        (r) => !(r.category === category && r.resource === resource)
+      );
     }
   }
 
+  renderUI(container) {
+    const topSection = document.createElement('div');
+    topSection.classList.add('project-top-section');
+    this.createSpaceshipAssignmentUI(topSection);
+    this.createProjectDetailsGridUI(topSection);
+    if (typeof renderSpaceStorageUI === 'function') {
+      renderSpaceStorageUI(this, topSection);
+    }
+    container.appendChild(topSection);
+    this.updateCostAndGains(projectElements[this.name]);
+  }
+
   updateUI() {
+    super.updateUI();
     if (typeof updateSpaceStorageUI === 'function') {
       updateSpaceStorageUI(this);
     }
@@ -30,12 +62,14 @@ class SpaceStorageProject extends TerraformingDurationProject {
     return {
       ...super.saveState(),
       usedStorage: this.usedStorage,
+      selectedResources: this.selectedResources,
     };
   }
 
   loadState(state) {
     super.loadState(state);
     this.usedStorage = state.usedStorage || 0;
+    this.selectedResources = state.selectedResources || [];
   }
 }
 

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -1,6 +1,44 @@
+const storageResourceOptions = [
+  { label: 'Metal', category: 'colony', resource: 'metal' },
+  { label: 'Components', category: 'colony', resource: 'components' },
+  { label: 'Electronics', category: 'colony', resource: 'electronics' },
+  { label: 'Superconductors', category: 'colony', resource: 'superconductors' },
+  { label: 'Oxygen', category: 'atmospheric', resource: 'oxygen' },
+  { label: 'Carbon Dioxide', category: 'atmospheric', resource: 'carbonDioxide' },
+  { label: 'Water', category: 'surface', resource: 'liquidWater' },
+  { label: 'Nitrogen', category: 'atmospheric', resource: 'inertGas' }
+];
+
 function renderSpaceStorageUI(project, container) {
   const card = document.createElement('div');
   card.classList.add('space-storage-card');
+  const checkboxContainer = document.createElement('div');
+  checkboxContainer.classList.add('space-storage-resources');
+
+  storageResourceOptions.forEach(opt => {
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('checkbox-container');
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.id = `${project.name}-res-${opt.resource}`;
+    input.addEventListener('change', e => {
+      project.toggleResourceSelection(opt.category, opt.resource, e.target.checked);
+    });
+    const label = document.createElement('label');
+    label.htmlFor = input.id;
+    label.textContent = opt.label;
+    wrapper.append(input, label);
+    checkboxContainer.appendChild(wrapper);
+
+    projectElements[project.name] = {
+      ...projectElements[project.name],
+      resourceCheckboxes: {
+        ...(projectElements[project.name]?.resourceCheckboxes || {}),
+        [opt.resource]: input
+      }
+    };
+  });
+
   card.innerHTML = `
     <div class="card-header">
       <span class="card-title">Space Storage</span>
@@ -9,28 +47,43 @@ function renderSpaceStorageUI(project, container) {
       <div class="stats-grid">
         <div class="stat-item"><span class="stat-label">Used Storage:</span><span id="ss-used"></span></div>
         <div class="stat-item"><span class="stat-label">Max Storage:</span><span id="ss-max"></span></div>
+        <div class="stat-item"><span class="stat-label">Base Storage:</span><span id="ss-base"></span></div>
       </div>
+      <p class="duration-note"><span class="info-tooltip-icon" title="Construction time is reduced for each terraformed planet">&#9432;</span> Duration reduced per terraformed planet.</p>
     </div>`;
+  card.querySelector('.card-body').appendChild(checkboxContainer);
   container.appendChild(card);
   projectElements[project.name] = {
     ...projectElements[project.name],
     storageCard: card,
     usedDisplay: card.querySelector('#ss-used'),
-    maxDisplay: card.querySelector('#ss-max')
+    maxDisplay: card.querySelector('#ss-max'),
+    baseDisplay: card.querySelector('#ss-base')
   };
 }
 
 function updateSpaceStorageUI(project) {
   const els = projectElements[project.name];
   if (!els) return;
-  if (els.storageCard) {
-    els.storageCard.style.display = project.isCompleted ? 'block' : 'none';
-  }
   if (els.usedDisplay) {
     els.usedDisplay.textContent = formatNumber(project.usedStorage, false, 0);
   }
   if (els.maxDisplay) {
     els.maxDisplay.textContent = formatNumber(project.maxStorage, false, 0);
+  }
+  if (els.baseDisplay) {
+    els.baseDisplay.textContent = formatNumber(project.capacityPerCompletion, false, 0);
+  }
+  if (els.resourceCheckboxes) {
+    storageResourceOptions.forEach(opt => {
+      const cb = els.resourceCheckboxes[opt.resource];
+      if (cb) {
+        const checked = project.selectedResources.some(
+          r => r.category === opt.category && r.resource === opt.resource
+        );
+        cb.checked = checked;
+      }
+    });
   }
 }
 

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
 
 describe('Space Storage project', () => {
   test('defined in parameters', () => {
@@ -16,6 +18,8 @@ describe('Space Storage project', () => {
     expect(project.duration).toBe(300000);
     expect(project.repeatable).toBe(true);
     expect(project.maxRepeatCount).toBe(Infinity);
+    expect(project.attributes.costPerShip.colony.energy).toBe(1_000_000_000);
+    expect(project.attributes.transportPerShip).toBe(1_000_000_000);
   });
 
   test('scales with terraformed worlds and saves used storage', () => {
@@ -33,12 +37,13 @@ describe('Space Storage project', () => {
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
-    const baseCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'TerraformingDurationProject.js'), 'utf8');
-    vm.runInContext(baseCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
+    const shipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(shipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
     const storageCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceStorageProject.js'), 'utf8');
     vm.runInContext(storageCode + '; this.SpaceStorageProject = SpaceStorageProject;', ctx);
 
-    const params = { name: 'spaceStorage', category: 'mega', cost: {}, duration: 300000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: {} };
+    const attrs = { costPerShip: { colony: { energy: 1_000_000_000 } }, transportPerShip: 1_000_000_000 };
+    const params = { name: 'spaceStorage', category: 'mega', cost: {}, duration: 300000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: attrs };
     const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
     expect(project.getBaseDuration()).toBeCloseTo(100000);
     project.repeatCount = 2;
@@ -48,5 +53,46 @@ describe('Space Storage project', () => {
     const loaded = new ctx.SpaceStorageProject(params, 'spaceStorage');
     loaded.loadState(saved);
     expect(loaded.usedStorage).toBe(1234);
+  });
+
+  test('renders assignment UI with resource checkboxes', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    const ctx = {
+      console,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      resources: { special: { spaceships: { value: 0 } }, colony: { energy: { displayName: 'Energy', value: 0 } } },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false,
+      document: dom.window.document,
+      spaceManager: { getTerraformedPlanetCount: () => 0 },
+      formatNumber: numbers.formatNumber,
+      formatBigInteger: numbers.formatBigInteger,
+      formatTotalCostDisplay: () => '',
+      formatTotalResourceGainDisplay: () => ''
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const shipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(shipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
+    const storageCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceStorageProject.js'), 'utf8');
+    vm.runInContext(storageCode + '; this.SpaceStorageProject = SpaceStorageProject;', ctx);
+
+    const attrs = { costPerShip: { colony: { energy: 1_000_000_000 } }, transportPerShip: 1_000_000_000 };
+    const params = { name: 'spaceStorage', category: 'mega', cost: {}, duration: 300000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: attrs };
+    const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
+    const container = dom.window.document.getElementById('root');
+    project.updateCostAndGains = () => {};
+    project.renderUI(container);
+    const checkboxes = container.querySelectorAll('.space-storage-resources input[type="checkbox"]');
+    expect(checkboxes.length).toBe(8);
+    checkboxes[0].checked = true;
+    checkboxes[0].dispatchEvent(new dom.window.Event('change'));
+    expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });
   });
 });

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -15,7 +15,7 @@ describe('Space Storage UI', () => {
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
     vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
 
-    const project = { name: 'spaceStorage', usedStorage: 0, maxStorage: 1000000000000, isCompleted: true };
+    const project = { name: 'spaceStorage', usedStorage: 0, maxStorage: 1000000000000, capacityPerCompletion: 1000000000000, selectedResources: [] };
     const container = dom.window.document.getElementById('container');
     ctx.renderSpaceStorageUI(project, container);
     ctx.updateSpaceStorageUI(project);


### PR DESCRIPTION
## Summary
- expand Space Storage into a spaceship project with assignment UI and resource checkboxes
- show base and used storage always and note terraformed-planet duration bonus
- expose cost and transport per ship parameters for Space Storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d6d9fa3e08327ac7ec35ebf7f8dd3