### PR TITLE
Refine RWG hot and cold orbit flux ranges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,3 +415,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator seeds now encode dropdown selections and override menu choices when used.
 - Fixed Gas Giant parent bodies showing a NaN radius in the Random World Generator.
 - Habitable zone orbit presets in the Random World Generator now vary distance to provide differing solar flux.
+- Hot and cold orbit presets in the Random World Generator now ensure solar flux above 1.5 kW/m² and below 500 W/m² respectively with randomized variability.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -130,11 +130,20 @@ function drawSingle(seed, options) {
     } else if (options.orbitPreset === 'hz-outer') {
       aAU = hz.outer - rng() * range / 3;
     } else {
+      const SOLAR_FLUX_1AU = 1361;
+      const lum = star.luminositySolar || 1;
       const mapping = {
-        'hot': Math.max(0.2, hz.inner * 0.5),
-        'cold': Math.min(30, hz.outer * 2)
+        'hot': () => {
+          const flux = 1500 + rng() * 1000; // 1500–2500 W/m²
+          return Math.sqrt((lum * SOLAR_FLUX_1AU) / flux);
+        },
+        'cold': () => {
+          const flux = 100 + rng() * 400; // 100–500 W/m²
+          return Math.sqrt((lum * SOLAR_FLUX_1AU) / flux);
+        }
       };
-      aAU = mapping[options.orbitPreset] ?? undefined;
+      const fn = mapping[options.orbitPreset];
+      aAU = typeof fn === 'function' ? fn() : undefined;
     }
   } else if (options?.target === 'auto') {
     aAU = sampleOrbitAU(rng, 0);

--- a/tests/rwgHotColdOrbitFlux.test.js
+++ b/tests/rwgHotColdOrbitFlux.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Random World Generator hot and cold orbits', () => {
+  function setup() {
+    const dom = new JSDOM('<div id="rwg-result"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.captureRes = null;
+    vm.runInContext(`
+      function isObject(o){ return o && typeof o === 'object' && !Array.isArray(o); }
+      function deepMerge(a,b){
+        if(!isObject(a) || !isObject(b)) return { ...(a||{}), ...(b||{}) };
+        const out = { ...a };
+        Object.keys(b).forEach(k => { out[k] = isObject(a[k]) && isObject(b[k]) ? deepMerge(a[k], b[k]) : b[k]; });
+        return out;
+      }
+      const defaultPlanetParameters = { name:'Default', resources:{ colony:{}, surface:{}, underground:{}, atmospheric:{}, special:{} }, buildingParameters:{}, populationParameters:{}, celestialParameters:{} };
+    `, ctx);
+    const rwgCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwg.js'), 'utf8');
+    const rwgUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+    vm.runInContext(`${rwgCode}\n${rwgUICode}\nrenderWorldDetail=function(res){captureRes=res;return ''};`, ctx);
+    return ctx;
+  }
+
+  test('hot orbit flux >= 1500 and varies across seeds', () => {
+    const ctx = setup();
+    vm.runInContext(`drawSingle('hot-one', { target: 'planet', orbitPreset: 'hot' });`, ctx);
+    const fluxA = vm.runInContext('estimateFlux(captureRes);', ctx);
+    vm.runInContext(`drawSingle('hot-two', { target: 'planet', orbitPreset: 'hot' });`, ctx);
+    const fluxB = vm.runInContext('estimateFlux(captureRes);', ctx);
+    expect(fluxA).toBeGreaterThanOrEqual(1500);
+    expect(fluxB).toBeGreaterThanOrEqual(1500);
+    expect(fluxA).not.toBeCloseTo(fluxB, 10);
+  });
+
+  test('cold orbit flux <= 500 and varies across seeds', () => {
+    const ctx = setup();
+    vm.runInContext(`drawSingle('cold-one', { target: 'planet', orbitPreset: 'cold' });`, ctx);
+    const fluxA = vm.runInContext('estimateFlux(captureRes);', ctx);
+    vm.runInContext(`drawSingle('cold-two', { target: 'planet', orbitPreset: 'cold' });`, ctx);
+    const fluxB = vm.runInContext('estimateFlux(captureRes);', ctx);
+    expect(fluxA).toBeLessThanOrEqual(500);
+    expect(fluxB).toBeLessThanOrEqual(500);
+    expect(fluxA).not.toBeCloseTo(fluxB, 10);
+  });
+});


### PR DESCRIPTION
## Summary
- Random World Generator hot orbit now samples solar flux between 1.5–2.5 kW/m², while cold orbit samples 100–500 W/m², producing corresponding orbital distances
- Documented hot/cold orbit flux behavior and added regression tests for flux thresholds and variability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68992c518bec83279616f07129159abc