### PR TITLE
Display special project costs on a single line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,3 +305,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Colony buildings now feature an upgrade arrow converting ten of a tier into one of the next at half the next tier's cost (excluding water).
 - Resource tooltips now use static DOM nodes updated without rebuilding innerHTML.
 - Project cost and gain displays now reuse list items and total cost updates a dedicated span.
+- Special project costs now display on a single line like building costs.

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -113,20 +113,28 @@ function createProjectItem(project) {
   if (project.cost && Object.keys(project.cost).length > 0) {
     const costElement = document.createElement('p');
     costElement.classList.add('project-cost');
-    const costLabel = document.createElement('span');
-    costLabel.textContent = 'Cost:';
-    const costList = document.createElement('ul');
+    const label = document.createElement('strong');
+    label.textContent = 'Cost:';
+    costElement.append(label, ' ');
+    const list = document.createElement('span');
+    costElement.appendChild(list);
     const costItems = {};
+    const items = [];
     for (const category in project.cost) {
       for (const resource in project.cost[category]) {
-        const item = document.createElement('li');
-        item.dataset.category = category;
-        item.dataset.resource = resource;
-        costList.appendChild(item);
-        costItems[`${category}.${resource}`] = item;
+        if (project.cost[category][resource] > 0) {
+          items.push({ category, resource });
+        }
       }
     }
-    costElement.append(costLabel, costList);
+    items.forEach((item, idx) => {
+      const span = document.createElement('span');
+      list.appendChild(span);
+      if (idx < items.length - 1) {
+        list.appendChild(document.createTextNode(', '));
+      }
+      costItems[`${item.category}.${item.resource}`] = span;
+    });
     projectDetails.appendChild(costElement);
     projectElements[project.name] = {
       ...projectElements[project.name],

--- a/tests/projectCostGainDisplay.test.js
+++ b/tests/projectCostGainDisplay.test.js
@@ -50,13 +50,14 @@ describe('project cost and gain lists', () => {
     ctx.createProjectItem(project);
     ctx.updateProjectUI('test_project');
 
-    const costItems = ctx.projectElements.test_project.costElement.querySelectorAll('li');
+    let costItems = ctx.projectElements.test_project.costElement.querySelectorAll('span span');
     expect(costItems.length).toBe(1);
     expect(costItems[0].textContent).toBe('Metal: 10');
     expect(costItems[0].style.color).toBe('red');
 
     ctx.resources.colony.metal.value = 15;
     ctx.updateProjectUI('test_project');
+    costItems = ctx.projectElements.test_project.costElement.querySelectorAll('span span');
     expect(costItems[0].style.color).toBe('');
 
     const gainItems = ctx.projectElements.test_project.resourceGainElement.querySelectorAll('li');


### PR DESCRIPTION
## Summary
- Show special project costs inline with comma-separated resources, matching building cost formatting
- Update cost display tests to cover new inline layout
- Document inline cost formatting in AGENTS changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ec0949a808327b1e455dd00d72296