### PR TITLE
Move WGC class description to details window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,3 +365,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Colony upgrade cost text now highlights only resources that are unaffordable.
 - Solis tab now features an Alien Artifact section unlocked by a flag, letting players donate artifacts for points and buy Research Upgrades that auto-research early infrastructure, including the Terraforming Bureau.
 - Added a Pre-travel save slot that automatically stores the game state before planet travel and remains hidden when empty.
+- WGC class descriptions now appear in the member details window instead of on the team card.

--- a/src/css/wgc.css
+++ b/src/css/wgc.css
@@ -179,11 +179,13 @@
   color: var(--wgc-border-color);
 }
 
-.team-slot .team-member-description {
-  font-size: 0.7em;
+
+.wgc-class-description {
+  font-size: 0.9em;
   text-align: center;
   width: 100%;
   color: var(--wgc-text-medium);
+  margin-bottom: 8px;
 }
 
 .team-slot .team-icon {

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -89,12 +89,10 @@ function generateWGCTeamCards() {
         const unspentPoints = m.getPointsToAllocate() > 0 ? '<div class="unspent-points-indicator">!</div>' : '';
         const hpPercent = Math.floor((m.health / m.maxHealth) * 100);
         const hpClass = hpPercent < 25 ? 'critical-hp' : (hpPercent < 50 ? 'low-hp' : '');
-        const desc = classDescriptions[m.classType] || '';
         return `<div class="team-slot filled" data-team="${tIdx}" data-slot="${sIdx}">
           <div class="team-hp-bar"><div class="team-hp-bar-fill ${hpClass}" style="height:${hpPercent}%;"></div></div>
           <div class="team-member-name">${m.firstName}</div>
           <div class="team-member-class">${m.classType}</div>
-          <div class="team-member-description">${desc}</div>
           <img src="${img}" class="team-icon">
           ${unspentPoints}
         </div>`;
@@ -312,6 +310,11 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
   }
   win.appendChild(classSelect);
 
+  const classDescDiv = document.createElement('div');
+  classDescDiv.classList.add('wgc-class-description');
+  classDescDiv.textContent = classDescriptions[classSelect.value] || '';
+  win.appendChild(classDescDiv);
+
   const lvl = member ? member.level : 1;
   const xp = member ? Math.floor(member.xp || 0) : 0;
   const xpReq = member ? member.getXPForNextLevel() : 10;
@@ -374,6 +377,7 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
       const statName = ['power', 'athletics', 'wit'][index];
       container.querySelector('span:nth-child(2)').textContent = statValues[statName];
     });
+    classDescDiv.textContent = classDescriptions[classSelect.value] || '';
   });
   win.appendChild(statsDiv);
   win.appendChild(remainingSpan);

--- a/tests/wgcClassDescription.test.js
+++ b/tests/wgcClassDescription.test.js
@@ -3,8 +3,8 @@ global.EffectableEntity = EffectableEntity;
 const { WGCTeamMember } = require('../src/js/team-member.js');
 const { generateWGCTeamCards } = require('../src/js/wgcUI.js');
 
-describe('WGC team card class descriptions', () => {
-  test('shows class description below class name', () => {
+describe('WGC class descriptions', () => {
+  test('removed from team card', () => {
     global.warpGateCommand = {
       teamNames: ['Alpha', 'Beta', 'Gamma', 'Delta'],
       teams: [
@@ -19,6 +19,6 @@ describe('WGC team card class descriptions', () => {
     };
     const html = generateWGCTeamCards();
     expect(html).toMatch(/<div class=\"team-member-class\">Soldier<\/div>/);
-    expect(html).toMatch(/Combat expert whose Power counts double in combat challenges./);
+    expect(html).not.toMatch(/Combat expert whose Power counts double in combat challenges./);
   });
 });


### PR DESCRIPTION
## Summary
- remove class descriptions from WGC team cards
- show class descriptions in the WGC member details window
- style and test updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6896c02a430083279877a2a8e5ecdd2b