### PR TITLE
Fix RWG equilibration progress bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,3 +389,4 @@ second time they speak in a chapter to help clarify who is talking.
 - RWG equilibration waits at least 10s, displays a progress window with a cancel button, and always finalizes on cancel.
 - Equilibrate button in Random World Generator can now be used repeatedly.
 - Fixed RWG UI crash by restoring the `attachEquilibrateHandler` function.
+- RWG equilibrate progress bar now fills as the simulation advances.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -170,8 +170,16 @@ function attachEquilibrateHandler(res, sStr, archetype, box) {
 
       eqBtn.disabled = true;
       try {
-        const result = await runEquilibration(res.override, { yearsMax: 10000, stepDays: 1, checkEvery: 5, absTol: 1e6, relTol: 1e-6, chunkSteps: 20, cancelToken }, (p) => {
-          bar.style.width = `${Math.round(p * 100)}%`;
+        const result = await runEquilibration(res.override, {
+          yearsMax: 10000,
+          stepDays: 1,
+          checkEvery: 5,
+          absTol: 1e6,
+          relTol: 1e-6,
+          chunkSteps: 20,
+          cancelToken
+        }, (p) => {
+          bar.style.width = `${(p * 100).toFixed(2)}%`;
         });
         const newRes = { ...res, override: result.override, merged: deepMerge(defaultPlanetParameters, result.override) };
         box.innerHTML = renderWorldDetail(newRes, sStr, archetype);

--- a/tests/rwgProgressBar.test.js
+++ b/tests/rwgProgressBar.test.js
@@ -1,0 +1,45 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('RWG progress bar', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<button id="rwg-equilibrate-btn"></button>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.getGameSpeed = () => 1;
+    global.setGameSpeed = () => {};
+    global.deepMerge = (a, b) => ({ ...a, ...b });
+    global.defaultPlanetParameters = {};
+  });
+
+  afterEach(() => {
+    delete global.document;
+    delete global.window;
+    delete global.getGameSpeed;
+    delete global.setGameSpeed;
+    delete global.deepMerge;
+    delete global.defaultPlanetParameters;
+  });
+
+  test('updates width for small progress', async () => {
+    let widthSeen = null;
+    global.runEquilibration = (_override, _opts, onProgress) => {
+      return new Promise((resolve, reject) => {
+        onProgress(0.001);
+        const bar = document.body.querySelector('div > div > div > div');
+        widthSeen = bar ? bar.style.width : null;
+        reject(new Error('cancelled'));
+      });
+    };
+    const { attachEquilibrateHandler } = require('../src/js/rwgUI.js');
+    const res = { override: {} };
+    const box = document.body;
+    attachEquilibrateHandler(res, 'seed', 'type', box);
+    document.getElementById('rwg-equilibrate-btn').click();
+    await new Promise(setImmediate);
+    expect(parseFloat(widthSeen)).toBeGreaterThan(0);
+    delete global.runEquilibration;
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Random World Generator equilibrate progress bar reflects progress smoothly
- test progress bar to verify small updates are visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6897d12b8d388327948ccdf4103eddc2