### PR TITLE
feat: allow storing glass in space storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,3 +371,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Solis research upgrade now lists upcoming technologies horizontally and crosses out each as it is purchased, clarifying that one tech is unlocked per purchase.
 - Chapter 13.2 reward now triggers a one-time alert on the Solis tab.
 - Journal objective for Warp Gate Command now displays "Complete an Operation of Difficulty X" for clarity.
+- Space Storage now allows storing glass.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -3,6 +3,7 @@ const storageResourceOptions = [
   { label: 'Components', category: 'colony', resource: 'components' },
   { label: 'Electronics', category: 'colony', resource: 'electronics' },
   { label: 'Superconductors', category: 'colony', resource: 'superconductors' },
+  { label: 'Glass', category: 'colony', resource: 'glass' },
   { label: 'Oxygen', category: 'atmospheric', resource: 'oxygen' },
   { label: 'Carbon Dioxide', category: 'atmospheric', resource: 'carbonDioxide' },
   { label: 'Water', category: 'surface', resource: 'liquidWater' },

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -100,7 +100,7 @@ describe('Space Storage project', () => {
     project.updateCostAndGains = () => {};
     project.renderUI(container);
     const checkboxes = container.querySelectorAll('#ss-resource-grid input[type="checkbox"]');
-    expect(checkboxes.length).toBe(8);
+    expect(checkboxes.length).toBe(9);
     const items = container.querySelectorAll('#ss-resource-grid .storage-resource-item');
     expect(items[0].children.length).toBe(3);
     checkboxes[0].checked = true;

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -61,7 +61,7 @@ describe('Space Storage UI', () => {
     expect(els.maxDisplay.textContent).toBe(String(numbers.formatNumber(1000000000000, false, 0)));
     expect(els.expansionCostDisplay.textContent).toBe(`Metal: ${numbers.formatNumber(metalCost, true)}`);
     const items = els.resourceGrid.querySelectorAll('.storage-resource-item');
-    expect(items.length).toBe(8);
+    expect(items.length).toBe(9);
     expect(items[0].children[2].textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();
     expect(els.withdrawButton).toBeDefined();
@@ -76,7 +76,7 @@ describe('Space Storage UI', () => {
     project.usedStorage = 500;
     ctx.updateSpaceStorageUI(project);
     const updatedItems = els.resourceGrid.querySelectorAll('.storage-resource-item');
-    expect(updatedItems.length).toBe(8);
+    expect(updatedItems.length).toBe(9);
     const metalItem = updatedItems[0];
     expect(metalItem.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
 


### PR DESCRIPTION
## Summary
- include glass among resources that Space Storage can store
- document the new capability in the changelog
- adjust Space Storage tests for the new resource option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689747ef41e48327998fe1ba9d90e1b4