### PR TITLE
Simplify RWG travel warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,3 +394,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Manager tracks random world seeds and colonist populations, blocks travel to terraformed seeds, and displays current world details.
 - Autosave slot can now be manually overwritten through the Save button.
 - Land resource tooltip now notes that land can be recovered by turning off the corresponding building.
+- Random World Generator travel warning now displays inline with triangle icons next to the Travel button.

--- a/src/css/warning.css
+++ b/src/css/warning.css
@@ -18,6 +18,11 @@ box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 animation: pulse 1s infinite;
 }
 
+.rwg-inline-warning {
+    color: #ff4d4d;
+    font-weight: bold;
+}
+
 @keyframes pulse {
 0% {
     transform: scale(1);

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -284,8 +284,8 @@ function renderWorldDetail(res, seedUsed, forcedType) {
       <div style="margin-bottom:8px; display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
         <button id="rwg-equilibrate-btn" class="rwg-btn">Equilibrate</button>
         <button id="rwg-travel-btn" class="rwg-btn" ${travelDisabled ? 'disabled' : ''}>Travel</button>
+        ${warningMsg ? `<span id="rwg-travel-warning" class="rwg-inline-warning">⚠ ${warningMsg} ⚠</span>` : ''}
       </div>
-      ${warningMsg ? `<div id="rwg-travel-warning" class="warning-message">${warningMsg}</div>` : ''}
       <div class="rwg-infobar">
         <div class="rwg-chip"><div class="label">Seed</div><div class="value">${seedUsed !== undefined ? seedUsed : ''}</div></div>
         <div class="rwg-chip"><div class="label">Orbit</div><div class="value">${(res.orbitAU ?? c.distanceFromSun)?.toFixed ? (res.orbitAU ?? c.distanceFromSun).toFixed(2) : (res.orbitAU ?? c.distanceFromSun)} AU</div></div>


### PR DESCRIPTION
## Summary
- Show inline triangle warning next to the Random World Generator travel button
- Add minimal styling for RWG travel warning
- Document RWG travel warning change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898fe3ff56c8327bab9fb823d9fd175