### PR TITLE
Handle androids over storage cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,3 +343,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Disposal project now displays the expected temperature reduction when jettisoning greenhouse gases.
 - Infrared Vision research now immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.
 - Android project assignments now keep androids in storage and tooltips show worker and project usage.
+- Androids above their storage cap no longer contribute workers, and excess project assignments are reduced.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -577,6 +577,25 @@ class ProjectManager extends EffectableEntity {
     return assignments;
   }
 
+  forceUnassignAndroids(count) {
+    let remaining = count;
+    for (const name in this.projects) {
+      if (remaining <= 0) break;
+      const project = this.projects[name];
+      if (project.assignedAndroids > 0) {
+        const toRemove = Math.min(project.assignedAndroids, remaining);
+        project.assignedAndroids -= toRemove;
+        remaining -= toRemove;
+        if (typeof project.adjustActiveDuration === 'function') {
+          project.adjustActiveDuration();
+        }
+        if (typeof updateProjectUI === 'function') {
+          updateProjectUI(project.name);
+        }
+      }
+    }
+  }
+
   applyProjectDurationReduction(effect) {
     this.durationMultiplier = 1 - effect.value;
 

--- a/tests/androidOverCapUnassign.test.js
+++ b/tests/androidOverCapUnassign.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('androids over cap', () => {
+  test('excess androids do not work and are unassigned from projects', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const populationCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'population.js'), 'utf8');
+    vm.runInContext(populationCode + '; this.PopulationModule = PopulationModule;', ctx);
+
+    ctx.resources = {
+      colony: {
+        colonists: { value: 0 },
+        workers: { value: 0, cap: 0 },
+        androids: { value: 10, cap: 5 }
+      }
+    };
+    ctx.updateProjectUI = () => {};
+    ctx.projectManager = new ctx.ProjectManager();
+    const config = { name: 'Test', category: 'general', cost: {}, duration: 100, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: {} };
+    const configStr = JSON.stringify(config);
+
+    vm.runInContext(`
+      const proj = new AndroidProject(${configStr}, 'test');
+      proj.assignedAndroids = 5;
+      projectManager.projects.test = proj;
+      const pop = new PopulationModule(resources, { workerRatio: 0 });
+      pop.updateWorkerCap();
+      this.cap = resources.colony.workers.cap;
+      this.assigned = proj.assignedAndroids;
+    `, ctx);
+
+    expect(ctx.cap).toBe(5);
+    expect(ctx.assigned).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid counting androids over their storage cap as workers
- drop extra project android assignments when no workers are available
- document android storage cap behavior in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68936698c83083279ea570b8ee1ba930