### PR TITLE
Add Space Random subtab framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage automation checkboxes are now created via the generic project UI like other project-specific controls.
 - Story objectives can now check the highest Warp Gate Command operation difficulty completed, and chapter 14.1 requires clearing a difficulty 0 operation.
 - Chapter 14.0 now enables the Warp Gate Command and automatically switches to its subtab.
+- Space tab now includes Story and Random subtabs with Random hidden by default.

--- a/index.html
+++ b/index.html
@@ -359,12 +359,23 @@
     <!-- *** NEW SPACE TAB CONTENT *** -->
     <div id="space" class="tab-content">
         <div class="container space-container"> <!-- Add specific class if needed -->
-            <h2>Planet Selection</h2>
-            <div id="planet-selection-options">
-                <!-- Planet options will be added dynamically here later -->
+            <div class="space-subtabs">
+                <div class="space-subtab active" data-subtab="space-story">Story</div>
+                <div class="space-subtab hidden" data-subtab="space-random">Random</div>
             </div>
-            <div id="travel-status">
-                <!-- Status messages about travel preparation/progress -->
+            <div class="space-subtab-content-wrapper">
+                <div id="space-story" class="space-subtab-content active">
+                    <h2>Planet Selection</h2>
+                    <div id="planet-selection-options">
+                        <!-- Planet options will be added dynamically here later -->
+                    </div>
+                    <div id="travel-status">
+                        <!-- Status messages about travel preparation/progress -->
+                    </div>
+                </div>
+                <div id="space-random" class="space-subtab-content hidden">
+                    <!-- Random events will appear here -->
+                </div>
             </div>
         </div>
     </div>

