### PR TITLE
fix: restore skill tree connections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,3 +308,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Special project costs now display on a single line like building costs.
 - Skill buttons reuse child elements, updating text only when values change, and skill connections redraw only after layout or prerequisite changes.
 - Warning messages now reuse a cached DOM node and update text content without touching innerHTML.
+- Recreated skill connector lines by clearing cached paths when rebuilding the skill tree.

--- a/src/js/skillsUI.js
+++ b/src/js/skillsUI.js
@@ -76,6 +76,9 @@ function createSkillTree() {
     if (!container || container.nodeType !== 1) return;
 
     container.innerHTML = ''; // Clear previous content
+    for (const key in skillPaths) {
+        delete skillPaths[key];
+    }
 
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.id = 'skill-lines';


### PR DESCRIPTION
## Summary
- reset cached skill connector paths when rebuilding the skill tree so lines draw correctly
- note the fix in AGENTS changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ec2f2ec2c83278af7b0274c2c6f5c