### PR TITLE
Enable Space Storage expansion without ship assignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,3 +284,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Biodome points display now shows fractional progress and no longer lists the maximum.
 - Space Storage ships now reduce duration up to 100 assignments, apply multipliers beyond that, support deposit/withdraw toggling and always show a resource table with current amounts.
 - Space Storage now features Store/Withdraw mode buttons with even capacity distribution and transfers calculated at launch.
+- Space Storage expansion progress bar activates once its metal cost requirements are satisfied.

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -151,6 +151,11 @@ class SpaceStorageProject extends SpaceshipProject {
     return { transfers, total };
   }
 
+  canStart() {
+    const base = Object.getPrototypeOf(SpaceshipProject.prototype);
+    return base.canStart.call(this);
+  }
+
   canStartShipOperation() {
     if (this.shipOperationIsActive) return false;
     if (this.assignedSpaceships <= 0) return false;

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -103,6 +103,67 @@ describe('Space Storage project', () => {
     expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });
   });
 
+  test('can start expansion when metal cost is met without spaceships', () => {
+    const ctx = {
+      console,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      resources: {
+        colony: {
+          metal: { value: 1000, decrease(v){ this.value -= v; } }
+        },
+        special: { spaceships: { value: 0 } }
+      },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const shipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(shipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const storageCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceStorageProject.js'), 'utf8');
+    vm.runInContext(storageCode + '; this.SpaceStorageProject = SpaceStorageProject;', ctx);
+
+    const params = { name: 'spaceStorage', category: 'mega', cost: { colony: { metal: 1000 } }, duration: 1000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: {} };
+    const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
+    expect(project.canStart()).toBe(true);
+    expect(project.start(ctx.resources)).toBe(true);
+    expect(ctx.resources.colony.metal.value).toBe(0);
+    expect(project.isActive).toBe(true);
+  });
+
+  test('cannot start expansion without required metal', () => {
+    const ctx = {
+      console,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      resources: {
+        colony: {
+          metal: { value: 500, decrease(v){ this.value -= v; } }
+        },
+        special: { spaceships: { value: 0 } }
+      },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const shipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(shipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const storageCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceStorageProject.js'), 'utf8');
+    vm.runInContext(storageCode + '; this.SpaceStorageProject = SpaceStorageProject;', ctx);
+
+    const params = { name: 'spaceStorage', category: 'mega', cost: { colony: { metal: 1000 } }, duration: 1000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: {} };
+    const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
+    expect(project.canStart()).toBe(false);
+  });
+
   test('withdraw mode distributes capacity and returns resources (water to colony)', () => {
     const ctx = {
       console,


### PR DESCRIPTION
## Summary
- Let Space Storage expansions start based solely on their metal cost
- Test Space Storage expansion start logic with and without enough metal
- Document Space Storage expansion progress bar behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d7afc5138832791d18d14351b53a4