### PR TITLE
fix: restore HOPE skill connectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,3 +309,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Skill buttons reuse child elements, updating text only when values change, and skill connections redraw only after layout or prerequisite changes.
 - Warning messages now reuse a cached DOM node and update text content without touching innerHTML.
 - Recreated skill connector lines by clearing cached paths when rebuilding the skill tree.
+- Skill connectors now render correctly when the skill tree is drawn while hidden.

--- a/src/js/skillsUI.js
+++ b/src/js/skillsUI.js
@@ -130,6 +130,11 @@ function drawSkillConnections() {
     if (!svg || !container || container.nodeType !== 1) return;
 
     const containerRect = container.getBoundingClientRect();
+    if (containerRect.width === 0 || containerRect.height === 0) {
+        // Skill tree is not visible; keep dirty flag so it redraws when shown
+        skillConnectionsDirty = true;
+        return;
+    }
     const used = new Set();
 
     for (const id in skillManager.skills) {


### PR DESCRIPTION
## Summary
- ensure HOPE skill connectors render after the skill tree becomes visible
- document skill connector fix in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ec462303c8327bc246bd877f50898