### PR TITLE
Display surface radiation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,3 +316,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Geothermal generators now require reduced maintenance instead of none.
 - Jumping to a chapter now reconstructs the journal after rewards and objectives are applied.
 - Terraforming Others box now displays surface radiation using new radiation utilities and stores the value for later use.
+- Moon parent bodies now include radius values for accurate distance-based radiation calculations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,3 +315,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Viewed research alerts remain cleared after loading a save.
 - Geothermal generators now require reduced maintenance instead of none.
 - Jumping to a chapter now reconstructs the journal after rewards and objectives are applied.
+- Terraforming Others box now displays surface radiation using new radiation utilities and stores the value for later use.

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
     <script src="src/js/hydrocarbon-cycle.js"></script>
     <script src="src/js/zones.js"></script>
     <script src="src/js/terraforming-utils.js"></script>
+    <script src="src/js/radiation-utils.js"></script>
     <script src="src/js/terraforming.js"></script>
     <script src="src/js/terraformingUI.js"></script>
     <script src="src/js/life.js"></script>

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -260,8 +260,9 @@ const titanOverrides = {
     rotationPeriod: 382.7,
     parentBody: {
       name: 'Saturn',
+      radius: 60268,        // km
       mass: 5.683e26,       // kg
-      orbitRadius: 1221870,  // km,
+      orbitRadius: 1221870, // km
       refDistance_Rp: 10,                 // convenient pivot in R_S
       parentBeltAtRef_mSvPerDay: 3.5,      // chosen so Titan @20.3 RS is ~0.05 airless
       beltFalloffExp: 6
@@ -364,6 +365,7 @@ const callistoOverrides = {
     rotationPeriod: 400.8,     // hours (16 .7 days tidally‑locked) :contentReference[oaicite:6]{index=6}
     parentBody: {
       name: 'Jupiter',
+      radius: 71492,       // km
       mass: 1.898e27,      // kg
       orbitRadius: 1882700, // km
       refDistance_Rp: 9.4,                 // Europa
@@ -459,11 +461,12 @@ const ganymedeOverrides = {
     rotationPeriod: 171.7,     // hours (7.155 days, tidally locked)
     parentBody: {
       name: 'Jupiter',
+      radius: 71492,      // km
       mass: 1.898e27,     // kg
       orbitRadius: 1070400, // km
       refDistance_Rp: 9.4,                 // Europa
       parentBeltAtRef_mSvPerDay: 5400,     // airless daily dose at Europa
-      beltFalloffExp: 10   
+      beltFalloffExp: 10
     }
   }
 };

--- a/src/js/radiation-utils.js
+++ b/src/js/radiation-utils.js
@@ -56,3 +56,8 @@ function estimateSurfaceDoseByColumn(column_gcm2,
   return { total, components: { gcr, belt, sep },
            meta: { column_gcm2: col, beltAirlessAtDistance } };
 }
+
+// Support CommonJS environments (tests) while remaining browser friendly
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { estimateSurfaceDoseByColumn };
+}

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -36,6 +36,9 @@ if (typeof module !== 'undefined' && module.exports) {
     var calculateMeltingFreezingRates = terraformUtils.calculateMeltingFreezingRates;
     var redistributePrecipitation = require('./phase-change-utils.js').redistributePrecipitation;
 
+    const radiation = require('./radiation-utils.js');
+    var estimateSurfaceDoseByColumn = radiation.estimateSurfaceDoseByColumn;
+
     const physics = require('./physics.js');
     if (typeof globalThis.surfaceAlbedoMix === 'undefined') {
         globalThis.surfaceAlbedoMix = physics.surfaceAlbedoMix;
@@ -232,10 +235,20 @@ class Terraforming extends EffectableEntity{
       unlocked: false
     };
 
+    // Current estimated surface radiation in mSv/day
+    this.surfaceRadiation = 0;
+
 
 
     this.updateLuminosity();
     this.updateSurfaceTemperature();
+    if (
+      typeof globalThis.resources !== 'undefined' &&
+      globalThis.resources.atmospheric &&
+      typeof calculateAtmosphericPressure === 'function'
+    ) {
+      this.updateSurfaceRadiation();
+    }
   }
 
   getMagnetosphereStatus() {
@@ -957,6 +970,34 @@ class Terraforming extends EffectableEntity{
       this.temperature.effectiveTempNoAtmosphere = effectiveTemp(this.luminosity.surfaceAlbedo, modifiedSolarFlux);
     }
 
+    // Estimate and store current surface radiation level in mSv/day
+    updateSurfaceRadiation() {
+      const pressurePa = this.calculateTotalPressure() * 1000; // kPa -> Pa
+      const g = this.celestialParameters.gravity || 1;
+      const column_gcm2 = g > 0 ? (pressurePa / g) * 0.1 : 0; // kg/m^2 -> g/cm^2
+
+      const parent = this.celestialParameters.parentBody || {};
+      let distance_Rp = parent.refDistance_Rp || 1;
+      if (parent.orbitRadius) {
+        const parentRadiiKm = { Saturn: 60268, Jupiter: 71492 };
+        const parentRadius = parent.radius || parentRadiiKm[parent.name];
+        if (parentRadius) {
+          distance_Rp = parent.orbitRadius / parentRadius;
+        }
+      }
+
+      const opts = {};
+      if (parent.beltFalloffExp !== undefined) opts.beltFalloffExp = parent.beltFalloffExp;
+      const dose = estimateSurfaceDoseByColumn(
+        column_gcm2,
+        distance_Rp,
+        parent.parentBeltAtRef_mSvPerDay || 0,
+        parent.refDistance_Rp || 1,
+        opts
+      );
+      this.surfaceRadiation = dose.total;
+    }
+
     calculateGroundAlbedo() {
         const baseAlbedo = this.celestialParameters.albedo;
         const upgradeAlbedo = 0.05;
@@ -1049,6 +1090,13 @@ class Terraforming extends EffectableEntity{
 
       // Synchronize zonal data back to global resources object for other systems/UI
       this.synchronizeGlobalResources();
+      if (
+        typeof calculateAtmosphericPressure === 'function' &&
+        typeof globalThis.resources !== 'undefined' &&
+        globalThis.resources.atmospheric
+      ) {
+        this.updateSurfaceRadiation();
+      }
 
     } // <-- Correct closing brace for the 'update' method
   

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -978,12 +978,8 @@ class Terraforming extends EffectableEntity{
 
       const parent = this.celestialParameters.parentBody || {};
       let distance_Rp = parent.refDistance_Rp || 1;
-      if (parent.orbitRadius) {
-        const parentRadiiKm = { Saturn: 60268, Jupiter: 71492 };
-        const parentRadius = parent.radius || parentRadiiKm[parent.name];
-        if (parentRadius) {
-          distance_Rp = parent.orbitRadius / parentRadius;
-        }
+      if (parent.orbitRadius && parent.radius) {
+        distance_Rp = parent.orbitRadius / parent.radius;
       }
 
       const opts = {};

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -607,9 +607,12 @@ function updateLifeBox() {
       ? 'The planet is sufficiently protected, providing a 50% boost to life growth'
       : 'No magnetosphere';
 
+    const rad = typeof terraforming.surfaceRadiation === 'number' ? terraforming.surfaceRadiation : 0;
+
     magnetosphereBox.innerHTML = `
       <h3>${terraforming.magnetosphere.name}</h3>
       <p>Magnetosphere: <span id="magnetosphere-status">${magnetosphereStatusText}</span></p>
+      <p>Surface radiation: <span id="surface-radiation">${formatNumber(rad, false, 2)}</span> mSv/day</p>
     `;
     const magnetosphereHeading = magnetosphereBox.querySelector('h3');
     if (magnetosphereHeading) {
@@ -623,6 +626,7 @@ function updateLifeBox() {
   function updateMagnetosphereBox() {
     const magnetosphereBox = document.getElementById('magnetosphere-box');
     const magnetosphereStatus = document.getElementById('magnetosphere-status');
+    const surfaceRadiation = document.getElementById('surface-radiation');
 
     // Update status based on boolean flag
     const magnetosphereStatusText = terraforming.isBooleanFlagSet('magneticShield') 
@@ -630,6 +634,10 @@ function updateLifeBox() {
       : 'No magnetosphere';
 
     magnetosphereStatus.textContent = magnetosphereStatusText;
+
+    if (surfaceRadiation) {
+      surfaceRadiation.textContent = formatNumber(terraforming.surfaceRadiation || 0, false, 2);
+    }
 
     if(terraforming.getMagnetosphereStatus()){
       magnetosphereBox.style.borderColor = 'green';

--- a/tests/surfaceRadiationDisplay.test.js
+++ b/tests/surfaceRadiationDisplay.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('surface radiation display', () => {
+  test('magnetosphere box shows surface radiation value', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="summary-terraforming"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const numbers = require('../src/js/numbers.js');
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
+    ctx.DEFAULT_SURFACE_ALBEDO = require('../src/js/physics.js').DEFAULT_SURFACE_ALBEDO;
+
+    ctx.resources = { atmospheric: { o2: { displayName: 'O2', value: 0 } } };
+    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.terraformingGasTargets = { o2: { min: 0, max: 100 } };
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    ctx.terraforming = {
+      temperature: { name: 'Temp', value: 0, emissivity: 1, effectiveTempNoAtmosphere: 0,
+        zones: { tropical: { value: 0, day: 0, night: 0 },
+                temperate: { value: 0, day: 0, night: 0 },
+                polar: { value: 0, day: 0, night: 0 } } },
+      atmosphere: { name: 'Atm' },
+      water: {},
+      luminosity: { name: 'Lum', albedo: 0, solarFlux: 0, modifiedSolarFlux: 0 },
+      life: { name: 'Life', target: 0.5 },
+      magnetosphere: { name: 'Mag' },
+      surfaceRadiation: 1.2345,
+      celestialParameters: { albedo: 0, gravity: 1, radius: 1, surfaceArea: 1 },
+      calculateSolarPanelMultiplier: () => 1,
+      calculateWindTurbineMultiplier: () => 1,
+      getAtmosphereStatus: () => true,
+      getLuminosityStatus: () => true,
+      getMagnetosphereStatus: () => true,
+      waterTarget: 0.2,
+      totalEvaporationRate: 0,
+      totalWaterSublimationRate: 0,
+      totalRainfallRate: 0,
+      totalSnowfallRate: 0,
+      totalMeltRate: 0,
+      totalFreezeRate: 0,
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: {}, temperate: {}, polar: {} }
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.createTerraformingSummaryUI();
+
+    const radEl = dom.window.document.getElementById('surface-radiation');
+    expect(radEl).not.toBeNull();
+    expect(radEl.textContent).toBe(numbers.formatNumber(1.2345, false, 2));
+  });
+});


### PR DESCRIPTION
## Summary
- compute and store surface radiation estimates on each planet
- show surface radiation in the Terraforming "Others" box
- add regression test for surface radiation display

## Testing
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_688f7927288c83279b0790431bf6fec2