### PR TITLE
Persist auto-build settings across planet travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,3 +356,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Warpgate Teams Equipment purchase now includes a tooltip explaining its artifact chance bonus.
 - Space Disposal project displays a 0K temperature change when no greenhouse gases are jettisoned.
 - Skill rolls in WGC operation logs now use formatNumber with two decimal places.
+- Auto-build percentages for buildings and colonies now persist through planet travel while all auto-build checkboxes reset.

--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -60,6 +60,28 @@ const autobuildCostTracker = {
     }
 };
 
+const savedAutoBuildSettings = {};
+
+function captureAutoBuildSettings(structures) {
+    for (const name in structures) {
+        const s = structures[name];
+        savedAutoBuildSettings[name] = {
+            percent: s.autoBuildPercent,
+        };
+    }
+}
+
+function restoreAutoBuildSettings(structures) {
+    for (const name in structures) {
+        const s = structures[name];
+        if (savedAutoBuildSettings[name]) {
+            s.autoBuildPercent = savedAutoBuildSettings[name].percent;
+        }
+        s.autoBuildEnabled = false;
+        s.autoBuildPriority = false;
+    }
+}
+
 function autoBuild(buildings, delta = 0) {
     autobuildCostTracker.update(delta);
     const population = resources.colony.colonists.value;
@@ -134,10 +156,12 @@ function autoBuild(buildings, delta = 0) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { autoBuild, autobuildCostTracker };
+    module.exports = { autoBuild, autobuildCostTracker, captureAutoBuildSettings, restoreAutoBuildSettings };
 }
 
 if (typeof window !== 'undefined') {
     window.autoBuild = autoBuild;
     window.autobuildCostTracker = autobuildCostTracker;
+    window.captureAutoBuildSettings = captureAutoBuildSettings;
+    window.restoreAutoBuildSettings = restoreAutoBuildSettings;
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -115,6 +115,9 @@ function initializeGameState(options = {}) {
   const preserveJournal = options.preserveJournal || false;
   const skipStoryInitialization = options.skipStoryInitialization || false;
   let savedAdvancedResearch = null;
+  if (preserveManagers && typeof captureAutoBuildSettings === 'function' && typeof structures !== 'undefined') {
+    captureAutoBuildSettings(structures);
+  }
   if (preserveManagers && resources && resources.colony && resources.colony.advancedResearch) {
     savedAdvancedResearch = {
       value: resources.colony.advancedResearch.value,
@@ -156,6 +159,9 @@ function initializeGameState(options = {}) {
   projectManager.initializeProjects(projectParameters);
   colonies = initializeColonies(colonyParameters);
   structures = { ...buildings, ...colonies };
+  if (preserveManagers && typeof restoreAutoBuildSettings === 'function') {
+    restoreAutoBuildSettings(structures);
+  }
   if (!preserveManagers || !researchManager) {
     researchManager = new ResearchManager(researchParameters);
   } else {

--- a/tests/autobuildTravelPersistence.test.js
+++ b/tests/autobuildTravelPersistence.test.js
@@ -1,0 +1,24 @@
+const { captureAutoBuildSettings, restoreAutoBuildSettings } = require('../src/js/autobuild');
+
+describe('autobuild travel persistence', () => {
+  test('percent persists and checkboxes reset', () => {
+    const before = {
+      Alpha: { autoBuildPercent: 2, autoBuildEnabled: true, autoBuildPriority: true },
+      Beta: { autoBuildPercent: 5, autoBuildEnabled: true, autoBuildPriority: true },
+    };
+    captureAutoBuildSettings(before);
+    const after = {
+      Alpha: { autoBuildPercent: 0.1, autoBuildEnabled: true, autoBuildPriority: true },
+      Beta: { autoBuildPercent: 0.1, autoBuildEnabled: true, autoBuildPriority: true },
+      Gamma: { autoBuildPercent: 0.1, autoBuildEnabled: true, autoBuildPriority: true },
+    };
+    restoreAutoBuildSettings(after);
+    expect(after.Alpha.autoBuildPercent).toBe(2);
+    expect(after.Beta.autoBuildPercent).toBe(5);
+    expect(after.Gamma.autoBuildPercent).toBe(0.1);
+    for (const key of Object.keys(after)) {
+      expect(after[key].autoBuildEnabled).toBe(false);
+      expect(after[key].autoBuildPriority).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- retain auto-build percentage values for buildings and colonies when traveling between planets
- reset all auto-build and priority checkboxes after each trip
- add tests for auto-build setting persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68940b3f65b0832781b77744d9eea832