### PR TITLE
Add Tractor Beams advanced research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,3 +320,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Moon parent bodies now include radius values for accurate distance-based radiation calculations.
 - Thruster Power subcard now shows exhaust velocity with a tooltip explaining specific impulse and aligns it in a column with the continuous power display.
 - Thruster Power subcard now keeps exhaust velocity beside continuous power and adds a Thrust/Power ratio column.
+- Added Tractor Beams advanced research setting planetary thrusters to a thrust-to-power ratio of 1.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -6,6 +6,7 @@ const G  = 6.67430e-11;
 const SOLAR_MASS   = 1.989e30;
 const AU_IN_METERS = 1.496e11;
 const FUSION_VE    = 1.0e5;               // 100 km s‑1
+const BASE_TP_RATIO = 2 / FUSION_VE;
 
 /* ---------- helpers ---------------------------------------------------- */
 const fmt=(n,int=false,d=0)=>isNaN(n)?"–":
@@ -23,20 +24,20 @@ function spinDeltaV(Rkm,curH,tgtH){
   return Math.abs((w2-w1)*R);
 }
 
-function spinEnergyRemaining(p, Rkm, targetDays){
+function spinEnergyRemaining(p, Rkm, targetDays, tpRatio){
   const k = p.kInertia || 0.4;                 // allow parameter override
   const curH = getRotHours(p);
   const dvEq = Math.abs(
         2*Math.PI/(targetDays*24*3600) - 2*Math.PI/(curH*3600)) * (Rkm*1e3);
-  return 0.5 * k * p.mass * FUSION_VE * dvEq;  // propellant energy
+  return k * p.mass * dvEq / tpRatio;
 }
 
 function spiralDeltaV(curAU,tgtAU,mu=G*SOLAR_MASS){
   const r1=curAU*AU_IN_METERS,r2=tgtAU*AU_IN_METERS;
   return Math.abs(Math.sqrt(mu/r1)-Math.sqrt(mu/r2));
 }
-function translationalEnergyRemaining(p,dvRem){
-  return 0.5*p.mass*FUSION_VE*dvRem;                 // ideal fusion rocket
+function translationalEnergyRemaining(p,dvRem,tpRatio){
+  return p.mass * dvRem / tpRatio;
 }
 
 function escapeDeltaV(parentM,orbitRkm){
@@ -60,6 +61,12 @@ class PlanetaryThrustersProject extends Project{
     this.startAU=null;
 
     this.el={};
+  }
+
+  getThrustPowerRatio(){
+    return this.isBooleanFlagSet && this.isBooleanFlagSet('tractorBeams')
+      ? 1
+      : BASE_TP_RATIO;
   }
 
 /* -----------------------  U I  --------------------------------------- */
@@ -109,7 +116,7 @@ class PlanetaryThrustersProject extends Project{
         <div class="stats-grid three-col">
           <div><span class="stat-label">Continuous:</span><span id="pwrVal" class="stat-value">0</span></div>
           <div><span class="stat-label">Exhaust Velocity:<span class="info-tooltip-icon" title="Specific impulse equals exhaust velocity divided by standard gravity (Isp = Ve / g₀).">&#9432;</span></span><span id="veVal" class="stat-value">${fmt(FUSION_VE,false,0)} m/s</span></div>
-          <div><span class="stat-label">Thrust / Power:<span class="info-tooltip-icon" title="An ideal rocket's thrust-to-power ratio equals 2 divided by exhaust velocity.">&#9432;</span></span><span id="tpVal" class="stat-value">${fmt(2/FUSION_VE,false,6)} N/W</span></div>
+          <div><span class="stat-label">Thrust / Power:<span class="info-tooltip-icon" title="An ideal rocket's thrust-to-power ratio equals 2 divided by exhaust velocity.">&#9432;</span></span><span id="tpVal" class="stat-value">${fmt(this.getThrustPowerRatio(),false,6)} N/W</span></div>
         </div>
         <div class="thruster-power-controls">
           <div class="main-buttons">
@@ -164,7 +171,7 @@ class PlanetaryThrustersProject extends Project{
     this.tgtDays=tgt;
     const dv=spinDeltaV(p.radius,getRotHours(p),this.tgtDays*24);
     this.el.rotDv.textContent=fmt(dv,false,3)+" m/s";
-    this.el.rotE.textContent =formatEnergy(spinEnergyRemaining(p,p.radius,this.tgtDays));
+    this.el.rotE.textContent =formatEnergy(spinEnergyRemaining(p,p.radius,this.tgtDays,this.getThrustPowerRatio()));
     if(this.spinInvest) this.prepareJob();
   }
 
@@ -182,12 +189,12 @@ class PlanetaryThrustersProject extends Project{
       this.el.parentName.textContent=parent.name||"Parent";
       this.el.parentRad.textContent=fmt(parent.orbitRadius,false,0)+" km";
       this.el.distDv.textContent="—";
-      this.el.distE.textContent=formatEnergy(0.5*p.mass*FUSION_VE*esc);
+      this.el.distE.textContent=formatEnergy(p.mass*esc/this.getThrustPowerRatio());
     }else{
       this.el.escRow.style.display=this.el.parentRow.style.display=this.el.moonWarn.style.display="none";
       const dv=spiralDeltaV(p.distanceFromSun||this.tgtAU,this.tgtAU);
       this.el.distDv.textContent=fmt(dv,false,3)+" m/s";
-      this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dv));
+      this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dv,this.getThrustPowerRatio()));
     }
     if(this.motionInvest) this.prepareJob();
   }
