### PR TITLE
Handle RWG equilibration timeouts for travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,3 +396,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Land resource tooltip now notes that land can be recovered by turning off the corresponding building.
 - Space UI now shows original planetary properties for story worlds.
 - Random World Generator travel warning now displays inline with triangle icons next to the Travel button.
+- Random World Generator equilibration timeout now counts as having used the button for enabling travel.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -209,7 +209,14 @@ function attachEquilibrateHandler(res, sStr, archetype, box) {
         attachEquilibrateHandler(newRes, sStr, archetype, box);
         attachTravelHandler(newRes, sStr);
       } catch (e) {
-        if (e?.message !== 'cancelled') console.error('Equilibration failed:', e);
+        if (e?.message === 'timeout') {
+          equilibratedWorlds.add(sStr);
+          box.innerHTML = renderWorldDetail(res, sStr, archetype);
+          attachEquilibrateHandler(res, sStr, archetype, box);
+          attachTravelHandler(res, sStr);
+        } else if (e?.message !== 'cancelled') {
+          console.error('Equilibration failed:', e);
+        }
       } finally {
         if (typeof setGameSpeed === 'function') setGameSpeed(prevSpeed);
         const btn = document.getElementById('rwg-equilibrate-btn');

--- a/tests/rwgEquilibrateTimeout.test.js
+++ b/tests/rwgEquilibrateTimeout.test.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Random World Generator equilibration timeout', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<div id="rwg-result"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.formatNumber = n => n;
+    global.calculateAtmosphericPressure = () => 0;
+    global.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+    global.getGameSpeed = () => 1;
+    global.setGameSpeed = () => {};
+    global.runEquilibration = jest.fn(async () => { throw new Error('timeout'); });
+    global.deepMerge = (a, b) => ({ ...a, ...b });
+    global.defaultPlanetParameters = {};
+  });
+
+  test('enables travel after timeout', async () => {
+    const { renderWorldDetail, attachEquilibrateHandler, attachTravelHandler } = require('../src/js/rwgUI.js');
+    const res = {
+      star: { name: 'Sun', spectralType: 'G', luminositySolar: 1, massSolar: 1, temperatureK: 5800, habitableZone: { inner: 0.5, outer: 1.5 } },
+      merged: {
+        celestialParameters: { distanceFromSun: 1, radius: 6000, gravity: 9.8, albedo: 0.3, rotationPeriod: 24 },
+        resources: {
+          atmospheric: {
+            carbonDioxide: { initialValue: 1 },
+            inertGas: { initialValue: 1 },
+            oxygen: { initialValue: 0 },
+            atmosphericWater: { initialValue: 0 },
+            atmosphericMethane: { initialValue: 0 }
+          },
+          surface: {}
+        },
+        classification: { archetype: 'mars-like' }
+      },
+      override: { resources: { atmospheric: {} } }
+    };
+    const box = document.getElementById('rwg-result');
+    box.innerHTML = renderWorldDetail(res, 'seed-timeout', 'mars-like');
+    attachEquilibrateHandler(res, 'seed-timeout', 'mars-like', box);
+    attachTravelHandler(res, 'seed-timeout');
+
+    const travelBtn = document.getElementById('rwg-travel-btn');
+    expect(travelBtn.disabled).toBe(true);
+
+    document.getElementById('rwg-equilibrate-btn').click();
+    await new Promise(setImmediate);
+    await new Promise(setImmediate);
+
+    const travelBtn2 = document.getElementById('rwg-travel-btn');
+    expect(travelBtn2.disabled).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow Random World Generator travel after equilibration timeouts
- cover timeout case with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68990135722c832789804111a550553f