### PR TITLE
Refactor RWG into effectable manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,3 +418,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Habitable zone orbit presets in the Random World Generator now vary distance to provide differing solar flux.
 - Hot and cold orbit presets in the Random World Generator now ensure solar flux above 1.5 kW/m² and below 500 W/m² respectively with randomized variability.
 - Hot orbit option in the Random World Generator is now locked, and Auto selects a random unlocked orbit preset.
+- Random World Generator is now handled by a manager extending EffectableEntity and tracks locked options internally.

--- a/tests/rwgManagerLocking.test.js
+++ b/tests/rwgManagerLocking.test.js
@@ -1,0 +1,23 @@
+const { RwgManager } = require('../src/js/rwg.js');
+
+describe('RwgManager locking system', () => {
+  test('locks are tracked and generation respects them', () => {
+    const mgr = new RwgManager();
+    // hot orbit locked by default
+    expect(mgr.isOrbitLocked('hot')).toBe(true);
+    mgr.unlockOrbit('hot');
+    expect(mgr.isOrbitLocked('hot')).toBe(false);
+    mgr.lockOrbit('cold');
+    const res = mgr.generateRandomPlanet('lock-test', { orbitPreset: 'auto' });
+    expect(res.orbitPreset).not.toBe('cold');
+  });
+
+  test('unlocking types exposes them in available list', () => {
+    const mgr = new RwgManager();
+    expect(mgr.isTypeLocked('venus-like')).toBe(true);
+    mgr.unlockType('venus-like');
+    expect(mgr.isTypeLocked('venus-like')).toBe(false);
+    const types = mgr.getAvailableTypes(false);
+    expect(types).toContain('venus-like');
+  });
+});


### PR DESCRIPTION
## Summary
- convert rwg.js into RwgManager extending EffectableEntity
- track locked orbit/type options and expose lock helpers
- add tests for RWG manager locking

## Testing
- `npx jest --reporters=default`

------
https://chatgpt.com/codex/tasks/task_b_689934b705bc832786eaf1d5934b779a