### PR TITLE
Reset completed flag for repeatable projects on load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,3 +359,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Skill rolls in WGC operation logs now use formatNumber with two decimal places.
 - Auto-build percentages for buildings and colonies now persist through planet travel while all auto-build checkboxes reset.
 - Colonists slightly over their cap (by less than 0.01) are now cropped to the cap instead of decaying.
+- Repeatable projects clear their completed flag on load when more repetitions remain.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -427,6 +427,12 @@ class Project extends EffectableEntity {
     this.remainingTime = state.remainingTime;
     this.startingDuration = state.startingDuration || this.getEffectiveDuration();
     this.repeatCount = state.repeatCount;
+
+    // If the project is repeatable and has not hit its max repeats, a saved
+    // completed flag may be stale. Clear it so the project can run again.
+    if (this.isCompleted && this.repeatable && this.repeatCount < this.maxRepeatCount) {
+      this.isCompleted = false;
+    }
     this.pendingResourceGains = state.pendingResourceGains;
     if (this.pendingResourceGains) {
       this.oneTimeResourceGainsDisplay = this.pendingResourceGains;

--- a/tests/projectRepeatableLoadCompletion.test.js
+++ b/tests/projectRepeatableLoadCompletion.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Project loadState repeatable completion handling', () => {
+  test('clears completed flag if repeats remain', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+
+    const config = { name: 'Test', category: 'resources', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 3, unlocked: true };
+    const project = new ctx.Project(config, 'test');
+
+    project.loadState({ isActive: false, isPaused: false, isCompleted: true, remainingTime: 0, startingDuration: 1, repeatCount: 1, pendingResourceGains: [] });
+
+    expect(project.isCompleted).toBe(false);
+  });
+
+  test('keeps completed flag when max repeats reached', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+
+    const config = { name: 'Test', category: 'resources', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 2, unlocked: true };
+    const project = new ctx.Project(config, 'test');
+
+    project.loadState({ isActive: false, isPaused: false, isCompleted: true, remainingTime: 0, startingDuration: 1, repeatCount: 2, pendingResourceGains: [] });
+
+    expect(project.isCompleted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure repeatable projects clear a stale completed flag when loading saves so they can run again
- Cover project load behavior with new tests
- Document change in repository changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6895e97ea3788327b323ca3585587c3d