### PR TITLE
refactor: avoid innerHTML in space status

### DIFF
--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -165,7 +165,8 @@ function updateSpaceUI() {
         const isTerraformed = _spaceManagerInstance.isPlanetTerraformed(key);
         ui.nameHeading.textContent = data.name + (isTerraformed ? ' (Terraformed)' : '');
         ui.nameHeading.style.color = isTerraformed ? '#4CAF50' : '';
-        ui.statusSpan.innerHTML = isTerraformed ? '<span style="color: #4CAF50;">Terraforming Complete</span>' : 'Terraforming pending';
+        ui.statusSpan.textContent = isTerraformed ? 'Terraforming Complete' : 'Terraforming pending';
+        ui.statusSpan.style.color = isTerraformed ? '#4CAF50' : '';
 
         if (key === currentKey) {
             ui.button.textContent = 'Current Location';


### PR DESCRIPTION
## Summary
- update space UI planet status using `textContent` and `style.color` instead of rewriting `innerHTML`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ebfee5df88327a42e73fe3dfb65ef