### PR TITLE
Fix WGC team count on load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,7 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC recruit dialog now updates HP and XP in real time when member stats change.
 - WGC artifact statistics now display totals using formatNumber with two decimal places.
 - WGC team slots reduced from five to four.
+- Loading saves now trims WGC teams to four slots.
 - Planetary thruster energy tracking now persists by category and resets only when their targets change.
 - Warpgate Teams Equipment purchase now includes a tooltip explaining its artifact chance bonus.
 - Space Disposal project displays a 0K temperature change when no greenhouse gases are jettisoned.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -528,13 +528,19 @@ class WarpGateCommand extends EffectableEntity {
         }
       }
     }
-    if (Array.isArray(data.teams)) {
-      this.teams = data.teams.map(team =>
-        Array.isArray(team) ? team.map(m => (m ? new WGCTeamMember(m) : null)) : [null, null, null, null]
-      );
-    }
-    if (Array.isArray(data.operations)) {
-      this.operations = data.operations.map(op => ({
+    const MAX_TEAMS = 4;
+    const teamData = Array.isArray(data.teams) ? data.teams.slice(0, MAX_TEAMS) : [];
+    this.teams = Array.from({ length: MAX_TEAMS }, (_, i) => {
+      const team = Array.isArray(teamData[i]) ? teamData[i].slice(0, 4) : [];
+      const members = team.map(m => (m ? new WGCTeamMember(m) : null));
+      while (members.length < 4) members.push(null);
+      return members;
+    });
+
+    const opData = Array.isArray(data.operations) ? data.operations.slice(0, MAX_TEAMS) : [];
+    this.operations = Array.from({ length: MAX_TEAMS }, (_, i) => {
+      const op = opData[i] || {};
+      return {
         active: !!op.active,
         progress: op.progress || 0,
         timer: op.timer || 0,
@@ -543,29 +549,39 @@ class WarpGateCommand extends EffectableEntity {
         successes: op.successes || 0,
         summary: op.summary || '',
         number: op.number || 1,
-        nextEvent: op.nextEvent || 60
-      }));
-    }
-    if (Array.isArray(data.teamOperationCounts)) {
-      this.teamOperationCounts = data.teamOperationCounts.slice();
-    }
-    if (Array.isArray(data.teamNextOperationNumber)) {
-      this.teamNextOperationNumber = data.teamNextOperationNumber.slice();
-    }
-    if (Array.isArray(data.logs)) {
-      this.logs = data.logs.map(l => l.slice(-100));
-    }
+        nextEvent: op.nextEvent || 60,
+      };
+    });
+
+    const countData = Array.isArray(data.teamOperationCounts) ? data.teamOperationCounts.slice(0, MAX_TEAMS) : [];
+    this.teamOperationCounts = Array.from({ length: MAX_TEAMS }, (_, i) => countData[i] || 0);
+
+    const nextOpData = Array.isArray(data.teamNextOperationNumber) ? data.teamNextOperationNumber.slice(0, MAX_TEAMS) : [];
+    this.teamNextOperationNumber = Array.from({ length: MAX_TEAMS }, (_, i) => nextOpData[i] || 1);
+
+    const logData = Array.isArray(data.logs) ? data.logs.slice(0, MAX_TEAMS) : [];
+    this.logs = Array.from({ length: MAX_TEAMS }, (_, i) =>
+      Array.isArray(logData[i]) ? logData[i].slice(-100) : []
+    );
+
     if (Array.isArray(data.teamNames)) {
-      this.teamNames = data.teamNames.map((n, i) => (typeof n === 'string' && n.trim() ? n.trim() : defaultTeamNames[i]));
+      const names = data.teamNames.slice(0, MAX_TEAMS);
+      this.teamNames = Array.from({ length: MAX_TEAMS }, (_, i) => {
+        const n = names[i];
+        return typeof n === 'string' && n.trim() ? n.trim() : defaultTeamNames[i];
+      });
     } else {
       this.teamNames = defaultTeamNames.slice();
     }
-    if (Array.isArray(data.stances)) {
-      this.stances = data.stances.map(s => ({
+
+    const stanceData = Array.isArray(data.stances) ? data.stances.slice(0, MAX_TEAMS) : [];
+    this.stances = Array.from({ length: MAX_TEAMS }, (_, i) => {
+      const s = stanceData[i] || {};
+      return {
         hazardousBiomass: s.hazardousBiomass || 'Neutral',
-        artifact: s.artifact || 'Neutral'
-      }));
-    }
+        artifact: s.artifact || 'Neutral',
+      };
+    });
     if (data.facilities) {
       for (const k in this.facilities) {
         if (typeof data.facilities[k] === 'number') {

--- a/tests/wgcTeamTrim.test.js
+++ b/tests/wgcTeamTrim.test.js
@@ -1,0 +1,26 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC loadState trims teams', () => {
+  test('only first four teams are kept when loading', () => {
+    const wgc = new WarpGateCommand();
+    const saveData = {
+      teams: Array.from({ length: 5 }, () => [null, null, null, null]),
+      operations: Array.from({ length: 5 }, () => ({})),
+      teamOperationCounts: [0, 0, 0, 0, 0],
+      teamNextOperationNumber: [1, 1, 1, 1, 1],
+      logs: Array.from({ length: 5 }, () => []),
+      teamNames: ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'],
+      stances: Array.from({ length: 5 }, () => ({ hazardousBiomass: 'Neutral', artifact: 'Neutral' })),
+    };
+    wgc.loadState(saveData);
+    expect(wgc.teams.length).toBe(4);
+    expect(wgc.operations.length).toBe(4);
+    expect(wgc.teamOperationCounts.length).toBe(4);
+    expect(wgc.teamNextOperationNumber.length).toBe(4);
+    expect(wgc.logs.length).toBe(4);
+    expect(wgc.teamNames.length).toBe(4);
+    expect(wgc.stances.length).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- clamp Warp Gate Command save data to four teams when loading
- test that extra teams in saves are discarded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896c86d792c8327bb4703da64dda41c