### PR TITLE
refactor: cache warning element

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,3 +305,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Colony buildings now feature an upgrade arrow converting ten of a tier into one of the next at half the next tier's cost (excluding water).
 - Resource tooltips now use static DOM nodes updated without rebuilding innerHTML.
 - Project cost and gain displays now reuse list items and total cost updates a dedicated span.
+- Warning messages now reuse a cached DOM node and update text content without touching innerHTML.

--- a/src/js/warning.js
+++ b/src/js/warning.js
@@ -1,16 +1,44 @@
-function updateWarnings() {
-    const warningContainer = document.getElementById('warning-container');
-    const colonists = resources.colony.colonists;
-    const tau = terraforming?.temperature?.opticalDepth || 0;
-    const tempK = terraforming?.temperature?.value || 0;
+const warningContainer = typeof document !== 'undefined'
+  ? document.getElementById('warning-container')
+  : null;
 
-    if (colonists.consumptionRate > colonists.productionRate) {
-      warningContainer.innerHTML = '<div class="warning-message">Warning: Colonists are dying!</div>';
-    } else if (tau > 10 && tempK > 313.15) {
-      warningContainer.innerHTML = '<div class="warning-message">Warning: Runaway Greenhouse Effect!</div>';
-    } else {
-      warningContainer.innerHTML = '';
+const warningMessage = typeof document !== 'undefined'
+  ? document.createElement('div')
+  : null;
+
+if (warningMessage) {
+  warningMessage.className = 'warning-message';
+}
+
+function updateWarnings() {
+  if (!warningContainer || !warningMessage) {
+    return;
+  }
+
+  const colonists = resources.colony.colonists;
+  const tau = terraforming?.temperature?.opticalDepth || 0;
+  const tempK = terraforming?.temperature?.value || 0;
+
+  let message = '';
+
+  if (colonists.consumptionRate > colonists.productionRate) {
+    message = 'Warning: Colonists are dying!';
+  } else if (tau > 10 && tempK > 313.15) {
+    message = 'Warning: Runaway Greenhouse Effect!';
+  }
+
+  if (message) {
+    warningMessage.textContent = message;
+    warningMessage.style.display = '';
+    if (!warningContainer.contains(warningMessage)) {
+      warningContainer.appendChild(warningMessage);
     }
+  } else {
+    warningMessage.style.display = 'none';
+    if (warningContainer.contains(warningMessage)) {
+      warningContainer.removeChild(warningMessage);
+    }
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/tests/warningCaching.test.js
+++ b/tests/warningCaching.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+
+describe('warning message DOM reuse', () => {
+  test('reuses cached element and hides when no warnings', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="warning-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.resources = { colony: { colonists: { consumptionRate: 2, productionRate: 1 } } };
+    ctx.terraforming = { temperature: { opticalDepth: 0, value: 0 } };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'warning.js'), 'utf8');
+    vm.runInContext(code + '; this.updateWarnings = updateWarnings;', ctx);
+
+    ctx.updateWarnings();
+    const box = dom.window.document.getElementById('warning-container');
+    const firstNode = box.firstElementChild;
+    expect(firstNode.textContent).toBe('Warning: Colonists are dying!');
+
+    ctx.resources.colony.colonists.consumptionRate = 0;
+    ctx.terraforming.temperature.opticalDepth = 11;
+    ctx.terraforming.temperature.value = 314.15;
+    ctx.updateWarnings();
+    expect(box.firstElementChild).toBe(firstNode);
+    expect(firstNode.textContent).toBe('Warning: Runaway Greenhouse Effect!');
+
+    ctx.terraforming.temperature.opticalDepth = 0;
+    ctx.terraforming.temperature.value = 0;
+    ctx.updateWarnings();
+    expect(box.childElementCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- cache warning message div at module load
- update warning text and show/hide without rewriting innerHTML
- test warning message node reuse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ebfe8b5c08327b4ab42f113cf5fef