### PR TITLE
Align expansion cost with spaceship assignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,3 +289,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Dyson Swarm and other mega projects can draw costs from Space Storage, with an option to prioritize stored resources.
 - Space Storage UI shows Used and Max storage side by side, includes expansion cost with terraforming tooltip, and displays spaceship assignment next to ship cost & gain.
 - Space Storage card now correctly displays the expansion metal cost.
+- Space Storage UI now places expansion cost alongside spaceship assignment and cost & gain.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -22,14 +22,43 @@ function renderSpaceStorageUI(project, container) {
         <div class="stat-item"><span class="stat-label">Used Storage:</span><span id="ss-used"></span></div>
         <div class="stat-item"><span class="stat-label">Max Storage:</span><span id="ss-max"></span></div>
       </div>
-      <p id="ss-expansion-cost"><strong>Expansion Cost:</strong> <span class="expansion-cost"></span> <span class="info-tooltip-icon" title="Construction time is reduced for each terraformed planet">&#9432;</span></p>
       <table class="storage-usage-table">
         <thead><tr><th></th><th>Resource</th><th>Used</th></tr></thead>
         <tbody id="ss-usage-body"></tbody>
       </table>
     </div>`;
   const usageBody = card.querySelector('#ss-usage-body');
-  const expansionCostDisplay = card.querySelector('#ss-expansion-cost .expansion-cost');
+  const cardBody = card.querySelector('.card-body');
+
+  const topSection = document.createElement('div');
+  topSection.classList.add('project-top-section');
+
+  if (typeof project.createSpaceshipAssignmentUI === 'function') {
+    project.createSpaceshipAssignmentUI(topSection);
+  }
+  if (typeof project.createProjectDetailsGridUI === 'function') {
+    project.createProjectDetailsGridUI(topSection);
+  }
+
+  const expansionSection = document.createElement('div');
+  expansionSection.classList.add('project-section-container');
+  const expansionTitle = document.createElement('h4');
+  expansionTitle.classList.add('section-title');
+  expansionTitle.textContent = 'Expansion';
+  expansionSection.appendChild(expansionTitle);
+
+  const expansionGrid = document.createElement('div');
+  expansionGrid.classList.add('project-details-grid');
+  const expansionCostRow = document.createElement('div');
+  expansionCostRow.id = 'ss-expansion-cost';
+  expansionCostRow.innerHTML = `<strong>Cost:</strong> <span class="expansion-cost"></span> <span class="info-tooltip-icon" title="Construction time is reduced for each terraformed planet">&#9432;</span>`;
+  expansionGrid.appendChild(expansionCostRow);
+  expansionSection.appendChild(expansionGrid);
+  topSection.appendChild(expansionSection);
+
+  cardBody.appendChild(topSection);
+
+  const expansionCostDisplay = expansionCostRow.querySelector('.expansion-cost');
 
   storageResourceOptions.forEach(opt => {
     const row = document.createElement('tr');

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -31,6 +31,26 @@ describe('Space Storage UI', () => {
       shipOperationIsActive: false,
       shipWithdrawMode: false,
       getEffectiveDuration: () => 1000,
+      createSpaceshipAssignmentUI(container) {
+        const doc = container.ownerDocument;
+        const section = doc.createElement('div');
+        section.classList.add('project-section-container');
+        const title = doc.createElement('h4');
+        title.classList.add('section-title');
+        title.textContent = 'Assignment';
+        section.appendChild(title);
+        container.appendChild(section);
+      },
+      createProjectDetailsGridUI(container) {
+        const doc = container.ownerDocument;
+        const section = doc.createElement('div');
+        section.classList.add('project-section-container');
+        const title = doc.createElement('h4');
+        title.classList.add('section-title');
+        title.textContent = 'Cost & Gain';
+        section.appendChild(title);
+        container.appendChild(section);
+      },
     };
     const container = dom.window.document.getElementById('container');
     ctx.renderSpaceStorageUI(project, container);
@@ -66,5 +86,9 @@ describe('Space Storage UI', () => {
     project.prioritizeMegaProjects = false;
     ctx.updateSpaceStorageUI(project);
     expect(els.prioritizeMegaCheckbox.checked).toBe(false);
+
+    const topSection = container.querySelector('.project-top-section');
+    const titles = Array.from(topSection.querySelectorAll('.section-title')).map(e => e.textContent);
+    expect(titles).toEqual(expect.arrayContaining(['Assignment', 'Cost & Gain', 'Expansion']));
   });
 });


### PR DESCRIPTION
## Summary
- Show space storage expansion cost beside ship assignment and cost/gain using project section styling
- Update UI test to confirm presence of assignment, cost/gain, and expansion sections
- Document the UI change in AGENTS instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d841ed7c48327a02567f6612283a2