### PR TITLE
Remove post-test journal logging

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -178,7 +178,6 @@ function processNextJournalEntry() {
         journalContainer.scrollTop = journalContainer.scrollHeight;
       }
 
-      console.log("Journal typing complete, dispatching storyJournalFinishedTyping event.");
       const storyEvent = new CustomEvent('storyJournalFinishedTyping', { detail: { eventId: journalCurrentEventId } });
       document.dispatchEvent(storyEvent);
 


### PR DESCRIPTION
## Summary
- stop Journal typing from logging to the console after completing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897c373e5e083279a1f5a5f90a95a7a