### PR TITLE
Unlock WGC during chapter 14

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,3 +295,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage card now uses a single spaceship assignment and cost/gain display with populated values.
 - Space Storage automation settings now sit next to the expansion auto start, which is labeled "Auto Start Expansion".
 - Space Storage automation checkboxes are now created via the generic project UI like other project-specific controls.
+- Chapter 14.0 now enables the Warp Gate Command and automatically switches to its subtab.

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -545,7 +545,8 @@ function addOrRemoveEffect(effect, action) {
     'oreScanner': oreScanner,
     'researchManager' : researchManager,
     'solisManager' : solisManager,
-    'spaceManager' : spaceManager
+    'spaceManager' : spaceManager,
+    'warpGateCommand' : warpGateCommand
   };
 
   if (effect.target in targetHandlers &&

--- a/src/js/story/ganymede.js
+++ b/src/js/story/ganymede.js
@@ -354,7 +354,17 @@ progressGanymede.chapters.push(
         objectives: [
             { type: 'project', projectId: 'draft_wgc_charter', repeatCount: 4 }
         ],
-        reward: []
+        reward: [
+            { target: 'warpGateCommand', type: 'enable' },
+            {
+                target: 'global',
+                type: 'activateSubtab',
+                subtabClass: 'hope-subtab',
+                contentClass: 'hope-subtab-content',
+                targetId: 'wgc-hope',
+                unhide: true
+            }
+        ]
     },
     {
         id: "chapter14.1",

--- a/tests/enableWGCTabEffect.test.js
+++ b/tests/enableWGCTabEffect.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const uiUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ui-utils.js'), 'utf8');
+const wgcUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+const wgcCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgc.js'), 'utf8');
+const hopeUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'hopeUI.js'), 'utf8');
+const progressGanymede = require('../src/js/story/ganymede.js');
+
+describe('chapter14.0 reward enables WGC and activates its tab', () => {
+  test('reward effects show and activate WGC subtab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="hope-subtab" data-subtab="awakening-hope"></div>
+      <div class="hope-subtab hidden" data-subtab="wgc-hope"></div>
+      <div id="awakening-hope" class="hope-subtab-content active"></div>
+      <div id="wgc-hope" class="hope-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    vm.runInContext(`${uiUtilsCode}\n${effectCode}\n${wgcUICode}\n${wgcCode}\n${hopeUICode}; this.EffectableEntity = EffectableEntity; this.WarpGateCommand = WarpGateCommand;`, ctx);
+    ctx.globalEffects = new ctx.EffectableEntity({ description: 'global' });
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    const chapter = progressGanymede.chapters.find(c => c.id === 'chapter14.0');
+    const wgcEffect = chapter.reward.find(e => e.target === 'warpGateCommand');
+    const tabEffect = chapter.reward.find(e => e.target === 'global');
+    ctx.warpGateCommand.addAndReplace(wgcEffect);
+    ctx.globalEffects.addAndReplace(tabEffect);
+    const tab = dom.window.document.querySelector('[data-subtab="wgc-hope"]');
+    const content = dom.window.document.getElementById('wgc-hope');
+    const visible = vm.runInContext('wgcTabVisible', ctx);
+    expect(ctx.warpGateCommand.enabled).toBe(true);
+    expect(visible).toBe(true);
+    expect(tab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+    expect(tab.classList.contains('active')).toBe(true);
+    expect(content.classList.contains('active')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Show Warp Gate Command after chapter 14.0 and jump to its tab
- Add effect handler so story rewards can enable the Warp Gate Command
- Document WGC unlock and cover it with a new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688e212886848327ad8a6869ac4f2a14