### PR TITLE
Track random world travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,3 +391,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Fixed RWG UI crash by restoring the `attachEquilibrateHandler` function.
 - RWG equilibrate progress bar now fills as the simulation advances.
 - Random World Generator now includes a Travel button that remains disabled until the world is equilibrated at least once and shows a warning until then.
+- Space Manager tracks random world seeds and colonist populations, blocks travel to terraformed seeds, and displays current world details.

--- a/index.html
+++ b/index.html
@@ -370,6 +370,13 @@
             </div>
             <div class="space-subtab-content-wrapper">
                 <div id="space-story" class="space-subtab-content active">
+                    <div id="current-world-section">
+                        <div id="current-world-header">Current World: <span id="current-world-name"></span></div>
+                        <details id="current-world-details-container">
+                            <summary>Original Properties</summary>
+                            <div id="current-world-details"></div>
+                        </details>
+                    </div>
                     <h2>Planet Selection</h2>
                     <div id="planet-selection-options">
                         <!-- Planet options will be added dynamically here later -->

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -132,6 +132,7 @@ function initializeSpaceUI(spaceManager) {
     });
 
     updateSpaceUI(); // Perform the initial draw using the stored instance
+    updateCurrentWorldUI();
 }
 
 /**
@@ -142,6 +143,7 @@ function initializeSpaceUI(spaceManager) {
 function updateSpaceUI() {
     if (!_spaceManagerInstance) return; // Guard clause
     updateSpaceRandomVisibility();
+    updateCurrentWorldUI();
 
     const statusContainer = document.getElementById('travel-status');
     const allPlanetData = typeof planetParameters !== 'undefined' ? planetParameters : null;
@@ -247,4 +249,30 @@ function selectPlanet(planetKey){
     }
 
     updateSpaceUI();
+}
+
+function updateCurrentWorldUI() {
+    if (!_spaceManagerInstance) return;
+    const nameSpan = document.getElementById('current-world-name');
+    const detailsBox = document.getElementById('current-world-details');
+    if (nameSpan) {
+        nameSpan.textContent = _spaceManagerInstance.getCurrentWorldName();
+    }
+    if (detailsBox) {
+        const data = _spaceManagerInstance.getCurrentWorldOriginal();
+        const seed = _spaceManagerInstance.getCurrentRandomSeed();
+        if (data && typeof renderWorldDetail === 'function') {
+            let html = renderWorldDetail(data, seed);
+            const wrapper = document.createElement('div');
+            wrapper.innerHTML = html;
+            wrapper.querySelector('#rwg-equilibrate-btn')?.remove();
+            wrapper.querySelector('#rwg-travel-btn')?.remove();
+            wrapper.querySelector('#rwg-travel-warning')?.remove();
+            wrapper.querySelectorAll('[id]').forEach(el => el.removeAttribute('id'));
+            detailsBox.innerHTML = '';
+            detailsBox.appendChild(wrapper);
+        } else {
+            detailsBox.innerHTML = '';
+        }
+    }
 }

--- a/tests/rwgTravelTerraformedSeed.test.js
+++ b/tests/rwgTravelTerraformedSeed.test.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('RWG prevents travel to terraformed seeds', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<div id="rwg-result"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.formatNumber = n => n;
+    global.calculateAtmosphericPressure = () => 0;
+    global.dayNightTemperaturesModel = () => ({ mean:0, day:0, night:0 });
+    global.getGameSpeed = () => 1;
+    global.setGameSpeed = () => {};
+    global.runEquilibration = jest.fn(async (o) => ({ override: o }));
+    global.deepMerge = (a,b) => ({ ...a, ...b });
+    global.defaultPlanetParameters = {};
+    global.spaceManager = new SpaceManager({ mars: {} });
+  });
+
+  test('travel button disabled when seed already terraformed', async () => {
+    spaceManager.randomWorldStatuses['123'] = { name:'World', terraformed:true };
+    const { renderWorldDetail, attachEquilibrateHandler } = require('../src/js/rwgUI.js');
+    const res = {
+      star: { name:'Sun', spectralType:'G', luminositySolar:1, massSolar:1, temperatureK:5800, habitableZone:{ inner:0.5, outer:1.5 } },
+      merged: {
+        celestialParameters:{ distanceFromSun:1, radius:6000, gravity:9.8, albedo:0.3, rotationPeriod:24 },
+        resources:{ atmospheric:{ carbonDioxide:{ initialValue:1 }, inertGas:{ initialValue:1 } }, surface:{} },
+        classification:{ archetype:'mars-like' }
+      },
+      override:{ resources:{ atmospheric:{} } }
+    };
+    const box = document.getElementById('rwg-result');
+    box.innerHTML = renderWorldDetail(res, '123', 'mars-like');
+    attachEquilibrateHandler(res, '123', 'mars-like', box);
+    document.getElementById('rwg-equilibrate-btn').click();
+    await new Promise(setImmediate);
+    await new Promise(setImmediate);
+    const btn = document.getElementById('rwg-travel-btn');
+    expect(btn.disabled).toBe(true);
+    expect(document.getElementById('rwg-travel-warning').textContent).toMatch(/already been terraformed/);
+  });
+});
+
+delete global.EffectableEntity;

--- a/tests/spaceManagerRandomTravel.test.js
+++ b/tests/spaceManagerRandomTravel.test.js
@@ -1,0 +1,27 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('SpaceManager random world travel population tracking', () => {
+  beforeEach(() => {
+    global.resources = { colony: { colonists: { value: 0 } } };
+    global.saveGameToSlot = jest.fn();
+    global.initializeGameState = jest.fn();
+    global.projectManager = { projects: { spaceStorage: { saveTravelState: jest.fn(() => null), loadTravelState: jest.fn() } } };
+    global.updateProjectUI = jest.fn();
+    global.updateSpaceUI = jest.fn();
+  });
+
+  test('records colonists when leaving worlds', () => {
+    const sm = new SpaceManager({ mars: { name: 'Mars' } });
+    resources.colony.colonists.value = 100;
+    sm.travelToRandomWorld({ merged: { name: 'Alpha' } }, '1');
+    expect(sm.planetStatuses.mars.colonists).toBe(100);
+    resources.colony.colonists.value = 50;
+    sm.travelToRandomWorld({ merged: { name: 'Beta' } }, '2');
+    expect(sm.randomWorldStatuses['1'].colonists).toBe(50);
+    expect(sm.getCurrentWorldName()).toBe('Beta');
+  });
+});
+
+delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- display current random world details and name in Space tab
- track random world seeds and colonist counts in SpaceManager and prevent revisiting terraformed seeds
- block RWG travel to terraformed seeds and document feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898f956d1cc832784aa0fe0db752c0e