### PR TITLE
Clear project subtab alerts when viewing tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Active building subtab alerts clear immediately when unlocking a structure while that subtab is open.
 - Pause button now sets game speed to 0 so time does not advance when paused.
 - Building subtab alerts now clear when switching subtabs.
+- Project subtab alerts now clear when viewing the projects tab while that subtab is active.
 - A grey "PAUSED" alert appears in the warning area whenever the game is paused.
 - Adapted fission power now doubles reactor water usage.
 - Resource tooltips show remaining time until cap or depletion based on current rates.

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -750,6 +750,10 @@ function updateProjectAlert() {
 }
 
 function markProjectsViewed() {
+  const active = document.querySelector('.projects-subtab.active');
+  if (active && typeof markProjectSubtabViewed === 'function') {
+    markProjectSubtabViewed(active.dataset.subtab);
+  }
   projectTabAlertNeeded = false;
   updateProjectAlert();
 }

--- a/tests/projectTabClearsSubtabAlert.test.js
+++ b/tests/projectTabClearsSubtabAlert.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('project subtab alert clears on tab view', () => {
+  test('clears active subtab alert when viewing projects tab', () => {
+    const html = `<!DOCTYPE html>
+      <div id="special-projects-tab"><span id="projects-alert" class="unlock-alert">!</span></div>
+      <div class="projects-subtabs">
+        <div id="resources-projects-tab" class="projects-subtab active" data-subtab="resources-projects">Resources<span id="resources-projects-alert" class="unlock-alert">!</span></div>
+      </div>
+      <div class="projects-subtab-content-wrapper"><div id="resources-projects" class="projects-subtab-content active"></div></div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.gameSettings = { silenceUnlockAlert: false };
+    ctx.projectManager = { projects: { probe: { category: 'resources', unlocked: true, alertedWhenUnlocked: false } } };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.registerProjectUnlockAlert('resources-projects');
+    expect(dom.window.document.getElementById('resources-projects-alert').style.display).toBe('inline');
+
+    ctx.markProjectsViewed();
+    expect(dom.window.document.getElementById('resources-projects-alert').style.display).toBe('none');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Clear project subtab alerts when opening the Special Projects tab and landing on an alerting subtab
- Document project subtab alert clearing
- Test that project subtab alerts clear when viewing the tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688e926a66b883278f65fd384e3a5a7f