### PR TITLE
Log recalled WGC operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,3 +345,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Android project assignments now keep androids in storage and tooltips show worker and project usage.
 - Androids above their storage cap no longer contribute workers, and excess project assignments are reduced.
 - Worker and android resource tooltips now reflect effective android counts when storage is over capacity.
+- Operation logs now add a "Recalled" entry when a team is recalled.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -422,6 +422,7 @@ class WarpGateCommand extends EffectableEntity {
   recallTeam(teamIndex) {
     const op = this.operations[teamIndex];
     if (op) {
+      this.addLog(teamIndex, `Team ${teamIndex + 1} - Recalled`);
       op.active = false;
       op.progress = 0;
       op.timer = 0;

--- a/tests/wgcRecallLog.test.js
+++ b/tests/wgcRecallLog.test.js
@@ -1,0 +1,17 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC recall logs Recalled', () => {
+  test('recalling operation adds log entry', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+    wgc.startOperation(0);
+    wgc.recallTeam(0);
+    const logs = wgc.logs[0];
+    expect(logs[logs.length - 1]).toBe('Team 1 - Recalled');
+  });
+});


### PR DESCRIPTION
## Summary
- log when a WGC team is recalled
- test that recalling an operation adds a Recalled entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893d197a7b883279f3ed066c08b2e49