### PR TITLE
Recalculate WGC team member HP on save load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,3 +377,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage now allows storing glass.
 - Space Storage now preserves its capacity and stored resources across planet travel using travel state save/load.
 - WGC team members now gain 10 Max Health per level instead of 1.
+- Loading saves now recalculates WGC team members' Max Health from their level.

--- a/src/js/team-member.js
+++ b/src/js/team-member.js
@@ -8,8 +8,11 @@ class WGCTeamMember {
     this.athletics = athletics;
     this.wit = wit;
     this.xp = xp;
-    this.maxHealth = typeof maxHealth === 'number' ? maxHealth : 100 + (this.level - 1) * 10;
-    this.health = typeof health === 'number' ? health : this.maxHealth;
+
+    // Recalculate max health from level on creation, ignoring saved values.
+    this.maxHealth = 100 + (this.level - 1) * 10;
+    // Clamp current health to the recalculated maximum.
+    this.health = typeof health === 'number' ? Math.min(health, this.maxHealth) : this.maxHealth;
   }
 
   static getBaseStats(classType) {

--- a/tests/wgcTeamMember.test.js
+++ b/tests/wgcTeamMember.test.js
@@ -32,4 +32,17 @@ describe('WGC team members', () => {
     expect(wgc2.teams[0][0].health).toBe(member.health);
     expect(wgc2.teams[0][0].maxHealth).toBe(member.maxHealth);
   });
+
+  test('load recalculates max health from level', () => {
+    // Simulate saved data with an incorrect maxHealth and health above the new max.
+    const data = {
+      enabled: true,
+      teams: [[{ firstName: 'Zoe', classType: 'Soldier', level: 3, health: 999, maxHealth: 1 }]]
+    };
+    const wgc2 = new WarpGateCommand();
+    wgc2.loadState(data);
+    const member = wgc2.teams[0][0];
+    expect(member.maxHealth).toBe(120);
+    expect(member.health).toBe(120);
+  });
 });


### PR DESCRIPTION
## Summary
- Recalculate WGC team member max health based on level during creation and load
- Clamp loaded health to the new maximum and verify via unit test
- Document save-load max health recalculation in AGENTS notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68976f411b5c8327af01db9a47d1a108