### PR TITLE
Move thruster power controls into Continuous column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,3 +320,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Moon parent bodies now include radius values for accurate distance-based radiation calculations.
 - Thruster Power subcard now shows exhaust velocity with a tooltip explaining specific impulse and aligns it in a column with the continuous power display.
 - Thruster Power subcard now keeps exhaust velocity beside continuous power and adds a Thrust/Power ratio column.
+- Thruster power control buttons now appear in the Continuous column.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -623,21 +623,16 @@
     justify-content: flex-start;
 }
 /* --- Planetary Thrusters Project --- */
-.power-controls-wrapper {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-}
-
-.power-controls-wrapper .stats-grid {
-    flex-grow: 1;
-}
-
 .thruster-power-controls {
     display: flex;
     flex-direction: column;
     gap: 5px;
     margin-left: 20px;
+}
+
+.stats-grid .thruster-power-controls {
+    margin-left: 0;
+    margin-top: 5px;
 }
 
 .thruster-power-controls .main-buttons, .thruster-power-controls .multiplier-container {

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -105,20 +105,19 @@ class PlanetaryThrustersProject extends Project{
     /* power */
     const pwrHTML=`<div class="card-header"><span class="card-title">Thruster Power</span></div>
     <div class="card-body">
-      <div class="power-controls-wrapper">
-        <div class="stats-grid three-col">
-          <div><span class="stat-label">Continuous:</span><span id="pwrVal" class="stat-value">0</span></div>
-          <div><span class="stat-label">Exhaust Velocity:<span class="info-tooltip-icon" title="Specific impulse equals exhaust velocity divided by standard gravity (Isp = Ve / g₀).">&#9432;</span></span><span id="veVal" class="stat-value">${fmt(FUSION_VE,false,0)} m/s</span></div>
-          <div><span class="stat-label">Thrust / Power:<span class="info-tooltip-icon" title="An ideal rocket's thrust-to-power ratio equals 2 divided by exhaust velocity.">&#9432;</span></span><span id="tpVal" class="stat-value">${fmt(2/FUSION_VE,false,6)} N/W</span></div>
-        </div>
-        <div class="thruster-power-controls">
-          <div class="main-buttons">
-            <button id="p0">0</button><button id="pMinus">-</button><button id="pPlus">+</button>
-          </div>
-          <div class="multiplier-container">
-            <button id="pDiv">/10</button><button id="pMul">x10</button>
+      <div class="stats-grid three-col">
+        <div><span class="stat-label">Continuous:</span><span id="pwrVal" class="stat-value">0</span>
+          <div class="thruster-power-controls">
+            <div class="main-buttons">
+              <button id="p0">0</button><button id="pMinus">-</button><button id="pPlus">+</button>
+            </div>
+            <div class="multiplier-container">
+              <button id="pDiv">/10</button><button id="pMul">x10</button>
+            </div>
           </div>
         </div>
+        <div><span class="stat-label">Exhaust Velocity:<span class="info-tooltip-icon" title="Specific impulse equals exhaust velocity divided by standard gravity (Isp = Ve / g₀).">&#9432;</span></span><span id="veVal" class="stat-value">${fmt(FUSION_VE,false,0)} m/s</span></div>
+        <div><span class="stat-label">Thrust / Power:<span class="info-tooltip-icon" title="An ideal rocket's thrust-to-power ratio equals 2 divided by exhaust velocity.">&#9432;</span></span><span id="tpVal" class="stat-value">${fmt(2/FUSION_VE,false,6)} N/W</span></div>
       </div>
     </div>`;
     const pwrCard=document.createElement('div');pwrCard.className="info-card";pwrCard.innerHTML=pwrHTML;c.appendChild(pwrCard);

--- a/tests/planetaryThrustersUIDefault.test.js
+++ b/tests/planetaryThrustersUIDefault.test.js
@@ -73,6 +73,8 @@ describe('Planetary Thrusters UI', () => {
     const grid = project.el.pwrCard.querySelector('.stats-grid.three-col');
     expect(grid).not.toBeNull();
     expect(grid.children.length).toBe(3);
+    const firstCol = grid.children[0];
+    expect(firstCol.querySelector('.thruster-power-controls')).not.toBeNull();
   });
 
   test('hides spiral delta v when moon bound', () => {


### PR DESCRIPTION
## Summary
- Place thruster power buttons beneath the Continuous stat in the Planetary Thrusters card
- Simplify styling so buttons align within the stats grid
- Cover new layout with a unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6890b07848588327bc751f3f39327197