### PR TITLE
Add travel option to random world generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,3 +390,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Equilibrate button in Random World Generator can now be used repeatedly.
 - Fixed RWG UI crash by restoring the `attachEquilibrateHandler` function.
 - RWG equilibrate progress bar now fills as the simulation advances.
+- Random World Generator now includes a Travel button that remains disabled until the world is equilibrated at least once and shows a warning until then.

--- a/tests/rwgTravelButton.test.js
+++ b/tests/rwgTravelButton.test.js
@@ -1,0 +1,59 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Random World Generator travel button', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<div id="rwg-result"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.formatNumber = n => n;
+    global.calculateAtmosphericPressure = () => 0;
+    global.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+    global.getGameSpeed = () => 1;
+    global.setGameSpeed = () => {};
+    global.runEquilibration = jest.fn(async (override) => ({ override }));
+    global.deepMerge = (a, b) => ({ ...a, ...b });
+    global.defaultPlanetParameters = {};
+    global.initializeGameState = jest.fn();
+  });
+
+  test('enables travel after equilibration', async () => {
+    const { renderWorldDetail, attachEquilibrateHandler, attachTravelHandler } = require('../src/js/rwgUI.js');
+    const res = {
+      star: { name: 'Sun', spectralType: 'G', luminositySolar: 1, massSolar: 1, temperatureK: 5800, habitableZone: { inner: 0.5, outer: 1.5 } },
+      merged: {
+        celestialParameters: { distanceFromSun: 1, radius: 6000, gravity: 9.8, albedo: 0.3, rotationPeriod: 24 },
+        resources: {
+          atmospheric: {
+            carbonDioxide: { initialValue: 1 },
+            inertGas: { initialValue: 1 },
+            oxygen: { initialValue: 0 },
+            atmosphericWater: { initialValue: 0 },
+            atmosphericMethane: { initialValue: 0 }
+          },
+          surface: {}
+        },
+        classification: { archetype: 'mars-like' }
+      },
+      override: { resources: { atmospheric: {} } }
+    };
+    const box = document.getElementById('rwg-result');
+    box.innerHTML = renderWorldDetail(res, 'seed', 'mars-like');
+    attachEquilibrateHandler(res, 'seed', 'mars-like', box);
+    attachTravelHandler(res, 'seed');
+
+    const travelBtn = document.getElementById('rwg-travel-btn');
+    expect(travelBtn.disabled).toBe(true);
+    expect(document.getElementById('rwg-travel-warning')).not.toBeNull();
+
+    document.getElementById('rwg-equilibrate-btn').click();
+    await new Promise(setImmediate);
+    await new Promise(setImmediate);
+
+    const travelBtn2 = document.getElementById('rwg-travel-btn');
+    expect(travelBtn2.disabled).toBe(false);
+    expect(document.getElementById('rwg-travel-warning')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add travel button to random world generator UI
- enable travel after equilibration and show warning until equilibrated
- cover new behavior with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897f25afb3c8327ba5ba7939ed89d75