### PR TITLE
Align space mirror focus slider with others

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -221,8 +221,11 @@
 .control-group label {
     font-weight: 600;
     color: #495057;
-    flex-basis: 140px;
+    flex: 0 0 140px;
     font-size: 0.9em;
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .control-group select,

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -62,9 +62,7 @@ function initializeMirrorOversightUI(container) {
         <span id="mirror-oversight-polar-value" class="slider-value">0%</span>
       </div>
       <div id="mirror-oversight-focus-group" class="control-group" style="display:none;">
-        <label for="mirror-oversight-focus">Focusing:
-          <span class="info-tooltip-icon" title="Concentrate mirror and lantern energy on a single point to melt surface ice into liquid water. Only surface ice melts and the warmest zone with ice is targeted first. Uses the heat required to warm the ice to 0°C plus the energy of fusion.">&#9432;</span>
-        </label>
+        <label for="mirror-oversight-focus">Focusing:<span class="info-tooltip-icon" title="Concentrate mirror and lantern energy on a single point to melt surface ice into liquid water. Only surface ice melts and the warmest zone with ice is targeted first. Uses the heat required to warm the ice to 0°C plus the energy of fusion.">&#9432;</span></label>
         <input type="range" id="mirror-oversight-focus" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-focus-value" class="slider-value">0%</span>
       </div>


### PR DESCRIPTION
## Summary
- Align the space mirror focus slider with other oversight sliders
- Ensure consistent label width and icon spacing for control groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689149c6dc808327bec7398824f4b639