### PR TITLE
Fix ice harvester infrared vision effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,3 +341,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Focused mirror energy melts only surface ice into liquid water, prioritizing the warmest zone with ice and showing rates in resource tooltips.
 - Space mirror facility now computes focused melting and zonal flux internally, keeping terraforming.js leaner.
 - Space Disposal project now displays the expected temperature reduction when jettisoning greenhouse gases.
+- Infrared Vision research now immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -452,13 +452,15 @@ class EffectableEntity {
     // Method to apply a boolean flag effect
     applyBooleanFlag(effect) {
       const { flagId, value } = effect;
+      const prevValue = this[flagId];
+
       if (value) {
         this.booleanFlags.add(flagId);
       } else {
         this.booleanFlags.delete(flagId);
       }
 
-      if (typeof this[flagId] === 'boolean') {
+      if (typeof prevValue === 'boolean') {
         this[flagId] = value;
       }
 
@@ -466,8 +468,12 @@ class EffectableEntity {
         this.sortAllResearches();
       }
 
-      if (flagId === 'dayNightActivity') {
-        // The call to applyDayNightSettingEffects is now handled in game-effects.js
+      if (flagId === 'dayNightActivity' && prevValue !== value) {
+        if (typeof applyGameEffects === 'function') {
+          applyGameEffects();
+        } else if (typeof applyDayNightSettingEffects === 'function') {
+          applyDayNightSettingEffects();
+        }
       }
 
       console.log(`Boolean flag "${flagId}" set to ${value} for ${this.name}.`);


### PR DESCRIPTION
## Summary
- ensure day-night toggle effects reapply when Infrared Vision removes ice harvester penalty
- document immediate day-night penalty removal for Infrared Vision

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6893553890d48327afad12182d520725