### PR TITLE
Display original stats for story worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,3 +394,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space Manager tracks random world seeds and colonist populations, blocks travel to terraformed seeds, and displays current world details.
 - Autosave slot can now be manually overwritten through the Save button.
 - Land resource tooltip now notes that land can be recovered by turning off the corresponding building.
+- Space UI now shows original planetary properties for story worlds.

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -1,5 +1,15 @@
 // space.js
 
+// Simple representation of the Sun used for original planet summaries
+const SOL_STAR = {
+    name: 'Sol',
+    spectralType: 'G2V',
+    luminositySolar: 1,
+    massSolar: 1,
+    temperatureK: 5778,
+    habitableZone: { inner: 0.95, outer: 1.37 }
+};
+
 class SpaceManager extends EffectableEntity {
     constructor(planetsData) { // Keep planetsData for validation
         super({ description: 'Manages planetary travel' });
@@ -99,7 +109,9 @@ class SpaceManager extends EffectableEntity {
         if (this.currentRandomSeed !== null) {
             return this.randomWorldStatuses[this.currentRandomSeed]?.original || null;
         }
-        return null;
+        const base = this.allPlanetsData[this.currentPlanetKey];
+        if (!base) return null;
+        return { merged: base, star: SOL_STAR };
     }
 
     getCurrentRandomSeed() {

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -261,8 +261,9 @@ function updateCurrentWorldUI() {
     if (detailsBox) {
         const data = _spaceManagerInstance.getCurrentWorldOriginal();
         const seed = _spaceManagerInstance.getCurrentRandomSeed();
+        const seedArg = seed === null ? undefined : seed;
         if (data && typeof renderWorldDetail === 'function') {
-            let html = renderWorldDetail(data, seed);
+            let html = renderWorldDetail(data, seedArg);
             const wrapper = document.createElement('div');
             wrapper.innerHTML = html;
             wrapper.querySelector('#rwg-equilibrate-btn')?.remove();

--- a/tests/spaceStoryWorldDetails.test.js
+++ b/tests/spaceStoryWorldDetails.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+const rwgUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+
+function loadScript(file, ctx) {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', file), 'utf8');
+  vm.runInContext(code, ctx);
+}
+
+describe('current world details for story planets', () => {
+  test('displays original properties', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="planet-selection-options"></div><div id="travel-status"></div><span id="current-world-name"></span><div id="current-world-details"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.console = console;
+    ctx.planetParameters = planetParameters;
+    ctx.calculateAtmosphericPressure = () => 0;
+    ctx.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+    ctx.getGameSpeed = () => 1;
+    ctx.setGameSpeed = () => {};
+    ctx.runEquilibration = async () => ({ res: {} });
+    ctx.deepMerge = (a, b) => ({ ...a, ...b });
+    ctx.defaultPlanetParameters = {};
+    ctx.initializeGameState = () => {};
+
+    vm.runInContext(`${effectCode}\n${spaceCode}; this.EffectableEntity = EffectableEntity; this.SpaceManager = SpaceManager;`, ctx);
+    vm.runInContext(rwgUICode, ctx);
+    loadScript('spaceUI.js', ctx);
+
+    ctx.spaceManager = new ctx.SpaceManager(planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+    ctx.updateCurrentWorldUI();
+
+    const details = dom.window.document.getElementById('current-world-details');
+    expect(details.innerHTML.trim()).not.toBe('');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Show solar system world's initial properties in the Space tab using a new Sun baseline
- Provide story planets to the world details renderer and hide seed output when traveling
- Verify story planet details render in the Space UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898fe7763e88327b05eb04bf0189934