### PR TITLE
Add biodome point generation and tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,3 +275,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Bio Factory renamed to Biodome, and Life Designer UI now shows a Biodomes section displaying points from biodomes.
 - Added TerraformedDurationProject base class; Space Storage and Dyson Swarm now scale duration with terraformed planets. Space Storage is repeatable with 1 trillion tons capacity per completion.
 - Biodomes now require 100 land each, and the Life Designer UI separates controls from biodomes with a new divider.
+- Biodomes now generate life design points hourly at log10(10×Biodomes); points accumulate fractionally and increase max design points by their floored total. The Biodomes section displays current points, hourly rate and max with a detailed tooltip.

--- a/src/js/life.js
+++ b/src/js/life.js
@@ -328,6 +328,9 @@ class LifeDesigner extends EffectableEntity {
       electronics: 0
     };
 
+    this.biodomePoints = 0;
+    this.biodomePointRate = 0;
+
     this.enabled = false;
   }
 
@@ -411,6 +414,18 @@ class LifeDesigner extends EffectableEntity {
         this.tentativeDesign = null;
       }
     }
+
+    this.updateBiodomePoints(delta);
+  }
+
+  updateBiodomePoints(delta) {
+    const biodomeCount =
+      typeof buildings !== 'undefined' && buildings.biodome
+        ? buildings.biodome.count
+        : 0;
+    const rate = biodomeCount > 0 ? Math.log10(10 * biodomeCount) : 0;
+    this.biodomePointRate = rate;
+    this.biodomePoints += (rate * delta) / 3600000;
   }
 
   cancelDeployment() {
@@ -458,7 +473,12 @@ class LifeDesigner extends EffectableEntity {
   maxLifeDesignPoints() {
     const totalPurchases = Object.values(this.purchaseCounts)
       .reduce((acc, val) => acc + val, 0);
-    return this.baseMaxPoints + this.designPointBonus + totalPurchases;
+    return (
+      this.baseMaxPoints +
+      this.designPointBonus +
+      totalPurchases +
+      Math.floor(this.biodomePoints)
+    );
   }
 
   saveState() {
@@ -470,6 +490,7 @@ class LifeDesigner extends EffectableEntity {
       totalTime: this.totalTime,
       elapsedTime: this.elapsedTime,
       purchaseCounts: { ...this.purchaseCounts },
+      biodomePoints: this.biodomePoints,
       // spaceEfficiency and geologicalBurial are saved within currentDesign/tentativeDesign
     };
     return data;
@@ -485,6 +506,7 @@ class LifeDesigner extends EffectableEntity {
     this.totalTime = data.totalTime;
     this.elapsedTime = data.elapsedTime;
     this.purchaseCounts = { ...data.purchaseCounts };
+    this.biodomePoints = data.biodomePoints || 0;
   }
 }
 

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -79,8 +79,13 @@ function initializeLifeTerraformingDesignerUI() {
                <hr style="margin: 15px 0;">
                <div id="life-biodomes-section" style="margin-top: 10px;">
                  <h4>Biodomes</h4>
-                 <p>Points from biodomes : <span id="life-biodome-points">0</span></p>
-               </div>
+                 <p>Points from biodomes :
+                   <span id="life-biodome-points">0</span> /
+                   <span id="life-biodome-max">0</span>
+                   <span id="life-biodome-rate">+0/hour</span>
+                  <span class="info-tooltip-icon" id="life-biodome-tooltip" title="Each Biodome generates life design points at log10(10 × Biodomes) per hour. Points accumulate fractionally. Only whole points increase your maximum design points, which equals purchased points plus these whole biodome points.">&#9432;</span>
+                </p>
+              </div>
                <hr style="margin: 15px 0;">
                <h3>Point Shop</h3>
             </div>
@@ -369,8 +374,16 @@ function updateLifeUI() {
     updateDesignValues();
     updatePointsDisplay();
     const biodomePointsSpan = document.getElementById('life-biodome-points');
+    const biodomeMaxSpan = document.getElementById('life-biodome-max');
+    const biodomeRateSpan = document.getElementById('life-biodome-rate');
     if (biodomePointsSpan) {
-      biodomePointsSpan.textContent = typeof lifeDesigner.biodomePoints !== 'undefined' ? lifeDesigner.biodomePoints : 0;
+      biodomePointsSpan.textContent = Math.floor(lifeDesigner.biodomePoints || 0);
+    }
+    if (biodomeMaxSpan) {
+      biodomeMaxSpan.textContent = Math.floor(lifeDesigner.maxLifeDesignPoints());
+    }
+    if (biodomeRateSpan) {
+      biodomeRateSpan.textContent = `+${formatNumber(lifeDesigner.biodomePointRate, false, 2)}/hour`;
     }
     // updateZonalBiomassDensities(); // Remove call to old function
     updateLifeStatusTable();

--- a/tests/biodomePointsGeneration.test.js
+++ b/tests/biodomePointsGeneration.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('biodome points generation', () => {
+  function createDesigner(biodomeCount, baseMax = 10) {
+    const dom = new JSDOM(``, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.buildings = { biodome: { count: biodomeCount } };
+    ctx.resources = { surface: { biomass: { value: 0 } } };
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const designer = new ctx.LifeDesigner();
+    designer.baseMaxPoints = baseMax;
+    return { designer, ctx };
+  }
+
+    test('gains points based on log10(10 * biodomes) per hour', () => {
+      const { designer } = createDesigner(2, 20);
+      designer.update(3600000); // one hour
+      expect(designer.biodomePoints).toBeCloseTo(Math.log10(20));
+      expect(Math.floor(designer.biodomePoints)).toBe(1);
+      expect(designer.biodomePointRate).toBeCloseTo(Math.log10(20));
+    });
+
+  test('accumulates fractional progress across updates', () => {
+    const { designer } = createDesigner(2, 20);
+    designer.update(1800000); // half hour
+    expect(Math.floor(designer.biodomePoints)).toBe(0);
+    designer.update(1800000); // another half hour
+    expect(Math.floor(designer.biodomePoints)).toBe(1);
+  });
+
+    test('maxLifeDesignPoints adds floor of biodome points', () => {
+      const { designer } = createDesigner(2, 10);
+      designer.update(3600000); // ~1.3 points
+      expect(designer.maxLifeDesignPoints()).toBe(11);
+      designer.update(3600000); // ~2.6 points total
+      expect(designer.maxLifeDesignPoints()).toBe(12);
+    });
+  });

--- a/tests/lifeUIBiodomesSection.test.js
+++ b/tests/lifeUIBiodomesSection.test.js
@@ -51,6 +51,16 @@ describe('lifeUI biodomes section', () => {
     expect(section.querySelector('h4').textContent).toBe('Biodomes');
     const points = dom.window.document.getElementById('life-biodome-points');
     expect(points.textContent).toBe('0');
+    const max = dom.window.document.getElementById('life-biodome-max');
+    expect(max.textContent).toBe('0');
+    const rate = dom.window.document.getElementById('life-biodome-rate');
+    expect(rate.textContent).toBe('+0/hour');
+    const tooltip = dom.window.document.getElementById('life-biodome-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.classList.contains('info-tooltip-icon')).toBe(true);
+    const title = tooltip.getAttribute('title');
+    expect(title).toMatch(/log10/);
+    expect(title).toMatch(/Only whole points/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Track biodome life design points as fractional values and add the floored total to purchases when calculating max design points.
- Clarify biodome point accumulation in Life UI with an updated tooltip and documentation.
- Test fractional accumulation and max point calculations.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d6f0363448327be9b0a1707427cbb