### PR TITLE
Add colony upgrade button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,3 +302,4 @@ second time they speak in a chapter to help clarify who is talking.
 - jumpToChapter now recursively completes prerequisite chapters, marks required special projects finished, skips typing animation and rebuilds the journal.
 - Claimed milestones in dark mode use a brighter green for clearer status.
 - Biodomes now always draw power via an `ignoreProductivity` consumption flag.
+- Colony buildings now feature an upgrade arrow converting ten of a tier into one of the next at half the next tier's cost (excluding water).

--- a/tests/colonyUpgrade.test.js
+++ b/tests/colonyUpgrade.test.js
@@ -1,0 +1,137 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('colony upgrade', () => {
+  function setupContext(html = '<!DOCTYPE html><div id="root"></div>') {
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.formatNumber = n => n;
+    ctx.formatBigInteger = n => String(n);
+    ctx.formatBuildingCount = n => String(n);
+    ctx.multiplyByTen = n => n * 10;
+    ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
+    ctx.capitalizeFirstLetter = s => s.charAt(0).toUpperCase() + s.slice(1);
+    ctx.updateColonyDetailsDisplay = () => {};
+    ctx.createColonyDetails = () => dom.window.document.createElement('div');
+    ctx.globalEffects = { isBooleanFlagSet: () => false };
+    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    ctx.dayNightCycle = { isNight: () => false };
+    ctx.toDisplayTemperature = () => 0;
+    ctx.getTemperatureUnit = () => 'K';
+    ctx.terraforming = null;
+    ctx.milestonesManager = { getHappinessBonus: () => 0 };
+    ctx.populationModule = {
+      getWorkerAvailabilityRatio: () => 1,
+      populationResource: { value: 0, cap: 0 },
+      getCurrentGrowthPercent: () => 0,
+      growthRate: 0,
+      getEffectiveGrowthMultiplier: () => 1
+    };
+    ctx.gameSettings = { disableDayNightCycle: false, silenceUnlockAlert: true };
+    ctx.registerBuildingUnlockAlert = () => {};
+
+    ctx.resources = {
+      colony: {
+        metal: { value: 0, displayName: 'Metal', decrease(v){ this.value -= v; } },
+        glass: { value: 0, displayName: 'Glass', decrease(v){ this.value -= v; } },
+        water: { value: 0, displayName: 'Water', decrease(v){ this.value -= v; } },
+        energy: { value: 0, consumptionRate: 0, productionRate: 0, displayName: 'Energy' },
+        food: { value: 0, consumptionRate: 0, productionRate: 0, displayName: 'Food' },
+        research: { value: 0, consumptionRate: 0, productionRate: 0, displayName: 'Research' },
+        colonists: { value: 0, cap: 0, displayName: 'Colonists', updateStorageCap: () => {} },
+        workers: { value: 0, displayName: 'Workers' }
+      },
+      surface: { land: { value: 1000, reserved: 0, reserve(v){ this.reserved += v; }, release(v){ this.reserved -= v; } } },
+      underground: {}
+    };
+    ctx.buildings = {};
+    ctx.maintenanceFraction = 0;
+
+    const effectable = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const building = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'building.js'), 'utf8');
+    const colony = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colony.js'), 'utf8');
+    const structuresUI = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+
+    vm.runInContext(effectable, ctx);
+    vm.runInContext(building, ctx);
+    vm.runInContext(colony, ctx);
+    vm.runInContext(structuresUI, ctx);
+
+    ctx.colonyParameters = {
+      t1_colony: {
+        name: 'Research Outpost',
+        category: 'Colony',
+        displayName: 'Research Outpost',
+        cost: { colony: { metal: 50, water: 50, glass: 100 } },
+        consumption: { colony: { energy: 50000, food: 1 } },
+        production: { colony: { research: 1 } },
+        storage: { colony: { colonists: 10 } },
+        baseComfort: 0,
+        dayNightActivity: false,
+        canBeToggled: true,
+        requiresMaintenance: true,
+        maintenanceFactor: 1,
+        unlocked: false,
+        requiresLand: 1
+      },
+      t2_colony: {
+        name: 'Permanent Outpost',
+        category: 'Colony',
+        displayName: 'Permanent Outpost',
+        cost: { colony: { metal: 250, water: 500, glass: 250 } },
+        consumption: { colony: { energy: 250000, food: 10 } },
+        production: { colony: { research: 10 } },
+        storage: { colony: { colonists: 100 } },
+        baseComfort: 0.2,
+        dayNightActivity: false,
+        canBeToggled: true,
+        requiresMaintenance: true,
+        maintenanceFactor: 1,
+        unlocked: false,
+        requiresLand: 10
+      }
+    };
+
+    ctx.colonies = ctx.initializeColonies(ctx.colonyParameters);
+    return { dom, ctx };
+  }
+
+  test('upgrade converts ten buildings and spends resources', () => {
+    const { dom, ctx } = setupContext('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
+    const t1 = ctx.colonies.t1_colony;
+    const t2 = ctx.colonies.t2_colony;
+    t1.unlocked = true;
+    t2.unlocked = true;
+    t1.count = t1.active = 10;
+    ctx.resources.colony.metal.value = 125;
+    ctx.resources.colony.glass.value = 125;
+
+    ctx.createColonyButtons(ctx.colonies);
+    ctx.updateStructureDisplay(ctx.colonies);
+
+    const button = dom.window.document.getElementById('t1_colony-upgrade-button');
+    expect(button.disabled).toBe(false);
+    button.click();
+
+    expect(t1.count).toBe(0);
+    expect(t2.count).toBe(1);
+    expect(ctx.resources.colony.metal.value).toBe(0);
+    expect(ctx.resources.colony.glass.value).toBe(0);
+    expect(ctx.resources.surface.land.reserved).toBe(0);
+  });
+
+  test('upgrade button hidden when next tier locked', () => {
+    const { dom, ctx } = setupContext('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
+    const t1 = ctx.colonies.t1_colony;
+    t1.unlocked = true;
+    ctx.colonies.t2_colony.unlocked = false;
+    ctx.createColonyButtons(ctx.colonies);
+    ctx.updateStructureDisplay(ctx.colonies);
+    const button = dom.window.document.getElementById('t1_colony-upgrade-button');
+    expect(button.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- add upgrade logic and cost handling for colony tiers
- wire up colony upgrade button with dynamic cost and state
- cover colony building upgrade with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ea6e3cfc48327badbdb7bd9d23fd2