### PR TITLE
Fix research alert persistence on load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,3 +311,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Advanced research unlocks now highlight the Research tab and subtab until viewed.
 - Recreated skill connector lines by clearing cached paths when rebuilding the skill tree.
 - Skill connectors now render correctly when the skill tree is drawn while hidden.
+- Viewed research alerts remain cleared after loading a save.

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -194,6 +194,9 @@ function loadGame(slotOrCustomString) {
       if (typeof updateAdvancedResearchVisibility === 'function') {
           updateAdvancedResearchVisibility();
       }
+      if (typeof initializeResearchAlerts === 'function') {
+          initializeResearchAlerts();
+      }
 
     // Restore ore scanning progress
     if (gameState.oreScanning) {

--- a/tests/researchAlertPersistence.test.js
+++ b/tests/researchAlertPersistence.test.js
@@ -1,0 +1,109 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('research alerts persist after loading', () => {
+  test('viewed research does not alert again on load', () => {
+    const html = `<!DOCTYPE html>
+      <div id="research-tab"><span id="research-alert" class="unlock-alert">!</span></div>
+      <div class="research-subtab" data-subtab="energy-research">Energy<span id="energy-research-alert" class="unlock-alert">!</span></div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.window = dom.window;
+    ctx.console = console;
+    ctx.gameSettings = { silenceUnlockAlert: false };
+    ctx.formatNumber = x => x;
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const researchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research.js'), 'utf8');
+    const researchUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'researchUI.js'), 'utf8');
+    const saveCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'save.js'), 'utf8');
+    vm.runInContext(effectCode + researchCode + researchUICode + saveCode + '; this.EffectableEntity = EffectableEntity; this.ResearchManagerRef = ResearchManager;', ctx);
+
+    // Stubs required by save.js
+    ctx.dayNightCycle = { saveState: () => ({}), loadState: () => {} };
+    ctx.resources = {};
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.projectManager = { saveState: () => ({}), loadState: () => {} };
+    ctx.oreScanner = { saveState: () => ({}), loadState: () => {} };
+    ctx.terraforming = { saveState: () => ({}), loadState: () => {} };
+    ctx.storyManager = { saveState: () => ({}), loadState: () => {}, appliedEffects: [], reapplyEffects: () => {} };
+    ctx.journalEntrySources = [];
+    ctx.journalHistorySources = [];
+    ctx.goldenAsteroid = { saveState: () => ({}), loadState: () => {} };
+    ctx.solisManager = { saveState: () => ({}), loadState: () => {}, reapplyEffects: () => {} };
+    ctx.warpGateCommand = { saveState: () => ({}), loadState: () => {}, reapplyEffects: () => {} };
+    ctx.lifeDesigner = { saveState: () => ({}), loadState: () => {} };
+    ctx.lifeManager = {};
+    ctx.milestonesManager = { saveState: () => ({}), loadState: () => {} };
+    ctx.skillManager = { saveState: () => ({}), loadState: () => {}, reapplyEffects: () => {} };
+    ctx.spaceManager = { saveState: () => ({}), loadState: () => {}, getCurrentPlanetKey: () => 'mars' };
+    ctx.selectedBuildCounts = {};
+    ctx.colonySliderSettings = {};
+    ctx.ghgFactorySettings = {};
+    ctx.mirrorOversightSettings = {};
+    ctx.playTimeSeconds = 0;
+    ctx.planetParameters = { mars: { resources: {} } };
+    ctx.currentPlanetParameters = ctx.planetParameters.mars;
+    ctx.buildingsParameters = {};
+    ctx.colonyParameters = {};
+    ctx.projectParameters = {};
+    ctx.skillParameters = {};
+    ctx.progressData = {};
+    ctx.tabManager = { resetVisibility: () => {}, activateTab: () => {} };
+    ctx.tabParameters = { tabs: [] };
+    ctx.createBuildingButtons = () => {};
+    ctx.initializeBuildingAlerts = () => {};
+    ctx.createColonyButtons = () => {};
+    ctx.initializeProjectsUI = () => {};
+    ctx.renderProjects = () => {};
+    ctx.initializeProjectAlerts = () => {};
+    ctx.initializeColonySlidersUI = () => {};
+    ctx.initializeResearchUI = () => {};
+    ctx.initializeHopeUI = () => {};
+    ctx.createMilestonesUI = () => {};
+    ctx.initializeSpaceUI = () => {};
+    ctx.updateSpaceUI = () => {};
+    ctx.createResourceDisplay = () => {};
+    ctx.updateDayNightDisplay = () => {};
+    ctx.updateBuildingDisplay = () => {};
+    ctx.updateResearchUI = () => {};
+    ctx.updateTerraformingUI = () => {};
+    ctx.updateWarnings = () => {};
+    ctx.updateMilestonesUI = () => {};
+    ctx.updateHopeUI = () => {};
+    ctx.applyDayNightSettingEffects = () => {};
+    ctx.updateAdvancedResearchVisibility = () => {};
+    ctx.updateAllResearchButtons = () => {};
+    ctx.mapSourcesToText = arr => arr;
+    ctx.loadJournalEntries = () => {};
+    ctx.reconstructJournalState = () => {};
+
+    const data = {
+      energy: [
+        { id: 'power', name: 'Power', description: '', cost: {}, prerequisites: [], effects: [] }
+      ]
+    };
+
+    // Create save with research viewed
+    ctx.researchManager = new ctx.ResearchManagerRef(data);
+    ctx.initializeResearchAlerts();
+    ctx.markResearchSubtabViewed('energy-research');
+    const saveString = JSON.stringify({ spaceManager: {}, story: { appliedEffects: [] }, research: ctx.researchManager.saveState() });
+
+    ctx.initializeGameState = () => {
+      ctx.researchManager = new ctx.ResearchManagerRef(data);
+      ctx.initializeResearchAlerts();
+    };
+
+    ctx.saved = saveString;
+    vm.runInContext('loadGame(saved);', ctx);
+
+    expect(dom.window.document.getElementById('research-alert').style.display).toBe('none');
+    expect(dom.window.document.getElementById('energy-research-alert').style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- prevent previously viewed research from re-alerting when loading a save
- document the persistence of cleared research alerts
- test that research alerts remain cleared after loading

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_688edaf607708327b3fe295406e9e650