### PR TITLE
Reduce Solis artifact donation reward to 10 points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,6 +368,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Added a Pre-travel save slot that automatically stores the game state before planet travel and remains hidden when empty.
 - WGC class descriptions now appear in the member details window instead of on the team card.
 - Solis artifact donation now uses the correct resource pool, properly displaying owned artifacts and enabling donations.
+- Solis artifact donations now grant 10 points per artifact instead of 100.
 - Solis research upgrade now lists upcoming technologies horizontally and crosses out each as it is purchased, clarifying that one tech is unlocked per purchase.
 - Chapter 13.2 reward now triggers a one-time alert on the Solis tab.
 - Journal objective for Warp Gate Command now displays "Complete an Operation of Difficulty X" for clarity.

--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -206,7 +206,7 @@ class SolisManager extends EffectableEntity {
     } else {
       res.value -= count;
     }
-    this.solisPoints += count * 100;
+    this.solisPoints += count * 10;
     return true;
   }
 

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -183,7 +183,7 @@ function initializeSolisUI() {
 
     const label = document.createElement('span');
     label.classList.add('solis-shop-item-label');
-    label.textContent = 'Donate artifacts for 100 Solis points each';
+    label.textContent = 'Donate artifacts for 10 Solis points each';
     item.appendChild(label);
 
     const actions = document.createElement('div');

--- a/tests/solisResearchUpgrade.test.js
+++ b/tests/solisResearchUpgrade.test.js
@@ -47,7 +47,7 @@ describe('Solis research upgrade', () => {
   test('donating artifacts grants points', () => {
     resources.special.alienArtifact.value = 5;
     expect(manager.donateArtifacts(2)).toBe(true);
-    expect(manager.solisPoints).toBe(200);
+    expect(manager.solisPoints).toBe(20);
     expect(resources.special.alienArtifact.value).toBe(3);
     expect(manager.donateArtifacts(10)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Reduce Solis point reward per donated artifact from 100 to 10 and update UI text.
- Adjust research upgrade test expectations and update changelog.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689750f20d68832783593df167e62790