### PR TITLE
Fix android tooltips to reflect effective counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,3 +344,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Infrared Vision research now immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.
 - Android project assignments now keep androids in storage and tooltips show worker and project usage.
 - Androids above their storage cap no longer contribute workers, and excess project assignments are reduced.
+- Worker and android resource tooltips now reflect effective android counts when storage is over capacity.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -228,20 +228,22 @@ function updateWorkerAssignments(assignmentsDiv) {
       assignmentsDiv.appendChild(androidDiv);
       assignmentsDiv._androidDiv = androidDiv;
     }
-    const total = resources.colony?.androids?.value || 0;
+    const stored = resources.colony?.androids?.value || 0;
+    const cap = resources.colony?.androids?.cap;
+    const effective = cap !== undefined ? Math.min(stored, cap) : stored;
     if (typeof projectManager !== 'undefined' && typeof projectManager.getAndroidAssignments === 'function') {
       const androidAssignments = projectManager.getAndroidAssignments();
       const assigned = androidAssignments.reduce((sum, [, count]) => sum + count, 0);
-      const workers = total - assigned;
+      const workers = Math.max(effective - assigned, 0);
       const parts = [];
       if (workers > 0) parts.push(`${formatNumber(workers, true)} workers`);
       androidAssignments.forEach(([name, count]) => {
         parts.push(`${formatNumber(count, true)} ${name}`);
       });
-      const androidText = `${formatNumber(total, true)} from androids${parts.length ? ` (${parts.join(', ')})` : ''}`;
+      const androidText = `${formatNumber(effective, true)} from androids${parts.length ? ` (${parts.join(', ')})` : ''}`;
       if (androidDiv.textContent !== androidText) androidDiv.textContent = androidText;
     } else {
-      const androidText = `${formatNumber(total, true)} from androids`;
+      const androidText = `${formatNumber(effective, true)} from androids`;
       if (androidDiv.textContent !== androidText) androidDiv.textContent = androidText;
     }
   }
@@ -303,10 +305,12 @@ function updateLandAssignments(assignmentsDiv) {
 
 function updateAndroidAssignments(assignmentsDiv) {
   if (!assignmentsDiv || typeof resources === 'undefined') return;
-  const total = resources.colony?.androids?.value || 0;
+  const stored = resources.colony?.androids?.value || 0;
+  const cap = resources.colony?.androids?.cap;
+  const effective = cap !== undefined ? Math.min(stored, cap) : stored;
   const androidAssignments = (typeof projectManager !== 'undefined' && typeof projectManager.getAndroidAssignments === 'function') ? projectManager.getAndroidAssignments() : [];
   const assigned = androidAssignments.reduce((sum, [, count]) => sum + count, 0);
-  const workers = total - assigned;
+  const workers = Math.max(effective - assigned, 0);
   const entries = [];
   if (workers > 0) entries.push(['Workers', workers]);
   androidAssignments.forEach(([name, count]) => entries.push([name, count]));

--- a/tests/androidTooltipAssignments.test.js
+++ b/tests/androidTooltipAssignments.test.js
@@ -12,7 +12,7 @@ describe('android resource tooltip', () => {
     ctx.formatNumber = numbers.formatNumber;
     ctx.formatDuration = numbers.formatDuration;
     ctx.resources = { colony: { androids: {
-      name: 'androids', displayName: 'Androids', category: 'colony', value: 5, cap: 10, hasCap: true,
+      name: 'androids', displayName: 'Androids', category: 'colony', value: 10, cap: 5, hasCap: true,
       reserved: 0, unlocked: true, productionRate: 0, consumptionRate: 0,
       productionRateBySource: {}, consumptionRateBySource: {}, unit: null
     } } };
@@ -21,8 +21,10 @@ describe('android resource tooltip', () => {
     vm.runInContext(code, ctx);
     ctx.createResourceDisplay(ctx.resources);
     ctx.updateResourceRateDisplay(ctx.resources.colony.androids);
-    const html = dom.window.document.getElementById('androids-tooltip').innerHTML;
-    expect(html).toContain('Workers');
-    expect(html).toContain('Deeper Mining');
+    const text = dom.window.document.getElementById('androids-tooltip-assignments').textContent;
+    expect(text).toContain('Workers');
+    expect(text).toContain('3');
+    expect(text).toContain('Deeper Mining');
+    expect(text).toContain('2');
   });
 });

--- a/tests/workerTooltip.test.js
+++ b/tests/workerTooltip.test.js
@@ -74,6 +74,35 @@ describe('worker resource tooltip', () => {
     expect(html).toContain('2 Deeper Mining');
   });
 
+  test('androids over cap show effective counts', () => {
+    const { dom, ctx } = setup();
+    ctx.projectManager = {
+      getAndroidAssignments: () => [['Deeper Mining', 4]],
+    };
+    ctx.resources.colony.androids = { value: 10, cap: 5 };
+    const workers = {
+      name: 'workers',
+      displayName: 'Workers',
+      category: 'colony',
+      value: 10,
+      cap: 60,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      unit: null,
+    };
+    ctx.createResourceDisplay({ colony: { workers } });
+    ctx.updateResourceRateDisplay(workers);
+    const html = dom.window.document.getElementById('workers-tooltip').innerHTML;
+    expect(html).toContain('5 from androids');
+    expect(html).toContain('1 workers');
+    expect(html).toContain('4 Deeper Mining');
+  });
+
   test('breakdown sorted by assigned workers', () => {
     const { dom, ctx } = setup();
     const workers = {


### PR DESCRIPTION
## Summary
- ensure worker tooltip uses android counts capped by storage
- show capped android assignments in android resource tooltip
- test android tooltips with over-cap counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68936ade452083278e4363a0cb10fe26