### PR TITLE
Crop minor colonist overages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,3 +358,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Disposal project displays a 0K temperature change when no greenhouse gases are jettisoned.
 - Skill rolls in WGC operation logs now use formatNumber with two decimal places.
 - Auto-build percentages for buildings and colonies now persist through planet travel while all auto-build checkboxes reset.
+- Colonists slightly over their cap (by less than 0.01) are now cropped to the cap instead of decaying.

--- a/src/js/population.js
+++ b/src/js/population.js
@@ -69,9 +69,18 @@ class PopulationModule extends EffectableEntity {
   
     updatePopulation(deltaTime) {
       // Get the current population and population cap
-      const currentPopulation = this.populationResource.value;
+      let currentPopulation = this.populationResource.value;
       const populationCap = this.populationResource.cap;
-  
+
+      // Crop tiny overages to the cap to avoid unnecessary decay
+      if (
+        currentPopulation > populationCap &&
+        currentPopulation - populationCap < 0.01
+      ) {
+        this.populationResource.value = populationCap;
+        currentPopulation = populationCap;
+      }
+
       this.growthRate = this.calculateGrowthRate();
 
       // Calculate logistic growth/decay

--- a/tests/colonistCapCrop.test.js
+++ b/tests/colonistCapCrop.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('colonist cap handling', () => {
+  function setup(popVal) {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = {
+      colony: {
+        colonists: {
+          value: popVal,
+          cap: 100,
+          modifyRate: jest.fn(),
+          increase(v) { this.value += v; },
+          decrease(v) { this.value -= v; }
+        },
+        workers: { value: 0, cap: 0 },
+        androids: { value: 0, cap: 0 }
+      }
+    };
+    ctx.buildings = {};
+    ctx.colonies = {
+      base: {
+        active: 1,
+        storage: { colony: { colonists: 100 } },
+        happiness: 0.5
+      }
+    };
+    ctx.projectManager = {
+      getAssignedAndroids: () => 0,
+      forceUnassignAndroids: () => {}
+    };
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'population.js'), 'utf8');
+    vm.runInContext(code + '; this.PopulationModule = PopulationModule;', ctx);
+    const module = new ctx.PopulationModule(ctx.resources, { workerRatio: 0.5 });
+    return { ctx, module };
+  }
+
+  test('cropped when slightly over cap', () => {
+    const { ctx, module } = setup(100.005);
+    module.updatePopulation(1000);
+    expect(ctx.resources.colony.colonists.value).toBeCloseTo(100);
+    expect(ctx.resources.colony.colonists.modifyRate).not.toHaveBeenCalled();
+  });
+
+  test('decays when noticeably over cap', () => {
+    const { ctx, module } = setup(101);
+    module.updatePopulation(1000);
+    expect(ctx.resources.colony.colonists.value).toBeLessThan(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid unnecessary decay by trimming colonists within 0.01 of their cap
- Test population cropping vs. decay when exceeding cap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689490e4e4d48327bd4537c9c28a0bb6