### PR TITLE
Display colony land usage in land tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,3 +276,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added TerraformedDurationProject base class; Space Storage and Dyson Swarm now scale duration with terraformed planets. Space Storage is repeatable with 1 trillion tons capacity per completion.
 - Biodomes now require 100 land each, and the Life Designer UI separates controls from biodomes with a new divider.
 - Land resource tooltip lists land usage per building sorted by amount.
+- Land resource tooltip now includes land used by colonies.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -309,14 +309,27 @@ function updateResourceRateDisplay(resource){
           tooltipContent += '</div>';
         }
       }
-    } else if (resource.name === 'land' && typeof buildings !== 'undefined') {
+    } else if (resource.name === 'land') {
       const assignments = [];
-      for (const name in buildings) {
-        const b = buildings[name];
-        if (b.active > 0 && b.requiresLand) {
-          const used = b.active * b.requiresLand;
-          if (used > 0) {
-            assignments.push([b.displayName || name, used]);
+      if (typeof buildings !== 'undefined') {
+        for (const name in buildings) {
+          const b = buildings[name];
+          if (b.active > 0 && b.requiresLand) {
+            const used = b.active * b.requiresLand;
+            if (used > 0) {
+              assignments.push([b.displayName || name, used]);
+            }
+          }
+        }
+      }
+      if (typeof colonies !== 'undefined') {
+        for (const name in colonies) {
+          const c = colonies[name];
+          if (c.active > 0 && c.requiresLand) {
+            const used = c.active * c.requiresLand;
+            if (used > 0) {
+              assignments.push([c.displayName || name, used]);
+            }
           }
         }
       }

--- a/tests/landTooltip.test.js
+++ b/tests/landTooltip.test.js
@@ -16,6 +16,9 @@ describe('land resource tooltip', () => {
       factory: { displayName: 'Factory', active: 2, requiresLand: 100 },
       greenhouse: { displayName: 'Greenhouse', active: 3, requiresLand: 10 }
     };
+    ctx.colonies = {
+      outpost: { displayName: 'Outpost', active: 1, requiresLand: 500 }
+    };
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
     vm.runInContext(code, ctx);
     return { dom, ctx };
@@ -40,11 +43,15 @@ describe('land resource tooltip', () => {
     ctx.createResourceDisplay({ surface: { land } });
     ctx.updateResourceRateDisplay(land);
     const html = dom.window.document.getElementById('land-tooltip').innerHTML;
+    expect(html).toContain('Outpost');
     expect(html).toContain('Factory');
     expect(html).toContain('Greenhouse');
-    const firstIndex = html.indexOf('Factory');
-    const secondIndex = html.indexOf('Greenhouse');
+    const firstIndex = html.indexOf('Outpost');
+    const secondIndex = html.indexOf('Factory');
+    const thirdIndex = html.indexOf('Greenhouse');
     expect(firstIndex).toBeLessThan(secondIndex);
+    expect(secondIndex).toBeLessThan(thirdIndex);
+    expect(html).toContain('500');
     expect(html).toContain('200');
     expect(html).toContain('30');
   });


### PR DESCRIPTION
## Summary
- Show colony land consumption in Land tooltip alongside building usage
- Test that colony land assignments appear and are sorted correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d6faa5e748327b7a7270f516cd09a