### PR TITLE
Refactor thruster power controls layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,3 +321,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Thruster Power subcard now shows exhaust velocity with a tooltip explaining specific impulse and aligns it in a column with the continuous power display.
 - Thruster Power subcard now keeps exhaust velocity beside continuous power and adds a Thrust/Power ratio column.
 - Thruster power control buttons now appear in the Continuous column.
+- Thruster Power controls now occupy a dedicated second column in a four-column layout.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -105,15 +105,14 @@ class PlanetaryThrustersProject extends Project{
     /* power */
     const pwrHTML=`<div class="card-header"><span class="card-title">Thruster Power</span></div>
     <div class="card-body">
-      <div class="stats-grid three-col">
-        <div><span class="stat-label">Continuous:</span><span id="pwrVal" class="stat-value">0</span>
-          <div class="thruster-power-controls">
-            <div class="main-buttons">
-              <button id="p0">0</button><button id="pMinus">-</button><button id="pPlus">+</button>
-            </div>
-            <div class="multiplier-container">
-              <button id="pDiv">/10</button><button id="pMul">x10</button>
-            </div>
+      <div class="stats-grid four-col">
+        <div><span class="stat-label">Continuous:</span><span id="pwrVal" class="stat-value">0</span></div>
+        <div class="thruster-power-controls">
+          <div class="main-buttons">
+            <button id="p0">0</button><button id="pMinus">-</button><button id="pPlus">+</button>
+          </div>
+          <div class="multiplier-container">
+            <button id="pDiv">/10</button><button id="pMul">x10</button>
           </div>
         </div>
         <div><span class="stat-label">Exhaust Velocity:<span class="info-tooltip-icon" title="Specific impulse equals exhaust velocity divided by standard gravity (Isp = Ve / g₀).">&#9432;</span></span><span id="veVal" class="stat-value">${fmt(FUSION_VE,false,0)} m/s</span></div>

--- a/tests/planetaryThrustersUIDefault.test.js
+++ b/tests/planetaryThrustersUIDefault.test.js
@@ -70,11 +70,12 @@ describe('Planetary Thrusters UI', () => {
     expect(icons.length).toBe(2);
     expect(icons[0].getAttribute('title')).toMatch(/Specific impulse/);
     expect(icons[1].getAttribute('title')).toMatch(/thrust-to-power ratio/i);
-    const grid = project.el.pwrCard.querySelector('.stats-grid.three-col');
+    const grid = project.el.pwrCard.querySelector('.stats-grid.four-col');
     expect(grid).not.toBeNull();
-    expect(grid.children.length).toBe(3);
-    const firstCol = grid.children[0];
-    expect(firstCol.querySelector('.thruster-power-controls')).not.toBeNull();
+    expect(grid.children.length).toBe(4);
+    const controlsCol = grid.children[1];
+    expect(controlsCol.classList.contains('thruster-power-controls')).toBe(true);
+    expect(grid.children[0].querySelector('.thruster-power-controls')).toBeNull();
   });
 
   test('hides spiral delta v when moon bound', () => {


### PR DESCRIPTION
## Summary
- switch Thruster Power subcard to a four-column stats grid
- dedicate the second column to the control buttons
- cover new layout with tests and document in AGENTS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890b5d4d75c83279672a7857b885b9a