--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -8,7 +8,8 @@ body.dark-mode {
 .dark-mode .research-subtabs,
 .dark-mode .projects-subtabs,
 .dark-mode .terraforming-subtabs,
-.dark-mode .hope-subtabs {
+.dark-mode .hope-subtabs,
+.dark-mode .space-subtabs {
     background-color: #1e1e1e;
 }
 
@@ -17,7 +18,8 @@ body.dark-mode {
 .dark-mode .research-subtab,
 .dark-mode .projects-subtab,
 .dark-mode .terraforming-subtab,
-.dark-mode .hope-subtab {
+.dark-mode .hope-subtab,
+.dark-mode .space-subtab {
     background-color: #2d2d2d;
     color: #ffffff;
 }
@@ -27,7 +29,8 @@ body.dark-mode {
 .dark-mode .research-subtab.active,
 .dark-mode .projects-subtab.active,
 .dark-mode .terraforming-subtab.active,
-.dark-mode .hope-subtab.active {
+.dark-mode .hope-subtab.active,
+.dark-mode .space-subtab.active {
     background-color: #4d4d4d;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -20,7 +20,8 @@ body {
 .research-subtabs,
 .projects-subtabs,
 .terraforming-subtabs,
-.hope-subtabs
+.hope-subtabs,
+.space-subtabs
  {
     display: flex;
     cursor: pointer;
@@ -34,7 +35,8 @@ body {
 .research-subtabs,
 .projects-subtabs,
 .terraforming-subtabs,
-.hope-subtabs
+.hope-subtabs,
+.space-subtabs
  {
     margin-right:25px;
 }
@@ -44,7 +46,8 @@ body {
 .research-subtab,
 .projects-subtab,
 .terraforming-subtab,
-.hope-subtab { /* Added projects-subtab */
+.hope-subtab,
+.space-subtab { /* Added space-subtab */
     flex: 1;
     padding: 10px;
     text-align: center;
@@ -64,7 +67,8 @@ body {
 .research-subtab.active,
 .projects-subtab.active,
 .terraforming-subtab.active,
-.hope-subtab.active { /* Added projects-subtab.active */
+.hope-subtab.active,
+.space-subtab.active { /* Added space-subtab.active */
     background-color: #666;
     color: #fff; /* Consistent text color for active state */
 }
@@ -116,7 +120,8 @@ body {
 .research-subtab-content,
 .projects-subtab-content,
 .terraforming-subtab-content,
-.hope-subtab-content { /* Added projects-subtab-content */
+.hope-subtab-content,
+.space-subtab-content { /* Added space-subtab-content */
     display: none;
 }
 
@@ -124,7 +129,8 @@ body {
 .research-subtab-content.active,
 .projects-subtab-content.active,
 .terraforming-subtab-content.active,
-.hope-subtab-content.active { /* Added projects-subtab-content.active */
+.hope-subtab-content.active,
+.space-subtab-content.active { /* Added space-subtab-content.active */
     display: block;
 }
 

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -10,6 +10,7 @@ class SpaceManager extends EffectableEntity {
         this.currentPlanetKey = 'mars';
         // Store status per planet including whether it's been visited
         this.planetStatuses = {};
+        this.randomTabEnabled = false;
 
         this._initializePlanetStatuses();
         // Mark the starting planet as visited
@@ -84,8 +85,19 @@ class SpaceManager extends EffectableEntity {
         return false;
     }
 
+    enableRandomTab() {
+        this.randomTabEnabled = true;
+        if (typeof showSpaceRandomTab === 'function') {
+            showSpaceRandomTab();
+        }
+    }
+
     enable(planetKey) {
-        this.enablePlanet(planetKey);
+        if (planetKey === 'space-random') {
+            this.enableRandomTab();
+        } else {
+            this.enablePlanet(planetKey);
+        }
     }
 
     /**

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -6,6 +6,53 @@ let _spaceManagerInstance = null;
 const planetUIElements = {};
 // Track whether the space UI has been generated already
 let spaceUIInitialized = false;
+// Track visibility of the Random subtab
+let spaceRandomTabVisible = false;
+
+function showSpaceRandomTab() {
+    spaceRandomTabVisible = true;
+    const tab = document.querySelector('.space-subtab[data-subtab="space-random"]');
+    const content = document.getElementById('space-random');
+    if (tab) tab.classList.remove('hidden');
+    if (content) content.classList.remove('hidden');
+}
+
+function hideSpaceRandomTab() {
+    spaceRandomTabVisible = false;
+    const tab = document.querySelector('.space-subtab[data-subtab="space-random"]');
+    const content = document.getElementById('space-random');
+    if (tab) tab.classList.add('hidden');
+    if (content) content.classList.add('hidden');
+}
+
+function updateSpaceRandomVisibility() {
+    if (!_spaceManagerInstance) return;
+    if (_spaceManagerInstance.randomTabEnabled) {
+        if (!spaceRandomTabVisible) {
+            showSpaceRandomTab();
+        }
+    } else if (spaceRandomTabVisible) {
+        hideSpaceRandomTab();
+    }
+}
+
+function initializeSpaceTabs() {
+    document.querySelectorAll('.space-subtab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            document.querySelectorAll('.space-subtab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.space-subtab-content').forEach(c => c.classList.remove('active'));
+            tab.classList.add('active');
+            const id = tab.dataset.subtab;
+            document.getElementById(id).classList.add('active');
+        });
+    });
+}
+
+function activateSpaceSubtab(subtabId) {
+    if (typeof activateSubtab === 'function') {
+        activateSubtab('space-subtab', 'space-subtab-content', subtabId, true);
+    }
+}
 
 /**
  * Initializes the Space Tab UI elements and stores the SpaceManager instance.
@@ -18,6 +65,8 @@ function initializeSpaceUI(spaceManager) {
     }
     _spaceManagerInstance = spaceManager; // Store the instance for later use
     console.log("Initializing Space UI with SpaceManager reference.");
+    initializeSpaceTabs();
+    hideSpaceRandomTab();
 
     // If the UI has already been generated, just update with the new instance
     if (spaceUIInitialized) {
@@ -92,6 +141,7 @@ function initializeSpaceUI(spaceManager) {
 
 function updateSpaceUI() {
     if (!_spaceManagerInstance) return; // Guard clause
+    updateSpaceRandomVisibility();
 
     const statusContainer = document.getElementById('travel-status');
     const allPlanetData = typeof planetParameters !== 'undefined' ? planetParameters : null;

--- a/tests/enableSpaceRandomTabEffect.test.js
+++ b/tests/enableSpaceRandomTabEffect.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('enable effect with SpaceManager and activateSpaceSubtab', () => {
+  test('reveals and activates the Random subtab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="space-subtab" data-subtab="space-story"></div>
+      <div class="space-subtab hidden" data-subtab="space-random"></div>
+      <div id="space-story" class="space-subtab-content active">
+        <div id="planet-selection-options"></div>
+        <div id="travel-status"></div>
+      </div>
+      <div id="space-random" class="space-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.planetParameters = {
+      mars: { name: 'Mars', celestialParameters: { distanceFromSun: 1, gravity: 3.7, radius: 3389, albedo: 0.25 } }
+    };
+    vm.createContext(ctx);
+    const uiUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ui-utils.js'), 'utf8');
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+    const spaceUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'spaceUI.js'), 'utf8');
+    vm.runInContext(`${uiUtilsCode}\n${effectCode}\n${spaceCode}\n${spaceUICode}; this.SpaceManager = SpaceManager; this.EffectableEntity = EffectableEntity;`, ctx);
+    ctx.spaceManager = new ctx.SpaceManager(ctx.planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+    ctx.globalEffects = new ctx.EffectableEntity({ description: 'global' });
+    ctx.spaceManager.addAndReplace({
+      target: 'spaceManager',
+      type: 'enable',
+      targetId: 'space-random',
+      effectId: 't1',
+      sourceId: 't1'
+    });
+    ctx.globalEffects.addAndReplace({
+      target: 'global',
+      type: 'activateSubtab',
+      subtabClass: 'space-subtab',
+      contentClass: 'space-subtab-content',
+      targetId: 'space-random',
+      unhide: true,
+      effectId: 't2',
+      sourceId: 't2'
+    });
+    const tab = dom.window.document.querySelector('[data-subtab="space-random"]');
+    const content = dom.window.document.getElementById('space-random');
+    const visible = vm.runInContext('spaceRandomTabVisible', ctx);
+    expect(visible).toBe(true);
+    expect(tab.classList.contains('hidden')).toBe(false);
+    expect(content.classList.contains('hidden')).toBe(false);
+    expect(tab.classList.contains('active')).toBe(true);
+    expect(content.classList.contains('active')).toBe(true);
+  });
+});

--- a/tests/spaceRandomTabHiddenByDefault.test.js
+++ b/tests/spaceRandomTabHiddenByDefault.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Space Random subtab hidden by default', () => {
+  test('initializeSpaceUI keeps Random subtab hidden', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="space-subtab" data-subtab="space-story"></div>
+      <div class="space-subtab hidden" data-subtab="space-random"></div>
+      <div id="space-story" class="space-subtab-content active">
+        <div id="planet-selection-options"></div>
+        <div id="travel-status"></div>
+      </div>
+      <div id="space-random" class="space-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.planetParameters = {
+      mars: { name: 'Mars', celestialParameters: { distanceFromSun: 1, gravity: 3.7, radius: 3389, albedo: 0.25 } }
+    };
+    vm.createContext(ctx);
+    const uiUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ui-utils.js'), 'utf8');
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+    const spaceUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'spaceUI.js'), 'utf8');
+    vm.runInContext(`${uiUtilsCode}\n${effectCode}\n${spaceCode}\n${spaceUICode}; this.SpaceManager = SpaceManager;`, ctx);
+    ctx.spaceManager = new ctx.SpaceManager(ctx.planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+    const tab = dom.window.document.querySelector('[data-subtab="space-random"]');
+    const content = dom.window.document.getElementById('space-random');
+    const visible = vm.runInContext('spaceRandomTabVisible', ctx);
+    expect(visible).toBe(false);
+    expect(tab.classList.contains('hidden')).toBe(true);
+    expect(content.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/tests/spaceRandomTabHiddenMarkup.test.js
+++ b/tests/spaceRandomTabHiddenMarkup.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Space Random subtab markup', () => {
+  test('index.html hides Random subtab by default', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    expect(html).toMatch(/<div class="space-subtab hidden" data-subtab="space-random">/);
+    expect(html).toMatch(/<div id="space-random" class="space-subtab-content hidden">/);
+  });
+});


### PR DESCRIPTION
## Summary
- Split Space tab into Story and Random subtabs, hiding Random until unlocked
- Wire SpaceManager and UI utilities to enable and activate the Random subtab via effects
- Style new Space subtabs and cover with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688e242c1e0c8327b293b703478f2adb