### PR TITLE
Add focused mirror melting effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,3 +338,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Ore and geothermal satellite UI now split Amount and Deposits into separate columns with aligned controls and fonts matching space mining projects.
 - Added Space Mirror Focusing advanced research applying a boolean flag to the space mirror facility.
 - Space mirror oversight controls include a Focusing slider revealed when the Space Mirror Focusing flag is set.
+- Focused mirror energy melts only surface ice into liquid water, prioritizing the warmest zone with ice and showing rates in resource tooltips.
+- Space mirror facility now computes focused melting and zonal flux internally, keeping terraforming.js leaner.

--- a/tests/calculateZoneSolarFlux.test.js
+++ b/tests/calculateZoneSolarFlux.test.js
@@ -1,6 +1,10 @@
 const { getZoneRatio, getZonePercentage } = require('../src/js/zones.js');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 const lifeParameters = require('../src/js/life-parameters.js');
+global.Project = class {};
+global.projectElements = {};
+const { mirrorOversightSettings } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+global.mirrorOversightSettings = mirrorOversightSettings;
 
 // globals expected by terraforming.js
 global.getZoneRatio = getZoneRatio;
@@ -27,7 +31,11 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0, focus: 0 }, applyToLantern: false };
+    mirrorOversightSettings.distribution.tropical = 0.5;
+    mirrorOversightSettings.distribution.temperate = 0;
+    mirrorOversightSettings.distribution.polar = 0;
+    mirrorOversightSettings.distribution.focus = 0;
+    mirrorOversightSettings.applyToLantern = false;
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -51,7 +59,11 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0, focus: 0 }, applyToLantern: false };
+    mirrorOversightSettings.distribution.tropical = 0.5;
+    mirrorOversightSettings.distribution.temperate = 0;
+    mirrorOversightSettings.distribution.polar = 0;
+    mirrorOversightSettings.distribution.focus = 0;
+    mirrorOversightSettings.applyToLantern = false;
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -76,7 +88,11 @@ describe('calculateZoneSolarFlux', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: (id) => id === 'spaceMirrorFacilityOversight'
     };
