### PR TITLE
Group space storage resources into three columns

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -94,6 +94,17 @@
     font-size: 0.9em;
 }
 
+/* Space Storage resource table */
+.storage-usage-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.storage-usage-table th,
+.storage-usage-table td {
+    padding: 4px;
+}
+
 /* Mode selection buttons for Space Storage */
 .mode-selection {
     display: flex;

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -23,11 +23,20 @@ function renderSpaceStorageUI(project, container) {
         <div class="stat-item"><span class="stat-label">Max Storage:</span><span id="ss-max"></span></div>
       </div>
       <table class="storage-usage-table">
-        <thead><tr><th></th><th>Resource</th><th>Used</th></tr></thead>
+        <thead><tr id="ss-usage-header"></tr></thead>
         <tbody id="ss-usage-body"></tbody>
       </table>
     </div>`;
+  const usageHeader = card.querySelector('#ss-usage-header');
   const usageBody = card.querySelector('#ss-usage-body');
+  for (let i = 0; i < 3; i++) {
+    const blank = document.createElement('th');
+    const res = document.createElement('th');
+    res.textContent = 'Resource';
+    const used = document.createElement('th');
+    used.textContent = 'Used';
+    usageHeader.append(blank, res, used);
+  }
   const cardBody = card.querySelector('.card-body');
 
   const topSection = document.createElement('div');
@@ -60,8 +69,12 @@ function renderSpaceStorageUI(project, container) {
 
   const expansionCostDisplay = expansionCostRow.querySelector('.expansion-cost');
 
-  storageResourceOptions.forEach(opt => {
-    const row = document.createElement('tr');
+  let currentRow;
+  storageResourceOptions.forEach((opt, index) => {
+    if (index % 3 === 0) {
+      currentRow = document.createElement('tr');
+      usageBody.appendChild(currentRow);
+    }
 
     const checkboxCell = document.createElement('td');
     const input = document.createElement('input');
@@ -81,8 +94,7 @@ function renderSpaceStorageUI(project, container) {
     amtCell.id = `${project.name}-usage-${opt.resource}`;
     amtCell.textContent = '0';
 
-    row.append(checkboxCell, nameCell, amtCell);
-    usageBody.appendChild(row);
+    currentRow.append(checkboxCell, nameCell, amtCell);
 
     projectElements[project.name] = {
       ...projectElements[project.name],

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -98,6 +98,8 @@ describe('Space Storage project', () => {
     project.renderUI(container);
     const checkboxes = container.querySelectorAll('.storage-usage-table input[type="checkbox"]');
     expect(checkboxes.length).toBe(8);
+    const rows = container.querySelectorAll('.storage-usage-table tbody tr');
+    expect(rows[0].children.length).toBe(9);
     checkboxes[0].checked = true;
     checkboxes[0].dispatchEvent(new dom.window.Event('change'));
     expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -60,7 +60,7 @@ describe('Space Storage UI', () => {
     expect(els.usedDisplay.textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.maxDisplay.textContent).toBe(String(numbers.formatNumber(1000000000000, false, 0)));
     expect(els.expansionCostDisplay.textContent).toBe(`Metal: ${numbers.formatNumber(metalCost, true)}`);
-    expect(els.usageBody.querySelectorAll('tr').length).toBe(8);
+    expect(els.usageBody.querySelectorAll('tr').length).toBe(3);
     expect(els.usageBody.querySelector('tr:first-child td:nth-child(3)').textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();
     expect(els.shipAutoStartCheckbox).toBeDefined();
@@ -76,7 +76,7 @@ describe('Space Storage UI', () => {
     project.resourceUsage = { metal: 500 };
     project.usedStorage = 500;
     ctx.updateSpaceStorageUI(project);
-    expect(els.usageBody.querySelectorAll('tr').length).toBe(8);
+    expect(els.usageBody.querySelectorAll('tr').length).toBe(3);
     const metalRow = Array.from(els.usageBody.querySelectorAll('tr')).find(r => r.children[1].textContent === 'Metal');
     expect(metalRow.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
 


### PR DESCRIPTION
## Summary
- Show Space Storage resources in three checkbox/name/amount groups per row
- Add styling for the expanded resource table
- Update tests for new table layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d86b667b8832786f279d8b6f0b57b