### PR TITLE
Align Space Storage automation checkboxes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,3 +293,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage UI now places expansion cost alongside spaceship assignment and cost & gain.
 - Space Elevator no longer negates Space Storage expansion metal cost, applying its metal cost reduction only to ships.
 - Space Storage card now uses a single spaceship assignment and cost/gain display with populated values.
+- Space Storage automation settings now sit next to the expansion auto start, which is labeled "Auto Start Expansion".
+- Space Storage automation checkboxes are now created via the generic project UI like other project-specific controls.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -9,6 +9,55 @@ const storageResourceOptions = [
   { label: 'Nitrogen', category: 'atmospheric', resource: 'inertGas' }
 ];
 
+if (typeof SpaceStorageProject !== 'undefined') {
+  SpaceStorageProject.prototype.createShipAutoStartCheckbox = function () {
+    const els = projectElements[this.name] || {};
+    if (els.autoStartCheckboxContainer) {
+      const autoLabel = els.autoStartCheckboxContainer.querySelector('label');
+      if (autoLabel) autoLabel.textContent = 'Auto Start Expansion';
+    }
+    const container = document.createElement('div');
+    container.classList.add('checkbox-container');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = `${this.name}-ship-auto-start`;
+    checkbox.addEventListener('change', (e) => {
+      this.shipOperationAutoStart = e.target.checked;
+    });
+    const label = document.createElement('label');
+    label.htmlFor = checkbox.id;
+    label.textContent = 'Auto Start Ships';
+    container.append(checkbox, label);
+    projectElements[this.name] = {
+      ...projectElements[this.name],
+      shipAutoStartCheckbox: checkbox,
+      shipAutoStartContainer: container,
+    };
+    return container;
+  };
+
+  SpaceStorageProject.prototype.createPrioritizeMegaCheckbox = function () {
+    const container = document.createElement('div');
+    container.classList.add('checkbox-container');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = `${this.name}-prioritize-space`;
+    checkbox.addEventListener('change', (e) => {
+      this.prioritizeMegaProjects = e.target.checked;
+    });
+    const label = document.createElement('label');
+    label.htmlFor = checkbox.id;
+    label.textContent = 'Prioritize space resources for mega projects';
+    container.append(checkbox, label);
+    projectElements[this.name] = {
+      ...projectElements[this.name],
+      prioritizeMegaCheckbox: checkbox,
+      prioritizeMegaContainer: container,
+    };
+    return container;
+  };
+}
+
 function renderSpaceStorageUI(project, container) {
   const card = document.createElement('div');
   card.classList.add('space-storage-card');
@@ -145,38 +194,6 @@ function renderSpaceStorageUI(project, container) {
 
   updateModeButtons();
 
-  const shipAutomationContainer = document.createElement('div');
-  shipAutomationContainer.classList.add('automation-settings-container');
-  const shipAutoStartContainer = document.createElement('div');
-  shipAutoStartContainer.classList.add('checkbox-container');
-  const shipAutoStartCheckbox = document.createElement('input');
-  shipAutoStartCheckbox.type = 'checkbox';
-  shipAutoStartCheckbox.id = `${project.name}-ship-auto-start`;
-  shipAutoStartCheckbox.addEventListener('change', e => {
-    project.shipOperationAutoStart = e.target.checked;
-  });
-  const shipAutoStartLabel = document.createElement('label');
-  shipAutoStartLabel.htmlFor = shipAutoStartCheckbox.id;
-  shipAutoStartLabel.textContent = 'Auto start ships';
-  shipAutoStartContainer.append(shipAutoStartCheckbox, shipAutoStartLabel);
-  shipAutomationContainer.appendChild(shipAutoStartContainer);
-
-  const prioritizeContainer = document.createElement('div');
-  prioritizeContainer.classList.add('checkbox-container');
-  const prioritizeCheckbox = document.createElement('input');
-  prioritizeCheckbox.type = 'checkbox';
-  prioritizeCheckbox.id = `${project.name}-prioritize-space`;
-  prioritizeCheckbox.addEventListener('change', e => {
-    project.prioritizeMegaProjects = e.target.checked;
-  });
-  const prioritizeLabel = document.createElement('label');
-  prioritizeLabel.htmlFor = prioritizeCheckbox.id;
-  prioritizeLabel.textContent = 'Prioritize space resources for mega projects';
-  prioritizeContainer.append(prioritizeCheckbox, prioritizeLabel);
-  shipAutomationContainer.appendChild(prioritizeContainer);
-
-  shipFooter.appendChild(shipAutomationContainer);
-
   card.appendChild(shipFooter);
   container.appendChild(card);
   projectElements[project.name] = {
@@ -187,8 +204,6 @@ function renderSpaceStorageUI(project, container) {
     resourceGrid,
     expansionCostDisplay,
     shipProgressButton,
-    shipAutoStartCheckbox,
-    prioritizeMegaCheckbox: prioritizeCheckbox,
     withdrawButton,
     storeButton,
     updateModeButtons
@@ -198,6 +213,16 @@ function renderSpaceStorageUI(project, container) {
 function updateSpaceStorageUI(project) {
   const els = projectElements[project.name];
   if (!els) return;
+  if (els.autoStartCheckboxContainer) {
+    const autoLabel = els.autoStartCheckboxContainer.querySelector('label');
+    if (autoLabel) autoLabel.textContent = 'Auto Start Expansion';
+  }
+  if (els.shipAutoStartContainer && els.prioritizeMegaContainer) {
+    const display = projectManager && typeof projectManager.isBooleanFlagSet === 'function' &&
+      projectManager.isBooleanFlagSet('automateSpecialProjects') ? 'block' : 'none';
+    els.shipAutoStartContainer.style.display = display;
+    els.prioritizeMegaContainer.style.display = display;
+  }
   if (els.usedDisplay) {
     els.usedDisplay.textContent = formatNumber(project.usedStorage, false, 0);
   }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -528,6 +528,14 @@ function updateProjectUI(projectName) {
       const tempControl = project.createTemperatureControl();
       elements.automationSettingsContainer.appendChild(tempControl);
     }
+    if (typeof SpaceStorageProject !== 'undefined' &&
+        project instanceof SpaceStorageProject &&
+        typeof project.createShipAutoStartCheckbox === 'function' &&
+        !elements.shipAutoStartContainer) {
+      const ship = project.createShipAutoStartCheckbox();
+      const prioritize = project.createPrioritizeMegaCheckbox();
+      elements.automationSettingsContainer.append(ship, prioritize);
+    }
   }
 
   if (typeof AndroidProject !== 'undefined' &&

--- a/tests/spaceStorageAutomationSettings.test.js
+++ b/tests/spaceStorageAutomationSettings.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Space Storage automation settings', () => {
+  test('adds ship and prioritize checkboxes next to expansion auto start', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.projectElements = {};
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = () => '';
+    ctx.SpaceMiningProject = function () {};
+    ctx.SpaceExportBaseProject = function () {};
+    ctx.SpaceStorageProject = function () {};
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    const storageUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
+    vm.runInContext(
+      uiCode + '\n' + storageUICode +
+      '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.projectElements = projectElements; this.updateSpaceStorageUI = updateSpaceStorageUI;',
+      ctx
+    );
+
+    const project = Object.assign(new ctx.SpaceStorageProject(), {
+      name: 'spaceStorage',
+      displayName: 'Space Storage',
+      description: '',
+      category: 'mega',
+      autoStart: false,
+      shipOperationAutoStart: false,
+      prioritizeMegaProjects: false,
+      renderUI: () => {},
+      updateUI() { ctx.updateSpaceStorageUI(this); },
+      getEffectiveDuration: () => 1000,
+      canStart: () => true,
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {}
+    });
+
+    ctx.projectManager = {
+      projects: { spaceStorage: project },
+      isBooleanFlagSet: () => true,
+      getProjectStatuses: () => [project]
+    };
+
+    ctx.createProjectItem(project);
+    ctx.updateProjectUI('spaceStorage');
+    const els = ctx.projectElements[project.name];
+    const labels = Array.from(els.automationSettingsContainer.querySelectorAll('label')).map(l => l.textContent);
+    expect(labels).toEqual([
+      'Auto Start Expansion',
+      'Auto Start Ships',
+      'Prioritize space resources for mega projects'
+    ]);
+
+    els.shipAutoStartCheckbox.checked = true;
+    els.shipAutoStartCheckbox.dispatchEvent(new dom.window.Event('change'));
+    expect(project.shipOperationAutoStart).toBe(true);
+
+    els.prioritizeMegaCheckbox.checked = true;
+    els.prioritizeMegaCheckbox.dispatchEvent(new dom.window.Event('change'));
+    expect(project.prioritizeMegaProjects).toBe(true);
+  });
+});

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -99,10 +99,10 @@ describe('Space Storage project', () => {
     const container = dom.window.document.getElementById('root');
     project.updateCostAndGains = () => {};
     project.renderUI(container);
-    const checkboxes = container.querySelectorAll('.storage-usage-table input[type="checkbox"]');
+    const checkboxes = container.querySelectorAll('#ss-resource-grid input[type="checkbox"]');
     expect(checkboxes.length).toBe(8);
-    const rows = container.querySelectorAll('.storage-usage-table tbody tr');
-    expect(rows[0].children.length).toBe(9);
+    const items = container.querySelectorAll('#ss-resource-grid .storage-resource-item');
+    expect(items[0].children.length).toBe(3);
     checkboxes[0].checked = true;
     checkboxes[0].dispatchEvent(new dom.window.Event('change'));
     expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -60,11 +60,10 @@ describe('Space Storage UI', () => {
     expect(els.usedDisplay.textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.maxDisplay.textContent).toBe(String(numbers.formatNumber(1000000000000, false, 0)));
     expect(els.expansionCostDisplay.textContent).toBe(`Metal: ${numbers.formatNumber(metalCost, true)}`);
-    expect(els.usageBody.querySelectorAll('tr').length).toBe(3);
-    expect(els.usageBody.querySelector('tr:first-child td:nth-child(3)').textContent).toBe(String(numbers.formatNumber(0, false, 0)));
+    const items = els.resourceGrid.querySelectorAll('.storage-resource-item');
+    expect(items.length).toBe(8);
+    expect(items[0].children[2].textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();
-    expect(els.shipAutoStartCheckbox).toBeDefined();
-    expect(els.prioritizeMegaCheckbox).toBeDefined();
     expect(els.withdrawButton).toBeDefined();
     expect(els.storeButton).toBeDefined();
 
@@ -76,16 +75,11 @@ describe('Space Storage UI', () => {
     project.resourceUsage = { metal: 500 };
     project.usedStorage = 500;
     ctx.updateSpaceStorageUI(project);
-    expect(els.usageBody.querySelectorAll('tr').length).toBe(3);
-    const metalRow = Array.from(els.usageBody.querySelectorAll('tr')).find(r => r.children[1].textContent === 'Metal');
-    expect(metalRow.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
+    const updatedItems = els.resourceGrid.querySelectorAll('.storage-resource-item');
+    expect(updatedItems.length).toBe(8);
+    const metalItem = updatedItems[0];
+    expect(metalItem.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
 
-    els.prioritizeMegaCheckbox.checked = true;
-    els.prioritizeMegaCheckbox.dispatchEvent(new dom.window.Event('change'));
-    expect(project.prioritizeMegaProjects).toBe(true);
-    project.prioritizeMegaProjects = false;
-    ctx.updateSpaceStorageUI(project);
-    expect(els.prioritizeMegaCheckbox.checked).toBe(false);
     const topSection = container.querySelector('.project-top-section');
     const titles = Array.from(topSection.querySelectorAll('.section-title')).map(e => e.textContent);
     expect(titles).toEqual(expect.arrayContaining(['Assignment', 'Cost & Gain', 'Expansion']));


### PR DESCRIPTION
## Summary
- Rename Space Storage expansion toggle to **Auto Start Expansion**
- Add ship auto-start and mega project priority checkboxes beside the expansion toggle
- Test Space Storage automation layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688d8d1c6394832791cd7e43c9d529be