### PR TITLE
Refine space storage layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,3 +284,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Biodome points display now shows fractional progress and no longer lists the maximum.
 - Space Storage ships now reduce duration up to 100 assignments, apply multipliers beyond that, support deposit/withdraw toggling and always show a resource table with current amounts.
 - Space Storage now features Store/Withdraw mode buttons with even capacity distribution and transfers calculated at launch.
+- Space Storage UI now combines resource checkboxes with usage in a single table and places spaceship assignment below storage controls.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -349,6 +349,13 @@
     padding-bottom: 10px;
 }
 
+.space-storage-top-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding-bottom: 10px;
+}
+
 .project-section-container {
     display: flex;
     flex-direction: column;

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -216,13 +216,14 @@ class SpaceStorageProject extends SpaceshipProject {
   }
 
   renderUI(container) {
+    projectElements[this.name] = projectElements[this.name] || {};
     const topSection = document.createElement('div');
-    topSection.classList.add('project-top-section');
-    this.createSpaceshipAssignmentUI(topSection);
+    topSection.classList.add('space-storage-top-section');
     this.createProjectDetailsGridUI(topSection);
     if (typeof renderSpaceStorageUI === 'function') {
       renderSpaceStorageUI(this, topSection);
     }
+    this.createSpaceshipAssignmentUI(topSection);
     container.appendChild(topSection);
     this.updateCostAndGains(projectElements[this.name]);
   }

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -96,7 +96,7 @@ describe('Space Storage project', () => {
     const container = dom.window.document.getElementById('root');
     project.updateCostAndGains = () => {};
     project.renderUI(container);
-    const checkboxes = container.querySelectorAll('.space-storage-resources input[type="checkbox"]');
+    const checkboxes = container.querySelectorAll('.storage-usage-table input[type="checkbox"]');
     expect(checkboxes.length).toBe(8);
     checkboxes[0].checked = true;
     checkboxes[0].dispatchEvent(new dom.window.Event('change'));

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -24,7 +24,7 @@ describe('Space Storage UI', () => {
     expect(els.usedDisplay.textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.maxDisplay.textContent).toBe(String(numbers.formatNumber(1000000000000, false, 0)));
     expect(els.usageBody.querySelectorAll('tr').length).toBe(8);
-    expect(els.usageBody.querySelector('tr:first-child td:nth-child(2)').textContent).toBe(String(numbers.formatNumber(0, false, 0)));
+    expect(els.usageBody.querySelector('tr:first-child td:nth-child(3)').textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();
     expect(els.shipAutoStartCheckbox).toBeDefined();
     expect(els.withdrawButton).toBeDefined();
@@ -39,7 +39,7 @@ describe('Space Storage UI', () => {
     project.usedStorage = 500;
     ctx.updateSpaceStorageUI(project);
     expect(els.usageBody.querySelectorAll('tr').length).toBe(8);
-    const metalRow = Array.from(els.usageBody.querySelectorAll('tr')).find(r => r.firstChild.textContent === 'Metal');
-    expect(metalRow.lastChild.textContent).toBe(String(numbers.formatNumber(500, false, 0)));
+    const metalRow = Array.from(els.usageBody.querySelectorAll('tr')).find(r => r.children[1].textContent === 'Metal');
+    expect(metalRow.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
   });
 });


### PR DESCRIPTION
## Summary
- simplify space storage table by combining resource selection checkboxes with usage stats
- stack spaceship assignment controls below storage details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d7aa4bd608327847af7cdb6581f7f