### PR TITLE
Align cargo rocket spaceship tooltip with label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,3 +402,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Cargo rocket ship purchases now raise future ship prices based on terraformed planets and decay by 1% per second.
 - Metal export cap now counts previously terraformed worlds excluding the current planet.
 - Life design biodome points now scale with active Biodomes instead of total built.
+- Cargo rocket spaceship tooltip now appears immediately to the right of the Spaceships label.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -353,6 +353,9 @@
 .cargo-resource-label {
     font-weight: 600;
     color: #495057;
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .cargo-buttons-container {

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -32,9 +32,14 @@ class CargoRocketProject extends Project {
         const label = document.createElement('span');
         label.classList.add('cargo-resource-label');
         if (resourceId === 'spaceships') {
-          label.innerHTML = `${resource.displayName} <span class="info-tooltip-icon" title="Each ship purchase raises prices based on terraformed planets and the increase decays by 1% per second.">&#9432;</span>`;
+          label.textContent = resource.displayName;
+          const tooltip = document.createElement('span');
+          tooltip.className = 'info-tooltip-icon';
+          tooltip.title = 'Each ship purchase raises prices based on terraformed planets and the increase decays by 1% per second.';
+          tooltip.innerHTML = '&#9432;';
+          label.appendChild(tooltip);
         } else {
-          label.textContent = `${resource.displayName}`;
+          label.textContent = resource.displayName;
         }
         resourceRow.appendChild(label);
 

--- a/tests/cargoRocketUI.test.js
+++ b/tests/cargoRocketUI.test.js
@@ -70,4 +70,68 @@ describe('Cargo Rocket project UI', () => {
     ctx.updateProjectUI('cargo_rocket');
     expect(value.style.color).toBe('');
   });
+
+  test('spaceship tooltip icon sits immediately after text', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <head></head>
+      <body>
+        <div class="projects-subtab-content-wrapper">
+          <div id="resources-projects-list" class="projects-list"></div>
+        </div>
+      </body>`, { runScripts: 'outside-only' });
+    const style = dom.window.document.createElement('style');
+    style.textContent = fs.readFileSync(path.join(__dirname, '..', 'src/css', 'projects.css'), 'utf8');
+    dom.window.document.head.appendChild(style);
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatBigInteger = numbers.formatBigInteger;
+    ctx.projectElements = {};
+    ctx.resources = {
+      colony: {
+        funding: { value: 0, displayName: 'Funding', unlocked: true },
+        metal: { value: 0, displayName: 'Metal', unlocked: true },
+        glass: { value: 0, displayName: 'Glass', unlocked: true },
+        water: { value: 0, displayName: 'Water', unlocked: true },
+        food: { value: 0, displayName: 'Food', unlocked: true },
+        components: { value: 0, displayName: 'Components', unlocked: true },
+        electronics: { value: 0, displayName: 'Electronics', unlocked: true },
+        androids: { value: 0, displayName: 'Androids', unlocked: true }
+      },
+      special: { spaceships: { value: 0, displayName: 'Spaceships', unlocked: true } }
+    };
+    ctx.buildings = {};
+    ctx.terraforming = {};
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager;', ctx);
+    const subclassCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(subclassCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.initializeProjects({ cargo_rocket: ctx.projectParameters.cargo_rocket });
+    ctx.projectManager.isBooleanFlagSet = () => false;
+
+    ctx.initializeProjectsUI();
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    ctx.createProjectItem(ctx.projectManager.projects.cargo_rocket);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    const label = ctx.projectElements.cargo_rocket.resourceSelectionContainer
+      .querySelector('#cargo_rocket-special-spaceships-row .cargo-resource-label');
+    const icon = label.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    const computed = dom.window.getComputedStyle(label);
+    expect(computed.display).toBe('flex');
+    expect(label.firstChild.textContent.trim()).toBe('Spaceships');
+    expect(label.lastElementChild).toBe(icon);
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure spaceship tooltip in Cargo Rocket project is appended as its own element and styled with flex for tight placement next to the label
- Document tooltip change in project changelog
- Test that tooltip icon renders next to text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689917ec6e808327ad8512301b32202d