### PR TITLE
Fix mirror oversight text contrast in dark mode

### DIFF
--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -100,6 +100,14 @@ body.dark-mode {
     background: #4d4d4d;
 }
 
+.dark-mode .mirror-oversight-card label {
+    color: #ffffff;
+}
+
+.dark-mode .mirror-oversight-card .slider-value {
+    color: #bbbbbb;
+}
+
 .dark-mode #mirror-flux-table th,
 .dark-mode #mirror-flux-table td {
     border-color: #444;


### PR DESCRIPTION
## Summary
- Improve dark mode readability for mirror oversight slider labels and values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ea21b367c832796ff125d61058dfd