### PR TITLE
Enhance space storage operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Land resource tooltip lists land usage per building sorted by amount.
 - Space Storage UI now removes base storage display, shows per-resource usage table and adds a second progress bar with its own auto-start.
 - Land resource tooltip now includes land used by colonies.
+- Space Storage ships now reduce duration up to 100 assignments, apply multipliers beyond that, support deposit/withdraw toggling and always show a resource table with current amounts.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -76,6 +76,20 @@ function renderSpaceStorageUI(project, container) {
   shipProgressButtonContainer.appendChild(shipProgressButton);
   shipFooter.appendChild(shipProgressButtonContainer);
 
+  const modeContainer = document.createElement('div');
+  modeContainer.classList.add('checkbox-container');
+  const modeToggle = document.createElement('input');
+  modeToggle.type = 'checkbox';
+  modeToggle.id = `${project.name}-withdraw-mode`;
+  modeToggle.addEventListener('change', e => {
+    project.shipWithdrawMode = e.target.checked;
+  });
+  const modeLabel = document.createElement('label');
+  modeLabel.htmlFor = modeToggle.id;
+  modeLabel.textContent = 'Withdraw';
+  modeContainer.append(modeToggle, modeLabel);
+  shipFooter.appendChild(modeContainer);
+
   const shipAutomationContainer = document.createElement('div');
   shipAutomationContainer.classList.add('automation-settings-container');
   const shipAutoStartContainer = document.createElement('div');
@@ -102,7 +116,8 @@ function renderSpaceStorageUI(project, container) {
     maxDisplay: card.querySelector('#ss-max'),
     usageBody: card.querySelector('#ss-usage-body'),
     shipProgressButton,
-    shipAutoStartCheckbox
+    shipAutoStartCheckbox,
+    withdrawToggle: modeToggle
   };
 }
 
@@ -118,16 +133,14 @@ function updateSpaceStorageUI(project) {
   if (els.usageBody) {
     els.usageBody.innerHTML = '';
     storageResourceOptions.forEach(opt => {
-      const amount = project.resourceUsage[opt.resource];
-      if (amount) {
-        const row = document.createElement('tr');
-        const nameCell = document.createElement('td');
-        nameCell.textContent = opt.label;
-        const amtCell = document.createElement('td');
-        amtCell.textContent = formatNumber(amount, false, 0);
-        row.append(nameCell, amtCell);
-        els.usageBody.appendChild(row);
-      }
+      const row = document.createElement('tr');
+      const nameCell = document.createElement('td');
+      nameCell.textContent = opt.label;
+      const amtCell = document.createElement('td');
+      const amount = project.resourceUsage[opt.resource] || 0;
+      amtCell.textContent = formatNumber(amount, false, 0);
+      row.append(nameCell, amtCell);
+      els.usageBody.appendChild(row);
     });
   }
   if (els.resourceCheckboxes) {
@@ -143,6 +156,9 @@ function updateSpaceStorageUI(project) {
   }
   if (els.shipAutoStartCheckbox) {
     els.shipAutoStartCheckbox.checked = project.shipOperationAutoStart;
+  }
+  if (els.withdrawToggle) {
+    els.withdrawToggle.checked = project.shipWithdrawMode;
   }
   if (els.shipProgressButton) {
     const duration = project.getEffectiveDuration();

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -15,7 +15,7 @@ describe('Space Storage UI', () => {
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
     vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
 
-    const project = { name: 'spaceStorage', usedStorage: 0, maxStorage: 1000000000000, resourceUsage: {}, selectedResources: [], shipOperationAutoStart: false, shipOperationRemainingTime: 0, shipOperationStartingDuration: 0, shipOperationIsActive: false, getEffectiveDuration: () => 1000 };
+    const project = { name: 'spaceStorage', usedStorage: 0, maxStorage: 1000000000000, resourceUsage: {}, selectedResources: [], shipOperationAutoStart: false, shipOperationRemainingTime: 0, shipOperationStartingDuration: 0, shipOperationIsActive: false, shipWithdrawMode: false, getEffectiveDuration: () => 1000 };
     const container = dom.window.document.getElementById('container');
     ctx.renderSpaceStorageUI(project, container);
     ctx.updateSpaceStorageUI(project);
@@ -23,13 +23,17 @@ describe('Space Storage UI', () => {
     const els = ctx.projectElements[project.name];
     expect(els.usedDisplay.textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.maxDisplay.textContent).toBe(String(numbers.formatNumber(1000000000000, false, 0)));
-    expect(els.usageBody.querySelectorAll('tr').length).toBe(0);
+    expect(els.usageBody.querySelectorAll('tr').length).toBe(8);
+    expect(els.usageBody.querySelector('tr:first-child td:nth-child(2)').textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();
     expect(els.shipAutoStartCheckbox).toBeDefined();
+    expect(els.withdrawToggle).toBeDefined();
 
     project.resourceUsage = { metal: 500 };
     project.usedStorage = 500;
     ctx.updateSpaceStorageUI(project);
-    expect(els.usageBody.querySelectorAll('tr').length).toBe(1);
+    expect(els.usageBody.querySelectorAll('tr').length).toBe(8);
+    const metalRow = Array.from(els.usageBody.querySelectorAll('tr')).find(r => r.firstChild.textContent === 'Metal');
+    expect(metalRow.lastChild.textContent).toBe(String(numbers.formatNumber(500, false, 0)));
   });
 });


### PR DESCRIPTION
## Summary
- Scale Space Storage spaceship duration like other space projects and add multiplier beyond 100 ships
- Track stored resources per type with deposit/withdraw operations and visible table
- Support deposit/withdraw toggle with tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d74a2dc58832786ae2c5b4a6d7651