### PR TITLE
Show gas pressures and Teq in story planet details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,7 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator equilibration timeout now counts as having used the button for enabling travel.
 - Cargo rocket ship purchases now add a flat +1 funding cost per ship divided by previously terraformed worlds (excluding the current planet) and decay by 1% per second.
 - Story world original properties now apply planet overrides and aggregate zonal surface data for accurate totals.
+- Story world original properties now list partial atmospheric pressures for key gases instead of a single total.
 - Cargo rocket ship purchases now raise future ship prices based on terraformed planets and decay by 1% per second.
 - Metal export cap now counts previously terraformed worlds excluding the current planet.
 - Life design biodome points now scale with active Biodomes instead of total built.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -312,6 +312,8 @@ function renderWorldDetail(res, seedUsed, forcedType) {
   const surf = r.surface || {};
   const temps = estimateWorldTemperatures(res);
   const fluxWm2 = estimateFlux(res);
+  const teqCalc = estimateEquilibriumTemp(res, fluxWm2);
+  const teqDisplay = cls?.TeqK || (teqCalc ? Math.round(teqCalc) : null);
   // Star summary + parent body if any
   const star = res.star;
   const starPanel = `
@@ -361,7 +363,7 @@ function renderWorldDetail(res, seedUsed, forcedType) {
         <div class="rwg-chip"><div class="label">Rotation</div><div class="value">${fmt(c.rotationPeriod)} h</div></div>
         <div class="rwg-chip"><div class="label">Flux</div><div class="value">${fmt((fluxWm2).toFixed ? fluxWm2.toFixed(0) : fluxWm2)} W/m²</div></div>
         <div class="rwg-chip"><div class="label">Type</div><div class="value">${forcedType && forcedType !== 'auto' ? forcedType : (cls?.archetype || '—')}</div></div>
-        <div class="rwg-chip"><div class="label">Teq</div><div class="value">${cls?.TeqK ? fmt(cls.TeqK) + ' K' : '—'}</div></div>
+        <div class="rwg-chip"><div class="label">Teq</div><div class="value">${teqDisplay ? fmt(teqDisplay) + ' K' : '—'}</div></div>
         ${temps ? `<div class="rwg-chip"><div class="label">Mean T</div><div class="value">${fmt(temps.mean.toFixed ? temps.mean.toFixed(0) : temps.mean)} K</div></div>` : ''}
         ${temps ? `<div class="rwg-chip"><div class="label">Day T</div><div class="value">${fmt(temps.day.toFixed ? temps.day.toFixed(0) : temps.day)} K</div></div>` : ''}
         ${temps ? `<div class="rwg-chip"><div class="label">Night T</div><div class="value">${fmt(temps.night.toFixed ? temps.night.toFixed(0) : temps.night)} K</div></div>` : ''}
@@ -446,17 +448,22 @@ function estimateFlux(res) {
   }
 }
 
+function estimateEquilibriumTemp(res, fluxWm2) {
+  try {
+    const c = res.merged?.celestialParameters || {};
+    const albedo = c.albedo ?? 0.3;
+    const sigma = 5.670374419e-8;
+    if (!fluxWm2) return null;
+    return Math.pow((fluxWm2 * (1 - albedo)) / (4 * sigma), 0.25);
+  } catch {
+    return null;
+  }
+}
+
 function renderResourceRow(label, value) {
   const fmt = typeof formatNumber === 'function' ? formatNumber : (n => n);
   const v = (value === undefined || value === null) ? '—' : fmt(value);
   return `<div class="rwg-row"><span>${label}</span><span>${v}</span></div>`;
-}
-
-function renderAtmoRow(label, amountTons, kPa) {
-  const fmt = typeof formatNumber === 'function' ? formatNumber : (n => n);
-  const amt = (amountTons === undefined || amountTons === null) ? '—' : fmt(amountTons);
-  const p = (typeof kPa === 'number' && isFinite(kPa)) ? `${(kPa).toFixed(1)} kPa` : '—';
-  return `<div class="rwg-row"><span>${label}</span><span>${amt} (${p})</span></div>`;
 }
 
 function estimateGasPressure(res, gasKey) {

--- a/tests/spaceStoryWorldTeqGasPressure.test.js
+++ b/tests/spaceStoryWorldTeqGasPressure.test.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const physics = require('../src/js/physics.js');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+global.EffectableEntity = require('../src/js/effectable-entity.js');
+const SpaceManager = require('../src/js/space.js');
+global.document = { addEventListener: () => {} };
+const { renderWorldDetail } = require('../src/js/rwgUI.js');
+
+// Ensure dependencies on globals
+
+global.formatNumber = numbers.formatNumber;
+global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+global.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+
+describe('story world detail', () => {
+  test('includes Teq and gas pressures', () => {
+    const sm = new SpaceManager(planetParameters);
+    const res = sm.getCurrentWorldOriginal();
+    const html = renderWorldDetail(res);
+    const dom = new JSDOM(html);
+    const chips = Array.from(dom.window.document.querySelectorAll('.rwg-chip'));
+    const findChip = label => chips.find(ch => ch.querySelector('.label')?.textContent === label);
+    const teqChip = findChip('Teq');
+    const pressureChip = findChip('Pressure');
+    expect(teqChip).toBeTruthy();
+    expect(pressureChip).toBeFalsy();
+    expect(teqChip.querySelector('.value').textContent).toMatch(/\d/);
+    const co2Row = Array.from(dom.window.document.querySelectorAll('.rwg-atmo-table .rwg-row'))
+      .find(row => row.children[0]?.textContent === 'CO₂');
+    expect(co2Row).toBeTruthy();
+    expect(co2Row.children[2].textContent).toMatch(/kPa/);
+  });
+});


### PR DESCRIPTION
## Summary
- display equilibrium temperature and per-gas atmospheric pressures for story worlds
- compute missing Teq and partial pressures from base parameters
- add regression test ensuring story planet details list gas pressures and no total

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68992aedc9848327a96195714c56a373