### PR TITLE
Integrate thruster energy tracking into spin and motion subcards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,4 +327,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Exhaust velocity displays as N/A when Tractor Beams are active.
 - Moon-based planetary thrusters no longer show target AU or spiral Δv, assuming a 1 AU target with all energy devoted to escape.
 - Added Cloning Concept advanced research enabling energy-intensive cloning facilities to produce colonists.
-- Planetary thrusters now display an Energy Spent section tracking energy used for spin and motion and resetting after a moon escape.
+- Planetary thruster Spin and Motion cards now include Energy Spent columns that persist when investment is toggled; motion energy resets only after a moon escapes its parent.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -166,6 +166,10 @@
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.stats-grid.five-col {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
 .stat-item {
     background-color: #fff;
     padding: 8px;

--- a/tests/planetaryThrustersUIDefault.test.js
+++ b/tests/planetaryThrustersUIDefault.test.js
@@ -38,8 +38,8 @@ describe('Planetary Thrusters UI', () => {
     expect(project.el.rotE.textContent).not.toBe('—');
     expect(project.el.distDv.textContent).not.toBe('—');
     expect(project.el.distE.textContent).not.toBe('—');
-    expect(project.el.spinSpent.textContent).toBe('0');
-    expect(project.el.motionSpent.textContent).toBe('0');
+    expect(project.el.rotSpent.textContent).toBe('0');
+    expect(project.el.distSpent.textContent).toBe('0');
   });
 
   test('uses defaults when targets cleared', () => {

--- a/tests/planetaryThrustersVisibility.test.js
+++ b/tests/planetaryThrustersVisibility.test.js
@@ -33,21 +33,18 @@ describe('Planetary Thrusters visibility', () => {
 
     expect(project.el.spinCard.style.display).toBe('none');
     expect(project.el.motCard.style.display).toBe('none');
-    expect(project.el.spentCard.style.display).toBe('none');
     expect(project.el.pwrCard.style.display).toBe('none');
 
     project.enable();
     project.updateUI();
     expect(project.el.spinCard.style.display).toBe('none');
     expect(project.el.motCard.style.display).toBe('none');
-    expect(project.el.spentCard.style.display).toBe('none');
     expect(project.el.pwrCard.style.display).toBe('none');
 
     project.complete();
     project.updateUI();
     expect(project.el.spinCard.style.display).toBe('block');
     expect(project.el.motCard.style.display).toBe('block');
-    expect(project.el.spentCard.style.display).toBe('block');
     expect(project.el.pwrCard.style.display).toBe('block');
   });
 });


### PR DESCRIPTION
## Summary
- show spin and motion energy spent directly on their respective thruster cards
- keep thruster energy totals when toggling investment, resetting motion only after escape
- add five-column grid style for expanded stat layouts

## Testing
- `npm test --silent 2>&1 | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_b_6890c63fce0c8327abc4a26d4ef318b1