### PR TITLE
Implement dynamic spaceship pricing with decay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,3 +397,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space UI now shows original planetary properties for story worlds.
 - Random World Generator travel warning now displays inline with triangle icons next to the Travel button.
 - Random World Generator equilibration timeout now counts as having used the button for enabling travel.
+- Cargo rocket ship purchases now raise future ship prices based on terraformed planets and decay by 1% per second.

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -390,8 +390,12 @@ function updateTotalCostDisplay(project) {
     const category = input.dataset.category;
     const resource = input.dataset.resource;
     const quantity = parseInt(input.value, 10);
-    const pricePerUnit = project.attributes.resourceChoiceGainCost[category][resource];
-    totalCost += quantity * pricePerUnit;
+    const basePrice = project.attributes.resourceChoiceGainCost[category][resource];
+    if (resource === 'spaceships' && typeof project.getSpaceshipTotalCost === 'function') {
+      totalCost += project.getSpaceshipTotalCost(quantity, basePrice);
+    } else {
+      totalCost += quantity * basePrice;
+    }
   });
 
   // Update the total cost display element

--- a/tests/shipPriceIncrease.test.js
+++ b/tests/shipPriceIncrease.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Spaceship price increase and decay', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console };
+    vm.createContext(ctx);
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+    vm.runInContext(spaceCode + '; this.SpaceManager = SpaceManager;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+  });
+
+  test('buying multiple ships raises and decays price', () => {
+    ctx.resources = {
+      colony: { funding: { value: 1_000_000, decrease(amount){ this.value -= amount; } } },
+      special: { spaceships: { value: 0, displayName: 'Spaceships', unlocked: true } }
+    };
+    ctx.spaceManager = new ctx.SpaceManager({ mars: {}, titan: {} });
+    ctx.spaceManager.planetStatuses.mars.terraformed = true;
+    ctx.spaceManager.planetStatuses.titan.terraformed = true;
+
+    const project = new ctx.CargoRocketProject(ctx.projectParameters.cargo_rocket, 'test');
+    project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 3 }];
+
+    const initialCost = project.getResourceChoiceGainCost();
+    expect(initialCost).toBeCloseTo(450_000);
+
+    project.deductResources(ctx.resources);
+    expect(ctx.resources.colony.funding.value).toBeCloseTo(550_000);
+    expect(project.spaceshipPriceIncrease).toBeCloseTo(1.5);
+
+    project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 1 }];
+    const costAfter = project.getResourceChoiceGainCost();
+    expect(costAfter).toBeCloseTo(250_000);
+
+    project.update(1000);
+    const decayedCost = project.getResourceChoiceGainCost();
+    expect(decayedCost).toBeCloseTo(248_500);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Track spaceship price increases within Cargo Rocket project and decay them over time
- Apply quadratic pricing for multi-ship purchases and update project UI to use project-specific cost math
- Add tests verifying multi-ship cost scaling and decay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68990bc5cc948327a1807a05437e136b