### PR TITLE
Add orbital radiation to Terraforming Others stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,4 +316,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Geothermal generators now require reduced maintenance instead of none.
 - Jumping to a chapter now reconstructs the journal after rewards and objectives are applied.
 - Terraforming Others box now displays surface radiation using new radiation utilities and stores the value for later use.
+- Terraforming Others box now shows orbital radiation assuming no atmospheric shielding.
 - Moon parent bodies now include radius values for accurate distance-based radiation calculations.

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -607,11 +607,13 @@ function updateLifeBox() {
       ? 'The planet is sufficiently protected, providing a 50% boost to life growth'
       : 'No magnetosphere';
 
+    const orbRad = typeof terraforming.orbitalRadiation === 'number' ? terraforming.orbitalRadiation : 0;
     const rad = typeof terraforming.surfaceRadiation === 'number' ? terraforming.surfaceRadiation : 0;
 
     magnetosphereBox.innerHTML = `
       <h3>${terraforming.magnetosphere.name}</h3>
       <p>Magnetosphere: <span id="magnetosphere-status">${magnetosphereStatusText}</span></p>
+      <p>Orbital radiation: <span id="orbital-radiation">${formatNumber(orbRad, false, 2)}</span> mSv/day</p>
       <p>Surface radiation: <span id="surface-radiation">${formatNumber(rad, false, 2)}</span> mSv/day</p>
     `;
     const magnetosphereHeading = magnetosphereBox.querySelector('h3');
@@ -627,6 +629,7 @@ function updateLifeBox() {
     const magnetosphereBox = document.getElementById('magnetosphere-box');
     const magnetosphereStatus = document.getElementById('magnetosphere-status');
     const surfaceRadiation = document.getElementById('surface-radiation');
+    const orbitalRadiation = document.getElementById('orbital-radiation');
 
     // Update status based on boolean flag
     const magnetosphereStatusText = terraforming.isBooleanFlagSet('magneticShield') 
@@ -635,6 +638,9 @@ function updateLifeBox() {
 
     magnetosphereStatus.textContent = magnetosphereStatusText;
 
+    if (orbitalRadiation) {
+      orbitalRadiation.textContent = formatNumber(terraforming.orbitalRadiation || 0, false, 2);
+    }
     if (surfaceRadiation) {
       surfaceRadiation.textContent = formatNumber(terraforming.surfaceRadiation || 0, false, 2);
     }

--- a/tests/radiationDisplay.test.js
+++ b/tests/radiationDisplay.test.js
@@ -4,8 +4,8 @@ const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules',
 const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 
-describe('surface radiation display', () => {
-  test('magnetosphere box shows surface radiation value', () => {
+describe('radiation display', () => {
+  test('magnetosphere box shows orbital and surface radiation values', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="summary-terraforming"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     const numbers = require('../src/js/numbers.js');
@@ -31,6 +31,7 @@ describe('surface radiation display', () => {
       life: { name: 'Life', target: 0.5 },
       magnetosphere: { name: 'Mag' },
       surfaceRadiation: 1.2345,
+      orbitalRadiation: 2.3456,
       celestialParameters: { albedo: 0, gravity: 1, radius: 1, surfaceArea: 1 },
       calculateSolarPanelMultiplier: () => 1,
       calculateWindTurbineMultiplier: () => 1,
@@ -52,6 +53,10 @@ describe('surface radiation display', () => {
     vm.runInContext(code, ctx);
 
     ctx.createTerraformingSummaryUI();
+
+    const orbitalEl = dom.window.document.getElementById('orbital-radiation');
+    expect(orbitalEl).not.toBeNull();
+    expect(orbitalEl.textContent).toBe(numbers.formatNumber(2.3456, false, 2));
 
     const radEl = dom.window.document.getElementById('surface-radiation');
     expect(radEl).not.toBeNull();


### PR DESCRIPTION
## Summary
- track orbital radiation alongside surface radiation in terraforming calculations
- show orbital radiation in Terraforming Others box before surface radiation
- test display of orbital and surface radiation values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890a8108fb4832797ebb364a440b838