### PR TITLE
Fix gas giant radius display in Random World Generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,3 +412,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Space UI caches the last world key and seed to skip redundant detail rendering.
 - Auto mode in Random World Generator no longer generates locked planet types.
 - Random World Generator now offers an Auto target option that randomly selects planets or moons.
+- Fixed Gas Giant parent bodies showing a NaN radius in the Random World Generator.

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -489,6 +489,7 @@ function hashStringToInt(str) {
       parentBody = {
         name: 'Gas Giant',
         mass: gg.mass,
+        radius: gg.radius_km,
         orbitRadius: gg.orbitRadius_km
       };
     }

--- a/tests/rwgGasGiantRadius.test.js
+++ b/tests/rwgGasGiantRadius.test.js
@@ -1,0 +1,11 @@
+const { generateRandomPlanet } = require('../src/js/rwg.js');
+
+describe('Random World Generator Gas Giant radius', () => {
+  test('moons include parent body radius', () => {
+    const { override } = generateRandomPlanet('seed-gg-radius', { isMoon: true });
+    const parent = override.celestialParameters.parentBody;
+    expect(parent).toBeDefined();
+    expect(typeof parent.radius).toBe('number');
+    expect(Number.isNaN(parent.radius)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- include gas giant radius when generating parent bodies for moons
- test that RWG moon generation exposes parent gas giant radius

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689925fdd8588327a9e7ef254470cc7c