### PR TITLE
Display N/A exhaust velocity when Tractor Beams active

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,3 +323,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Tractor Beams advanced research setting planetary thrusters to a thrust-to-power ratio of 1.
 - Thruster power control buttons now appear in the Continuous column.
 - Thruster Power controls now occupy a dedicated second column in a four-column layout.
+- Exhaust velocity displays as N/A when Tractor Beams are active.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -63,10 +63,12 @@ class PlanetaryThrustersProject extends Project{
     this.el={};
   }
 
+  hasTractorBeams(){
+    return this.isBooleanFlagSet && this.isBooleanFlagSet('tractorBeams');
+  }
+
   getThrustPowerRatio(){
-    return this.isBooleanFlagSet && this.isBooleanFlagSet('tractorBeams')
-      ? 1
-      : BASE_TP_RATIO;
+    return this.hasTractorBeams() ? 1 : BASE_TP_RATIO;
   }
 
 /* -----------------------  U I  --------------------------------------- */
@@ -110,6 +112,9 @@ class PlanetaryThrustersProject extends Project{
     motCard.style.display=this.isCompleted?"block":"none";
 
     /* power */
+    const veDisplay = this.hasTractorBeams()
+      ? 'N/A'
+      : `${fmt(FUSION_VE,false,0)} m/s`;
     const pwrHTML=`<div class="card-header"><span class="card-title">Thruster Power</span></div>
     <div class="card-body">
       <div class="stats-grid four-col">
@@ -122,7 +127,7 @@ class PlanetaryThrustersProject extends Project{
             <button id="pDiv">/10</button><button id="pMul">x10</button>
           </div>
         </div>
-      <div><span class="stat-label">Exhaust Velocity:<span class="info-tooltip-icon" title="Specific impulse equals exhaust velocity divided by standard gravity (Isp = Ve / g₀).">&#9432;</span></span><span id="veVal" class="stat-value">${fmt(FUSION_VE,false,0)} m/s</span></div>
+      <div><span class="stat-label">Exhaust Velocity:<span class="info-tooltip-icon" title="Specific impulse equals exhaust velocity divided by standard gravity (Isp = Ve / g₀).">&#9432;</span></span><span id="veVal" class="stat-value">${veDisplay}</span></div>
       <div><span class="stat-label">Thrust / Power:<span class="info-tooltip-icon" title="An ideal rocket's thrust-to-power ratio equals 2 divided by exhaust velocity.">&#9432;</span></span><span id="tpVal" class="stat-value">${fmt(this.getThrustPowerRatio(),false,6)} N/W</span></div>
 
       </div>
@@ -235,7 +240,9 @@ class PlanetaryThrustersProject extends Project{
         fmt(p.parentBody.orbitRadius,false,0)+" km" :
         fmt(p.distanceFromSun||0,false,3)+" AU";
     this.el.pwrVal.textContent = formatNumber(this.power, true)+" W";
-    if(this.el.veVal) this.el.veVal.textContent = fmt(FUSION_VE,false,0)+" m/s";
+    if(this.el.veVal) this.el.veVal.textContent = this.hasTractorBeams()
+      ? 'N/A'
+      : fmt(FUSION_VE,false,0)+" m/s";
     if(this.el.tpVal) this.el.tpVal.textContent = fmt(this.getThrustPowerRatio(),false,6)+" N/W";
     this.el.pPlus.textContent="+"+formatNumber(this.step,true);
     this.el.pMinus.textContent="-"+formatNumber(this.step,true);

--- a/tests/tractorBeamsResearch.test.js
+++ b/tests/tractorBeamsResearch.test.js
@@ -39,16 +39,20 @@ describe('Tractor Beams advanced research', () => {
     project.updateUI();
 
     const defaultTP = project.el.tpVal.textContent;
+    const defaultVE = project.el.veVal.textContent;
     const defaultEnergy = ctx.translationalEnergyRemaining({ mass: 1 }, 10, project.getThrustPowerRatio());
 
     project.addEffect({ type: 'booleanFlag', flagId: 'tractorBeams', value: true });
     project.updateUI();
     const tractorTP = project.el.tpVal.textContent;
+    const tractorVE = project.el.veVal.textContent;
     const tractorEnergy = ctx.translationalEnergyRemaining({ mass: 1 }, 10, project.getThrustPowerRatio());
 
     const expectedTP = (1).toLocaleString(undefined, { minimumFractionDigits: 6, maximumFractionDigits: 6 }) + '\u202FN/W';
     expect(tractorTP).toBe(expectedTP);
     expect(defaultTP).not.toBe(expectedTP);
+    expect(defaultVE).not.toBe('N/A');
+    expect(tractorVE).toBe('N/A');
     expect(tractorEnergy).toBeCloseTo(10);
     expect(tractorEnergy).toBeLessThan(defaultEnergy);
   });


### PR DESCRIPTION
## Summary
- show "N/A" for exhaust velocity when Tractor Beams are enabled, keeping thrust-to-power updates consistent
- cover Tractor Beams exhaust velocity behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6890b866e3288327850fc56efde505ca