### PR TITLE
Refresh WGC recruit dialog when team stats change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,3 +347,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Worker and android resource tooltips now reflect effective android counts when storage is over capacity.
 - Operation logs now add a "Recalled" entry when a team is recalled.
 - WGC artifact statistics now display totals using formatNumber with two decimal places.
+- WGC recruit dialog now updates HP and XP in real time when member stats change.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -297,6 +297,7 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   const hp = member ? member.health : 100;
   const hpMax = member ? member.maxHealth : 100;
   const level = document.createElement('div');
+  level.classList.add('wgc-member-level');
   level.textContent = `Level: ${lvl} | XP: ${xp} / ${xpReq} | HP: ${formatNumber(hp)} / ${hpMax}`;
   win.appendChild(level);
 
@@ -409,6 +410,10 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   overlay.addEventListener('click', e => { if (e.target === overlay) closeRecruitDialog(); });
   document.body.appendChild(overlay);
   activeDialog = overlay;
+  activeDialog._member = member;
+  activeDialog._levelEl = level;
+  activeDialog._alloc = alloc;
+  activeDialog._remainingSpan = remainingSpan;
 }
 
 function generateWGCLayout() {
@@ -638,6 +643,21 @@ function updateWGCUI() {
       logEl.textContent = (warpGateCommand.logs[tIdx] || []).join('\n');
     }
   });
+
+  if (activeDialog && activeDialog._member) {
+    const m = activeDialog._member;
+    const lvlEl = activeDialog._levelEl;
+    const remSpan = activeDialog._remainingSpan;
+    const alloc = activeDialog._alloc || { power: 0, athletics: 0, wit: 0 };
+    if (lvlEl) {
+      const xpReq = m.getXPForNextLevel();
+      lvlEl.textContent = `Level: ${m.level} | XP: ${Math.floor(m.xp || 0)} / ${xpReq} | HP: ${formatNumber(m.health)} / ${m.maxHealth}`;
+    }
+    if (remSpan) {
+      const pts = m.getPointsToAllocate() - (alloc.power + alloc.athletics + alloc.wit);
+      remSpan.textContent = `Points left: ${pts}`;
+    }
+  }
 }
 
 function redrawWGCTeamCards() {

--- a/tests/wgcRecruitDialogUpdate.test.js
+++ b/tests/wgcRecruitDialogUpdate.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC recruit dialog updates dynamically', () => {
+  test('HP and XP reflect background changes', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WGCTeamMember = WGCTeamMember;
+    ctx.WarpGateCommand = WarpGateCommand;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.warpGateCommand.enable();
+    ctx.updateWGCUI();
+
+    const member = ctx.WGCTeamMember.create('Alice', '', 'Soldier', {});
+    ctx.warpGateCommand.recruitMember(0, 0, member);
+    ctx.redrawWGCTeamCards();
+    ctx.openRecruitDialog(0, 0, member);
+
+    const levelDiv = dom.window.document.querySelector('.wgc-member-level');
+    expect(levelDiv.textContent).toContain('HP: 100 / 100');
+
+    member.health = 50;
+    member.xp = 5;
+    ctx.updateWGCUI();
+
+    expect(levelDiv.textContent).toContain('HP: 50 / 100');
+    expect(levelDiv.textContent).toContain('XP: 5 / 10');
+  });
+});


### PR DESCRIPTION
## Summary
- Make the Warp Gate Command recruit dialog refresh HP, XP and available points in real time while it is open
- Track dialog state so updateWGCUI can redraw the open member's stats
- Cover dynamic updates with a dedicated recruit dialog test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893d338d07c8327a16ea3f4d827c4de