### PR TITLE
Clarify Space Storage progress buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,3 +288,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage UI now combines resource checkboxes with usage in a single table and places spaceship assignment below storage controls.
 - Dyson Swarm and other mega projects can draw costs from Space Storage, with an option to prioritize stored resources.
 - Space Storage UI shows Used and Max storage side by side, includes expansion cost with terraforming tooltip, and displays spaceship assignment next to ship cost & gain.
+- Space Storage progress buttons now read "Start ship transfers" and "Start storage expansion".

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -229,13 +229,13 @@ function updateSpaceStorageUI(project) {
       els.shipProgressButton.textContent = `In Progress: ${timeRemaining} seconds remaining (${progressPercent.toFixed(2)}%)`;
       els.shipProgressButton.style.background = `linear-gradient(to right, #4caf50 ${progressPercent}%, #ccc ${progressPercent}%)`;
     } else if (project.shipOperationIsPaused) {
-      els.shipProgressButton.textContent = `Resume Ships (${timeRemaining}s left)`;
+      els.shipProgressButton.textContent = `Resume ship transfers (${timeRemaining}s left)`;
       els.shipProgressButton.style.background = project.canStartShipOperation() ? '#4caf50' : '#f44336';
     } else if (project.canStartShipOperation && project.canStartShipOperation()) {
-      els.shipProgressButton.textContent = `Start Ships (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
+      els.shipProgressButton.textContent = `Start ship transfers (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
       els.shipProgressButton.style.background = '#4caf50';
     } else {
-      els.shipProgressButton.textContent = `Start Ships (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
+      els.shipProgressButton.textContent = `Start ship transfers (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
       els.shipProgressButton.style.background = '#f44336';
     }
   }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -476,12 +476,20 @@ function updateProjectUI(projectName) {
           elements.progressButton.style.background = '#4caf50';
         } else if (project.isPaused) {
           const timeRemaining = Math.max(0, project.remainingTime / 1000).toFixed(2);
-          elements.progressButton.textContent = `Resume ${project.displayName} (${timeRemaining}s left)`;
+          if (typeof SpaceStorageProject !== 'undefined' && project instanceof SpaceStorageProject) {
+            elements.progressButton.textContent = `Resume storage expansion (${timeRemaining}s left)`;
+          } else {
+            elements.progressButton.textContent = `Resume ${project.displayName} (${timeRemaining}s left)`;
+          }
           elements.progressButton.style.background = project.canStart() ? '#4caf50' : '#f44336';
         } else {
           // Update dynamic duration for spaceMining projects
           let duration = project.getEffectiveDuration();
-          elements.progressButton.textContent = `Start ${project.displayName} (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
+          if (typeof SpaceStorageProject !== 'undefined' && project instanceof SpaceStorageProject) {
+            elements.progressButton.textContent = `Start storage expansion (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
+          } else {
+            elements.progressButton.textContent = `Start ${project.displayName} (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
+          }
 
         // Set background color based on whether the project can start
         if (project.canStart()) {

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -15,7 +15,7 @@ describe('Space Storage UI', () => {
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
     vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
 
-    const project = { name: 'spaceStorage', usedStorage: 0, maxStorage: 1000000000000, resourceUsage: {}, selectedResources: [], shipOperationAutoStart: false, shipOperationRemainingTime: 0, shipOperationStartingDuration: 0, shipOperationIsActive: false, shipWithdrawMode: false, prioritizeMegaProjects: false, getEffectiveDuration: () => 1000 };
+    const project = { name: 'spaceStorage', usedStorage: 0, maxStorage: 1000000000000, resourceUsage: {}, selectedResources: [], shipOperationAutoStart: false, shipOperationRemainingTime: 0, shipOperationStartingDuration: 0, shipOperationIsActive: false, shipWithdrawMode: false, prioritizeMegaProjects: false, getEffectiveDuration: () => 1000, canStartShipOperation: () => true };
     const container = dom.window.document.getElementById('container');
     ctx.renderSpaceStorageUI(project, container);
     ctx.updateSpaceStorageUI(project);
@@ -49,5 +49,9 @@ describe('Space Storage UI', () => {
     project.prioritizeMegaProjects = false;
     ctx.updateSpaceStorageUI(project);
     expect(els.prioritizeMegaCheckbox.checked).toBe(false);
+    project.shipOperationIsActive = false;
+    project.shipOperationIsPaused = false;
+    ctx.updateSpaceStorageUI(project);
+    expect(els.shipProgressButton.textContent).toBe('Start ship transfers (Duration: 1.00 seconds)');
   });
 });


### PR DESCRIPTION
## Summary
- Rename Space Storage ship operation control to "Start ship transfers" and update resume text
- Show "Start storage expansion" for the expansion progress bar
- Cover new labels with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d833655388327a3527cd80d184c06