@@ -230,16 +237,17 @@ class PlanetaryThrustersProject extends Project{
         fmt(p.distanceFromSun||0,false,3)+" AU";
     this.el.pwrVal.textContent = formatNumber(this.power, true)+" W";
     if(this.el.veVal) this.el.veVal.textContent = fmt(FUSION_VE,false,0)+" m/s";
+    if(this.el.tpVal) this.el.tpVal.textContent = fmt(this.getThrustPowerRatio(),false,6)+" N/W";
     this.el.pPlus.textContent="+"+formatNumber(this.step,true);
     this.el.pMinus.textContent="-"+formatNumber(this.step,true);
 
     /* live energy cost refresh */
     if(p && !p.parentBody){
       const dvRem=Math.max(0,this.dVreq-this.dVdone);
-      this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dvRem));
+      this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dvRem,this.getThrustPowerRatio()));
     }
     if(p && this.spinInvest){
-      this.el.rotE.textContent=formatEnergy(spinEnergyRemaining(p,p.radius,this.tgtDays));
+      this.el.rotE.textContent=formatEnergy(spinEnergyRemaining(p,p.radius,this.tgtDays,this.getThrustPowerRatio()));
     }
   }
 
@@ -259,7 +267,7 @@ class PlanetaryThrustersProject extends Project{
     if(resources.colony.energy.value<need) return;
     resources.colony.energy.decrease(need);
 
-    const a=2*this.power/(FUSION_VE*p.mass);
+    const a=this.power*this.getThrustPowerRatio()/p.mass;
     const dvTick=a*dt; this.dVdone+=dvTick;
 
     /* ------ spin -------- */

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1255,7 +1255,27 @@ const researchParameters = {
             value: true
           }
         ]
+      },
+      {
+        id: 'tractor_beams',
+        name: 'Tractor Beams',
+        description: 'Sets planetary thrusters to a thrust-to-power ratio of 1, greatly reducing energy needs.',
+        cost: { advancedResearch: 10000000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'project',
+            targetId: 'planetaryThruster',
+            type: 'booleanFlag',
+            flagId: 'tractorBeams',
+            value: true
+          }
+        ]
       }
     ]
   };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = researchParameters;
+}
   

--- a/tests/tractorBeamsResearch.test.js
+++ b/tests/tractorBeamsResearch.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const researchParameters = require('../src/js/research-parameters.js');
+
+describe('Tractor Beams advanced research', () => {
+  test('defines research with tractor beam flag on planetary thrusters', () => {
+    const research = researchParameters.advanced.find(r => r.id === 'tractor_beams');
+    expect(research).toBeDefined();
+    expect(research.cost).toEqual({ advancedResearch: 10000000 });
+    const flag = research.effects.find(e => e.target === 'project' && e.targetId === 'planetaryThruster' && e.type === 'booleanFlag' && e.flagId === 'tractorBeams' && e.value === true);
+    expect(flag).toBeDefined();
+  });
+
+  test('sets thrust to power ratio to one and reduces energy cost', () => {
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const thrusterCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'PlanetaryThrustersProject.js'), 'utf8');
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    ctx.terraforming = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.resources = { colony: { energy: { value: 0, decrease() {}, updateStorageCap() {} } } };
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(thrusterCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const project = new ctx.PlanetaryThrustersProject(ctx.projectParameters.planetaryThruster, 'thruster');
+    project.renderUI(dom.window.document.getElementById('container'));
+    project.updateUI();
+
+    const defaultTP = project.el.tpVal.textContent;
+    const defaultEnergy = ctx.translationalEnergyRemaining({ mass: 1 }, 10, project.getThrustPowerRatio());
+
+    project.addEffect({ type: 'booleanFlag', flagId: 'tractorBeams', value: true });
+    project.updateUI();
+    const tractorTP = project.el.tpVal.textContent;
+    const tractorEnergy = ctx.translationalEnergyRemaining({ mass: 1 }, 10, project.getThrustPowerRatio());
+
+    const expectedTP = (1).toLocaleString(undefined, { minimumFractionDigits: 6, maximumFractionDigits: 6 }) + '\u202FN/W';
+    expect(tractorTP).toBe(expectedTP);
+    expect(defaultTP).not.toBe(expectedTP);
+    expect(tractorEnergy).toBeCloseTo(10);
+    expect(tractorEnergy).toBeLessThan(defaultEnergy);
+  });
+});


### PR DESCRIPTION
## Summary
- add Tractor Beams advanced research for 10M advanced research that flags the Planetary Thrusters project
- let planetary thrusters use an internal thrust-to-power ratio flag and update energy costs
- test tractor beam research and reduced thruster energy use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890b11cd4a08327829cb6432bb074a0