### PR TITLE
feat: support biodome power draw at zero productivity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,3 +301,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space tab now includes Story and Random subtabs with Random hidden by default.
 - jumpToChapter now recursively completes prerequisite chapters, marks required special projects finished, skips typing animation and rebuilds the journal.
 - Claimed milestones in dark mode use a brighter green for clearer status.
+- Biodomes now always draw power via an `ignoreProductivity` consumption flag.

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -446,7 +446,7 @@ const buildingsParameters = {
     category: 'terraforming',
     description: 'Produces life using water, carbon dioxide and artificial light.  Produces a small amount of oxygen.  Requires an active life design that can survive somewhere to function.  Also produces life design points regardless.',
     cost: {colony: {metal: 50, glass: 500, components: 10, electronics: 10}},
-    consumption: {colony: {energy: 10000000, water: 0.1}, atmospheric : {carbonDioxide : 0.244}},
+    consumption: {colony: {energy: { amount: 10000000, ignoreProductivity: true }, water: 0.1}, atmospheric : {carbonDioxide : 0.244}},
     production: {atmospheric: {oxygen : 0.177388}, surface: {biomass : 0.166612}},
     storage: {},
     dayNightActivity: false,

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -75,7 +75,8 @@ class Colony extends Building {
           continue;
         }
   
-        const baseConsumption = this.active * this.consumption[category][resource] * effectiveMultiplier * this.getEffectiveResourceConsumptionMultiplier(category, resource);
+        const { amount } = this.getConsumptionResource(category, resource);
+        const baseConsumption = this.active * amount * effectiveMultiplier * this.getEffectiveResourceConsumptionMultiplier(category, resource);
         const scaledConsumption = baseConsumption * popConsumptionRatio * (deltaTime / 1000);
   
         const availableAmount = resources[category][resource].value;
@@ -117,7 +118,8 @@ class Colony extends Building {
           continue;
         }
   
-        const baseConsumption = this.active * this.consumption[category][resource] * effectiveMultiplier * this.getEffectiveResourceConsumptionMultiplier(category, resource);
+        const { amount } = this.getConsumptionResource(category, resource);
+        const baseConsumption = this.active * amount * effectiveMultiplier * this.getEffectiveResourceConsumptionMultiplier(category, resource);
         const scaledConsumption = baseConsumption * consumptionRatio * (deltaTime / 1000);
   
         // Track actual consumption in the building

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -250,7 +250,9 @@ function calculateProductionRates(deltaTime, buildings) {
     // Calculate scaled consumption rates
     for (const category in building.consumption) {
       for (const resource in building.consumption[category]) {
-        const actualConsumption = (building.consumption[category][resource] || 0) * building.active * building.getConsumptionRatio() * building.getEffectiveConsumptionMultiplier() * building.getEffectiveResourceConsumptionMultiplier(category, resource);
+        const entry = building.getConsumptionResource ? building.getConsumptionResource(category, resource) : { amount: building.consumption[category][resource] };
+        const amount = entry.amount || 0;
+        const actualConsumption = amount * building.active * building.getConsumptionRatio() * building.getEffectiveConsumptionMultiplier() * building.getEffectiveResourceConsumptionMultiplier(category, resource);
         // Specify 'building' as the rateType
         resources[category][resource].modifyRate(-actualConsumption, building.displayName, 'building');
       }

--- a/tests/ignoreProductivityConsumption.test.js
+++ b/tests/ignoreProductivityConsumption.test.js
@@ -1,0 +1,45 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+
+describe('ignoreProductivity consumption', () => {
+  beforeEach(() => {
+    global.resources = {
+      colony: {
+        energy: { value: 1000, modifyRate: jest.fn(), productionRate: 0, consumptionRate: 0 },
+        water: { value: 1000, modifyRate: jest.fn(), productionRate: 0, consumptionRate: 0 }
+      },
+      surface: {},
+      underground: {},
+      atmospheric: {}
+    };
+  });
+
+  test('resource with ignoreProductivity consumes even at zero productivity', () => {
+    const config = {
+      name: 'Biodome',
+      category: 'terraforming',
+      cost: { colony: {} },
+      consumption: { colony: { energy: { amount: 100, ignoreProductivity: true }, water: 1 } },
+      production: {},
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true
+    };
+
+    const building = new Building(config, 'biodome');
+    building.active = 1;
+    building.productivity = 0; // simulate zero productivity
+
+    const accumulatedChanges = { colony: { energy: 0, water: 0 }, surface: {}, underground: {}, atmospheric: {} };
+    building.consume(accumulatedChanges, 1000);
+
+    expect(accumulatedChanges.colony.energy).toBeCloseTo(-100);
+    expect(accumulatedChanges.colony.water).toBeCloseTo(0);
+  });
+});


### PR DESCRIPTION
## Summary
- allow building consumption entries to ignore productivity
- ensure biodomes consume energy even when inactive
- add test for ignoreProductivity consumption

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688e9ee4efb48327a295397fd1dca1be