-    global.mirrorOversightSettings = { distribution: { tropical: 0.5, temperate: 0, polar: 0, focus: 0 }, applyToLantern: true };
+    mirrorOversightSettings.distribution.tropical = 0.5;
+    mirrorOversightSettings.distribution.temperate = 0;
+    mirrorOversightSettings.distribution.polar = 0;
+    mirrorOversightSettings.distribution.focus = 0;
+    mirrorOversightSettings.applyToLantern = true;
 
     Terraforming.prototype.calculateLanternFlux = function(){
       const lantern = buildings.hyperionLantern;

--- a/tests/spaceMirrorFocusingEffect.test.js
+++ b/tests/spaceMirrorFocusingEffect.test.js
@@ -1,0 +1,141 @@
+const { getPlanetParameters } = require('../src/js/planet-parameters.js');
+const { getZoneRatio, getZonePercentage } = require('../src/js/zones.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const lifeParameters = require('../src/js/life-parameters.js');
+const physics = require('../src/js/physics.js');
+const dryIce = require('../src/js/dry-ice-cycle.js');
+global.Project = class {};
+global.projectElements = {};
+const { mirrorOversightSettings } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+mirrorOversightSettings.distribution.focus = 1;
+mirrorOversightSettings.applyToLantern = false;
+
+// set up required globals for terraforming.js
+const flags = new Set(['spaceMirrorFocusing', 'spaceMirrorFacilityOversight']);
+global.getZoneRatio = getZoneRatio;
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+global.projectManager = {
+  isBooleanFlagSet: id => flags.has(id),
+  projects: { spaceMirrorFacility: { isBooleanFlagSet: id => flags.has(id) } }
+};
+global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+global.calculateEmissivity = physics.calculateEmissivity;
+global.dayNightTemperaturesModel = physics.dayNightTemperaturesModel;
+global.effectiveTemp = physics.effectiveTemp;
+global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
+global.airDensity = physics.airDensity;
+
+global.sublimationRateCO2 = dryIce.sublimationRateCO2;
+global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+global.R_AIR = 287;
+
+const Terraforming = require('../src/js/terraforming.js');
+
+global.buildings = { spaceMirror: { surfaceArea: 0, active: 1 } };
+
+function createResources() {
+  return {
+    atmospheric: {
+      atmosphericWater: { value: 0, modifyRate: jest.fn() },
+      carbonDioxide: { value: 0, modifyRate: jest.fn() }
+    },
+    surface: {
+      liquidWater: { value: 0, modifyRate: jest.fn() },
+      ice: { value: 10, modifyRate: jest.fn() },
+      dryIce: { value: 0, modifyRate: jest.fn() }
+    },
+    colony: {},
+    special: { albedoUpgrades: { value: 0 } }
+  };
+}
+
+describe('focused mirror melt', () => {
+  test('focusing converts ice to water using mirror power', () => {
+    const params = getPlanetParameters('mars');
+    global.currentPlanetParameters = params;
+    const res = createResources();
+    global.resources = res;
+    const terra = new Terraforming(res, params.celestialParameters);
+    terra.calculateInitialValues();
+
+    // simplify environment: no water except polar ice and set cold zone temps
+    for (const z of ['tropical','temperate','polar']) {
+      terra.zonalWater[z].liquid = 0;
+      terra.zonalWater[z].ice = 0;
+      terra.zonalWater[z].buriedIce = 0;
+      terra.zonalSurface[z] = { dryIce: 0 };
+      terra.temperature.zones[z].value = 150;
+      terra.temperature.zones[z].day = 150;
+      terra.temperature.zones[z].night = 150;
+    }
+    terra.zonalWater.polar.ice = 10;
+    res.surface.liquidWater.value = 0;
+    res.surface.ice.value = 10;
+
+    // set global average temperature below freezing for energy calc
+    terra.temperature.value = 263;
+
+    // stub power sources
+    terra.calculateMirrorEffect = () => ({ interceptedPower: 1e9, powerPerUnitArea: 0 });
+    terra.calculateLanternFlux = () => 0;
+
+    terra.updateResources(1000);
+
+    const deltaT = 273.15 - terra.temperature.value;
+    const energyPerKg = 2100 * deltaT + 334000;
+    const meltKgPerSec = 1e9 / energyPerKg;
+    const durationSeconds = 86400; // in-game seconds per tick
+    const potentialMelt = meltKgPerSec * durationSeconds / 1000;
+    const expectedMelt = Math.min(potentialMelt, 10);
+    const expectedRate = expectedMelt; // rate per day equals amount melted
+    const waterCall = res.surface.liquidWater.modifyRate.mock.calls.find(c => c[1] === 'Focused Melt');
+    const iceCall = res.surface.ice.modifyRate.mock.calls.find(c => c[1] === 'Focused Melt');
+    expect(waterCall).toBeDefined();
+    expect(iceCall).toBeDefined();
+    expect(waterCall[0]).toBeCloseTo(expectedRate, 5);
+    expect(iceCall[0]).toBeCloseTo(-expectedRate, 5);
+    expect(res.surface.liquidWater.value).toBeCloseTo(expectedMelt, 5);
+    expect(res.surface.ice.value).toBeCloseTo(10 - expectedMelt, 5);
+  });
+
+  test('focusing does nothing without surface ice', () => {
+    const params = getPlanetParameters('mars');
+    global.currentPlanetParameters = params;
+    const res = createResources();
+    global.resources = res;
+    const terra = new Terraforming(res, params.celestialParameters);
+    terra.calculateInitialValues();
+
+    for (const z of ['tropical','temperate','polar']) {
+      terra.zonalWater[z].liquid = 0;
+      terra.zonalWater[z].ice = 0;
+      terra.zonalWater[z].buriedIce = 10;
+      terra.zonalSurface[z] = { dryIce: 0 };
+      terra.temperature.zones[z].value = 150;
+      terra.temperature.zones[z].day = 150;
+      terra.temperature.zones[z].night = 150;
+    }
+    res.surface.liquidWater.value = 0;
+    res.surface.ice.value = 0;
+
+    terra.temperature.value = 263;
+
+    const deltaT = 273.15 - terra.temperature.value;
+    const energyPerKg = 2100 * deltaT + 334000;
+    const desiredMelt = 5; // attempt
+    const durationSeconds = 86400;
+    const interceptPower = desiredMelt * 1000 * energyPerKg / durationSeconds;
+    terra.calculateMirrorEffect = () => ({ interceptedPower: interceptPower, powerPerUnitArea: 0 });
+    terra.calculateLanternFlux = () => 0;
+
+    terra.updateResources(1000);
+
+    expect(res.surface.liquidWater.value).toBeCloseTo(0, 5);
+    expect(res.surface.ice.value).toBeCloseTo(0, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- Offload focused mirror melting and zonal flux calculations to the Space Mirror Facility, keeping `terraforming.js` slimmer
- Expose helper functions for applying focused melt and computing zonal flux, with `terraforming.js` delegating to them
- Document that the Space Mirror Facility now owns focused melt and flux logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_689140dcbe9483279f148d290786bb4f