### PR TITLE
Align thruster stats and add thrust-power ratio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,3 +319,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Terraforming Others box now shows orbital radiation assuming no atmospheric shielding.
 - Moon parent bodies now include radius values for accurate distance-based radiation calculations.
 - Thruster Power subcard now shows exhaust velocity with a tooltip explaining specific impulse and aligns it in a column with the continuous power display.
+- Thruster Power subcard now keeps exhaust velocity beside continuous power and adds a Thrust/Power ratio column.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -629,6 +629,10 @@
     align-items: center;
 }
 
+.power-controls-wrapper .stats-grid {
+    flex-grow: 1;
+}
+
 .thruster-power-controls {
     display: flex;
     flex-direction: column;

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -106,9 +106,10 @@ class PlanetaryThrustersProject extends Project{
     const pwrHTML=`<div class="card-header"><span class="card-title">Thruster Power</span></div>
     <div class="card-body">
       <div class="power-controls-wrapper">
-        <div class="stats-grid two-col">
+        <div class="stats-grid three-col">
           <div><span class="stat-label">Continuous:</span><span id="pwrVal" class="stat-value">0</span></div>
           <div><span class="stat-label">Exhaust Velocity:<span class="info-tooltip-icon" title="Specific impulse equals exhaust velocity divided by standard gravity (Isp = Ve / g₀).">&#9432;</span></span><span id="veVal" class="stat-value">${fmt(FUSION_VE,false,0)} m/s</span></div>
+          <div><span class="stat-label">Thrust / Power:<span class="info-tooltip-icon" title="An ideal rocket's thrust-to-power ratio equals 2 divided by exhaust velocity.">&#9432;</span></span><span id="tpVal" class="stat-value">${fmt(2/FUSION_VE,false,6)} N/W</span></div>
         </div>
         <div class="thruster-power-controls">
           <div class="main-buttons">
@@ -133,7 +134,7 @@ class PlanetaryThrustersProject extends Project{
       escRow:g('#escapeRow',motCard),escDv:g('#escDv',motCard),
       parentRow:g('#parentRow',motCard),parentName:g('#parentName',motCard),
       parentRad:g('#parentRad',motCard),moonWarn:g('#moonWarn',motCard),
-      pwrVal:g('#pwrVal',pwrCard),veVal:g('#veVal',pwrCard),
+      pwrVal:g('#pwrVal',pwrCard),veVal:g('#veVal',pwrCard),tpVal:g('#tpVal',pwrCard),
       pPlus:g('#pPlus',pwrCard),pMinus:g('#pMinus',pwrCard),
       pDiv:g('#pDiv',pwrCard),pMul:g('#pMul',pwrCard),p0:g('#p0',pwrCard)};
 

--- a/tests/planetaryThrustersUIDefault.test.js
+++ b/tests/planetaryThrustersUIDefault.test.js
@@ -41,7 +41,7 @@ describe('Planetary Thrusters UI', () => {
     expect(project.el.distE.textContent).not.toBe('—');
   });
 
-  test('displays exhaust velocity with tooltip', () => {
+  test('displays exhaust velocity and thrust to power ratio with tooltip', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.document = dom.window.document;
@@ -64,12 +64,15 @@ describe('Planetary Thrusters UI', () => {
 
     const expectedVe = (1e5).toLocaleString() + '\u202Fm/s';
     expect(project.el.veVal.textContent).toBe(expectedVe);
-    const icon = project.el.pwrCard.querySelector('.info-tooltip-icon');
-    expect(icon).not.toBeNull();
-    expect(icon.getAttribute('title')).toMatch(/Specific impulse/);
-    const grid = project.el.pwrCard.querySelector('.stats-grid.two-col');
+    const expectedTP = (2 / 1e5).toLocaleString(undefined, { minimumFractionDigits: 6, maximumFractionDigits: 6 }) + '\u202FN/W';
+    expect(project.el.tpVal.textContent).toBe(expectedTP);
+    const icons = project.el.pwrCard.querySelectorAll('.info-tooltip-icon');
+    expect(icons.length).toBe(2);
+    expect(icons[0].getAttribute('title')).toMatch(/Specific impulse/);
+    expect(icons[1].getAttribute('title')).toMatch(/thrust-to-power ratio/i);
+    const grid = project.el.pwrCard.querySelector('.stats-grid.three-col');
     expect(grid).not.toBeNull();
-    expect(grid.children.length).toBe(2);
+    expect(grid.children.length).toBe(3);
   });
 
   test('hides spiral delta v when moon bound', () => {


### PR DESCRIPTION
## Summary
- align exhaust velocity next to continuous power in Planetary Thrusters
- add thrust-to-power ratio display (2/Ve)
- allow thruster stats grid to expand for side-by-side layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6890ae2c2d108327bde9ef8d3b4a52fe