### PR TITLE
Limit jumpToChapter journal to selected chapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,3 +314,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Resource tooltips show numeric years for time to full and time to empty instead of >1 year.
 - Viewed research alerts remain cleared after loading a save.
 - Geothermal generators now require reduced maintenance instead of none.
+- Jumping to a chapter now only rebuilds the journal with that chapter's entry.

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -591,8 +591,6 @@ class StoryManager {
                         addEffect(effect);
                     });
                 }
-
-                pushJournal(ev);
             }
         });
 

--- a/tests/jumpToChapter.test.js
+++ b/tests/jumpToChapter.test.js
@@ -43,7 +43,12 @@ describe('StoryManager jumpToChapter', () => {
     expect(Array.from(manager.completedEventIds)).toEqual(['c1']);
     expect(manager.activeEventIds.has('c2')).toBe(true);
     expect(context.addJournalEntry).toHaveBeenCalledWith('two', 'c2', { type: 'chapter', id: 'c2' });
-    expect(context.loadJournalEntries).toHaveBeenCalled();
+    expect(context.loadJournalEntries).toHaveBeenCalledWith(
+      ['two'],
+      ['two'],
+      [{ type: 'chapter', id: 'c2' }],
+      [{ type: 'chapter', id: 'c2' }]
+    );
     expect(context.addEffect).toHaveBeenCalledWith({ target: 'global', type: 'dummy' });
   });
 


### PR DESCRIPTION
## Summary
- Prevent `jumpToChapter` from preloading all prior chapters into the journal
- Verify journal reconstruction only includes the selected chapter during chapter jumps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688f6bdd195c8327a56904f6f17aaff8