### PR TITLE
Display Space Storage expansion cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,3 +287,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage expansion progress bar activates once its metal cost requirements are satisfied.
 - Space Storage UI now combines resource checkboxes with usage in a single table and places spaceship assignment below storage controls.
 - Space Storage UI shows Used and Max storage side by side, includes expansion cost with terraforming tooltip, and displays spaceship assignment next to ship cost & gain.
+- Space Storage card now correctly displays the expansion metal cost.

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -226,6 +226,9 @@ class SpaceStorageProject extends SpaceshipProject {
     topSection.classList.add('space-storage-top-section');
     if (typeof renderSpaceStorageUI === 'function') {
       renderSpaceStorageUI(this, topSection);
+      if (typeof updateSpaceStorageUI === 'function') {
+        updateSpaceStorageUI(this);
+      }
     }
     const assignmentAndCost = document.createElement('div');
     assignmentAndCost.classList.add('project-top-section');

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -11,11 +11,27 @@ describe('Space Storage UI', () => {
     ctx.document = dom.window.document;
     ctx.projectElements = {};
     ctx.formatNumber = numbers.formatNumber;
+    ctx.resources = { colony: { metal: { displayName: 'Metal' } } };
 
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
     vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
 
-    const project = { name: 'spaceStorage', usedStorage: 0, maxStorage: 1000000000000, resourceUsage: {}, selectedResources: [], shipOperationAutoStart: false, shipOperationRemainingTime: 0, shipOperationStartingDuration: 0, shipOperationIsActive: false, shipWithdrawMode: false, getEffectiveDuration: () => 1000 };
+    const metalCost = 1000000000000;
+    const project = {
+      name: 'spaceStorage',
+      cost: { colony: { metal: metalCost } },
+      getScaledCost() { return this.cost; },
+      usedStorage: 0,
+      maxStorage: 1000000000000,
+      resourceUsage: {},
+      selectedResources: [],
+      shipOperationAutoStart: false,
+      shipOperationRemainingTime: 0,
+      shipOperationStartingDuration: 0,
+      shipOperationIsActive: false,
+      shipWithdrawMode: false,
+      getEffectiveDuration: () => 1000,
+    };
     const container = dom.window.document.getElementById('container');
     ctx.renderSpaceStorageUI(project, container);
     ctx.updateSpaceStorageUI(project);
@@ -23,6 +39,7 @@ describe('Space Storage UI', () => {
     const els = ctx.projectElements[project.name];
     expect(els.usedDisplay.textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.maxDisplay.textContent).toBe(String(numbers.formatNumber(1000000000000, false, 0)));
+    expect(els.expansionCostDisplay.textContent).toBe(`Metal: ${numbers.formatNumber(metalCost, true)}`);
     expect(els.usageBody.querySelectorAll('tr').length).toBe(8);
     expect(els.usageBody.querySelector('tr:first-child td:nth-child(3)').textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();


### PR DESCRIPTION
## Summary
- Ensure Space Storage project renders its expansion metal cost immediately
- Test Space Storage UI shows expansion cost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d81a964bc8327bff1dd5638343b70