### PR TITLE
Enable manual autosave saving

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,3 +391,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Fixed RWG UI crash by restoring the `attachEquilibrateHandler` function.
 - RWG equilibrate progress bar now fills as the simulation advances.
 - Random World Generator now includes a Travel button that remains disabled until the world is equilibrated at least once and shows a warning until then.
+- Autosave slot can now be manually overwritten through the Save button.

--- a/index.html
+++ b/index.html
@@ -464,7 +464,7 @@
                         <td>Autosave</td>
                         <td id="autosave-date">Empty</td>
                         <td>
-                            <button class="save-button" data-slot="autosave" disabled>Save</button>
+                            <button class="save-button" data-slot="autosave">Save</button>
                             <button class="load-button" data-slot="autosave">Load</button>
                             <button class="delete-button" data-slot="autosave">Delete</button>
                         </td>

--- a/tests/autosaveManualSave.test.js
+++ b/tests/autosaveManualSave.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+
+describe('autosave slot', () => {
+  test('save button is enabled', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const saveButton = dom.window.document.querySelector('.save-button[data-slot="autosave"]');
+    expect(saveButton).not.toBeNull();
+    expect(saveButton.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow the Autosave slot to be manually overwritten by enabling its Save button
- Document autosave overwrite capability in AGENTS notes
- Test that autosave save button is enabled in settings UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898fa52a2c08327891161a0a987e8df