### PR TITLE
Display radiation penalties in terraforming UI and life systems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Jumping to a chapter now reconstructs the journal after rewards and objectives are applied.
 - Terraforming Others box now displays surface radiation using new radiation utilities and stores the value for later use.
 - Terraforming Others box now shows orbital radiation assuming no atmospheric shielding.
+- Terraforming Others box now displays radiation growth penalty and lifeforms mitigate it with radiation resistance.
 - Moon parent bodies now include radius values for accurate distance-based radiation calculations.
 - Thruster Power subcard now shows exhaust velocity with a tooltip explaining specific impulse and aligns it in a column with the continuous power display.
 - Thruster Power subcard now keeps exhaust velocity beside continuous power and adds a Thrust/Power ratio column.

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -636,7 +636,9 @@ function updateLifeStatusTable() {
                 ? (terraforming.calculateSolarPanelMultiplier ? terraforming.calculateSolarPanelMultiplier() : 1)
                 : (terraforming.calculateZonalSolarPanelMultiplier ? terraforming.calculateZonalSolarPanelMultiplier(zone) : 1);
             const tempMult = growthTempResults[zone]?.multiplier || 0;
-            const radMult = terraforming.getMagnetosphereStatus() ? 1 : (0.5 + 0.5 * designToCheck.getRadiationMitigationRatio());
+              const radMitigation = designToCheck.getRadiationMitigationRatio();
+              const radPenalty = terraforming.getMagnetosphereStatus() ? 0 : (terraforming.radiationPenalty || 0) * (1 - radMitigation);
+              const radMult = 1 - radPenalty;
             const waterMult = (terraforming.zonalWater[zone]?.liquid || 0) > 1e-9 ? 1 : 0;
             const otherMult = (typeof lifeManager !== 'undefined' && lifeManager.getEffectiveLifeGrowthMultiplier) ? lifeManager.getEffectiveLifeGrowthMultiplier() : 1;
             const finalRate = baseRate * lumMult * tempMult * capacityMult * radMult * waterMult * otherMult;

--- a/src/js/radiation-utils.js
+++ b/src/js/radiation-utils.js
@@ -59,7 +59,7 @@ function estimateSurfaceDoseByColumn(column_gcm2,
 
 // Support CommonJS environments (tests) while remaining browser friendly
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { estimateSurfaceDoseByColumn };
+  module.exports = { estimateSurfaceDoseByColumn, radiationPenalty };
 }
 
 /**

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -36,8 +36,9 @@ if (typeof module !== 'undefined' && module.exports) {
     var calculateMeltingFreezingRates = terraformUtils.calculateMeltingFreezingRates;
     var redistributePrecipitation = require('./phase-change-utils.js').redistributePrecipitation;
 
-    const radiation = require('./radiation-utils.js');
-    var estimateSurfaceDoseByColumn = radiation.estimateSurfaceDoseByColumn;
+      const radiation = require('./radiation-utils.js');
+      var estimateSurfaceDoseByColumn = radiation.estimateSurfaceDoseByColumn;
+      var radiationPenalty = radiation.radiationPenalty;
 
     const physics = require('./physics.js');
     if (typeof globalThis.surfaceAlbedoMix === 'undefined') {
@@ -241,8 +242,9 @@ class Terraforming extends EffectableEntity{
     };
 
     // Current estimated surface and orbital radiation in mSv/day
-    this.surfaceRadiation = 0;
-    this.orbitalRadiation = 0;
+      this.surfaceRadiation = 0;
+      this.orbitalRadiation = 0;
+      this.radiationPenalty = 0;
 
 
 
@@ -1003,14 +1005,15 @@ class Terraforming extends EffectableEntity{
       const beltDose = parent.parentBeltAtRef_mSvPerDay || 0;
       const refDistance = parent.refDistance_Rp || 1;
 
-      const dose = estimateSurfaceDoseByColumn(
-        column_gcm2,
-        distance_Rp,
-        beltDose,
-        refDistance,
-        opts
-      );
-      this.surfaceRadiation = dose.total;
+        const dose = estimateSurfaceDoseByColumn(
+          column_gcm2,
+          distance_Rp,
+          beltDose,
+          refDistance,
+          opts
+        );
+        this.surfaceRadiation = dose.total;
+        this.radiationPenalty = radiationPenalty(this.surfaceRadiation);
 
       const orbitalDose = estimateSurfaceDoseByColumn(
         0,

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -607,15 +607,17 @@ function updateLifeBox() {
       ? 'The planet is sufficiently protected, providing a 50% boost to life growth'
       : 'No magnetosphere';
 
-    const orbRad = typeof terraforming.orbitalRadiation === 'number' ? terraforming.orbitalRadiation : 0;
-    const rad = typeof terraforming.surfaceRadiation === 'number' ? terraforming.surfaceRadiation : 0;
+      const orbRad = typeof terraforming.orbitalRadiation === 'number' ? terraforming.orbitalRadiation : 0;
+      const rad = typeof terraforming.surfaceRadiation === 'number' ? terraforming.surfaceRadiation : 0;
+      const radPenalty = typeof terraforming.radiationPenalty === 'number' ? terraforming.radiationPenalty : 0;
 
     magnetosphereBox.innerHTML = `
       <h3>${terraforming.magnetosphere.name}</h3>
       <p>Magnetosphere: <span id="magnetosphere-status">${magnetosphereStatusText}</span></p>
-      <p>Orbital radiation: <span id="orbital-radiation">${formatNumber(orbRad, false, 2)}</span> mSv/day</p>
-      <p>Surface radiation: <span id="surface-radiation">${formatNumber(rad, false, 2)}</span> mSv/day</p>
-    `;
+        <p>Orbital radiation: <span id="orbital-radiation">${formatNumber(orbRad, false, 2)}</span> mSv/day</p>
+        <p>Surface radiation: <span id="surface-radiation">${formatNumber(rad, false, 2)}</span> mSv/day</p>
+        <p>Radiation penalty: <span id="surface-radiation-penalty">${formatNumber(radPenalty * 100, false, 0)}</span>%</p>
+      `;
     const magnetosphereHeading = magnetosphereBox.querySelector('h3');
     if (magnetosphereHeading) {
       magnetosphereHeading.appendChild(magInfo);
@@ -627,9 +629,10 @@ function updateLifeBox() {
   // Function to update the magnetosphere box with the latest values
   function updateMagnetosphereBox() {
     const magnetosphereBox = document.getElementById('magnetosphere-box');
-    const magnetosphereStatus = document.getElementById('magnetosphere-status');
-    const surfaceRadiation = document.getElementById('surface-radiation');
-    const orbitalRadiation = document.getElementById('orbital-radiation');
+      const magnetosphereStatus = document.getElementById('magnetosphere-status');
+      const surfaceRadiation = document.getElementById('surface-radiation');
+      const orbitalRadiation = document.getElementById('orbital-radiation');
+      const surfaceRadiationPenalty = document.getElementById('surface-radiation-penalty');
 
     // Update status based on boolean flag
     const magnetosphereStatusText = terraforming.isBooleanFlagSet('magneticShield') 
@@ -638,12 +641,15 @@ function updateLifeBox() {
 
     magnetosphereStatus.textContent = magnetosphereStatusText;
 
-    if (orbitalRadiation) {
-      orbitalRadiation.textContent = formatNumber(terraforming.orbitalRadiation || 0, false, 2);
-    }
-    if (surfaceRadiation) {
-      surfaceRadiation.textContent = formatNumber(terraforming.surfaceRadiation || 0, false, 2);
-    }
+      if (orbitalRadiation) {
+        orbitalRadiation.textContent = formatNumber(terraforming.orbitalRadiation || 0, false, 2);
+      }
+      if (surfaceRadiation) {
+        surfaceRadiation.textContent = formatNumber(terraforming.surfaceRadiation || 0, false, 2);
+      }
+      if (surfaceRadiationPenalty) {
+        surfaceRadiationPenalty.textContent = formatNumber((terraforming.radiationPenalty || 0) * 100, false, 0);
+      }
 
     if(terraforming.getMagnetosphereStatus()){
       magnetosphereBox.style.borderColor = 'green';

--- a/tests/lifeRadiationPenaltyDisplay.test.js
+++ b/tests/lifeRadiationPenaltyDisplay.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const physics = require('../src/js/physics.js');
+const numbers = require('../src/js/numbers.js');
+
+describe('life radiation penalty display', () => {
+  test('global radiation cell shows penalty reduced by resistance', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { day: 293.15 }, temperate: { day: 293.15 }, polar: { day: 293.15 } } },
+      zonalSurface: { tropical:{ biomass:0 }, temperate:{ biomass:0 }, polar:{ biomass:0 } },
+      zonalWater: { tropical:{ liquid:0 }, temperate:{ liquid:0 }, polar:{ liquid:0 } },
+      getMagnetosphereStatus: () => false,
+      radiationPenalty: 0.4,
+      calculateSolarPanelMultiplier: () => 1,
+      calculateZonalSolarPanelMultiplier: () => 1,
+      celestialParameters: { surfaceArea: 1, gravity:1, radius:1 }
+    };
+
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,100,0,0,0,0,0);
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    const radCell = dom.window.document.getElementById('radiation-global-status');
+    expect(radCell.textContent).toContain('40%');
+  });
+});

--- a/tests/radiationDisplay.test.js
+++ b/tests/radiationDisplay.test.js
@@ -32,6 +32,7 @@ describe('radiation display', () => {
       magnetosphere: { name: 'Mag' },
       surfaceRadiation: 1.2345,
       orbitalRadiation: 2.3456,
+      radiationPenalty: 0.1234,
       celestialParameters: { albedo: 0, gravity: 1, radius: 1, surfaceArea: 1 },
       calculateSolarPanelMultiplier: () => 1,
       calculateWindTurbineMultiplier: () => 1,
@@ -61,5 +62,9 @@ describe('radiation display', () => {
     const radEl = dom.window.document.getElementById('surface-radiation');
     expect(radEl).not.toBeNull();
     expect(radEl.textContent).toBe(numbers.formatNumber(1.2345, false, 2));
+
+    const penEl = dom.window.document.getElementById('surface-radiation-penalty');
+    expect(penEl).not.toBeNull();
+    expect(penEl.textContent).toBe(numbers.formatNumber(0.1234 * 100, false, 0));
   });
 });


### PR DESCRIPTION
## Summary
- export `radiationPenalty` utility and use it to compute growth penalties from surface radiation
- show surface radiation penalty in the terraforming "Others" box and apply radiation resistance in life growth calculations
- add tests for displaying and mitigating radiation penalties

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893e2690640832790afbc038f11106c