### PR TITLE
Show numeric years in resource tooltips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Atmosphere box shows a green check or red X for each gas requirement.
 - Temperature unit preference now persists when traveling to another planet.
 - Metal export projects now cap each export at max(terraformed planets, 1) billion metal.
-- Time to cap/empty tooltips now display 0s when a resource is already full or empty.
+- Time to full/empty tooltips now display 0s when a resource is already full or empty.
 - Story project journal entries now include a separator line and prefix showing progress.
 - Deeper mining supports android assignments for massive speed boosts.
 - Android assignment UI initializes hidden and shows once the upgrade is researched.
@@ -311,3 +311,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Advanced research unlocks now highlight the Research tab and subtab until viewed.
 - Recreated skill connector lines by clearing cached paths when rebuilding the skill tree.
 - Skill connectors now render correctly when the skill tree is drawn while hidden.
+- Resource tooltips show numeric years for time to full and time to empty instead of >1 year.

--- a/src/js/numbers.js
+++ b/src/js/numbers.js
@@ -66,8 +66,10 @@ function getTemperatureUnit() {
   }
 
 function formatDuration(seconds) {
-  if (seconds >= 365 * 24 * 3600) {
-    return '>1 year';
+  const yearSeconds = 365 * 24 * 3600;
+  if (seconds >= yearSeconds) {
+    const years = Math.floor(seconds / yearSeconds);
+    return `${formatNumber(years, true)} year${years !== 1 ? 's' : ''}`;
   }
   if (seconds >= 24 * 3600) {
     const days = Math.floor(seconds / (24 * 3600));

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -558,7 +558,7 @@ function updateResourceRateDisplay(resource){
     if (resource.name !== 'land') {
       if (netRate > 0 && resource.hasCap) {
         const time = (resource.cap - resource.value) / netRate;
-        timeDiv.textContent = `Time to cap: ${formatDuration(Math.max(time, 0))}`;
+        timeDiv.textContent = `Time to full: ${formatDuration(Math.max(time, 0))}`;
       } else if (netRate < 0) {
         const time = resource.value / Math.abs(netRate);
         timeDiv.textContent = `Time to empty: ${formatDuration(Math.max(time, 0))}`;

--- a/tests/numbers.test.js
+++ b/tests/numbers.test.js
@@ -1,4 +1,4 @@
-const { formatNumber, formatBigInteger, formatBuildingCount, formatPlayTime } = require('../src/js/numbers.js');
+const { formatNumber, formatBigInteger, formatBuildingCount, formatPlayTime, formatDuration } = require('../src/js/numbers.js');
 
 describe('formatNumber', () => {
   test('formats thousands with suffix k', () => {
@@ -42,5 +42,12 @@ describe('formatPlayTime', () => {
   test('converts days to years and days string', () => {
     expect(formatPlayTime(730)).toBe('2 years 0 days');
     expect(formatPlayTime(40)).toBe('40 days');
+  });
+});
+
+describe('formatDuration', () => {
+  test('displays years for long durations', () => {
+    const seconds = 2 * 365 * 24 * 3600;
+    expect(formatDuration(seconds)).toBe('2 years');
   });
 });

--- a/tests/resourceTooltipTime.test.js
+++ b/tests/resourceTooltipTime.test.js
@@ -17,7 +17,7 @@ describe('resource tooltip time remaining', () => {
     return { dom, ctx };
   }
 
-  test('shows time to cap for positive rate', () => {
+  test('shows time to full for positive rate', () => {
     const { dom, ctx } = setup();
     const resource = {
       name: 'metal', displayName: 'Metal', category: 'colony',
@@ -28,7 +28,7 @@ describe('resource tooltip time remaining', () => {
     ctx.createResourceDisplay({ colony: { metal: resource } });
     ctx.updateResourceRateDisplay(resource);
     const html = dom.window.document.getElementById('metal-tooltip').innerHTML;
-    expect(html).toContain('Time to cap');
+    expect(html).toContain('Time to full');
     const expected = numbers.formatDuration((100 - 50) / 2);
     expect(html).toContain(expected);
   });
@@ -49,7 +49,7 @@ describe('resource tooltip time remaining', () => {
     expect(html).toContain(expected);
   });
 
-  test('shows 0 time to cap when already full', () => {
+  test('shows 0 time to full when already full', () => {
     const { dom, ctx } = setup();
     const resource = {
       name: 'oxygen', displayName: 'O2', category: 'colony',
@@ -60,7 +60,7 @@ describe('resource tooltip time remaining', () => {
     ctx.createResourceDisplay({ colony: { oxygen: resource } });
     ctx.updateResourceRateDisplay(resource);
     const html = dom.window.document.getElementById('oxygen-tooltip').innerHTML;
-    expect(html).toContain('Time to cap');
+    expect(html).toContain('Time to full');
     expect(html).toContain('0s');
   });
 
@@ -77,5 +77,37 @@ describe('resource tooltip time remaining', () => {
     const html = dom.window.document.getElementById('fuel-tooltip').innerHTML;
     expect(html).toContain('Time to empty');
     expect(html).toContain('0s');
+  });
+
+  test('shows years for long time to full', () => {
+    const { dom, ctx } = setup();
+    const YEAR = 365 * 24 * 3600;
+    const resource = {
+      name: 'hydrogen', displayName: 'Hydrogen', category: 'colony',
+      value: 0, cap: YEAR * 2, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 1, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'kg'
+    };
+    ctx.createResourceDisplay({ colony: { hydrogen: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('hydrogen-tooltip').innerHTML;
+    expect(html).toContain('Time to full');
+    expect(html).toContain('2 years');
+  });
+
+  test('shows years for long time to empty', () => {
+    const { dom, ctx } = setup();
+    const YEAR = 365 * 24 * 3600;
+    const resource = {
+      name: 'nitrogen', displayName: 'Nitrogen', category: 'colony',
+      value: YEAR * 2, cap: YEAR * 2, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 1,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'kg'
+    };
+    ctx.createResourceDisplay({ colony: { nitrogen: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const html = dom.window.document.getElementById('nitrogen-tooltip').innerHTML;
+    expect(html).toContain('Time to empty');
+    expect(html).toContain('2 years');
   });
 });


### PR DESCRIPTION
## Summary
- Replace "Time to cap" with "Time to full" in resource tooltips
- Display time to full/empty in numeric years when exceeding one year
- Add tests for long duration formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688edb1c8810832783bbb255a42edc7c