### PR TITLE
Fix planetary thruster delta v updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,3 +323,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Tractor Beams advanced research setting planetary thrusters to a thrust-to-power ratio of 1.
 - Thruster power control buttons now appear in the Continuous column.
 - Thruster Power controls now occupy a dedicated second column in a four-column layout.
+- Planetary thruster delta v values update every tick and default to 1 AU/1 day when unset.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -240,13 +240,48 @@ class PlanetaryThrustersProject extends Project{
     this.el.pPlus.textContent="+"+formatNumber(this.step,true);
     this.el.pMinus.textContent="-"+formatNumber(this.step,true);
 
-    /* live energy cost refresh */
-    if(p && !p.parentBody){
-      const dvRem=Math.max(0,this.dVreq-this.dVdone);
-      this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dvRem,this.getThrustPowerRatio()));
+    /* delta v and energy refresh */
+    if(this.el.rotTarget){
+      let tgtDays = 1;
+      try{
+        const v=this.el.rotTarget.value;
+        const n=parseFloat(v);
+        if(!isNaN(n)) tgtDays=n;
+      }catch(e){ tgtDays=1; }
+      this.tgtDays = tgtDays;
+      if(p && p.radius){
+        const dv=spinDeltaV(p.radius,getRotHours(p),tgtDays*24);
+        this.el.rotDv.textContent=fmt(dv,false,3)+" m/s";
+        this.el.rotE.textContent=formatEnergy(spinEnergyRemaining(p,p.radius,tgtDays,this.getThrustPowerRatio()));
+      }
     }
-    if(p && this.spinInvest){
-      this.el.rotE.textContent=formatEnergy(spinEnergyRemaining(p,p.radius,this.tgtDays,this.getThrustPowerRatio()));
+
+    if(this.el.distTarget){
+      let tgtAU = 1;
+      try{
+        const v=this.el.distTarget.value;
+        const n=parseFloat(v);
+        if(!isNaN(n)) tgtAU=n;
+      }catch(e){ tgtAU=1; }
+      this.tgtAU = tgtAU;
+      if(p && p.parentBody){
+        const parent=p.parentBody;
+        const esc=escapeDeltaV(parent.mass,parent.orbitRadius);
+        this.el.escDv.textContent=fmt(esc,false,3)+" m/s";
+        this.el.escRow.style.display="block";
+        this.el.parentRow.style.display="block";this.el.moonWarn.style.display="block";
+        this.el.parentName.textContent=parent.name||"Parent";
+        this.el.parentRad.textContent=fmt(parent.orbitRadius,false,0)+" km";
+        this.el.distDv.textContent="—";
+        this.el.distE.textContent=formatEnergy(p.mass*esc/this.getThrustPowerRatio());
+      }else if(p){
+        this.el.escRow.style.display=this.el.parentRow.style.display=this.el.moonWarn.style.display="none";
+        const curAU=p.distanceFromSun||tgtAU;
+        const dv=spiralDeltaV(curAU,tgtAU);
+        this.el.distDv.textContent=fmt(dv,false,3)+" m/s";
+        const dvRem=this.motionInvest?Math.max(0,this.dVreq-this.dVdone):dv;
+        this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dvRem,this.getThrustPowerRatio()));
+      }
     }
   }
 

--- a/tests/planetaryThrustersUIDefault.test.js
+++ b/tests/planetaryThrustersUIDefault.test.js
@@ -32,13 +32,41 @@ describe('Planetary Thrusters UI', () => {
     const container = dom.window.document.getElementById('container');
     project.renderUI(container);
     ctx.projectElements = vm.runInContext('projectElements', ctx);
-    vm.runInContext('project.calcSpinCost(); project.calcMotionCost();', ctx);
     project.updateUI();
 
     expect(project.el.rotDv.textContent).not.toBe('—');
     expect(project.el.rotE.textContent).not.toBe('—');
     expect(project.el.distDv.textContent).not.toBe('—');
     expect(project.el.distE.textContent).not.toBe('—');
+  });
+
+  test('uses defaults when targets cleared', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.terraforming = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 30, distanceFromSun: 1.5 } };
+    ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
+
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(thrusterCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.planetaryThruster;
+    const project = new ctx.PlanetaryThrustersProject(config, 'thruster');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    project.el.rotTarget.value = '';
+    project.el.distTarget.value = '';
+    project.updateUI();
+
+    expect(project.tgtDays).toBe(1);
+    expect(project.tgtAU).toBe(1);
+    expect(project.el.rotDv.textContent).not.toBe('—');
+    expect(project.el.distDv.textContent).not.toBe('—');
   });
 
   test('displays exhaust velocity and thrust to power ratio with tooltip', () => {
@@ -99,7 +127,6 @@ describe('Planetary Thrusters UI', () => {
     const container = dom.window.document.getElementById('container');
     project.renderUI(container);
     ctx.projectElements = vm.runInContext('projectElements', ctx);
-    vm.runInContext('project.calcMotionCost();', ctx);
     project.updateUI();
 
     expect(project.el.distDv.textContent).toBe('—');


### PR DESCRIPTION
## Summary
- refresh planetary thruster delta-v and energy values every tick, defaulting to 1 AU/1 day when inputs are missing
- document thruster delta-v refresh in AGENTS changelog
- test defaults and UI for planetary thrusters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6890b847d4188327b48eaa524e2267e7