### PR TITLE
Allow WGC team names to be edited and saved

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,3 +345,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Android project assignments now keep androids in storage and tooltips show worker and project usage.
 - Androids above their storage cap no longer contribute workers, and excess project assignments are reduced.
 - Worker and android resource tooltips now reflect effective android counts when storage is over capacity.
+- WGC teams can now be renamed and team names persist through saves.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -17,6 +17,8 @@ const baseOperationEvents = [
 
 const operationStartText = 'Setting out through Warp Gate';
 
+const defaultTeamNames = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'];
+
 class WarpGateCommand extends EffectableEntity {
   constructor() {
     super({ description: 'Warp Gate Command manager' });
@@ -47,6 +49,7 @@ class WarpGateCommand extends EffectableEntity {
       library: 0,
     };
     this.facilityCooldown = 0;
+    this.teamNames = defaultTeamNames.slice();
   }
 
   addLog(teamIndex, text) {
@@ -488,7 +491,8 @@ class WarpGateCommand extends EffectableEntity {
       combatDifficulty: this.combatDifficulty,
       stances: this.stances.map(s => ({ hazardousBiomass: s.hazardousBiomass, artifact: s.artifact })),
       facilities: { ...this.facilities },
-      facilityCooldown: this.facilityCooldown
+      facilityCooldown: this.facilityCooldown,
+      teamNames: this.teamNames.slice()
     };
   }
 
@@ -528,6 +532,11 @@ class WarpGateCommand extends EffectableEntity {
     if (Array.isArray(data.logs)) {
       this.logs = data.logs.map(l => l.slice(-100));
     }
+    if (Array.isArray(data.teamNames)) {
+      this.teamNames = data.teamNames.map((n, i) => (typeof n === 'string' && n.trim() ? n.trim() : defaultTeamNames[i]));
+    } else {
+      this.teamNames = defaultTeamNames.slice();
+    }
     if (Array.isArray(data.stances)) {
       this.stances = data.stances.map(s => ({
         hazardousBiomass: s.hazardousBiomass || 'Neutral',
@@ -549,6 +558,14 @@ class WarpGateCommand extends EffectableEntity {
     this.highestDifficulty = typeof data.highestDifficulty === 'number' ? data.highestDifficulty : -1;
     this.pendingCombat = data.pendingCombat || false;
     this.combatDifficulty = data.combatDifficulty || 1;
+  }
+
+  renameTeam(index, name) {
+    if (typeof index !== 'number' || typeof name !== 'string') return;
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    if (!Array.isArray(this.teamNames)) this.teamNames = defaultTeamNames.slice();
+    this.teamNames[index] = trimmed;
   }
 }
 

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -33,7 +33,7 @@ const facilityDescriptions = {
   library: 'Boosts Wit for challenges by 1% per level.'
 };
 const facilityElements = {};
-const teamNames = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'];
+var teamNames = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'];
 const teamUnlocks = [0, 100, 500, 1000, 5000];
 const classImages = {
   'Team Leader': 'assets/images/team_leader.png',
@@ -69,7 +69,8 @@ function updateWGCVisibility() {
 }
 
 function generateWGCTeamCards() {
-  return teamNames.map((name, tIdx) => {
+  const names = (typeof warpGateCommand !== 'undefined' && warpGateCommand.teamNames) ? warpGateCommand.teamNames : teamNames;
+  return names.map((name, tIdx) => {
     const slots = (typeof warpGateCommand !== 'undefined' && warpGateCommand.teams[tIdx]) ? warpGateCommand.teams[tIdx] : [null, null, null, null];
     const op = (typeof warpGateCommand !== 'undefined' && warpGateCommand.operations[tIdx]) ? warpGateCommand.operations[tIdx] : { active: false, progress: 0, summary: '' };
     const slotMarkup = slots.map((m, sIdx) => {
@@ -94,7 +95,7 @@ function generateWGCTeamCards() {
     const artVal = (typeof warpGateCommand !== 'undefined' && warpGateCommand.stances && warpGateCommand.stances[tIdx]) ? warpGateCommand.stances[tIdx].artifact : 'Neutral';
     return `
       <div class="wgc-team-card" data-team="${tIdx}">
-        <div class="team-header">Team ${name}</div>
+        <div class="team-header">Team <span class="team-name" data-team="${tIdx}">${name}</span> <button class="rename-team" data-team="${tIdx}">Rename</button></div>
         <div class="wgc-team-body">
           <div class="team-slots">${slotMarkup}</div>
           <div class="team-stances">
@@ -474,6 +475,16 @@ function initializeWGCUI() {
           if (log) log.classList.toggle('hidden');
           return;
         }
+        if (e.target.classList.contains('rename-team')) {
+          const t = parseInt(e.target.dataset.team, 10);
+          const current = (warpGateCommand.teamNames && warpGateCommand.teamNames[t]) ? warpGateCommand.teamNames[t] : '';
+          const name = typeof prompt === 'function' ? prompt('Enter team name', current) : null;
+          if (name && name.trim()) {
+            warpGateCommand.renameTeam(t, name);
+            redrawWGCTeamCards();
+          }
+          return;
+        }
 
         const slot = e.target.closest('.team-slot');
         if (!slot) return;
@@ -519,6 +530,7 @@ function initializeWGCUI() {
 }
 
 function updateWGCUI() {
+  const names = (typeof warpGateCommand !== 'undefined' && warpGateCommand.teamNames) ? warpGateCommand.teamNames : teamNames;
   const opEl = document.getElementById('wgc-stat-operation');
   if (opEl) {
     opEl.textContent = `Operations Completed: ${warpGateCommand.totalOperations}`;
@@ -563,7 +575,7 @@ function updateWGCUI() {
     }
   }
 
-  teamNames.forEach((_, tIdx) => {
+  names.forEach((_, tIdx) => {
     const card = document.querySelector(`.wgc-team-card[data-team="${tIdx}"]`);
     if (!card) return;
     const startBtn = card.querySelector('.start-button');
@@ -632,7 +644,7 @@ function updateWGCUI() {
     });
   });
 
-  teamNames.forEach((_, tIdx) => {
+  names.forEach((_, tIdx) => {
     const logEl = document.querySelector(`.wgc-team-card[data-team="${tIdx}"] .team-log pre`);
     if (logEl) {
       logEl.textContent = (warpGateCommand.logs[tIdx] || []).join('\n');

--- a/tests/wgcTeamNamePersistence.test.js
+++ b/tests/wgcTeamNamePersistence.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC team name persistence', () => {
+  test('renamed team name saves and loads', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WGCTeamMember = WGCTeamMember;
+    ctx.WarpGateCommand = WarpGateCommand;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.warpGateCommand.enable();
+    ctx.updateWGCUI();
+
+    ctx.warpGateCommand.renameTeam(0, 'Renamed');
+    ctx.redrawWGCTeamCards();
+    let header = dom.window.document.querySelector('.wgc-team-card[data-team="0"] .team-name');
+    expect(header.textContent).toBe('Renamed');
+
+    const saved = ctx.warpGateCommand.saveState();
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.warpGateCommand.loadState(saved);
+    ctx.redrawWGCTeamCards();
+    header = dom.window.document.querySelector('.wgc-team-card[data-team="0"] .team-name');
+    expect(header.textContent).toBe('Renamed');
+  });
+});


### PR DESCRIPTION
## Summary
- Allow renaming WGC teams with a Rename button on each team card
- Persist custom team names through save/load via WarpGateCommand
- Add tests for team name persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893d272205883278667e9eed2e2bd2a