### PR TITLE
Track android assignments without reducing storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,3 +342,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space mirror facility now computes focused melting and zonal flux internally, keeping terraforming.js leaner.
 - Space Disposal project now displays the expected temperature reduction when jettisoning greenhouse gases.
 - Infrared Vision research now immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.
+- Android project assignments now keep androids in storage and tooltips show worker and project usage.

--- a/src/js/population.js
+++ b/src/js/population.js
@@ -129,7 +129,9 @@ class PopulationModule extends EffectableEntity {
   updateWorkerCap() {
     // Set the worker cap based on the current population and worker ratio
     const ratio = this.getEffectiveWorkerRatio();
-    const workerCap = Math.floor(ratio * this.populationResource.value) + resources.colony.androids.value;
+    const assignedAndroids = (typeof projectManager !== 'undefined' && typeof projectManager.getAssignedAndroids === 'function') ? projectManager.getAssignedAndroids() : 0;
+    const availableAndroids = Math.max(0, resources.colony.androids.value - assignedAndroids);
+    const workerCap = Math.floor(ratio * this.populationResource.value) + availableAndroids;
     this.workerResource.cap = workerCap;
 
     // Adjust the worker value if it exceeds the cap

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -554,6 +554,29 @@ class ProjectManager extends EffectableEntity {
     }
   }
 
+  getAssignedAndroids(exclude) {
+    let total = 0;
+    for (const name in this.projects) {
+      const project = this.projects[name];
+      if (project === exclude) continue;
+      if (typeof project.assignedAndroids === 'number') {
+        total += project.assignedAndroids;
+      }
+    }
+    return total;
+  }
+
+  getAndroidAssignments() {
+    const assignments = [];
+    for (const name in this.projects) {
+      const project = this.projects[name];
+      if (project && project.assignedAndroids > 0) {
+        assignments.push([project.displayName || name, project.assignedAndroids]);
+      }
+    }
+    return assignments;
+  }
+
   applyProjectDurationReduction(effect) {
     this.durationMultiplier = 1 - effect.value;
 

--- a/tests/androidTooltipAssignments.test.js
+++ b/tests/androidTooltipAssignments.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('android resource tooltip', () => {
+  test('shows worker and project assignments', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.resources = { colony: { androids: {
+      name: 'androids', displayName: 'Androids', category: 'colony', value: 5, cap: 10, hasCap: true,
+      reserved: 0, unlocked: true, productionRate: 0, consumptionRate: 0,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: null
+    } } };
+    ctx.projectManager = { getAndroidAssignments: () => [['Deeper Mining', 2]] };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.createResourceDisplay(ctx.resources);
+    ctx.updateResourceRateDisplay(ctx.resources.colony.androids);
+    const html = dom.window.document.getElementById('androids-tooltip').innerHTML;
+    expect(html).toContain('Workers');
+    expect(html).toContain('Deeper Mining');
+  });
+});

--- a/tests/assignAndroidsMethod.test.js
+++ b/tests/assignAndroidsMethod.test.js
@@ -8,6 +8,7 @@ describe('AndroidProject.assignAndroids', () => {
     const ctx = { console, EffectableEntity };
     ctx.resources = { colony: { androids: { value: 5 } } };
     ctx.buildings = { oreMine: { count: 1 } };
+    ctx.projectManager = { projects: {}, getAssignedAndroids(exclude){ let t=0; for(const n in this.projects){const p=this.projects[n]; if(p!==exclude) t+=p.assignedAndroids||0;} return t;} };
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
@@ -16,6 +17,7 @@ describe('AndroidProject.assignAndroids', () => {
 
     global.resources = ctx.resources;
     global.buildings = ctx.buildings;
+    global.projectManager = ctx.projectManager;
 
     const config = {
       name: 'Test',
@@ -29,10 +31,11 @@ describe('AndroidProject.assignAndroids', () => {
       attributes: {}
     };
     const project = new ctx.AndroidProject(config, 'test');
+    ctx.projectManager.projects.test = project;
 
     project.assignAndroids(3);
     expect(project.assignedAndroids).toBe(3);
-    expect(ctx.resources.colony.androids.value).toBe(2);
+    expect(ctx.resources.colony.androids.value).toBe(5);
 
     project.assignAndroids(-10);
     expect(project.assignedAndroids).toBe(0);
@@ -43,6 +46,7 @@ describe('AndroidProject.assignAndroids', () => {
     const ctx = { console, EffectableEntity };
     ctx.resources = { colony: { androids: { value: 1_000_000_000 } } };
     ctx.buildings = { oreMine: { count: 1000 } };
+    ctx.projectManager = { projects: {}, getAssignedAndroids(exclude){ let t=0; for(const n in this.projects){const p=this.projects[n]; if(p!==exclude) t+=p.assignedAndroids||0;} return t;} };
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
@@ -51,6 +55,7 @@ describe('AndroidProject.assignAndroids', () => {
 
     global.resources = ctx.resources;
     global.buildings = ctx.buildings;
+    global.projectManager = ctx.projectManager;
 
     const config = {
       name: 'Test',
@@ -64,6 +69,7 @@ describe('AndroidProject.assignAndroids', () => {
       attributes: {}
     };
     const project = new ctx.AndroidProject(config, 'test');
+    ctx.projectManager.projects.test = project;
     project.booleanFlags.add('androidAssist');
     project.assignAndroids(1_000_000_000);
     const mult = project.getAndroidSpeedMultiplier();

--- a/tests/workerTooltip.test.js
+++ b/tests/workerTooltip.test.js
@@ -47,6 +47,33 @@ describe('worker resource tooltip', () => {
     expect(html).toContain('5 from androids');
   });
 
+  test('android assignments show worker and project breakdown', () => {
+    const { dom, ctx } = setup();
+    ctx.projectManager = {
+      getAndroidAssignments: () => [['Deeper Mining', 2]],
+    };
+    const workers = {
+      name: 'workers',
+      displayName: 'Workers',
+      category: 'colony',
+      value: 10,
+      cap: 60,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      unit: null
+    };
+    ctx.createResourceDisplay({ colony: { workers } });
+    ctx.updateResourceRateDisplay(workers);
+    const html = dom.window.document.getElementById('workers-tooltip').innerHTML;
+    expect(html).toContain('3 workers');
+    expect(html).toContain('2 Deeper Mining');
+  });
+
   test('breakdown sorted by assigned workers', () => {
     const { dom, ctx } = setup();
     const workers = {


### PR DESCRIPTION
## Summary
- Track androids assigned to each project without decreasing colony android count
- Subtract project-assigned androids from worker cap and show breakdown in worker and android tooltips
- Cover android assignment logic and tooltips with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893636b20b883278ca7940c4e0b5602