### PR TITLE
Allow deeper mining without androids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,3 +360,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Auto-build percentages for buildings and colonies now persist through planet travel while all auto-build checkboxes reset.
 - Colonists slightly over their cap (by less than 0.01) are now cropped to the cap instead of decaying.
 - Repeatable projects clear their completed flag on load when more repetitions remain.
+- Deeper mining now proceeds without android assignments, running at normal speed.

--- a/src/js/projects/DeeperMiningProject.js
+++ b/src/js/projects/DeeperMiningProject.js
@@ -29,7 +29,7 @@ class DeeperMiningProject extends AndroidProject {
     if (this.averageDepth >= this.maxDepth) {
       return false;
     }
-    return super.canStart();
+    return Project.prototype.canStart.call(this);
   }
 
   getScaledCost() {

--- a/tests/deeperMiningAndroidAssistOptional.test.js
+++ b/tests/deeperMiningAndroidAssistOptional.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Deeper mining android assistance optional', () => {
+  test('can start without androids when androidAssist flag set', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = { colony: { androids: { value: 0 } } };
+    ctx.buildings = { oreMine: { count: 1 } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const deeperCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'DeeperMiningProject.js'), 'utf8');
+    vm.runInContext(deeperCode + '; this.DeeperMiningProject = DeeperMiningProject;', ctx);
+    const config = {
+      name: 'deeperMining',
+      category: 'infrastructure',
+      cost: {},
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxDepth: Infinity,
+      unlocked: true,
+      attributes: {}
+    };
+    const project = new ctx.DeeperMiningProject(config, 'deeperMining');
+    project.booleanFlags.add('androidAssist');
+    expect(project.canStart()).toBe(true);
+    expect(project.getAndroidSpeedMultiplier()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- let Deeper Mining run without assigned androids, removing forced requirement
- add regression test for optional android assistance
- document change in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896a108a398832799ca9343eb42ee9e