### PR TITLE
feat: add Solis research upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,3 +362,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Repeatable projects clear their completed flag on load when more repetitions remain.
 - Deeper mining now proceeds without android assignments, running at normal speed.
 - Colony upgrade cost text now highlights only resources that are unaffordable.
+- Solis tab now features an Alien Artifact section unlocked by a flag, letting players donate artifacts for points and buy Research Upgrades that auto-research early infrastructure, including the Terraforming Bureau.

--- a/index.html
+++ b/index.html
@@ -421,8 +421,14 @@
                                 <input type="checkbox" id="solis-silence-toggle"> Silence quest alert
                             </label>
                         </div>
+                        <div id="solis-donation-section" class="hidden">
+                            <div id="solis-donation-items"></div>
+                        </div>
                         <div class="solis-shop">
                             <div id="solis-shop-items"></div>
+                        </div>
+                        <div id="solis-research-shop" class="solis-shop hidden">
+                            <div id="solis-research-shop-items"></div>
                         </div>
                     </div>
                 </div>

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -11,6 +11,7 @@ const shopDescriptions = {
   water: 'Increase starting water and base storage by 1M',
   androids: 'Increase starting androids and base storage by 100',
   colonistRocket: 'Increase colonists per import rocket by 1',
+  researchUpgrade: 'Auto-complete early infrastructure research'
 };
 
 function showSolisTab() {
@@ -140,6 +141,61 @@ function initializeSolisUI() {
     });
   }
 
+  const donationContainer = document.getElementById('solis-donation-items');
+  if (donationContainer) {
+    const parent = donationContainer.parentElement;
+    parent.classList.add('solis-shop-container', 'hidden');
+    const title = document.createElement('h3');
+    title.textContent = 'Alien Artifact Donation';
+    parent.insertBefore(title, donationContainer);
+
+    const item = document.createElement('div');
+    item.classList.add('solis-shop-item');
+
+    const label = document.createElement('span');
+    label.classList.add('solis-shop-item-label');
+    label.textContent = 'Donate artifacts for 100 Solis points each';
+    item.appendChild(label);
+
+    const actions = document.createElement('div');
+    actions.classList.add('solis-shop-item-actions');
+
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.id = 'solis-donation-input';
+    input.min = '1';
+    input.value = '1';
+    actions.appendChild(input);
+
+    const button = document.createElement('button');
+    button.id = 'solis-donation-button';
+    button.textContent = 'Donate';
+    button.addEventListener('click', () => {
+      const amount = parseInt(input.value, 10) || 0;
+      solisManager.donateArtifacts(amount);
+      updateSolisUI();
+    });
+    actions.appendChild(button);
+
+    const owned = document.createElement('span');
+    owned.classList.add('solis-shop-item-count');
+    owned.innerHTML = `Owned: <span id="solis-donation-count">0</span>`;
+    actions.appendChild(owned);
+
+    item.appendChild(actions);
+    donationContainer.appendChild(item);
+  }
+
+  const researchShopItems = document.getElementById('solis-research-shop-items');
+  if (researchShopItems) {
+    const parent = researchShopItems.parentElement;
+    parent.classList.add('solis-shop-container', 'hidden');
+    const title = document.createElement('h3');
+    title.textContent = 'Research Upgrades';
+    parent.insertBefore(title, researchShopItems);
+    researchShopItems.appendChild(createShopItem('researchUpgrade'));
+  }
+
   const questText = document.getElementById('solis-quest-text');
   if (questText) {
     questText.textContent = '';
@@ -193,6 +249,15 @@ function updateSolisUI() {
   const cooldownDiv = document.getElementById('solis-cooldown');
   const cooldownText = document.getElementById('solis-cooldown-text');
   const cooldownBar = document.getElementById('solis-cooldown-bar');
+  const donationSection = document.getElementById('solis-donation-section');
+  const donationCount = document.getElementById('solis-donation-count');
+  const donationInput = document.getElementById('solis-donation-input');
+  const donationButton = document.getElementById('solis-donation-button');
+  const researchShop = document.getElementById('solis-research-shop');
+
+  const flag = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisAlienArtifactUpgrade');
+  if (donationSection) donationSection.classList.toggle('hidden', !flag);
+  if (researchShop) researchShop.classList.toggle('hidden', !flag);
 
   if (pointsSpan) {
     pointsSpan.textContent = solisManager.solisPoints;
@@ -248,6 +313,13 @@ function updateSolisUI() {
       cooldownText.textContent = '';
       cooldownBar.style.width = '0%';
     }
+  }
+  if (donationCount && resources.colony && resources.colony.alienArtifact) {
+    donationCount.textContent = resources.colony.alienArtifact.value;
+  }
+  if (donationButton && donationInput && resources.colony && resources.colony.alienArtifact) {
+    const amt = parseInt(donationInput.value, 10) || 0;
+    donationButton.disabled = amt <= 0 || amt > resources.colony.alienArtifact.value;
   }
 
   for (const key in shopElements) {

--- a/tests/solisResearchUpgrade.test.js
+++ b/tests/solisResearchUpgrade.test.js
@@ -1,0 +1,55 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis research upgrade', () => {
+  const order = [
+    'launch_pads',
+    'colony_sliders',
+    'construction_office',
+    'space_mirror_oversight',
+    'terraforming_bureau',
+    'atmospheric_monitoring'
+  ];
+  let manager;
+
+  beforeEach(() => {
+    manager = new SolisManager();
+    global.researchManager = {
+      completed: [],
+      completeResearchInstant(id) {
+        if (!this.completed.includes(id)) {
+          this.completed.push(id);
+        }
+      }
+    };
+    global.resources = { colony: { alienArtifact: { value: 0, decrease(n) { this.value -= n; } } } };
+    global.globalGameIsLoadingFromSave = false;
+  });
+
+  test('auto research upgrade cost and order', () => {
+    manager.solisPoints = 3000;
+    order.forEach((id, idx) => {
+      expect(manager.getUpgradeCost('researchUpgrade')).toBe(100 * (idx + 1));
+      expect(manager.purchaseUpgrade('researchUpgrade')).toBe(true);
+      expect(researchManager.completed[idx]).toBe(id);
+    });
+    expect(manager.purchaseUpgrade('researchUpgrade')).toBe(false);
+  });
+
+  test('reapplyEffects triggers research based on purchases', () => {
+    manager.shopUpgrades.researchUpgrade.purchases = 3;
+    researchManager.completed = [];
+    manager.reapplyEffects();
+    expect(researchManager.completed).toEqual(order.slice(0, 3));
+  });
+
+  test('donating artifacts grants points', () => {
+    resources.colony.alienArtifact.value = 5;
+    expect(manager.donateArtifacts(2)).toBe(true);
+    expect(manager.solisPoints).toBe(200);
+    expect(resources.colony.alienArtifact.value).toBe(3);
+    expect(manager.donateArtifacts(10)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- rename Solis shop's alien artifact upgrades to Research Upgrades
- include Terraforming Bureau in the auto-research sequence
- document and test Solis research upgrades and donations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896a73969648327b8cca1896721a309