### PR TITLE
Format WGC artifact stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,3 +345,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Android project assignments now keep androids in storage and tooltips show worker and project usage.
 - Androids above their storage cap no longer contribute workers, and excess project assignments are reduced.
 - Worker and android resource tooltips now reflect effective android counts when storage is over capacity.
+- WGC artifact statistics now display totals using formatNumber with two decimal places.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -525,7 +525,7 @@ function updateWGCUI() {
   }
   const artEl = document.getElementById('wgc-stat-artifact');
   if (artEl) {
-    artEl.textContent = `Artifacts Collected: ${warpGateCommand.totalArtifacts}`;
+    artEl.textContent = `Artifacts Collected: ${formatNumber(warpGateCommand.totalArtifacts, false, 2)}`;
   }
   const diffEl = document.getElementById('wgc-stat-difficulty');
   if (diffEl) {

--- a/tests/wgcArtifactDisplayFormat.test.js
+++ b/tests/wgcArtifactDisplayFormat.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('WGC artifact display', () => {
+  test('uses formatNumber with two decimals', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-stat-artifact"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+    const numbersCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'numbers.js'), 'utf8');
+    vm.runInContext(numbersCode, ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+    ctx.warpGateCommand = { totalArtifacts: 1.2345, totalOperations: 0, highestDifficulty: 0, facilityCooldown: 0 };
+    ctx.updateWGCUI();
+    const artEl = dom.window.document.getElementById('wgc-stat-artifact');
+    expect(artEl.textContent).toBe('Artifacts Collected: 1.23');
+  });
+});


### PR DESCRIPTION
## Summary
- format Warp Gate Command artifact statistics using `formatNumber` with two decimal places
- cover WGC artifact display with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6893d0f2fd5883278b4b116fad734b3b