### PR TITLE
Add space mirror focusing slider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,3 +337,4 @@ second time they speak in a chapter to help clarify who is talking.
 - ProjectManager now applies project gains each tick via applyCostAndGain, keeping estimateCostAndGain as a pure rate estimate.
 - Ore and geothermal satellite UI now split Amount and Deposits into separate columns with aligned controls and fonts matching space mining projects.
 - Added Space Mirror Focusing advanced research applying a boolean flag to the space mirror facility.
+- Space mirror oversight controls include a Focusing slider revealed when the Space Mirror Focusing flag is set.

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1232,7 +1232,7 @@ class Terraforming extends EffectableEntity{
       ) {
         const dist = mirrorOversightSettings.distribution || {};
         const zonePerc = dist[zone] || 0;
-        const globalPerc = 1 - ((dist.tropical || 0) + (dist.temperate || 0) + (dist.polar || 0));
+          const globalPerc = 1 - ((dist.tropical || 0) + (dist.temperate || 0) + (dist.polar || 0) + (dist.focus || 0));
 
         distributedMirrorPower = totalMirrorPower * globalPerc;
         focusedMirrorPower = totalMirrorPower * zonePerc;

--- a/tests/calculateZoneSolarFlux.test.js
+++ b/tests/calculateZoneSolarFlux.test.js
@@ -27,7 +27,7 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0 }, applyToLantern: false };
+    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0, focus: 0 }, applyToLantern: false };
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -51,7 +51,7 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0 }, applyToLantern: false };
+    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0, focus: 0 }, applyToLantern: false };
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -76,7 +76,7 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0 }, applyToLantern: true };
+    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0, focus: 0 }, applyToLantern: true };
 
     Terraforming.prototype.calculateLanternFlux = function(){
       const lantern = buildings.hyperionLantern;

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -95,5 +95,5 @@ test('initializeGameState resets colony sliders to defaults', () => {
   }
 
   expect(settings).toEqual({ workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 });
-  expect(oversight).toEqual({ distribution: { tropical: 0, temperate: 0, polar: 0 }, applyToLantern: false });
+  expect(oversight).toEqual({ distribution: { tropical: 0, temperate: 0, polar: 0, focus: 0 }, applyToLantern: false });
 });

--- a/tests/mirrorOversightSettings.test.js
+++ b/tests/mirrorOversightSettings.test.js
@@ -20,9 +20,11 @@ describe('mirror oversight settings', () => {
   test('setters modify settings', () => {
     setMirrorDistribution('tropical', 40);
     setMirrorDistribution('temperate', 30);
+    setMirrorDistribution('focus', 10);
     mirrorOversightSettings.applyToLantern = true;
     expect(mirrorOversightSettings.distribution.tropical).toBeCloseTo(0.4);
     expect(mirrorOversightSettings.distribution.temperate).toBeCloseTo(0.3);
+    expect(mirrorOversightSettings.distribution.focus).toBeCloseTo(0.1);
     expect(mirrorOversightSettings.applyToLantern).toBe(true);
   });
 
@@ -30,9 +32,10 @@ describe('mirror oversight settings', () => {
     mirrorOversightSettings.distribution.tropical = 0.2;
     mirrorOversightSettings.distribution.temperate = 0.3;
     mirrorOversightSettings.distribution.polar = 0.4;
+    mirrorOversightSettings.distribution.focus = 0.1;
     mirrorOversightSettings.applyToLantern = true;
     resetMirrorOversightSettings();
-    expect(mirrorOversightSettings.distribution).toEqual({ tropical: 0, temperate: 0, polar: 0 });
+    expect(mirrorOversightSettings.distribution).toEqual({ tropical: 0, temperate: 0, polar: 0, focus: 0 });
     expect(mirrorOversightSettings.applyToLantern).toBe(false);
   });
 });

--- a/tests/spaceMirrorFocusingResearch.test.js
+++ b/tests/spaceMirrorFocusingResearch.test.js
@@ -13,7 +13,7 @@ describe('Space Mirror Focusing advanced research', () => {
     const advanced = ctx.researchParameters.advanced;
     const research = advanced.find(r => r.id === 'space_mirror_focusing');
     expect(research).toBeDefined();
-    expect(research.cost.advancedResearch).toBe(20000);
+    expect(research.cost.advancedResearch).toBe(80000);
     const flagEffect = research.effects.find(
       e =>
         e.target === 'project' &&

--- a/tests/spaceMirrorFocusingSlider.test.js
+++ b/tests/spaceMirrorFocusingSlider.test.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+const originalProject = global.Project;
+const originalProjectElements = global.projectElements;
+const originalBuildings = global.buildings;
+const originalTerraforming = global.terraforming;
+const originalFormatNumber = global.formatNumber;
+
+global.Project = class {};
+global.projectElements = {};
+global.buildings = {};
+global.terraforming = { calculateZoneSolarFlux: () => 0 };
+global.formatNumber = () => '';
+
+const { initializeMirrorOversightUI, updateMirrorOversightUI } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+
+afterAll(() => {
+  global.Project = originalProject;
+  global.projectElements = originalProjectElements;
+  global.buildings = originalBuildings;
+  global.terraforming = originalTerraforming;
+  global.formatNumber = originalFormatNumber;
+});
+
+test('focus slider visibility toggles with flag', () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>');
+  const originalDoc = global.document;
+  const originalProjectManager = global.projectManager;
+
+  global.document = dom.window.document;
+
+  const flags = new Set(['spaceMirrorFacilityOversight']);
+  global.projectManager = {
+    isBooleanFlagSet: id => flags.has(id),
+    projects: { spaceMirrorFacility: { isBooleanFlagSet: id => flags.has(id) } }
+  };
+
+  const container = document.getElementById('container');
+  initializeMirrorOversightUI(container);
+
+  updateMirrorOversightUI();
+  const group = document.getElementById('mirror-oversight-focus-group');
+  expect(group.style.display).toBe('none');
+
+  flags.add('spaceMirrorFocusing');
+  updateMirrorOversightUI();
+  expect(group.style.display).toBe('block');
+
+  global.document = originalDoc;
+  global.projectManager = originalProjectManager;
+});


### PR DESCRIPTION
## Summary
- add hidden Focusing slider to space mirror oversight controls and reveal it when the `spaceMirrorFocusing` flag is active
- ensure distribution math and zone flux calculations account for the new focusing allocation
- document feature and expand tests for focusing slider and research

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68913dd1869083278729ea589eaabc2f