### PR TITLE
Refine Space Storage layout and cost display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,3 +286,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage now features Store/Withdraw mode buttons with even capacity distribution and transfers calculated at launch.
 - Space Storage expansion progress bar activates once its metal cost requirements are satisfied.
 - Space Storage UI now combines resource checkboxes with usage in a single table and places spaceship assignment below storage controls.
+- Space Storage UI shows Used and Max storage side by side, includes expansion cost with terraforming tooltip, and displays spaceship assignment next to ship cost & gain.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -125,6 +125,10 @@
     gap: 8px;
 }
 
+.stats-grid.two-col {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
 .stats-grid.three-col {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -224,11 +224,14 @@ class SpaceStorageProject extends SpaceshipProject {
     projectElements[this.name] = projectElements[this.name] || {};
     const topSection = document.createElement('div');
     topSection.classList.add('space-storage-top-section');
-    this.createProjectDetailsGridUI(topSection);
     if (typeof renderSpaceStorageUI === 'function') {
       renderSpaceStorageUI(this, topSection);
     }
-    this.createSpaceshipAssignmentUI(topSection);
+    const assignmentAndCost = document.createElement('div');
+    assignmentAndCost.classList.add('project-top-section');
+    this.createSpaceshipAssignmentUI(assignmentAndCost);
+    this.createProjectDetailsGridUI(assignmentAndCost);
+    topSection.appendChild(assignmentAndCost);
     container.appendChild(topSection);
     this.updateCostAndGains(projectElements[this.name]);
   }

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -17,17 +17,18 @@ function renderSpaceStorageUI(project, container) {
       <span class="card-title">Space Storage</span>
     </div>
     <div class="card-body">
-      <div class="stats-grid">
+      <div class="stats-grid two-col">
         <div class="stat-item"><span class="stat-label">Used Storage:</span><span id="ss-used"></span></div>
         <div class="stat-item"><span class="stat-label">Max Storage:</span><span id="ss-max"></span></div>
       </div>
+      <p id="ss-expansion-cost"><strong>Expansion Cost:</strong> <span class="expansion-cost"></span> <span class="info-tooltip-icon" title="Construction time is reduced for each terraformed planet">&#9432;</span></p>
       <table class="storage-usage-table">
         <thead><tr><th></th><th>Resource</th><th>Used</th></tr></thead>
         <tbody id="ss-usage-body"></tbody>
       </table>
-      <p class="duration-note"><span class="info-tooltip-icon" title="Construction time is reduced for each terraformed planet">&#9432;</span> Duration reduced per terraformed planet.</p>
     </div>`;
   const usageBody = card.querySelector('#ss-usage-body');
+  const expansionCostDisplay = card.querySelector('#ss-expansion-cost .expansion-cost');
 
   storageResourceOptions.forEach(opt => {
     const row = document.createElement('tr');
@@ -144,6 +145,7 @@ function renderSpaceStorageUI(project, container) {
     usedDisplay: card.querySelector('#ss-used'),
     maxDisplay: card.querySelector('#ss-max'),
     usageBody,
+    expansionCostDisplay,
     shipProgressButton,
     shipAutoStartCheckbox,
     withdrawButton,
@@ -160,6 +162,18 @@ function updateSpaceStorageUI(project) {
   }
   if (els.maxDisplay) {
     els.maxDisplay.textContent = formatNumber(project.maxStorage, false, 0);
+  }
+  if (els.expansionCostDisplay) {
+    const cost = project.getScaledCost ? project.getScaledCost() : project.cost;
+    const parts = [];
+    for (const category in cost) {
+      for (const resource in cost[category]) {
+        const res = resources[category][resource];
+        const name = res.displayName || resource.charAt(0).toUpperCase() + resource.slice(1);
+        parts.push(`${name}: ${formatNumber(cost[category][resource], true)}`);
+      }
+    }
+    els.expansionCostDisplay.textContent = parts.join(', ');
   }
   if (els.usageCells) {
     storageResourceOptions.forEach(opt => {

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -18,7 +18,7 @@ describe('Space Storage project', () => {
     expect(project.duration).toBe(300000);
     expect(project.repeatable).toBe(true);
     expect(project.maxRepeatCount).toBe(Infinity);
-    expect(project.attributes.costPerShip.colony.energy).toBe(500_000_000);
+    expect(project.attributes.costPerShip.colony.energy).toBe(250_000_000);
     expect(project.attributes.transportPerShip).toBe(1_000_000);
   });
 


### PR DESCRIPTION
## Summary
- Display Space Storage "Used" and "Max" capacities side by side.
- Show expansion cost with terraforming tooltip and align ship assignment with cost & gain.
- Update Space Storage project test for current per-ship energy cost.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d7ec66cb083278ee7462fef44043c