### PR TITLE
feat: expand jumpToChapter prerequisites handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,3 +296,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage automation settings now sit next to the expansion auto start, which is labeled "Auto Start Expansion".
 - Space Storage automation checkboxes are now created via the generic project UI like other project-specific controls.
 - Chapter 14.0 now enables the Warp Gate Command and automatically switches to its subtab.
+- jumpToChapter now recursively completes prerequisite chapters, marks required special projects finished, skips typing animation and rebuilds the journal.

--- a/tests/jumpToChapter.test.js
+++ b/tests/jumpToChapter.test.js
@@ -9,20 +9,23 @@ describe('StoryManager jumpToChapter', () => {
       console,
       setTimeout: (fn) => fn(),
       clearTimeout: () => {},
-      document: { 
-        addEventListener: () => {}, 
+      document: {
+        addEventListener: () => {},
         removeEventListener: () => {},
-        getElementById: () => null 
+        getElementById: () => null
       },
       addEffect: jest.fn(),
       removeEffect: jest.fn(),
       clearJournal: jest.fn(),
+      loadJournalEntries: jest.fn(),
       createPopup: () => {},
+      createSystemPopup: () => {},
       addJournalEntry: jest.fn(),
       buildings: {},
       colonies: {},
       resources: {},
       terraforming: {},
+      projectManager: { projects: {} },
       progressData: {
         chapters: [
           { id: 'c1', type: 'journal', narrative: 'one', reward: [{ target: 'global', type: 'dummy' }] },
@@ -40,6 +43,54 @@ describe('StoryManager jumpToChapter', () => {
     expect(Array.from(manager.completedEventIds)).toEqual(['c1']);
     expect(manager.activeEventIds.has('c2')).toBe(true);
     expect(context.addJournalEntry).toHaveBeenCalledWith('two', 'c2', { type: 'chapter', id: 'c2' });
+    expect(context.loadJournalEntries).toHaveBeenCalled();
     expect(context.addEffect).toHaveBeenCalledWith({ target: 'global', type: 'dummy' });
+  });
+
+  test('marks project objectives completed when jumping', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress.js'), 'utf8');
+    const context = {
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      document: {
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        getElementById: () => null
+      },
+      addEffect: jest.fn(),
+      removeEffect: jest.fn(),
+      clearJournal: jest.fn(),
+      loadJournalEntries: jest.fn(),
+      createPopup: () => {},
+      createSystemPopup: () => {},
+      addJournalEntry: jest.fn(),
+      buildings: {},
+      colonies: {},
+      resources: {},
+      terraforming: {},
+      projectManager: { projects: { proj: { repeatCount: 0, unlocked: false, isCompleted: false } } },
+      progressData: {
+        chapters: [
+          {
+            id: 'c1',
+            type: 'journal',
+            narrative: 'one',
+            objectives: [{ type: 'project', projectId: 'proj', repeatCount: 2 }]
+          },
+          { id: 'c2', type: 'journal', narrative: 'two', prerequisites: ['c1'] }
+        ]
+      }
+    };
+    vm.createContext(context);
+    vm.runInContext(code + '; this.StoryManager = StoryManager;', context);
+    const manager = new context.StoryManager(context.progressData);
+    context.window = { storyManager: manager };
+
+    manager.jumpToChapter('c2');
+
+    const proj = context.projectManager.projects.proj;
+    expect(proj.repeatCount).toBe(2);
+    expect(proj.isCompleted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- ensure `jumpToChapter` recursively marks prerequisite chapters and project objectives complete
- rebuild the journal instantly when jumping between chapters
- document new debug behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688e234c2f30832799ae094c6117d207