### PR TITLE
Refactor RWG random option handling

### DIFF
--- a/tests/rwgAutoSkipLockedOrbit.test.js
+++ b/tests/rwgAutoSkipLockedOrbit.test.js
@@ -18,23 +18,17 @@ describe('RWG Auto mode skips locked hot orbit', () => {
       function formatNumber(n){ return n; }
       function estimateFlux(){ return 1000; }
       function estimateGasPressure(){ return undefined; }
-      function generateRandomPlanet(seed, opts){
-        return {
-          star: opts.star,
-          orbitAU: opts.aAU,
-          override: { classification: { archetype: 'test' } },
-          merged: { name: 'Test', celestialParameters: { radius: 1, gravity: 1, albedo: 0.3, rotationPeriod: 24 }, resources: { atmospheric: {}, surface: {}, underground: {}, colony: {}, special: {} } }
-        };
-      }
       ${rwgCode}
+      const realGen = generateRandomPlanet;
+      generateRandomPlanet = function(seed, opts){ const r = realGen(seed, opts); globalThis.lastResult = r; return r; };
       ${rwgUICode}
       initializeRandomWorldUI();
     `, ctx);
     dom.window.document.getElementById('rwg-seed').value = '123';
     dom.window.document.getElementById('rwg-generate-planet').click();
-    const orbit = dom.window.document.getElementById('rwg-orbit').value;
-    expect(orbit).not.toBe('auto');
-    expect(orbit).not.toBe('hot');
-    expect(['hz-inner','hz-mid','hz-outer','cold']).toContain(orbit);
+    const orbitSel = dom.window.document.getElementById('rwg-orbit').value;
+    expect(orbitSel).toBe('auto');
+    expect(ctx.lastResult.orbitPreset).not.toBe('hot');
+    expect(['hz-inner','hz-mid','hz-outer','cold']).toContain(ctx.lastResult.orbitPreset);
   });
 });

--- a/tests/rwgAutoSkipLockedTypes.test.js
+++ b/tests/rwgAutoSkipLockedTypes.test.js
@@ -18,23 +18,16 @@ describe('RWG Auto mode skips locked types', () => {
       function formatNumber(n){ return n; }
       function estimateFlux(){ return 1000; }
       function estimateGasPressure(){ return undefined; }
-      function generateRandomPlanet(seed, opts){
-        globalThis.lastArchetype = opts.archetype;
-        return {
-          star: opts.star,
-          orbitAU: opts.aAU,
-          override: { classification: { archetype: opts.archetype } },
-          merged: { name: 'Test', celestialParameters: { radius: 1, gravity: 1, albedo: 0.3, rotationPeriod: 24 }, resources: { atmospheric: {}, surface: {}, underground: {}, colony: {}, special: {} } }
-        };
-      }
       ${rwgCode}
+      const realGen = generateRandomPlanet;
+      generateRandomPlanet = function(seed, opts){ const r = realGen(seed, opts); globalThis.lastResult = r; return r; };
       ${rwgUICode}
       initializeRandomWorldUI();
     `, ctx);
     dom.window.document.getElementById('rwg-seed').value = '42';
     dom.window.document.getElementById('rwg-generate-planet').click();
-    expect(ctx.lastArchetype).not.toBe('hot-rocky');
-    expect(ctx.lastArchetype).not.toBe('venus-like');
+    expect(ctx.lastResult.archetype).not.toBe('hot-rocky');
+    expect(ctx.lastResult.archetype).not.toBe('venus-like');
   });
 
   test('High flux does not force locked venus-like', () => {
@@ -50,23 +43,14 @@ describe('RWG Auto mode skips locked types', () => {
       function formatNumber(n){ return n; }
       function estimateFlux(){ return 3000; }
       function estimateGasPressure(){ return undefined; }
-      globalThis.callCount = 0;
-      function generateRandomPlanet(seed, opts){
-        globalThis.callCount++;
-        globalThis.lastArchetype = opts.archetype;
-        return {
-          star: opts.star,
-          orbitAU: opts.aAU,
-          override: { classification: { archetype: opts.archetype } },
-          merged: { name: 'Test', celestialParameters: { radius: 1, gravity: 1, albedo: 0.3, rotationPeriod: 24 }, resources: { atmospheric: {}, surface: {}, underground: {}, colony: {}, special: {} } }
-        };
-      }
       ${rwgCode}
+      const realGen = generateRandomPlanet;
+      generateRandomPlanet = function(seed, opts){ const r = realGen(seed, opts); globalThis.lastResult = r; return r; };
       ${rwgUICode}
       initializeRandomWorldUI();
     `, ctx);
     dom.window.document.getElementById('rwg-seed').value = '99';
     dom.window.document.getElementById('rwg-generate-planet').click();
-    expect(ctx.lastArchetype).not.toBe('venus-like');
+    expect(ctx.lastResult.archetype).not.toBe('venus-like');
   });
 });

--- a/tests/rwgSeedOverride.test.js
+++ b/tests/rwgSeedOverride.test.js
@@ -19,16 +19,9 @@ describe('RWG seed encodes selections and overrides menus', () => {
       function estimateFlux(){ return 1000; }
       function estimateGasPressure(){ return undefined; }
       globalThis.callArgs = [];
-      generateRandomPlanet = function(seed, opts){
-        callArgs.push(opts);
-        return {
-          star: opts.star,
-          orbitAU: opts.aAU,
-          override:{ classification:{ archetype: opts.archetype } },
-          merged:{ name:'Test', celestialParameters:{ radius:1, gravity:1, albedo:0.3, rotationPeriod:24 }, resources:{ atmospheric:{}, surface:{}, underground:{}, colony:{}, special:{} } }
-        };
-      };
       ${rwgCode}
+      const realGen = generateRandomPlanet;
+      generateRandomPlanet = function(seed, opts){ const r = realGen(seed, opts); callArgs.push(r); return r; };
       ${rwgUICode}
       initializeRandomWorldUI();
     `, ctx);
@@ -55,7 +48,7 @@ describe('RWG seed encodes selections and overrides menus', () => {
     const second = ctx.callArgs[1];
     expect(second.isMoon).toBe(first.isMoon);
     expect(second.archetype).toBe(first.archetype);
-    expect(second.aAU).toBeCloseTo(first.aAU, 10);
+    expect(second.orbitAU).toBeCloseTo(first.orbitAU, 10);
     expect(doc.getElementById('rwg-target').value).toBe('moon');
     expect(doc.getElementById('rwg-type').value).toBe('icy-moon');
     expect(doc.getElementById('rwg-orbit').value).toBe('hz-inner');

--- a/tests/rwgTargetAuto.test.js
+++ b/tests/rwgTargetAuto.test.js
@@ -20,15 +20,8 @@ describe('RWG target auto mode', () => {
       function estimateGasPressure(){ return undefined; }
       ${rwgCode}
       globalThis.callArgs = [];
-      generateRandomPlanet = function(seed, opts){
-        globalThis.callArgs.push(opts);
-        return {
-          star: opts.star,
-          orbitAU: opts.aAU,
-          override: { classification: { archetype: opts.archetype } },
-          merged: { name: 'Test', celestialParameters: { radius: 1, gravity: 1, albedo: 0.3, rotationPeriod: 24 }, resources: { atmospheric: {}, surface: {}, underground: {}, colony: {}, special: {} } }
-        };
-      };
+      const realGen = generateRandomPlanet;
+      generateRandomPlanet = function(seed, opts){ const r = realGen(seed, opts); globalThis.callArgs.push(r); return r; };
       ${rwgUICode}
       initializeRandomWorldUI();
     `, ctx);


### PR DESCRIPTION
## Summary
- Move orbit and archetype auto-selection logic into `generateRandomPlanet`
- Simplify `rwgUI` to delegate randomization to generator without altering user selections
- Update RWG tests for new randomized option handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68993230d3e48327920ebeaa8a438295