### PR TITLE
Rebuild journal after chapter jumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,4 +314,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Resource tooltips show numeric years for time to full and time to empty instead of >1 year.
 - Viewed research alerts remain cleared after loading a save.
 - Geothermal generators now require reduced maintenance instead of none.
-- Jumping to a chapter now only rebuilds the journal with that chapter's entry.
+- Jumping to a chapter now reconstructs the journal after rewards and objectives are applied.

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -560,18 +560,6 @@ class StoryManager {
         this.appliedEffects.forEach(effect => removeEffect(effect));
         this.appliedEffects = [];
 
-        const journalEntries = [];
-        const journalSources = [];
-        const pushJournal = (ev) => {
-            const text = joinLines(ev.narrative);
-            if (ev.title) {
-                journalEntries.push([`${ev.title}`, text].join('\n'));
-            } else {
-                journalEntries.push(text);
-            }
-            journalSources.push({ type: 'chapter', id: ev.id });
-        };
-
         // Re-apply rewards and mark project objectives for completed chapters
         this.progressData.chapters.forEach(cfg => {
             if (completedChapterIds.has(cfg.id)) {
@@ -599,17 +587,14 @@ class StoryManager {
             targetEvent.prerequisites.forEach(handleProjectObjective);
         }
 
-        // Add target chapter's text to the journal reconstruction
-        pushJournal(targetEvent);
-
         console.log(`Jumping to ${chapterId}. Required completed chapters:`, Array.from(completedChapterIds));
         this.activateEvent(targetEvent);
 
-        if (typeof loadJournalEntries === 'function') {
-            loadJournalEntries(journalEntries, journalEntries, journalSources, journalSources);
-        }
-
         this.updateCurrentObjectiveUI();
+
+        if (typeof reconstructJournalState === 'function') {
+            reconstructJournalState(this, projectManager);
+        }
     }
 
     saveState() { // Keep as is


### PR DESCRIPTION
## Summary
- Reconstruct journal via `reconstructJournalState` after jumping to a chapter
- Update AGENTS changelog and tests for journal reconstruction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f6d6231f483279472db16261c064f