### PR TITLE
Clarify WGC operation difficulty objective

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,3 +370,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Solis artifact donation now uses the correct resource pool, properly displaying owned artifacts and enabling donations.
 - Solis research upgrade now lists upcoming technologies horizontally and crosses out each as it is purchased, clarifying that one tech is unlocked per purchase.
 - Chapter 13.2 reward now triggers a one-time alert on the Solis tab.
+- Journal objective for Warp Gate Command now displays "Complete an Operation of Difficulty X" for clarity.

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -431,8 +431,8 @@ class StoryManager {
                     ? warpGateCommand.highestDifficulty : -1;
                const dispCurrent = Math.max(0, current + 1);
                const target = (objective.difficulty || 0) + 1;
-               return `Highest Operation Difficulty: ${format(dispCurrent, true)}/${format(target, true)}`;
-          }
+               return `Complete an Operation of Difficulty ${format(target, true)} (Highest Completed: ${format(dispCurrent, true)})`;
+         }
           default:
                return '';
        }

--- a/tests/wgcHighestDifficultyObjective.test.js
+++ b/tests/wgcHighestDifficultyObjective.test.js
@@ -16,7 +16,7 @@ describe('wgcHighestDifficulty objective', () => {
     global.solisManager = null;
   });
 
-  test('completes when required difficulty reached', () => {
+  test('describes progress and completes when required difficulty reached', () => {
     const data = {
       chapters: [{
         id: 'test',
@@ -30,8 +30,10 @@ describe('wgcHighestDifficulty objective', () => {
     const sm = new StoryManager(data);
     const ev = sm.findEventById('test');
     const obj = ev.objectives[0];
+    expect(sm.describeObjective(obj)).toBe('Complete an Operation of Difficulty 1 (Highest Completed: 0)');
     expect(sm.isObjectiveComplete(obj, ev)).toBe(false);
     warpGateCommand.highestDifficulty = 0;
+    expect(sm.describeObjective(obj)).toBe('Complete an Operation of Difficulty 1 (Highest Completed: 1)');
     expect(sm.isObjectiveComplete(obj, ev)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- clarify Warp Gate Command journal objective text to "Complete an Operation of Difficulty X"
- document new journal wording in changelog
- test operation difficulty objective description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896cbeeb5308327967be704457d5275