### PR TITLE
Use active biodome count for life design points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,3 +398,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator travel warning now displays inline with triangle icons next to the Travel button.
 - Random World Generator equilibration timeout now counts as having used the button for enabling travel.
 - Metal export cap now counts previously terraformed worlds excluding the current planet.
+- Life design biodome points now scale with active Biodomes instead of total built.

--- a/src/js/life.js
+++ b/src/js/life.js
@@ -416,7 +416,7 @@ class LifeDesigner extends EffectableEntity {
   updateBiodomePoints(delta) {
     const biodomeCount =
       typeof buildings !== 'undefined' && buildings.biodome
-        ? buildings.biodome.count
+        ? buildings.biodome.active
         : 0;
     const rate = biodomeCount > 0 ? Math.log10(10 * biodomeCount) : 0;
     this.biodomePointRate = rate;

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -82,7 +82,7 @@ function initializeLifeTerraformingDesignerUI() {
                  <p>Points from biodomes :
                    <span id="life-biodome-points">0</span>
                    <span id="life-biodome-rate">+0/hour</span>
-                  <span class="info-tooltip-icon" id="life-biodome-tooltip" title="Each Biodome generates life design points at log10(10 × Biodomes) per hour. Points accumulate fractionally. Only whole points increase your maximum design points, which equals purchased points plus these whole biodome points.">&#9432;</span>
+                  <span class="info-tooltip-icon" id="life-biodome-tooltip" title="Each active Biodome generates life design points at log10(10 × Active Biodomes) per hour. Points accumulate fractionally. Only whole points increase your maximum design points, which equals purchased points plus these whole biodome points.">&#9432;</span>
                 </p>
               </div>
                <hr style="margin: 15px 0;">

--- a/tests/biodomePointsGeneration.test.js
+++ b/tests/biodomePointsGeneration.test.js
@@ -5,11 +5,11 @@ const vm = require('vm');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('biodome points generation', () => {
-  function createDesigner(biodomeCount, baseMax = 10) {
+  function createDesigner(biodomeCount, activeCount = biodomeCount, baseMax = 10) {
     const dom = new JSDOM(``, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.EffectableEntity = EffectableEntity;
-    ctx.buildings = { biodome: { count: biodomeCount } };
+    ctx.buildings = { biodome: { count: biodomeCount, active: activeCount } };
     ctx.resources = { surface: { biomass: { value: 0 } } };
     const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
     vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
@@ -19,7 +19,7 @@ describe('biodome points generation', () => {
   }
 
     test('gains points based on log10(10 * biodomes) per hour', () => {
-      const { designer } = createDesigner(2, 20);
+      const { designer } = createDesigner(2, 2, 20);
       designer.update(3600000); // one hour
       expect(designer.biodomePoints).toBeCloseTo(Math.log10(20));
       expect(Math.floor(designer.biodomePoints)).toBe(1);
@@ -27,7 +27,7 @@ describe('biodome points generation', () => {
     });
 
   test('accumulates fractional progress across updates', () => {
-    const { designer } = createDesigner(2, 20);
+    const { designer } = createDesigner(2, 2, 20);
     designer.update(1800000); // half hour
     expect(Math.floor(designer.biodomePoints)).toBe(0);
     designer.update(1800000); // another half hour
@@ -35,10 +35,17 @@ describe('biodome points generation', () => {
   });
 
     test('maxLifeDesignPoints adds floor of biodome points', () => {
-      const { designer } = createDesigner(2, 10);
+      const { designer } = createDesigner(2, 2, 10);
       designer.update(3600000); // ~1.3 points
       expect(designer.maxLifeDesignPoints()).toBe(11);
       designer.update(3600000); // ~2.6 points total
       expect(designer.maxLifeDesignPoints()).toBe(12);
+    });
+
+    test('uses active biodomes for point generation', () => {
+      const { designer } = createDesigner(5, 2, 20);
+      designer.update(3600000); // one hour
+      expect(designer.biodomePoints).toBeCloseTo(Math.log10(20));
+      expect(designer.biodomePointRate).toBeCloseTo(Math.log10(20));
     });
   });


### PR DESCRIPTION
## Summary
- Base life design biodome point generation on active biodomes instead of total built
- Clarify biodome tooltip to mention active structures
- Cover active biodome behavior with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68990ebb2a14832791c28694959019c4