### PR TITLE
refactor: pass world parameters to calculateInitialValues

### DIFF
--- a/src/js/rwgEquilibrate.js
+++ b/src/js/rwgEquilibrate.js
@@ -174,7 +174,7 @@
         globalThis.calculateZoneSolarFluxWithFacility = undefined;
 
         const terra = new TF(sandboxResources, fullParams.celestialParameters || {});
-        terra.calculateInitialValues();
+        terra.calculateInitialValues(fullParams);
 
         let stepIdx = 0;
         let stableCount = 0;

--- a/tests/effectiveAlbedoLife.test.js
+++ b/tests/effectiveAlbedoLife.test.js
@@ -32,7 +32,7 @@ describe('effective albedo with biomass', () => {
     global.currentPlanetParameters = params;
     const celestial = { radius: 1, gravity: 1, albedo: 0.5, surfaceArea: 1, distanceFromSun: 1 };
     const terra = new Terraforming(global.resources, celestial);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
 
     const baseAlbedo = terra.calculateEffectiveAlbedo();
 

--- a/tests/equilibriumConstants.test.js
+++ b/tests/equilibriumConstants.test.js
@@ -59,7 +59,7 @@ describe('equilibrium constants', () => {
     const res = createResources(params.resources);
     global.resources = res;
     const terra = new Terraforming(res, params.celestialParameters);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
     debugTools.calculateEquilibriumConstants.call(terra);
 
     terra.updateResources(1000); // one tick

--- a/tests/flowMeltRate.test.js
+++ b/tests/flowMeltRate.test.js
@@ -54,7 +54,7 @@ describe('flow melt tracking', () => {
     const res = createResources();
     global.resources = res;
     const terra = new Terraforming(res, params.celestialParameters);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
 
     // remove initial water to avoid other melt
     for (const z of ['tropical','temperate','polar']) {

--- a/tests/initialTemperature.test.js
+++ b/tests/initialTemperature.test.js
@@ -41,7 +41,7 @@ describe('initial planetary temperatures', () => {
     const res = createResources(params.resources);
     global.resources = res;
     const terra = new Terraforming(res, params.celestialParameters);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
     terra._updateZonalCoverageCache(); // Manually populate cache for test
     const initial = terra.temperature.value;
     terra.updateSurfaceTemperature();

--- a/tests/methaneRates.test.js
+++ b/tests/methaneRates.test.js
@@ -61,7 +61,7 @@ describe('methane atmospheric rate tracking', () => {
     const res = createResources();
     global.resources = res;
     const terra = new Terraforming(res, params.celestialParameters);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
 
     // ensure some methane in atmosphere so condensation path runs
     res.atmospheric.atmosphericMethane.value = 50;

--- a/tests/spaceMirrorFocusingEffect.test.js
+++ b/tests/spaceMirrorFocusingEffect.test.js
@@ -61,7 +61,7 @@ describe('focused mirror melt', () => {
     const res = createResources();
     global.resources = res;
     const terra = new Terraforming(res, params.celestialParameters);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
 
     // simplify environment: no water except polar ice and set cold zone temps
     for (const z of ['tropical','temperate','polar']) {
@@ -109,7 +109,7 @@ describe('focused mirror melt', () => {
     const res = createResources();
     global.resources = res;
     const terra = new Terraforming(res, params.celestialParameters);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
 
     for (const z of ['tropical','temperate','polar']) {
       terra.zonalWater[z].liquid = 0;

--- a/tests/terraformingUtilsIntegration.test.js
+++ b/tests/terraformingUtilsIntegration.test.js
@@ -51,7 +51,7 @@ describe('terraforming-utils integration', () => {
     // set some water for coverage
     terra.zonalWater.tropical.liquid = 1e6;
     terra.zonalWater.temperate.liquid = 5e5;
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
     terra._updateZonalCoverageCache();
 
     const expectedStatus = calculateAverageCoverage(terra, 'liquidWater') > terra.waterTarget;
@@ -75,7 +75,7 @@ describe('terraforming-utils integration', () => {
     global.resources = res;
     const terra = new Terraforming(res, params.celestialParameters);
 
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
 
     terra.zonalWater.polar.ice = 1000;
     const initialCov = calculateZonalCoverage(terra, 'polar', 'ice');

--- a/tests/zonalSurfaceOverride.test.js
+++ b/tests/zonalSurfaceOverride.test.js
@@ -34,7 +34,7 @@ describe('zonal surface overrides', () => {
     global.resources = resources;
 
     const terra = new Terraforming(resources, params.celestialParameters);
-    terra.calculateInitialValues();
+    terra.calculateInitialValues(params);
 
     expect(terra.zonalSurface.tropical.dryIce).toBeCloseTo(params.zonalSurface.tropical.dryIce);
     expect(terra.zonalSurface.temperate.dryIce).toBeCloseTo(params.zonalSurface.temperate.dryIce);


### PR DESCRIPTION
## Summary
- refactor `calculateInitialValues` to accept explicit planet parameters
- update terraforming initialization and save loading to supply current world data
- adjust rwg equilibrium and tests to pass planet configs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897bd2e74408327b7630ecc933ccb5d