### PR TITLE
Use planet overrides for story world surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,3 +397,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space UI now shows original planetary properties for story worlds.
 - Random World Generator travel warning now displays inline with triangle icons next to the Travel button.
 - Random World Generator equilibration timeout now counts as having used the button for enabling travel.
+- Story world original properties now apply planet overrides and aggregate zonal surface data for accurate totals.

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -481,6 +481,8 @@ const planetSpecificOverrides = {
   ganymede: ganymedeOverrides
   // Add future planets here by defining their override objects
 };
+// Expose overrides for modules needing raw planet data
+const planetOverrides = planetSpecificOverrides;
 
 /**
  * Gets the fully merged parameters for a specific planet by combining
@@ -517,5 +519,5 @@ const planetParameters = {
 // If the codebase evolves to use the getPlanetParameters function directly,
 // the export could be changed to: export { getPlanetParameters, defaultPlanetParameters };
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { getPlanetParameters, planetParameters, defaultPlanetParameters };
+  module.exports = { getPlanetParameters, planetParameters, defaultPlanetParameters, planetOverrides };
 }

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -111,7 +111,41 @@ class SpaceManager extends EffectableEntity {
         }
         const base = this.allPlanetsData[this.currentPlanetKey];
         if (!base) return null;
-        return { merged: base, star: SOL_STAR };
+        const override = typeof planetOverrides !== 'undefined' ? planetOverrides[this.currentPlanetKey] : null;
+        const merged = JSON.parse(JSON.stringify(base));
+        const zones = ['tropical', 'temperate', 'polar'];
+        let totalLiquidWater = 0, totalIce = 0, totalDryIce = 0,
+            totalBiomass = 0, totalLiquidMethane = 0, totalHydrocarbonIce = 0;
+
+        zones.forEach(z => {
+            const zw = merged.zonalWater?.[z] || {};
+            totalLiquidWater += zw.liquid || 0;
+            totalIce += (zw.ice || 0) + (zw.buriedIce || 0);
+            const zs = merged.zonalSurface?.[z] || {};
+            totalDryIce += zs.dryIce || 0;
+            totalBiomass += zs.biomass || 0;
+            const zh = merged.zonalHydrocarbons?.[z] || {};
+            totalLiquidMethane += zh.liquid || 0;
+            totalHydrocarbonIce += (zh.ice || 0) + (zh.buriedIce || 0);
+        });
+
+        if (!merged.resources) merged.resources = {};
+        if (!merged.resources.surface) merged.resources.surface = {};
+        merged.resources.surface.liquidWater = merged.resources.surface.liquidWater || {};
+        merged.resources.surface.ice = merged.resources.surface.ice || {};
+        merged.resources.surface.dryIce = merged.resources.surface.dryIce || {};
+        merged.resources.surface.biomass = merged.resources.surface.biomass || {};
+        merged.resources.surface.liquidMethane = merged.resources.surface.liquidMethane || {};
+        merged.resources.surface.hydrocarbonIce = merged.resources.surface.hydrocarbonIce || {};
+
+        merged.resources.surface.liquidWater.initialValue = totalLiquidWater;
+        merged.resources.surface.ice.initialValue = totalIce;
+        merged.resources.surface.dryIce.initialValue = totalDryIce;
+        merged.resources.surface.biomass.initialValue = totalBiomass;
+        merged.resources.surface.liquidMethane.initialValue = totalLiquidMethane;
+        merged.resources.surface.hydrocarbonIce.initialValue = totalHydrocarbonIce;
+
+        return { merged, override, star: SOL_STAR };
     }
 
     getCurrentRandomSeed() {

--- a/tests/storyWorldOriginalSurface.test.js
+++ b/tests/storyWorldOriginalSurface.test.js
@@ -1,0 +1,25 @@
+const { planetParameters, planetOverrides } = require('../src/js/planet-parameters.js');
+global.planetOverrides = planetOverrides;
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('story world original properties', () => {
+  test('override used and zonal surface sums applied', () => {
+    const sm = new SpaceManager(planetParameters);
+    sm._setCurrentPlanetKey('callisto');
+    const original = sm.getCurrentWorldOriginal();
+    expect(original.override).toBe(planetOverrides.callisto);
+    const zones = ['tropical', 'temperate', 'polar'];
+    let expectedIce = 0;
+    let expectedDryIce = 0;
+    zones.forEach(z => {
+      const zw = planetOverrides.callisto.zonalWater[z];
+      expectedIce += (zw.ice || 0) + (zw.buriedIce || 0);
+      const zs = planetOverrides.callisto.zonalSurface[z];
+      expectedDryIce += zs.dryIce || 0;
+    });
+    expect(original.merged.resources.surface.ice.initialValue).toBeCloseTo(expectedIce);
+    expect(original.merged.resources.surface.dryIce.initialValue).toBeCloseTo(expectedDryIce);
+  });
+});


### PR DESCRIPTION
## Summary
- expose raw planet overrides for reuse
- calculate story world surface totals from zonal data
- test that story worlds aggregate zonal surface values

## Testing
- `npm test`
- `npx jest tests/storyWorldOriginalSurface.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_68990d0c9388832793bd5ae5758bd21c