### PR TITLE
Refactor project cost and gain display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,3 +303,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Claimed milestones in dark mode use a brighter green for clearer status.
 - Biodomes now always draw power via an `ignoreProductivity` consumption flag.
 - Colony buildings now feature an upgrade arrow converting ten of a tier into one of the next at half the next tier's cost (excluding water).
+- Project cost and gain displays now reuse list items and total cost updates a dedicated span.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -76,6 +76,11 @@ class CargoRocketProject extends Project {
     const totalCostDisplay = document.createElement('p');
     totalCostDisplay.id = `${this.name}-total-cost-display`;
     totalCostDisplay.classList.add('total-cost-display');
+    const totalCostLabel = document.createElement('span');
+    totalCostLabel.textContent = 'Total Cost: ';
+    const totalCostValue = document.createElement('span');
+    totalCostValue.id = `${this.name}-total-cost-display-value`;
+    totalCostDisplay.append(totalCostLabel, totalCostValue);
     container.appendChild(totalCostDisplay);
 
     projectElements[this.name] = {

--- a/tests/cargoRocketUI.test.js
+++ b/tests/cargoRocketUI.test.js
@@ -58,5 +58,16 @@ describe('Cargo Rocket project UI', () => {
     expect(elements.resourceSelectionContainer).toBeDefined();
     const display = elements.resourceSelectionContainer.querySelector('#cargo_rocket-total-cost-display');
     expect(display).not.toBeNull();
+    const value = display.querySelector('#cargo_rocket-total-cost-display-value');
+    expect(value).not.toBeNull();
+
+    const metalInput = elements.resourceSelectionContainer.querySelector('.resource-selection-cargo_rocket[data-resource="metal"]');
+    metalInput.value = 2;
+    ctx.updateProjectUI('cargo_rocket');
+    expect(value.textContent).toBe(numbers.formatNumber(10, true));
+    expect(value.style.color).toBe('red');
+    ctx.resources.colony.funding.value = 100;
+    ctx.updateProjectUI('cargo_rocket');
+    expect(value.style.color).toBe('');
   });
 });

--- a/tests/projectCostGainDisplay.test.js
+++ b/tests/projectCostGainDisplay.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('project cost and gain lists', () => {
+  test('updates list items without rebuilding HTML', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper">
+        <div id="resources-projects-list" class="projects-list"></div>
+      </div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatBigInteger = numbers.formatBigInteger;
+    ctx.projectElements = {};
+    ctx.resources = {
+      colony: {
+        metal: { value: 5, displayName: 'Metal', unlocked: true },
+        funding: { value: 0, displayName: 'Funding', unlocked: true }
+      }
+    };
+    ctx.buildings = {};
+    ctx.colonies = {};
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.projectElements = projectElements;', ctx);
+
+    const params = {
+      name: 'test_project',
+      displayName: 'Test Project',
+      category: 'resources',
+      cost: { colony: { metal: 10 } },
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: { resourceGain: { colony: { metal: 1 } } }
+    };
+    const project = new ctx.Project(params, 'test_project');
+    ctx.projectManager = { projects: { test_project: project }, getProjectStatuses: () => [project], isBooleanFlagSet: () => false };
+
+    ctx.createProjectItem(project);
+    ctx.updateProjectUI('test_project');
+
+    const costItems = ctx.projectElements.test_project.costElement.querySelectorAll('li');
+    expect(costItems.length).toBe(1);
+    expect(costItems[0].textContent).toBe('Metal: 10');
+    expect(costItems[0].style.color).toBe('red');
+
+    ctx.resources.colony.metal.value = 15;
+    ctx.updateProjectUI('test_project');
+    expect(costItems[0].style.color).toBe('');
+
+    const gainItems = ctx.projectElements.test_project.resourceGainElement.querySelectorAll('li');
+    expect(gainItems.length).toBe(1);
+    expect(gainItems[0].textContent).toBe('Metal: 1');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Build cost and gain sections with reusable list items
- Update total cost via a dedicated span with color feedback
- Document cost/gain display refactor in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688eba43cc508327806f10a1564e5439