### PR TITLE
Randomize RWG habitable zone orbits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,3 +414,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator now offers an Auto target option that randomly selects planets or moons.
 - Random World Generator seeds now encode dropdown selections and override menu choices when used.
 - Fixed Gas Giant parent bodies showing a NaN radius in the Random World Generator.
+- Habitable zone orbit presets in the Random World Generator now vary distance to provide differing solar flux.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -122,14 +122,20 @@ function drawSingle(seed, options) {
   let aAU;
   if (options?.orbitPreset && options.orbitPreset !== 'auto') {
     const hz = star.habitableZone;
-    const mapping = {
-      'hz-inner': hz.inner,
-      'hz-mid': (hz.inner + hz.outer) / 2,
-      'hz-outer': hz.outer,
-      'hot': Math.max(0.2, hz.inner * 0.5),
-      'cold': Math.min(30, hz.outer * 2)
-    };
-    aAU = mapping[options.orbitPreset] ?? undefined;
+    const range = hz.outer - hz.inner;
+    if (options.orbitPreset === 'hz-inner') {
+      aAU = hz.inner + rng() * range / 3;
+    } else if (options.orbitPreset === 'hz-mid') {
+      aAU = hz.inner + range / 3 + rng() * range / 3;
+    } else if (options.orbitPreset === 'hz-outer') {
+      aAU = hz.outer - rng() * range / 3;
+    } else {
+      const mapping = {
+        'hot': Math.max(0.2, hz.inner * 0.5),
+        'cold': Math.min(30, hz.outer * 2)
+      };
+      aAU = mapping[options.orbitPreset] ?? undefined;
+    }
   } else if (options?.target === 'auto') {
     aAU = sampleOrbitAU(rng, 0);
   }

--- a/tests/rwgHZOrbitVariability.test.js
+++ b/tests/rwgHZOrbitVariability.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Random World Generator HZ orbit variability', () => {
+  test('hz-mid orbit flux differs across seeds', () => {
+    const dom = new JSDOM('<div id="rwg-result"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.captureRes = null;
+    vm.runInContext(`
+      function isObject(o){ return o && typeof o === 'object' && !Array.isArray(o); }
+      function deepMerge(a,b){
+        if(!isObject(a) || !isObject(b)) return { ...(a||{}), ...(b||{}) };
+        const out = { ...a };
+        Object.keys(b).forEach(k => { out[k] = isObject(a[k]) && isObject(b[k]) ? deepMerge(a[k], b[k]) : b[k]; });
+        return out;
+      }
+      const defaultPlanetParameters = { name:'Default', resources:{ colony:{}, surface:{}, underground:{}, atmospheric:{}, special:{} }, buildingParameters:{}, populationParameters:{}, celestialParameters:{} };
+    `, ctx);
+    const rwgCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwg.js'), 'utf8');
+    const rwgUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+    vm.runInContext(`${rwgCode}\n${rwgUICode}\nrenderWorldDetail=function(res){captureRes=res;return ''};`, ctx);
+    vm.runInContext(`drawSingle('seed-one', { target: 'planet', orbitPreset: 'hz-mid' });`, ctx);
+    const fluxA = vm.runInContext('estimateFlux(captureRes);', ctx);
+    vm.runInContext(`drawSingle('seed-two', { target: 'planet', orbitPreset: 'hz-mid' });`, ctx);
+    const fluxB = vm.runInContext('estimateFlux(captureRes);', ctx);
+    expect(fluxA).not.toBeCloseTo(fluxB, 10);
+  });
+});


### PR DESCRIPTION
## Summary
- vary habitable zone orbit presets in Random World Generator so solar flux isn't fixed
- record change in developer notes
- test that hz-mid preset produces different fluxes for different seeds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689928d96c548327873620668ed3587f