### PR TITLE
Add Solis tab alert for chapter 13.2 reward

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,3 +368,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC class descriptions now appear in the member details window instead of on the team card.
 - Solis artifact donation now uses the correct resource pool, properly displaying owned artifacts and enabling donations.
 - Solis research upgrade now lists upcoming technologies horizontally and crosses out each as it is purchased, clarifying that one tech is unlocked per purchase.
+- Chapter 13.2 reward now triggers a one-time alert on the Solis tab.

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -140,6 +140,11 @@ class EffectableEntity {
         case 'booleanFlag':  // New effect type to handle boolean flags
           this.applyBooleanFlag(effect);
           break;
+        case 'solisTabAlert':
+          if (typeof this.setSolisTabAlert === 'function') {
+            this.setSolisTabAlert(effect.value);
+          }
+          break;
         case 'oneTimeStart':
           if (typeof CargoRocketProject !== 'undefined' && this instanceof CargoRocketProject) {
             this.applyOneTimeStart(effect);

--- a/src/js/hopeUI.js
+++ b/src/js/hopeUI.js
@@ -6,6 +6,9 @@ function initializeHopeTabs() {
             tab.classList.add('active');
             const id = tab.dataset.subtab;
             document.getElementById(id).classList.add('active');
+            if (id === 'solis-hope' && typeof solisManager !== 'undefined' && typeof solisManager.setSolisTabAlert === 'function') {
+                solisManager.setSolisTabAlert(false);
+            }
         });
     });
 }
@@ -32,14 +35,16 @@ function updateHopeAlert() {
     const solisEl = document.getElementById('solis-subtab-alert');
     const wgcEl = document.getElementById('wgc-subtab-alert');
     if (!alertEl && !solisEl && !wgcEl) return;
-    let solisShow = typeof solisManager !== 'undefined' && solisManager && solisManager.currentQuest && solisTabVisible;
-    const wgcShow = typeof warpGateCommand !== 'undefined' && warpGateCommand && wgcTabVisible && warpGateCommand.facilityCooldown <= 0;
-    if (typeof gameSettings !== 'undefined' && gameSettings.silenceSolisAlert) {
-        solisShow = false;
-        if (solisEl) solisEl.style.display = 'none';
-    } else if (solisEl) {
-        solisEl.style.display = solisShow ? 'inline' : 'none';
+    let solisShow = false;
+    if (typeof solisManager !== 'undefined' && solisManager && solisTabVisible) {
+        if (solisManager.solisTabAlert) {
+            solisShow = true;
+        } else if (!(typeof gameSettings !== 'undefined' && gameSettings.silenceSolisAlert)) {
+            solisShow = !!solisManager.currentQuest;
+        }
     }
+    const wgcShow = typeof warpGateCommand !== 'undefined' && warpGateCommand && wgcTabVisible && warpGateCommand.facilityCooldown <= 0;
+    if (solisEl) solisEl.style.display = solisShow ? 'inline' : 'none';
     if (wgcEl) wgcEl.style.display = wgcShow ? 'inline' : 'none';
     if (alertEl) alertEl.style.display = (solisShow || wgcShow) ? 'inline' : 'none';
 }

--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -37,6 +37,7 @@ class SolisManager extends EffectableEntity {
     this.postCompletionCooldownUntil = 0;
     this.questInterval = 15 * 60 * 1000; // 15 minutes
     this.refreshCooldown = 5 * 60 * 1000; // 5 minutes
+    this.solisTabAlert = false;
 
     // Purchasable upgrades for the Solis shop
     this.shopUpgrades = {
@@ -122,6 +123,13 @@ class SolisManager extends EffectableEntity {
       }
     } else {
       this.rewardMultiplier = 1;
+    }
+  }
+
+  setSolisTabAlert(value) {
+    this.solisTabAlert = value;
+    if (typeof updateHopeAlert === 'function') {
+      updateHopeAlert();
     }
   }
 
@@ -275,6 +283,7 @@ class SolisManager extends EffectableEntity {
       lastQuestTime: this.lastQuestTime,
       lastRefreshTime: this.lastRefreshTime,
       postCompletionCooldownUntil: this.postCompletionCooldownUntil,
+      solisTabAlert: this.solisTabAlert,
       upgrades: Object.keys(this.shopUpgrades).reduce((o, k) => {
         o[k] = this.shopUpgrades[k].purchases;
         return o;
@@ -289,6 +298,7 @@ class SolisManager extends EffectableEntity {
     this.lastQuestTime = data.lastQuestTime || 0;
     this.lastRefreshTime = data.lastRefreshTime || 0;
     this.postCompletionCooldownUntil = data.postCompletionCooldownUntil || 0;
+    this.solisTabAlert = data.solisTabAlert || false;
     if (data.upgrades) {
       for (const k in data.upgrades) {
         if (this.shopUpgrades[k]) {

--- a/src/js/story/ganymede.js
+++ b/src/js/story/ganymede.js
@@ -401,6 +401,12 @@ progressGanymede.chapters.push(
             type: 'booleanFlag',
             flagId: 'solisAlienArtifactUpgrade',
             value: true
+        },
+        {
+            target: 'solisManager',
+            type: 'solisTabAlert',
+            value: true,
+            oneTimeFlag: true
         }]
     },
     {

--- a/tests/chapter13_2SolisAlert.test.js
+++ b/tests/chapter13_2SolisAlert.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Chapter 13.2 Solis reward alert', () => {
+  test('shows alert once and clears when viewed', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div id="hope-tab"><span id="hope-alert" class="hope-alert">!</span></div>
+      <div class="hope-subtab" data-subtab="solis-hope">Solis<span id="solis-subtab-alert" class="hope-alert">!</span></div>
+      <div id="solis-hope" class="hope-subtab-content"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.solisManager = new SolisManager();
+    ctx.solisTabVisible = true;
+    ctx.initializeSkillsUI = () => {};
+    ctx.initializeSolisUI = () => {};
+    ctx.initializeWGCUI = () => {};
+    ctx.updateSkillTreeUI = () => {};
+    ctx.updateSolisUI = () => {};
+    ctx.updateWGCVisibility = () => {};
+    ctx.updateWGCUI = () => {};
+    const hopeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'hopeUI.js'), 'utf8');
+    vm.runInContext(hopeCode, ctx);
+
+    ctx.initializeHopeUI();
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('solis-subtab-alert').style.display).toBe('none');
+
+    ctx.solisManager.addAndReplace({ type: 'solisTabAlert', value: true });
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('solis-subtab-alert').style.display).toBe('inline');
+
+    ctx.solisManager.setSolisTabAlert(false);
+    ctx.updateHopeUI();
+    expect(dom.window.document.getElementById('solis-subtab-alert').style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- Trigger a one-time Solis tab alert when chapter 13.2 is rewarded
- Handle `solisTabAlert` in SolisManager and effect system to show/hide alerts
- Test Solis tab alert lifecycle

## Testing
- `npm test --silent 2>&1 | tail -n 10`

------
https://chatgpt.com/codex/tasks/task_b_6896c8b2d2108327b955dd9ff240be6d