### PR TITLE
Hide story world seed and type in space UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Autosave slot can now be manually overwritten through the Save button.
 - Land resource tooltip now notes that land can be recovered by turning off the corresponding building.
 - Space UI now shows original planetary properties for story worlds.
+- Story world details no longer display seed or type in the Space UI.
 - Random World Generator travel warning now displays inline with triangle icons next to the Travel button.
 - Random World Generator equilibration timeout now counts as having used the button for enabling travel.
 - Cargo rocket ship purchases now add a flat +1 funding cost per ship divided by previously terraformed worlds (excluding the current planet) and decay by 1% per second.

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -270,6 +270,14 @@ function updateCurrentWorldUI() {
             wrapper.querySelector('#rwg-travel-btn')?.remove();
             wrapper.querySelector('#rwg-travel-warning')?.remove();
             wrapper.querySelectorAll('[id]').forEach(el => el.removeAttribute('id'));
+            if (seedArg === undefined) {
+                wrapper.querySelectorAll('.rwg-chip').forEach(chip => {
+                    const label = chip.querySelector('.label')?.textContent;
+                    if (label === 'Seed' || label === 'Type') {
+                        chip.remove();
+                    }
+                });
+            }
             detailsBox.innerHTML = '';
             detailsBox.appendChild(wrapper);
         } else {

--- a/tests/shipPriceIncrease.test.js
+++ b/tests/shipPriceIncrease.test.js
@@ -33,19 +33,19 @@ describe('Spaceship price increase and decay', () => {
     project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 3 }];
 
     const initialCost = project.getResourceChoiceGainCost();
-    expect(initialCost).toBeCloseTo(112_500);
+    expect(initialCost).toBeCloseTo(75_003);
 
     project.deductResources(ctx.resources);
-    expect(ctx.resources.colony.funding.value).toBeCloseTo(887_500);
-    expect(project.spaceshipPriceIncrease).toBeCloseTo(1.5);
+    expect(ctx.resources.colony.funding.value).toBeCloseTo(924_997);
+    expect(project.spaceshipPriceIncrease).toBeCloseTo(3);
 
     project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 1 }];
     const costAfter = project.getResourceChoiceGainCost();
-    expect(costAfter).toBeCloseTo(62_500);
+    expect(costAfter).toBeCloseTo(25_003);
 
     project.update(1000);
     const decayedCost = project.getResourceChoiceGainCost();
-    expect(decayedCost).toBeCloseTo(62_125);
+    expect(decayedCost).toBeCloseTo(25_003, 0);
   });
 });
 

--- a/tests/spaceStoryWorldSeedTypeHidden.test.js
+++ b/tests/spaceStoryWorldSeedTypeHidden.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { planetParameters, planetOverrides } = require('../src/js/planet-parameters.js');
+const SpaceManager = require('../src/js/space.js');
+
+describe('story world details omit seed and type', () => {
+  test('Space UI hides seed and type for story world', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div id="current-world-name"></div>
+      <div id="current-world-details"></div>
+      <div id="planet-selection-options"></div>
+      <div id="travel-status"></div>
+      <div class="space-subtab" data-subtab="space-random"></div>
+      <div id="space-random" class="space-subtab-content"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = n => n;
+    ctx.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+    ctx.calculateAtmosphericPressure = () => 0;
+    ctx.planetParameters = planetParameters;
+    ctx.planetOverrides = planetOverrides;
+
+    const spaceUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'spaceUI.js'), 'utf8');
+    const rwgUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+    vm.runInContext(spaceUICode, ctx);
+    vm.runInContext(rwgUICode, ctx);
+    ctx.SpaceManager = SpaceManager;
+    vm.runInContext('initializeSpaceUI(new SpaceManager(planetParameters));', ctx);
+
+    const labels = Array.from(dom.window.document.querySelectorAll('#current-world-details .rwg-chip .label')).map(el => el.textContent);
+    expect(labels).not.toContain('Seed');
+    expect(labels).not.toContain('Type');
+  });
+});
+


### PR DESCRIPTION
## Summary
- hide story world seed and type in Space tab details
- align cargo rocket price test with current pricing
- cover story world detail hiding with a dedicated test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68991cd026f483278879c33fc67c7eba