### PR TITLE
feat: mention land recovery in tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,3 +391,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Fixed RWG UI crash by restoring the `attachEquilibrateHandler` function.
 - RWG equilibrate progress bar now fills as the simulation advances.
 - Random World Generator now includes a Travel button that remains disabled until the world is equilibrated at least once and shows a warning until then.
+- Land resource tooltip now notes that land can be recovered by turning off the corresponding building.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -38,6 +38,13 @@ function createTooltipElement(resourceName) {
   timeDiv.id = `${resourceName}-tooltip-time`;
   tooltip.appendChild(timeDiv);
 
+  if (resourceName === 'land') {
+    const noteDiv = document.createElement('div');
+    noteDiv.id = `${resourceName}-tooltip-note`;
+    noteDiv.textContent = 'Land can be recovered by turning off the corresponding building';
+    tooltip.appendChild(noteDiv);
+  }
+
   const assignmentsDiv = document.createElement('div');
   assignmentsDiv.id = `${resourceName}-tooltip-assignments`;
   tooltip.appendChild(assignmentsDiv);

--- a/tests/landTooltip.test.js
+++ b/tests/landTooltip.test.js
@@ -42,7 +42,9 @@ describe('land resource tooltip', () => {
     };
     ctx.createResourceDisplay({ surface: { land } });
     ctx.updateResourceRateDisplay(land);
-    const html = dom.window.document.getElementById('land-tooltip').innerHTML;
+    const tooltip = dom.window.document.getElementById('land-tooltip');
+    const html = tooltip.innerHTML;
+    expect(tooltip.textContent).toContain('Land can be recovered by turning off the corresponding building');
     expect(html).toContain('Outpost');
     expect(html).toContain('Factory');
     expect(html).toContain('Greenhouse');


### PR DESCRIPTION
## Summary
- note that disabling buildings recovers land in the land tooltip
- test land tooltip note and order of usage breakdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898f9d4ddc88327badbbe1e818ea3d3