### PR TITLE
Preserve thruster energy by category

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,3 +351,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC artifact statistics now display totals using formatNumber with two decimal places.
 - WGC recruit dialog now updates HP and XP in real time when member stats change.
 - WGC artifact statistics now display totals using formatNumber with two decimal places.
+- Planetary thruster energy tracking now persists by category and resets only when their targets change.


### PR DESCRIPTION
## Summary
- track planetary thruster energy separately for spin and motion
- only reset energy when a category's target changes
- test thruster energy persistence and reset behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6893d83fc5e4832793963613e5877eeb