### PR TITLE
Allow partial colony upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Claimed milestones in dark mode use a brighter green for clearer status.
 - Biodomes now always draw power via an `ignoreProductivity` consumption flag.
 - Colony buildings now feature an upgrade arrow converting ten of a tier into one of the next at half the next tier's cost (excluding water).
+- Colony upgrade buttons now allow fewer than ten buildings, scaling metal, glass, water and land costs for the missing structures.
 - Resource tooltips now use static DOM nodes updated without rebuilding innerHTML.
 - Project cost and gain displays now reuse list items and total cost updates a dedicated span.
 - Special project costs now display on a single line like building costs.

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -491,17 +491,9 @@ function updateDecreaseButtonText(button, buildCount) {
     }
     button.textContent = `\u2192 ${parts.join(', ')}`;
 
-    let canAfford = true;
-    for (const category in cost) {
-      for (const resource in cost[category]) {
-        if (resources[category][resource].value < cost[category][resource]) {
-          canAfford = false;
-        }
-      }
-    }
-
+    const canAfford = colony.canAffordUpgrade();
     button.style.color = canAfford ? 'inherit' : 'red';
-    button.disabled = colony.count < 10 || !canAfford;
+    button.disabled = colony.count <= 0 || !canAfford;
     button.style.display = 'inline-block';
   }
   

--- a/tests/colonyUpgrade.test.js
+++ b/tests/colonyUpgrade.test.js
@@ -124,6 +124,32 @@ describe('colony upgrade', () => {
     expect(ctx.resources.surface.land.reserved).toBe(0);
   });
 
+  test('upgrade scales costs when fewer than ten buildings', () => {
+    const { dom, ctx } = setupContext('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
+    const t1 = ctx.colonies.t1_colony;
+    const t2 = ctx.colonies.t2_colony;
+    t1.unlocked = true;
+    t2.unlocked = true;
+    t1.count = t1.active = 1;
+    ctx.resources.colony.metal.value = 237.5;
+    ctx.resources.colony.glass.value = 237.5;
+    ctx.resources.colony.water.value = 450;
+
+    ctx.createColonyButtons(ctx.colonies);
+    ctx.updateStructureDisplay(ctx.colonies);
+
+    const button = dom.window.document.getElementById('t1_colony-upgrade-button');
+    expect(button.disabled).toBe(false);
+    button.click();
+
+    expect(t1.count).toBe(0);
+    expect(t2.count).toBe(1);
+    expect(ctx.resources.colony.metal.value).toBeCloseTo(0);
+    expect(ctx.resources.colony.glass.value).toBeCloseTo(0);
+    expect(ctx.resources.colony.water.value).toBeCloseTo(0);
+    expect(ctx.resources.surface.land.reserved).toBe(9);
+  });
+
   test('upgrade button hidden when next tier locked', () => {
     const { dom, ctx } = setupContext('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
     const t1 = ctx.colonies.t1_colony;


### PR DESCRIPTION
## Summary
- allow upgrading colonies even when fewer than ten are built
- scale upgrade costs for metal, glass, water, and land based on missing structures
- update UI and tests for partial colony upgrades

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68940dde65cc83278eaf63bf96686295