### PR TITLE
Preserve WGC difficulty on recall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,3 +379,4 @@ second time they speak in a chapter to help clarify who is talking.
 - WGC team members now gain 10 Max Health per level instead of 1.
 - Loading saves now recalculates WGC team members' Max Health from their level.
 - Skill points are now granted only when traveling from a fully terraformed planet to one not yet terraformed.
+- Recalling a Warp Gate Command team no longer resets its difficulty.

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -315,7 +315,7 @@ class StoryManager {
           }
           case 'wgcHighestDifficulty': {
                if (typeof warpGateCommand !== 'undefined') {
-                    const current = warpGateCommand.highestDifficulty || 0;
+                    const current = warpGateCommand.highestDifficulty;
                     return compareValues(current, objective.difficulty || 0, objective.comparison);
                }
                return false;
@@ -429,8 +429,8 @@ class StoryManager {
           case 'wgcHighestDifficulty': {
                const current = typeof warpGateCommand !== 'undefined'
                     ? warpGateCommand.highestDifficulty : -1;
-               const dispCurrent = Math.max(0, current);
-               const target = (objective.difficulty || 0);
+               const dispCurrent = Math.max(0, current + 1);
+               const target = (objective.difficulty || 0) + 1;
                return `Complete an Operation of Difficulty ${format(target, true)} (Highest Completed: ${format(dispCurrent, true)})`;
          }
           default:

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -452,7 +452,6 @@ class WarpGateCommand extends EffectableEntity {
       op.progress = 0;
       op.timer = 0;
       op.nextEvent = 60;
-      op.difficulty = 0;
     }
   }
 

--- a/tests/wgcRecallDifficulty.test.js
+++ b/tests/wgcRecallDifficulty.test.js
@@ -1,0 +1,16 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC recall preserves difficulty', () => {
+  test('recalling a team keeps its selected difficulty', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+    wgc.startOperation(0, 3);
+    wgc.recallTeam(0);
+    expect(wgc.operations[0].difficulty).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep Warp Gate Command operation difficulty unchanged when recalling a team
- Correct highest difficulty objective to display and compare using 1-based difficulty
- Add regression test for WGC difficulty preservation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689778e6e46883278fa48dbc0a5d608b