### PR TITLE
Avoid double-counting current planet in terraforming bonuses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,3 +379,5 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC team members now gain 10 Max Health per level instead of 1.
 - Loading saves now recalculates WGC team members' Max Health from their level.
 - Skill points are now granted only when traveling from a fully terraformed planet to one not yet terraformed.
+- Introduced `getTerraformedPlanetCountIncludingCurrent` in SpaceManager to avoid double counting the current planet when
+  applying terraforming bonuses.

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -19,12 +19,12 @@ class SpaceStorageProject extends SpaceshipProject {
   getDurationWithTerraformBonus(baseDuration) {
     if (
       typeof spaceManager === 'undefined' ||
-      typeof spaceManager.getTerraformedPlanetCount !== 'function'
+      typeof spaceManager.getTerraformedPlanetCountIncludingCurrent !== 'function'
     ) {
       return baseDuration;
     }
-    const count = spaceManager.getTerraformedPlanetCount();
-    return baseDuration / (count + 1);
+    const count = spaceManager.getTerraformedPlanetCountIncludingCurrent();
+    return baseDuration / count;
   }
 
   get maxStorage() {

--- a/src/js/projects/TerraformingDurationProject.js
+++ b/src/js/projects/TerraformingDurationProject.js
@@ -2,12 +2,12 @@ class TerraformingDurationProject extends Project {
   getDurationWithTerraformBonus(baseDuration) {
     if (
       typeof spaceManager === 'undefined' ||
-      typeof spaceManager.getTerraformedPlanetCount !== 'function'
+      typeof spaceManager.getTerraformedPlanetCountIncludingCurrent !== 'function'
     ) {
       return baseDuration;
     }
-    const count = spaceManager.getTerraformedPlanetCount();
-    return baseDuration / (count + 1);
+    const count = spaceManager.getTerraformedPlanetCountIncludingCurrent();
+    return baseDuration / count;
   }
 }
 

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -64,11 +64,23 @@ class SpaceManager extends EffectableEntity {
 
     /**
      * Counts how many planets have been fully terraformed.
+     * The current planet only contributes if it is terraformed.
      * @returns {number}
      */
     getTerraformedPlanetCount() {
         return Object.values(this.planetStatuses)
             .filter(status => status.terraformed).length;
+    }
+
+    /**
+     * Counts terraformed planets and includes the current planet if it isn't
+     * terraformed yet. Used for terraforming-related bonuses that previously
+     * added 1 unconditionally.
+     * @returns {number}
+     */
+    getTerraformedPlanetCountIncludingCurrent() {
+        const count = this.getTerraformedPlanetCount();
+        return this.isPlanetTerraformed(this.currentPlanetKey) ? count : count + 1;
     }
 
     /**

--- a/tests/dysonSwarmCollectorDuration.test.js
+++ b/tests/dysonSwarmCollectorDuration.test.js
@@ -15,9 +15,14 @@ describe('Dyson Swarm collector duration UI', () => {
     ctx.projectElements = {};
     ctx.resources = { colony: { glass: { displayName: 'Glass' }, electronics: { displayName: 'Electronics' }, components: { displayName: 'Components' } } };
     ctx.spaceManager = {
+      currentPlanetKey: 'mars',
       planetStatuses: { mars: { terraformed: false } },
       getTerraformedPlanetCount() {
         return Object.values(this.planetStatuses).filter(p => p.terraformed).length;
+      },
+      getTerraformedPlanetCountIncludingCurrent() {
+        const count = this.getTerraformedPlanetCount();
+        return this.planetStatuses[this.currentPlanetKey].terraformed ? count : count + 1;
       }
     };
 
@@ -30,9 +35,9 @@ describe('Dyson Swarm collector duration UI', () => {
       collectors: 0,
       energyPerCollector: 0,
       get collectorDuration() {
-        const count = ctx.spaceManager.getTerraformedPlanetCount ?
-          ctx.spaceManager.getTerraformedPlanetCount() : 0;
-        return 60000 / (count + 1);
+        const count = ctx.spaceManager.getTerraformedPlanetCountIncludingCurrent ?
+          ctx.spaceManager.getTerraformedPlanetCountIncludingCurrent() : 1;
+        return 60000 / count;
       },
       collectorProgress: 0,
       autoDeployCollectors: false,

--- a/tests/spaceManagerTerraformedCount.test.js
+++ b/tests/spaceManagerTerraformedCount.test.js
@@ -1,0 +1,20 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('SpaceManager terraformed planet counting', () => {
+  test('includes current planet only when not terraformed', () => {
+    const sm = new SpaceManager({ mars: {}, titan: {} });
+    sm.planetStatuses.titan.terraformed = true;
+
+    expect(sm.getTerraformedPlanetCount()).toBe(1);
+    expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(2);
+
+    sm.planetStatuses.mars.terraformed = true;
+    expect(sm.getTerraformedPlanetCount()).toBe(2);
+    expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(2);
+  });
+});
+
+delete global.EffectableEntity;
+

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -31,9 +31,12 @@ describe('Space Storage project', () => {
       colonies: {},
       projectElements: {},
       addEffect: () => {},
-      globalGameIsLoadingFromSave: false,
-      spaceManager: { getTerraformedPlanetCount: () => 2 }
-    };
+        globalGameIsLoadingFromSave: false,
+        spaceManager: {
+          getTerraformedPlanetCount: () => 2,
+          getTerraformedPlanetCountIncludingCurrent: () => 3
+        }
+      };
     vm.createContext(ctx);
     vm.runInContext('function capitalizeFirstLetter(s){ return s.charAt(0).toUpperCase() + s.slice(1); }', ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -74,9 +77,12 @@ describe('Space Storage project', () => {
       projectElements: {},
       addEffect: () => {},
       globalGameIsLoadingFromSave: false,
-      document: dom.window.document,
-      spaceManager: { getTerraformedPlanetCount: () => 0 },
-      formatNumber: numbers.formatNumber,
+        document: dom.window.document,
+        spaceManager: {
+          getTerraformedPlanetCount: () => 0,
+          getTerraformedPlanetCountIncludingCurrent: () => 1
+        },
+        formatNumber: numbers.formatNumber,
       formatBigInteger: numbers.formatBigInteger,
       formatTotalCostDisplay: () => '',
       formatTotalResourceGainDisplay: () => '',
@@ -134,9 +140,12 @@ describe('Space Storage project', () => {
       projectElements: {},
       addEffect: () => {},
       globalGameIsLoadingFromSave: false,
-      document: dom.window.document,
-      spaceManager: { getTerraformedPlanetCount: () => 0 },
-      formatNumber: numbers.formatNumber,
+        document: dom.window.document,
+        spaceManager: {
+          getTerraformedPlanetCount: () => 0,
+          getTerraformedPlanetCountIncludingCurrent: () => 1
+        },
+        formatNumber: numbers.formatNumber,
       formatBigInteger: numbers.formatBigInteger,
       formatTotalCostDisplay: () => '',
       formatTotalResourceGainDisplay: () => ''
@@ -178,9 +187,12 @@ describe('Space Storage project', () => {
       projectElements: {},
       addEffect: () => {},
       globalGameIsLoadingFromSave: false,
-      document: dom.window.document,
-      spaceManager: { getTerraformedPlanetCount: () => 0 },
-      formatNumber: numbers.formatNumber,
+        document: dom.window.document,
+        spaceManager: {
+          getTerraformedPlanetCount: () => 0,
+          getTerraformedPlanetCountIncludingCurrent: () => 1
+        },
+        formatNumber: numbers.formatNumber,
       formatBigInteger: numbers.formatBigInteger,
       formatTotalCostDisplay: () => '',
       formatTotalResourceGainDisplay: () => ''
@@ -281,10 +293,13 @@ describe('Space Storage project', () => {
       buildings: {},
       colonies: {},
       projectElements: {},
-      addEffect: () => {},
-      globalGameIsLoadingFromSave: false,
-      spaceManager: { getTerraformedPlanetCount: () => 0 }
-    };
+        addEffect: () => {},
+        globalGameIsLoadingFromSave: false,
+        spaceManager: {
+          getTerraformedPlanetCount: () => 0,
+          getTerraformedPlanetCountIncludingCurrent: () => 1
+        }
+      };
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
@@ -324,10 +339,13 @@ describe('Space Storage project', () => {
       buildings: {},
       colonies: {},
       projectElements: {},
-      addEffect: () => {},
-      globalGameIsLoadingFromSave: false,
-      spaceManager: { getTerraformedPlanetCount: () => 0 }
-    };
+        addEffect: () => {},
+        globalGameIsLoadingFromSave: false,
+        spaceManager: {
+          getTerraformedPlanetCount: () => 0,
+          getTerraformedPlanetCountIncludingCurrent: () => 1
+        }
+      };
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
@@ -411,10 +429,13 @@ describe('Space Storage project', () => {
       buildings: {},
       colonies: {},
       projectElements: {},
-      addEffect: () => {},
-      globalGameIsLoadingFromSave: false,
-      spaceManager: { getTerraformedPlanetCount: () => 0 }
-    };
+        addEffect: () => {},
+        globalGameIsLoadingFromSave: false,
+        spaceManager: {
+          getTerraformedPlanetCount: () => 0,
+          getTerraformedPlanetCountIncludingCurrent: () => 1
+        }
+      };
     vm.createContext(ctx);
     vm.runInContext('function capitalizeFirstLetter(s){ return s.charAt(0).toUpperCase() + s.slice(1); }', ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');


### PR DESCRIPTION
## Summary
- Add `getTerraformedPlanetCountIncludingCurrent` to `SpaceManager` for bonus calculations
- Use the new method in `SpaceStorageProject` and `TerraformingDurationProject`
- Update tests to cover conditional counting of the current planet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897781e96d48327a93ad59b3e28003d