### PR TITLE
Preserve Dyson Swarm collectors across planet travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Selecting another world via `selectPlanet(key)` soft resets the colony while kee
 * `SolisManager` keeps quests, points and shop upgrades.
 * `SpaceManager` records which planets have been visited or terraformed.
 * `StoryManager` continues tracking active events and re‑applies their rewards.
-* The **Dyson Swarm Receiver** project's collector count persists, maintaining its energy contribution across planets.
+* The **Dyson Swarm Receiver** project's collector count persists across planets, but the receiver must be rebuilt to regain energy production.
 
 When loading a save or switching planets, call each manager's `reapplyEffects` method so stored modifiers affect the newly created game objects.
 
@@ -371,3 +371,5 @@ second time they speak in a chapter to help clarify who is talking.
 - Solis research upgrade now lists upcoming technologies horizontally and crosses out each as it is purchased, clarifying that one tech is unlocked per purchase.
 - Chapter 13.2 reward now triggers a one-time alert on the Solis tab.
 - Journal objective for Warp Gate Command now displays "Complete an Operation of Difficulty X" for clarity.
+- Fixed Dyson Swarm collectors resetting after planet travel; collector counts now persist across worlds while the receiver must be rebuilt on each planet.
+- Collector persistence is managed through ProjectManager travel state so only the Dyson Swarm's collector count carries over between planets.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -115,6 +115,10 @@ function initializeGameState(options = {}) {
   const preserveJournal = options.preserveJournal || false;
   const skipStoryInitialization = options.skipStoryInitialization || false;
   let savedAdvancedResearch = null;
+  let savedProjectTravelState = null;
+  if (preserveManagers && typeof projectManager !== 'undefined' && typeof projectManager.saveTravelState === 'function') {
+    savedProjectTravelState = projectManager.saveTravelState();
+  }
   if (preserveManagers && typeof captureAutoBuildSettings === 'function' && typeof structures !== 'undefined') {
     captureAutoBuildSettings(structures);
   }
@@ -157,6 +161,9 @@ function initializeGameState(options = {}) {
   buildings = initializeBuildings(buildingsParameters);
   projectManager = new ProjectManager();
   projectManager.initializeProjects(projectParameters);
+  if (savedProjectTravelState && typeof projectManager.loadTravelState === 'function') {
+    projectManager.loadTravelState(savedProjectTravelState);
+  }
   colonies = initializeColonies(colonyParameters);
   structures = { ...buildings, ...colonies };
   if (preserveManagers && typeof restoreAutoBuildSettings === 'function') {

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -667,5 +667,25 @@ class ProjectManager extends EffectableEntity {
       initializeProjectAlerts();
     }
   }
+
+  saveTravelState() {
+    const travelState = {};
+    for (const name in this.projects) {
+      const project = this.projects[name];
+      if (typeof project.saveTravelState === 'function') {
+        travelState[name] = project.saveTravelState();
+      }
+    }
+    return travelState;
+  }
+
+  loadTravelState(travelState = {}) {
+    for (const name in travelState) {
+      const project = this.projects[name];
+      if (project && typeof project.loadTravelState === 'function') {
+        project.loadTravelState(travelState[name]);
+      }
+    }
+  }
 }
 

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -146,6 +146,14 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
     this.collectorProgress = state.collectorProgress || 0;
     this.autoDeployCollectors = state.autoDeployCollectors || false;
   }
+
+  saveTravelState() {
+    return { collectors: this.collectors };
+  }
+
+  loadTravelState(state = {}) {
+    this.collectors = state.collectors || 0;
+  }
 }
 
 if (typeof globalThis !== 'undefined') {

--- a/tests/dysonSwarmTravelPersistence.test.js
+++ b/tests/dysonSwarmTravelPersistence.test.js
@@ -1,0 +1,115 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Dyson Swarm collectors persist across planet travel', () => {
+  test('collector count remains after traveling to another planet', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) { this.config = config; },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      updateSpaceUI=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+
+    vm.runInContext('projectManager.projects.dysonSwarmReceiver.unlocked = true;', ctx);
+    vm.runInContext('projectManager.projects.dysonSwarmReceiver.isCompleted = true;', ctx);
+    vm.runInContext('projectManager.projects.dysonSwarmReceiver.collectors = 5;', ctx);
+    vm.runInContext('projectManager.projects.dysonSwarmReceiver.autoDeployCollectors = true;', ctx);
+    vm.runInContext('projectManager.projects.dysonSwarmReceiver.collectorProgress = 12345;', ctx);
+
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const collectors = vm.runInContext('projectManager.projects.dysonSwarmReceiver.collectors', ctx);
+    const unlocked = vm.runInContext('projectManager.projects.dysonSwarmReceiver.unlocked', ctx);
+    const completed = vm.runInContext('projectManager.projects.dysonSwarmReceiver.isCompleted', ctx);
+    const autoDeploy = vm.runInContext('projectManager.projects.dysonSwarmReceiver.autoDeployCollectors', ctx);
+    const progress = vm.runInContext('projectManager.projects.dysonSwarmReceiver.collectorProgress', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(collectors).toBe(5);
+    expect(unlocked).toBe(false);
+    expect(completed).toBe(false);
+    expect(autoDeploy).toBe(false);
+    expect(progress).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Persist only Dyson Swarm collector counts across worlds, leaving receiver unlocked/completion flags reset
- Clarify in the AGENTS guide that energy resumes only after rebuilding the receiver
- Expand collector travel regression test to verify receiver resets while collectors remain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689747b5fe988327aa6d9b91021c7cf5