### PR TITLE
Switch cargo rocket ship price scaling to additive model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,6 @@ second time they speak in a chapter to help clarify who is talking.
 - Space UI now shows original planetary properties for story worlds.
 - Random World Generator travel warning now displays inline with triangle icons next to the Travel button.
 - Random World Generator equilibration timeout now counts as having used the button for enabling travel.
-- Cargo rocket ship purchases now raise future ship prices based on terraformed planets and decay by 1% per second.
+- Cargo rocket ship purchases now add a flat +1 funding cost per ship divided by previously terraformed worlds (excluding the current planet) and decay by 1% per second.
 - Metal export cap now counts previously terraformed worlds excluding the current planet.
 - Life design biodome points now scale with active Biodomes instead of total built.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -117,7 +117,7 @@ class CargoRocketProject extends Project {
             if (priceElement) {
               let price = this.attributes.resourceChoiceGainCost[category][resourceId];
               if (resourceId === 'spaceships') {
-                price *= this.getSpaceshipPriceMultiplier();
+                price += this.getSpaceshipPriceIncrease();
               }
               priceElement.textContent = `${formatNumber(price, true)}`;
             }
@@ -148,31 +148,32 @@ class CargoRocketProject extends Project {
     }
   }
 
-  getSpaceshipPriceMultiplier() {
-    return 1 + this.spaceshipPriceIncrease;
+  getSpaceshipPriceIncrease() {
+    return this.spaceshipPriceIncrease;
   }
 
   applySpaceshipPurchase(count) {
-    const planetCount = Math.max(
-      1,
-      typeof spaceManager !== 'undefined' && typeof spaceManager.getTerraformedPlanetCount === 'function'
-        ? spaceManager.getTerraformedPlanetCount()
-        : 0
-    );
-    this.spaceshipPriceIncrease += count / planetCount;
+    const total = typeof spaceManager !== 'undefined' && typeof spaceManager.getTerraformedPlanetCount === 'function'
+      ? spaceManager.getTerraformedPlanetCount()
+      : 0;
+    const currentTerraformed = typeof spaceManager !== 'undefined' && typeof spaceManager.isPlanetTerraformed === 'function' && typeof spaceManager.getCurrentPlanetKey === 'function'
+      ? spaceManager.isPlanetTerraformed(spaceManager.getCurrentPlanetKey())
+      : false;
+    const divisor = Math.max(1, total - (currentTerraformed ? 1 : 0));
+    this.spaceshipPriceIncrease += count / divisor;
   }
 
   getSpaceshipTotalCost(quantity, basePrice) {
-    const planetCount = Math.max(
-      1,
-      typeof spaceManager !== 'undefined' && typeof spaceManager.getTerraformedPlanetCount === 'function'
-        ? spaceManager.getTerraformedPlanetCount()
-        : 0
-    );
-    const delta = 1 / planetCount;
+    const total = typeof spaceManager !== 'undefined' && typeof spaceManager.getTerraformedPlanetCount === 'function'
+      ? spaceManager.getTerraformedPlanetCount()
+      : 0;
+    const currentTerraformed = typeof spaceManager !== 'undefined' && typeof spaceManager.isPlanetTerraformed === 'function' && typeof spaceManager.getCurrentPlanetKey === 'function'
+      ? spaceManager.isPlanetTerraformed(spaceManager.getCurrentPlanetKey())
+      : false;
+    const divisor = Math.max(1, total - (currentTerraformed ? 1 : 0));
+    const delta = 1 / divisor;
     const current = this.spaceshipPriceIncrease;
-    const totalMultiplier = quantity * (1 + current) + delta * quantity * (quantity - 1) / 2;
-    return basePrice * totalMultiplier;
+    return basePrice * quantity + current * quantity + delta * quantity * (quantity - 1) / 2;
   }
 
   update(delta) {

--- a/tests/shipPriceIncrease.test.js
+++ b/tests/shipPriceIncrease.test.js
@@ -29,22 +29,23 @@ describe('Spaceship price increase and decay', () => {
     ctx.spaceManager.planetStatuses.titan.terraformed = true;
 
     const project = new ctx.CargoRocketProject(ctx.projectParameters.cargo_rocket, 'test');
+    const basePrice = project.attributes.resourceChoiceGainCost.special.spaceships;
     project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 3 }];
 
     const initialCost = project.getResourceChoiceGainCost();
-    expect(initialCost).toBeCloseTo(450_000);
+    expect(initialCost).toBeCloseTo(basePrice * 3 + 3);
 
     project.deductResources(ctx.resources);
-    expect(ctx.resources.colony.funding.value).toBeCloseTo(550_000);
-    expect(project.spaceshipPriceIncrease).toBeCloseTo(1.5);
+    expect(ctx.resources.colony.funding.value).toBeCloseTo(1_000_000 - initialCost);
+    expect(project.spaceshipPriceIncrease).toBeCloseTo(3);
 
     project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 1 }];
     const costAfter = project.getResourceChoiceGainCost();
-    expect(costAfter).toBeCloseTo(250_000);
+    expect(costAfter).toBeCloseTo(basePrice + 3);
 
     project.update(1000);
     const decayedCost = project.getResourceChoiceGainCost();
-    expect(decayedCost).toBeCloseTo(248_500);
+    expect(decayedCost).toBeCloseTo(basePrice + 3 * 0.99);
   });
 });
 


### PR DESCRIPTION
## Summary
- Make cargo rocket spaceship purchases add a flat +1 funding cost per ship scaled by previously terraformed worlds (excluding the current planet)
- Update tests for new additive pricing and decay behavior
- Document cargo rocket pricing change in AGENTS notes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_689913a118c483278a21eb740e25da93