### PR TITLE
Persist space storage across planet travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,3 +372,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Chapter 13.2 reward now triggers a one-time alert on the Solis tab.
 - Journal objective for Warp Gate Command now displays "Complete an Operation of Difficulty X" for clarity.
 - Space Storage now allows storing glass.
+- Space Storage now preserves its capacity and stored resources across planet travel using travel state save/load.

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -292,6 +292,20 @@ class SpaceStorageProject extends SpaceshipProject {
     this.shipOperationAutoStart = ship.autoStart || false;
     this.shipWithdrawMode = ship.mode === 'withdraw';
   }
+
+  saveTravelState() {
+    return {
+      repeatCount: this.repeatCount,
+      usedStorage: this.usedStorage,
+      resourceUsage: this.resourceUsage,
+    };
+  }
+
+  loadTravelState(state = {}) {
+    this.repeatCount = state.repeatCount || 0;
+    this.usedStorage = state.usedStorage || 0;
+    this.resourceUsage = state.resourceUsage || {};
+  }
 }
 
 if (typeof globalThis !== 'undefined') {

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -218,6 +218,11 @@ function selectPlanet(planetKey){
     if (typeof saveGameToSlot === 'function') {
         saveGameToSlot('pretravel');
     }
+
+    const storageState = projectManager?.projects?.spaceStorage?.saveTravelState
+        ? projectManager.projects.spaceStorage.saveTravelState()
+        : null;
+
     if(!_spaceManagerInstance.changeCurrentPlanet(planetKey)) return;
 
     const firstVisit = _spaceManagerInstance.visitPlanet(planetKey);
@@ -231,5 +236,13 @@ function selectPlanet(planetKey){
     }
 
     initializeGameState({preserveManagers: true, preserveJournal: true});
+
+    if (storageState && projectManager?.projects?.spaceStorage?.loadTravelState) {
+        projectManager.projects.spaceStorage.loadTravelState(storageState);
+        if (typeof updateProjectUI === 'function') {
+            updateProjectUI('spaceStorage');
+        }
+    }
+
     updateSpaceUI();
 }

--- a/tests/spaceStorageTravelPersistence.test.js
+++ b/tests/spaceStorageTravelPersistence.test.js
@@ -1,0 +1,114 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Space Storage travel persistence', () => {
+  test('stored capacity and resources persist across planet travel', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) { this.config = config; },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'" ]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeProjectsUI=()=>{};
+      renderProjects=()=>{};
+      initializeProjectAlerts=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      updateProjectUI=()=>{};
+      updateSpaceUI=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      renderSpaceStorageUI=()=>{};
+      updateSpaceStorageUI=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+
+    vm.runInContext('projectManager.projects.spaceStorage.unlocked = true;', ctx);
+    vm.runInContext('projectManager.projects.spaceStorage.repeatCount = 3; projectManager.projects.spaceStorage.usedStorage = 123; projectManager.projects.spaceStorage.resourceUsage = { metal: 100, glass: 23 };', ctx);
+
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const repeat = vm.runInContext('projectManager.projects.spaceStorage.repeatCount', ctx);
+    const storedMetal = vm.runInContext('projectManager.projects.spaceStorage.resourceUsage.metal', ctx);
+    const used = vm.runInContext('projectManager.projects.spaceStorage.usedStorage', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(repeat).toBe(3);
+    expect(storedMetal).toBe(100);
+    expect(used).toBe(123);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure selecting a new planet saves and restores Space Storage's travel state
- add travel state methods to SpaceStorageProject for repeat count and stored resources
- test that Space Storage capacity and contents persist when traveling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68974cd710d08327a5c44cf930dcd3df