### PR TITLE
Add tooltip for WGC equipment upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,3 +351,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC artifact statistics now display totals using formatNumber with two decimal places.
 - WGC recruit dialog now updates HP and XP in real time when member stats change.
 - WGC artifact statistics now display totals using formatNumber with two decimal places.
+- Warpgate Teams Equipment purchase now includes a tooltip explaining its artifact chance bonus.

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -18,6 +18,9 @@ const rdItems = {
   androidsEfficiency: 'Androids production efficiency',
   foodProduction: 'Food production efficiency'
 };
+const rdDescriptions = {
+  wgtEquipment: 'Each purchase increases artifact chance by 0.1% up to a +90% bonus (100% total).'
+};
 const rdElements = {};
 const facilityItems = {
   infirmary: 'Infirmary',
@@ -145,7 +148,14 @@ function createRDItem(key, label) {
 
   const nameSpan = document.createElement('span');
   nameSpan.classList.add('wgc-rd-label');
-  nameSpan.textContent = label;
+  nameSpan.textContent = label + ' ';
+  if (rdDescriptions[key]) {
+    const icon = document.createElement('span');
+    icon.classList.add('info-tooltip-icon');
+    icon.innerHTML = '&#9432;';
+    icon.title = rdDescriptions[key];
+    nameSpan.appendChild(icon);
+  }
   div.appendChild(nameSpan);
 
   const multSpan = document.createElement('span');

--- a/tests/wgcEquipmentTooltip.test.js
+++ b/tests/wgcEquipmentTooltip.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC equipment tooltip', () => {
+  test('equipment upgrade has descriptive tooltip', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    ctx.WGCTeamMember = require('../src/js/team-member.js').WGCTeamMember;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    const label = dom.window.document.querySelector('#wgc-wgtEquipment-button').parentElement.querySelector('.wgc-rd-label');
+    const icon = label.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    const title = icon.getAttribute('title');
+    expect(title).toMatch(/artifact chance/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add descriptive tooltip for Warpgate Teams Equipment in WGC R&D menu
- cover equipment tooltip with unit test
- document WGC tooltip in AGENTS changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6893d706e91883279bac492767ec0224