### PR TITLE
feat: track WGC operation difficulty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,3 +295,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage card now uses a single spaceship assignment and cost/gain display with populated values.
 - Space Storage automation settings now sit next to the expansion auto start, which is labeled "Auto Start Expansion".
 - Space Storage automation checkboxes are now created via the generic project UI like other project-specific controls.
+- Story objectives can now check the highest Warp Gate Command operation difficulty completed, and chapter 14.1 requires clearing a difficulty 0 operation.

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -312,6 +312,13 @@ class StoryManager {
                console.warn(`Condition function not found: ${objective.conditionId}`);
                return false;
           }
+          case 'wgcHighestDifficulty': {
+               if (typeof warpGateCommand !== 'undefined') {
+                    const current = warpGateCommand.highestDifficulty || 0;
+                    return compareValues(current, objective.difficulty || 0, objective.comparison);
+               }
+               return false;
+          }
           default:
                console.error(`Unknown objective type: ${objective.type}`);
                return false;
@@ -412,14 +419,21 @@ class StoryManager {
                 return `Travel to ${name}`;
           }
           case 'solisPoints': {
-                const current = solisManager ? solisManager.solisPoints || 0 : 0;
-                return `Solis Points: ${format(current, true)}/${format(objective.points, true)}`;
-            }
+               const current = solisManager ? solisManager.solisPoints || 0 : 0;
+               return `Solis Points: ${format(current, true)}/${format(objective.points, true)}`;
+           }
           case 'condition': {
-                return objective.description || '';
+               return objective.description || '';
           }
-           default:
-                return '';
+          case 'wgcHighestDifficulty': {
+               const current = typeof warpGateCommand !== 'undefined'
+                    ? warpGateCommand.highestDifficulty : -1;
+               const dispCurrent = Math.max(0, current + 1);
+               const target = (objective.difficulty || 0) + 1;
+               return `Highest Operation Difficulty: ${format(dispCurrent, true)}/${format(target, true)}`;
+          }
+          default:
+               return '';
        }
    }
 

--- a/src/js/story/ganymede.js
+++ b/src/js/story/ganymede.js
@@ -363,7 +363,7 @@ progressGanymede.chapters.push(
         narrative: "Mary: “A hundred volunteers rotating shifts. No AI weapons, no drones—only human resolve.”\nFeroza: “Admirable and under‑caffeinated. Tell Logistics to send coffee.”",
         prerequisites: ["chapter14.0"],
         objectives: [
-            { type: 'collection', resourceType: 'colony', resource: 'colonists', quantity: 100 }
+            { type: 'wgcHighestDifficulty', difficulty: 0 }
         ],
         reward: []
     },

--- a/tests/wgcHighestDifficultyObjective.test.js
+++ b/tests/wgcHighestDifficultyObjective.test.js
@@ -1,0 +1,37 @@
+const { StoryManager } = require('../src/js/progress.js');
+
+describe('wgcHighestDifficulty objective', () => {
+  beforeEach(() => {
+    global.document = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      getElementById: () => null,
+    };
+    global.warpGateCommand = { highestDifficulty: -1 };
+    global.resources = {};
+    global.buildings = {};
+    global.colonies = {};
+    global.terraforming = null;
+    global.projectManager = null;
+    global.solisManager = null;
+  });
+
+  test('completes when required difficulty reached', () => {
+    const data = {
+      chapters: [{
+        id: 'test',
+        type: 'journal',
+        chapter: 0,
+        narrative: '',
+        objectives: [{ type: 'wgcHighestDifficulty', difficulty: 0 }],
+        reward: []
+      }]
+    };
+    const sm = new StoryManager(data);
+    const ev = sm.findEventById('test');
+    const obj = ev.objectives[0];
+    expect(sm.isObjectiveComplete(obj, ev)).toBe(false);
+    warpGateCommand.highestDifficulty = 0;
+    expect(sm.isObjectiveComplete(obj, ev)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- support `wgcHighestDifficulty` objectives to read Warp Gate Command progress
- require clearing a difficulty 0 operation for Ganymede chapter 14.1
- document new story objective behavior and add coverage test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688e218210548327bd5939268f174693