### PR TITLE
Improve dark mode milestone color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,3 +300,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Chapter 14.0 now enables the Warp Gate Command and automatically switches to its subtab.
 - Space tab now includes Story and Random subtabs with Random hidden by default.
 - jumpToChapter now recursively completes prerequisite chapters, marks required special projects finished, skips typing animation and rebuilds the journal.
+- Claimed milestones in dark mode use a brighter green for clearer status.

--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -199,6 +199,12 @@ body.dark-mode {
     cursor: not-allowed;
 }
 
+.dark-mode .milestone-button.completed {
+    background-color: #3cb371;
+    border-color: #3cb371;
+    color: #fff;
+}
+
 .dark-mode input,
 .dark-mode select,
 .dark-mode textarea {


### PR DESCRIPTION
## Summary
- Make claimed milestone buttons brighter in dark mode for clearer distinction
- Log this UI change in AGENTS changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688e9dea2e40832780c630f5bc0251a1