### PR TITLE
Fix Dyson Swarm energy production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,3 +331,6 @@ second time they speak in a chapter to help clarify who is talking.
 - Planetary thrusters now display an Energy Spent section tracking energy used for spin and motion and resetting after a moon escape.
 - Planetary thruster invest selections now persist through saves and reloads with checkboxes and targets restored on load.
 - Satellite projects now display discovered and maximum deposit counts.
+- Dyson Swarm collectors now contribute their generated energy to the colony instead of only displaying it.
+- Moon-based planetary thrusters show an Escape Δv row and hide spiral Δv when bound to a parent body.
+- ProjectManager now applies project gains each tick via applyCostAndGain, keeping estimateCostAndGain as a pure rate estimate.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -369,7 +369,7 @@ class Project extends EffectableEntity {
 
 
 
-  estimateProjectCostAndGain() {
+  estimateProjectCostAndGain(deltaTime = 1000) {
     if (this.isActive && this.autoStart) {
       const rate = 1000 / this.getEffectiveDuration();
 
@@ -399,9 +399,11 @@ class Project extends EffectableEntity {
     }
   }
 
-  estimateCostAndGain() {
-    this.estimateProjectCostAndGain();
+  estimateCostAndGain(deltaTime = 1000) {
+    this.estimateProjectCostAndGain(deltaTime);
   }
+
+  applyCostAndGain(deltaTime = 1000) {}
 
   saveState() {
     return {
@@ -511,6 +513,10 @@ class ProjectManager extends EffectableEntity {
 
       // Always update so subclasses can run logic after completion
       project.update(deltaTime);
+
+      if (typeof project.applyCostAndGain === 'function') {
+        project.applyCostAndGain(deltaTime);
+      }
     }
   }
 
@@ -539,11 +545,11 @@ class ProjectManager extends EffectableEntity {
     this.projectOrder = newOrder;
   }
 
-  estimateProjects() {
+  estimateProjects(deltaTime = 1000) {
     for (const projectName in this.projects){
       const project = this.projects[projectName];
       if (typeof project.estimateCostAndGain === 'function') {
-        project.estimateCostAndGain();
+        project.estimateCostAndGain(deltaTime);
       }
     }
   }

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -240,11 +240,11 @@ class PlanetaryThrustersProject extends Project{
     if(parent){
       this.tgtAU=1;
       this.el.distTargetRow.style.display = "none";
-      this.el.distDvRow.style.display = "block"; // Show spiral Δv
+      this.el.distDvRow.style.display = "none"; // Hide spiral Δv
       const r_hill = hillRadiusMeters(p, parent);
       const esc = escapeSpiralDeltaV(parent.orbitRadius, r_hill, parent.mass);
-      this.el.distDv.textContent = fmt(esc, false, 3) + " m/s";
-      this.el.escRow.style.display = "none"; // Hide old escape row
+      this.el.escDv.textContent = fmt(esc, false, 3) + " m/s";
+      this.el.escRow.style.display = "block"; // Show escape row
       this.el.parentRow.style.display = "block";
       this.el.moonWarn.style.display = "block";
       this.el.hillRow.style.display = "block";
@@ -337,22 +337,22 @@ class PlanetaryThrustersProject extends Project{
 
     if(this.el.distTarget){
       if(p && p.parentBody){
-        this.tgtAU = 1;
-        this.el.distTargetRow.style.display="none";
-        this.el.distDvRow.style.display="none";
-        const parent=p.parentBody;
-        const r_hill = hillRadiusMeters(p, parent);
-        const esc = escapeSpiralDeltaV(parent.orbitRadius, r_hill, parent.mass);
-        this.el.distDv.textContent = fmt(esc, false, 3) + " m/s";
-        this.el.escRow.style.display = "none";
-        this.el.parentRow.style.display = "block";
-        this.el.moonWarn.style.display = "block";
-        this.el.hillRow.style.display = "block";
-        this.el.hillVal.textContent = fmt(r_hill / 1e3, false, 0) + " km";
-        this.el.parentName.textContent = parent.name || "Parent";
-        this.el.parentRad.textContent = fmt(parent.orbitRadius, false, 0) + " km";
-        const dvRem=esc;
-        this.el.distE.textContent=formatEnergy(p.mass*dvRem/this.getThrustPowerRatio());
+      this.tgtAU = 1;
+      this.el.distTargetRow.style.display="none";
+      this.el.distDvRow.style.display="none";
+      const parent=p.parentBody;
+      const r_hill = hillRadiusMeters(p, parent);
+      const esc = escapeSpiralDeltaV(parent.orbitRadius, r_hill, parent.mass);
+      this.el.escRow.style.display = "block";
+      this.el.escDv.textContent = fmt(esc, false, 3) + " m/s";
+      this.el.parentRow.style.display = "block";
+      this.el.moonWarn.style.display = "block";
+      this.el.hillRow.style.display = "block";
+      this.el.hillVal.textContent = fmt(r_hill / 1e3, false, 0) + " km";
+      this.el.parentName.textContent = parent.name || "Parent";
+      this.el.parentRad.textContent = fmt(parent.orbitRadius, false, 0) + " km";
+      const dvRem=esc;
+      this.el.distE.textContent=formatEnergy(p.mass*dvRem/this.getThrustPowerRatio());
       }else if(p){
         let tgtAU = 1;
         try{

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -116,10 +116,18 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
     }
   }
 
-  estimateCostAndGain() {
+  estimateCostAndGain(deltaTime = 1000) {
     if (this.isCompleted && this.collectors > 0) {
       const rate = this.collectors * this.energyPerCollector;
       resources.colony.energy.modifyRate(rate, 'Dyson Swarm', 'project');
+    }
+  }
+
+  applyCostAndGain(deltaTime = 1000) {
+    if (this.isCompleted && this.collectors > 0) {
+      const rate = this.collectors * this.energyPerCollector;
+      const energyGain = rate * (deltaTime / 1000);
+      resources.colony.energy.increase(energyGain);
     }
   }
 

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -370,7 +370,7 @@ function produceResources(deltaTime, buildings) {
   }
 
   if(projectManager){
-    projectManager.estimateProjects();
+    projectManager.estimateProjects(deltaTime);
   }
 
   // Apply accumulated changes to resources

--- a/tests/dysonSwarmEnergyProduction.test.js
+++ b/tests/dysonSwarmEnergyProduction.test.js
@@ -11,7 +11,12 @@ describe('Dyson Swarm energy production', () => {
       EffectableEntity,
       resources: {
         colony: {
-          energy: { value: 0, modifyRate: jest.fn(), updateStorageCap: () => {} },
+          energy: {
+            value: 0,
+            modifyRate: jest.fn(),
+            updateStorageCap: () => {},
+            increase(amount) { this.value += amount; }
+          },
           glass: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
           electronics: { value: 2000, decrease: () => {}, updateStorageCap: () => {} },
           components: { value: 2000, decrease: () => {}, updateStorageCap: () => {} }
@@ -38,7 +43,9 @@ describe('Dyson Swarm energy production', () => {
     project.energyPerCollector = 50;
 
     project.estimateCostAndGain();
+    project.applyCostAndGain(1000);
 
     expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalledWith(150, 'Dyson Swarm', 'project');
+    expect(ctx.resources.colony.energy.value).toBe(150);
   });
 });


### PR DESCRIPTION
## Summary
- keep estimateCostAndGain a pure rate calculation with a new applyCostAndGain hook invoked each update
- apply Dyson Swarm energy through applyCostAndGain so collectors add power while estimates show production
- document project gain hook and extend regression test for new method

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6890dc7434d48327bbb04635336d295c