### PR TITLE
Fix WGC team member leveling

### DIFF
--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -374,6 +374,14 @@ class WarpGateCommand extends EffectableEntity {
         let gain = xpGain;
         if (m.xp < currentMax) gain *= 1.5;
         m.xp = Math.min(m.xp + gain, newMax);
+        let req = m.getXPForNextLevel();
+        while (m.xp >= req && req > 0) {
+          m.xp -= req;
+          m.level += 1;
+          m.maxHealth = 100 + m.level - 1;
+          m.health = Math.min(m.health, m.maxHealth);
+          req = m.getXPForNextLevel();
+        }
       });
     }
     const summary = `Operation ${op.number} Complete: ${successes} success(es), ${art} artifact(s)`;

--- a/tests/wgcLevelUp.test.js
+++ b/tests/wgcLevelUp.test.js
@@ -1,0 +1,21 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC leveling', () => {
+  test('team members level up when gaining enough XP', () => {
+    const wgc = new WarpGateCommand();
+    const member = WGCTeamMember.create('Bob', '', 'Soldier', {});
+    wgc.recruitMember(0, 0, member);
+    const op = wgc.operations[0];
+    op.successes = 15;
+    op.artifacts = 0;
+    op.difficulty = 0;
+    op.number = 1;
+    wgc.finishOperation(0);
+    expect(member.level).toBe(2);
+    expect(member.xp).toBe(5);
+    expect(member.getXPForNextLevel()).toBe(20);
+  });
+});

--- a/tests/wgcXPCatchup.test.js
+++ b/tests/wgcXPCatchup.test.js
@@ -25,6 +25,9 @@ describe('WGC XP catch-up bonus', () => {
 
     wgc.finishOperation(0);
 
-    wgc.teams[0].forEach(m => expect(m.xp).toBe(80));
+    wgc.teams[0].forEach(m => {
+      expect(m.level).toBe(4);
+      expect(m.xp).toBe(20);
+    });
   });
 });

--- a/tests/wgcXPScaling.test.js
+++ b/tests/wgcXPScaling.test.js
@@ -19,7 +19,10 @@ describe('WGC XP scaling', () => {
     jest.spyOn(Math, 'random').mockReturnValue(0);
     expect(wgc.startOperation(0, 3)).toBe(true);
     wgc.update(600000);
-    wgc.teams[0].forEach(m => expect(m.xp).toBeCloseTo(9 * 1.3));
+    wgc.teams[0].forEach(m => {
+      const total = m.xp + 10 * (m.level - 1) * m.level / 2;
+      expect(total).toBeCloseTo(9 * 1.3);
+    });
     Math.random.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- ensure Warp Gate Command team members level up and update XP correctly after operations
- cover level-up logic with new tests and adjust XP tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893d1277978832786842b07957ba5fa