### PR TITLE
Display deposit caps on satellite projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,3 +329,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Added Cloning Concept advanced research enabling energy-intensive cloning facilities to produce colonists.
 - Planetary thrusters now display an Energy Spent section tracking energy used for spin and motion and resetting after a moon escape.
 - Planetary thruster invest selections now persist through saves and reloads with checkboxes and targets restored on load.
+- Satellite projects now display discovered and maximum deposit counts.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -311,6 +311,7 @@ class ScannerProject extends Project {
   renderUI(container) {
     const wrapper = document.createElement('div');
     wrapper.className = 'power-controls-wrapper';
+
     const countContainer = document.createElement('div');
     countContainer.className = 'invested-container';
     const label = document.createElement('span');
@@ -352,9 +353,37 @@ class ScannerProject extends Project {
 
     controls.append(main, mult);
     wrapper.append(countContainer, controls);
+
     container.appendChild(wrapper);
 
+    let dVal, dMax;
+    if (this.attributes?.scanner?.depositType) {
+      const depositContainer = document.createElement('div');
+      depositContainer.className = 'invested-container';
+      const dLabel = document.createElement('span');
+      dLabel.className = 'stat-label';
+      dLabel.textContent = 'Deposits:';
+      dVal = document.createElement('span');
+      dVal.id = `${this.name}-deposit-current`;
+      dVal.className = 'stat-value';
+      const dSlash = document.createElement('span');
+      dSlash.textContent = ' / ';
+      dMax = document.createElement('span');
+      dMax.id = `${this.name}-deposit-max`;
+      dMax.className = 'stat-value';
+      const dInfo = document.createElement('span');
+      dInfo.className = 'info-tooltip-icon';
+      dInfo.title = 'Shows discovered and maximum deposits satellites can find on this planet.';
+      dInfo.innerHTML = '&#9432;';
+      depositContainer.append(dLabel, dVal, dSlash, dMax, dInfo);
+      container.appendChild(depositContainer);
+    }
+
     this.el = { val, max, bPlus, bMinus, bMul, bDiv, b0 };
+    if (dVal && dMax) {
+      this.el.dVal = dVal;
+      this.el.dMax = dMax;
+    }
 
     const refresh = () => {
       if (typeof updateProjectUI === 'function') {
@@ -380,6 +409,14 @@ class ScannerProject extends Project {
     }
     if (this.el.bMinus) {
       this.el.bMinus.textContent = `-${formatNumber(this.step, true)}`;
+    }
+    if (this.el.dVal && this.el.dMax) {
+      const depositType = this.attributes?.scanner?.depositType;
+      const data = depositType && this.scanData ? this.scanData[depositType] : null;
+      const current = data ? data.D_current : 0;
+      const max = data ? data.D_max : 0;
+      this.el.dVal.textContent = formatNumber(current, true);
+      this.el.dMax.textContent = formatNumber(max, true);
     }
   }
 

--- a/tests/scannerProjectUIUpdate.test.js
+++ b/tests/scannerProjectUIUpdate.test.js
@@ -18,7 +18,15 @@ describe('ScannerProject UI update', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.resources = { colony: { colonists: { value: 15000, displayName: 'Colonists' }, metal:{value:0,decrease(){},updateStorageCap(){}}, electronics:{value:0,decrease(){},updateStorageCap(){}}, energy:{value:0,decrease(){},updateStorageCap(){}} } };
+    ctx.resources = {
+      colony: {
+        colonists: { value: 15000, displayName: 'Colonists' },
+        metal:{value:0,decrease(){},updateStorageCap(){}},
+        electronics:{value:0,decrease(){},updateStorageCap(){}},
+        energy:{value:0,decrease(){},updateStorageCap(){}}
+      },
+      underground: { ore: { value: 0, addDeposit(){} } }
+    };
     ctx.oreScanner = { scanData:{ ore:{ currentScanningStrength:0 } }, adjustScanningStrength(){}, startScan(){} };
 
     vm.createContext(ctx);
@@ -28,12 +36,15 @@ describe('ScannerProject UI update', () => {
     vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
 
     const project = new ctx.ScannerProject(ctx.projectParameters.satellite, 'sat');
+    project.initializeScanner({ resources: { underground: { ore: { initialValue: 0, maxDeposits: 10, areaTotal: 100 } } } });
     const container = ctx.document.getElementById('c');
     project.renderUI(container);
     project.updateUI();
 
     expect(project.el.val.textContent).toBe('1');
     expect(project.el.max.textContent).toBe('2');
+    expect(project.el.dVal.textContent).toBe('0');
+    expect(project.el.dMax.textContent).toBe('10');
     expect(project.el.bPlus.textContent).toBe('+1');
     expect(project.el.bMinus.textContent).toBe('-1');
 


### PR DESCRIPTION
## Summary
- Show discovered and maximum deposit counts for satellite scanners
- Document satellite deposit display in AGENTS changelog
- Cover UI update with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6890cafa8b80832784eaa5a6fe343803