### PR TITLE
Format WGC skill roll numbers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,3 +354,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Planetary thruster energy tracking now persists by category and resets only when their targets change.
 - Warpgate Teams Equipment purchase now includes a tooltip explaining its artifact chance bonus.
 - Space Disposal project displays a 0K temperature change when no greenhouse gases are jettisoned.
+- Skill rolls in WGC operation logs now use formatNumber with two decimal places.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -5,6 +5,17 @@ if (typeof globalThis.WGCTeamMember === 'undefined' && isNodeWGC) {
   } catch (e) {}
 }
 
+if (typeof globalThis.formatNumber === 'undefined') {
+  try {
+    if (typeof require !== 'undefined') {
+      globalThis.formatNumber = require('./numbers.js').formatNumber;
+    }
+  } catch (e) {}
+  if (typeof globalThis.formatNumber === 'undefined') {
+    globalThis.formatNumber = v => v;
+  }
+}
+
 const baseOperationEvents = [
   { name: 'Team Power Challenge', type: 'team', skill: 'power', weight: 1 },
   { name: 'Team Athletics Challenge', type: 'team', skill: 'athletics', weight: 1 },
@@ -215,12 +226,13 @@ class WarpGateCommand extends EffectableEntity {
     const outcome = success ? (critical ? 'Critical Success' : 'Success') : 'Fail';
     const rollerName = roller ? ` (${roller.firstName})` : '';
     const artText = artifact ? ` +${artifactReward} Artifact${artifactReward === 1 ? '' : 's'}` : '';
-    let skillDetail = skillTotal;
+    let skillDetail = formatNumber(skillTotal, false, 2);
     if (event.type === 'individual' || event.type === 'science') {
-      skillDetail = `${baseSkill}`;
-      if (leaderBonus) skillDetail += ` + leader ${leaderBonus}`;
+      skillDetail = `${formatNumber(baseSkill, false, 2)}`;
+      if (leaderBonus) skillDetail += ` + leader ${formatNumber(leaderBonus, false, 2)}`;
     }
-    const summary = `${event.name}${rollerName}: roll [${rollsStr}] + skill ${skillDetail} (total ${rollResult.sum + skillTotal}) vs DC ${dc} => ${outcome}${artText}`;
+    const total = rollResult.sum + skillTotal;
+    const summary = `${event.name}${rollerName}: roll [${rollsStr}] + skill ${skillDetail} (total ${formatNumber(total, false, 2)}) vs DC ${dc} => ${outcome}${artText}`;
     op.summary = summary;
     this.addLog(teamIndex, `Team ${teamIndex + 1} - Op ${op.number} - ${summary}`);
 

--- a/tests/wgcSkillRollFormat.test.js
+++ b/tests/wgcSkillRollFormat.test.js
@@ -1,0 +1,23 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC skill roll formatting', () => {
+  test('log uses formatNumber with two decimals for skills', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+    wgc.facilities.obstacleCourse = 1; // +1% athletics -> decimal skill
+    wgc.roll = () => ({ sum: 40, rolls: [10, 10, 10, 10] });
+    wgc.chooseEvent = () => ({ name: 'Team Athletics Challenge', type: 'team', skill: 'athletics' });
+    jest.spyOn(Math, 'random').mockReturnValue(1); // prevent artifact
+    wgc.startOperation(0);
+    wgc.update(60000);
+    const entry = wgc.logs[0][1];
+    expect(entry).toContain('skill 4.04');
+    expect(entry).toContain('total 44.04');
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure WGC operation logs format skill values and totals with `formatNumber` for consistent two-decimal display
- cover log formatting with a regression test
- document the change in the project changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893dd2fdc9883278edd9cde10ecae93