### PR TITLE
Display WGC class descriptions on team cards

### DIFF
--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -125,7 +125,7 @@
 
 .team-slot {
   width: 80px;
-  height: 110px;
+  height: 140px;
   border: 1px solid var(--wgc-text-dark);
   background-color: var(--wgc-bg-dark);
   display: flex;
@@ -142,7 +142,7 @@
 .team-slot.filled {
   cursor: pointer;
   border-color: var(--wgc-border-color);
-  justify-content: space-between;
+  justify-content: flex-start;
 }
 
 .team-slot.filled:hover {
@@ -170,6 +170,20 @@
   text-overflow: ellipsis;
   width: 100%;
   color: var(--wgc-text-light);
+}
+
+.team-slot .team-member-class {
+  font-size: 0.75em;
+  text-align: center;
+  width: 100%;
+  color: var(--wgc-border-color);
+}
+
+.team-slot .team-member-description {
+  font-size: 0.7em;
+  text-align: center;
+  width: 100%;
+  color: var(--wgc-text-medium);
 }
 
 .team-slot .team-icon {

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -45,6 +45,12 @@ const classImages = {
   'Natural Scientist': 'assets/images/natural_scientist.png',
   'Social Scientist': 'assets/images/social_scientist.png'
 };
+const classDescriptions = {
+  'Team Leader': 'Balances all skills and lends half their skill to others.',
+  'Soldier': 'Combat expert whose Power counts double in combat challenges.',
+  'Natural Scientist': 'Researcher who excels at natural science challenges and doubles artifact rewards.',
+  'Social Scientist': 'Diplomatic specialist handling social science challenges and reducing conflict.'
+};
 let activeDialog = null;
 
 function showWGCTab() {
@@ -83,9 +89,12 @@ function generateWGCTeamCards() {
         const unspentPoints = m.getPointsToAllocate() > 0 ? '<div class="unspent-points-indicator">!</div>' : '';
         const hpPercent = Math.floor((m.health / m.maxHealth) * 100);
         const hpClass = hpPercent < 25 ? 'critical-hp' : (hpPercent < 50 ? 'low-hp' : '');
+        const desc = classDescriptions[m.classType] || '';
         return `<div class="team-slot filled" data-team="${tIdx}" data-slot="${sIdx}">
           <div class="team-hp-bar"><div class="team-hp-bar-fill ${hpClass}" style="height:${hpPercent}%;"></div></div>
           <div class="team-member-name">${m.firstName}</div>
+          <div class="team-member-class">${m.classType}</div>
+          <div class="team-member-description">${desc}</div>
           <img src="${img}" class="team-icon">
           ${unspentPoints}
         </div>`;

--- a/tests/wgcClassDescription.test.js
+++ b/tests/wgcClassDescription.test.js
@@ -1,0 +1,24 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { generateWGCTeamCards } = require('../src/js/wgcUI.js');
+
+describe('WGC team card class descriptions', () => {
+  test('shows class description below class name', () => {
+    global.warpGateCommand = {
+      teamNames: ['Alpha', 'Beta', 'Gamma', 'Delta'],
+      teams: [
+        [WGCTeamMember.create('Bob', '', 'Soldier', {}), null, null, null],
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, null, null, null]
+      ],
+      operations: Array.from({ length: 4 }, () => ({ active: false, progress: 0, summary: '' })),
+      totalOperations: 0,
+      stances: Array.from({ length: 4 }, () => ({ hazardousBiomass: 'Neutral', artifact: 'Neutral' }))
+    };
+    const html = generateWGCTeamCards();
+    expect(html).toMatch(/<div class=\"team-member-class\">Soldier<\/div>/);
+    expect(html).toMatch(/Combat expert whose Power counts double in combat challenges./);
+  });
+});


### PR DESCRIPTION
## Summary
- show each WGC team member's class and description in team cards
- style team slots for class info
- test class descriptions render correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6896be02999c8327a2096ff9271ed742