### PR TITLE
Add early termination option for RWG fast-forward

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,3 +401,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Cargo rocket ship purchases now raise future ship prices based on terraformed planets and decay by 1% per second.
 - Metal export cap now counts previously terraformed worlds excluding the current planet.
 - Life design biodome points now scale with active Biodomes instead of total built.
+- Random World Generator equilibration window now offers an End Early button after the minimum fast-forward, enabling travel with current planet parameters.

--- a/src/js/rwgEquilibrate.js
+++ b/src/js/rwgEquilibrate.js
@@ -207,6 +207,8 @@
         }
 
         function loopChunk() {
+          let elapsed = Date.now() - startTime;
+          if (cancelToken && cancelToken.endEarly && elapsed >= minRunMs) { finalize(true); return; }
           if (timedOut) { finalize(false); reject(new Error('timeout')); return; }
           if (cancelToken && cancelToken.cancelled) { finalize(false); reject(new Error('cancelled')); return; }
           const end = Math.min(stepIdx + chunkSteps, stepsMax);
@@ -251,7 +253,7 @@
               }
             }
           }
-          const elapsed = Date.now() - startTime;
+          elapsed = Date.now() - startTime;
           if (stepIdx >= stepsMax) {
             if (elapsed >= minRunMs) {
               if (onProgress) onProgress(1, { step: stepIdx, stableCount, label: 'Finished' });

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -178,12 +178,19 @@ function attachEquilibrateHandler(res, sStr, archetype, box) {
       bar.style.background = '#0f0';
       barContainer.appendChild(bar);
 
+      const endBtn = document.createElement('button');
+      endBtn.id = 'rwg-end-early-btn';
+      endBtn.textContent = 'End Early';
+      endBtn.style.display = 'none';
+      endBtn.onclick = () => { cancelToken.endEarly = true; };
+
       const cancelBtn = document.createElement('button');
       cancelBtn.textContent = 'Cancel';
       cancelBtn.onclick = () => { cancelToken.cancelled = true; };
 
       win.appendChild(progressLabel);
       win.appendChild(barContainer);
+      win.appendChild(endBtn);
       win.appendChild(cancelBtn);
       overlay.appendChild(win);
       document.body.appendChild(overlay);
@@ -199,10 +206,11 @@ function attachEquilibrateHandler(res, sStr, archetype, box) {
           chunkSteps: 20,
           cancelToken
         }, (p, info) => {
-           const label = document.getElementById('rwg-progress-label');
-           if (label && info?.label) label.textContent = info.label;
-           bar.style.width = `${(p * 100).toFixed(2)}%`;
-       });
+          const label = document.getElementById('rwg-progress-label');
+          if (label && info?.label) label.textContent = info.label;
+          bar.style.width = `${(p * 100).toFixed(2)}%`;
+          if (info?.label === 'Additional fast-forward') endBtn.style.display = '';
+        });
         const newRes = { ...res, override: result.override, merged: deepMerge(defaultPlanetParameters, result.override) };
         equilibratedWorlds.add(sStr);
         box.innerHTML = renderWorldDetail(newRes, sStr, archetype);

--- a/tests/rwgEndEarlyButton.test.js
+++ b/tests/rwgEndEarlyButton.test.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Random World Generator End Early button', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<div id="rwg-result"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.formatNumber = n => n;
+    global.calculateAtmosphericPressure = () => 0;
+    global.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+    global.getGameSpeed = () => 1;
+    global.setGameSpeed = () => {};
+    global.deepMerge = (a, b) => ({ ...a, ...b });
+    global.defaultPlanetParameters = {};
+  });
+
+  afterEach(() => {
+    delete global.document;
+    delete global.window;
+    delete global.formatNumber;
+    delete global.calculateAtmosphericPressure;
+    delete global.dayNightTemperaturesModel;
+    delete global.getGameSpeed;
+    delete global.setGameSpeed;
+    delete global.deepMerge;
+    delete global.defaultPlanetParameters;
+    delete global.runEquilibration;
+    delete global.spaceManager;
+  });
+
+  test('enables travel after ending early', async () => {
+    const cancelTokenRef = { cancelToken: null };
+    global.runEquilibration = jest.fn((override, opts, onProgress) => {
+      cancelTokenRef.cancelToken = opts.cancelToken;
+      return new Promise(resolve => {
+        onProgress(0, { label: 'Additional fast-forward' });
+        const check = () => {
+          if (opts.cancelToken.endEarly) resolve({ override });
+          else setTimeout(check, 0);
+        };
+        check();
+      });
+    });
+    const { renderWorldDetail, attachEquilibrateHandler, attachTravelHandler } = require('../src/js/rwgUI.js');
+    const res = {
+      star: { name: 'Sun', spectralType: 'G', luminositySolar: 1, massSolar: 1, temperatureK: 5800, habitableZone: { inner: 0.5, outer: 1.5 } },
+      merged: {
+        celestialParameters: { distanceFromSun: 1, radius: 6000, gravity: 9.8, albedo: 0.3, rotationPeriod: 24 },
+        resources: { atmospheric: {}, surface: {} },
+        classification: { archetype: 'mars-like' }
+      },
+      override: { resources: { atmospheric: {} } }
+    };
+    const box = document.getElementById('rwg-result');
+    box.innerHTML = renderWorldDetail(res, 'seed-end', 'mars-like');
+    attachEquilibrateHandler(res, 'seed-end', 'mars-like', box);
+    attachTravelHandler(res, 'seed-end');
+
+    document.getElementById('rwg-equilibrate-btn').click();
+    await new Promise(setImmediate);
+
+    const endBtn = document.getElementById('rwg-end-early-btn');
+    expect(endBtn).not.toBeNull();
+    endBtn.click();
+    await new Promise(setImmediate);
+    await new Promise(setImmediate);
+
+    const travelBtn = document.getElementById('rwg-travel-btn');
+    expect(travelBtn.disabled).toBe(false);
+  });
+});

--- a/tests/rwgEquilibrate.test.js
+++ b/tests/rwgEquilibrate.test.js
@@ -73,6 +73,14 @@ describe('RWG equilibration (isolated Terraforming)', () => {
     await expect(runEquilibration(res.override, { cancelToken, sync: true })).rejects.toThrow();
   });
 
+  test('endEarly resolves run', async () => {
+    const seed = 'rwg-eq-test-end-early';
+    const res = generateRandomPlanet(seed, { archetype: 'mars-like' });
+    const cancelToken = { endEarly: true };
+    const { steps } = await runEquilibration(res.override, { cancelToken, sync: true, minRunMs: 0 });
+    expect(steps).toBeGreaterThanOrEqual(0);
+  });
+
   test('honors minimum runtime', async () => {
     const seed = 'rwg-eq-test-min-time';
     const res = generateRandomPlanet(seed, { archetype: 'mars-like' });


### PR DESCRIPTION
## Summary
- enable Random World Generator equilibration to finish early after 10s minimum
- support "End Early" button in RWG progress UI
- test early end flow and travel enablement

## Testing
- `npm test` *(1 failing: shipPriceIncrease.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_689916655db88327900a808bcdb76677