### PR TITLE
Award skill point only when leaving terraformed planets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,3 +378,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Storage now preserves its capacity and stored resources across planet travel using travel state save/load.
 - WGC team members now gain 10 Max Health per level instead of 1.
 - Loading saves now recalculates WGC team members' Max Health from their level.
+- Skill points are now granted only when traveling from a fully terraformed planet to one not yet terraformed.

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -226,7 +226,9 @@ function selectPlanet(planetKey){
     if(!_spaceManagerInstance.changeCurrentPlanet(planetKey)) return;
 
     const firstVisit = _spaceManagerInstance.visitPlanet(planetKey);
-    if(firstVisit && typeof skillManager !== 'undefined' && skillManager){
+    const departingTerraformed = _spaceManagerInstance.isPlanetTerraformed(currentKey);
+    const destinationTerraformed = _spaceManagerInstance.isPlanetTerraformed(planetKey);
+    if(firstVisit && departingTerraformed && !destinationTerraformed && typeof skillManager !== 'undefined' && skillManager){
         skillManager.skillPoints += 1;
     }
 

--- a/tests/travelSkillPoint.test.js
+++ b/tests/travelSkillPoint.test.js
@@ -82,12 +82,16 @@ describe('skill point gained on first planet visit', () => {
     `;
     vm.runInContext(overrides, ctx);
     vm.runInContext('initializeGameState();', ctx);
-    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
 
     const initialPoints = vm.runInContext('skillManager.skillPoints', ctx);
     vm.runInContext("selectPlanet('titan');", ctx);
+    const afterFailedTravel = vm.runInContext('skillManager.skillPoints', ctx);
+    expect(afterFailedTravel).toBe(initialPoints);
+
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+    vm.runInContext("selectPlanet('titan');", ctx);
     const afterFirstTravel = vm.runInContext('skillManager.skillPoints', ctx);
-    expect(afterFirstTravel).toBe(initialPoints + 1);
+    expect(afterFirstTravel).toBe(afterFailedTravel + 1);
 
     vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
     vm.runInContext("selectPlanet('mars');", ctx);


### PR DESCRIPTION
## Summary
- Require current planet to be fully terraformed and destination un-terraforming before awarding a skill point on travel
- Test that skill points aren't granted when attempting travel early and only once per new world
- Document new travel skill point rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68977446bef88327bbfee2fc9c7c0b22