### PR TITLE
Respect Celsius setting in RWG UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,3 +418,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Habitable zone orbit presets in the Random World Generator now vary distance to provide differing solar flux.
 - Hot and cold orbit presets in the Random World Generator now ensure solar flux above 1.5 kW/m² and below 500 W/m² respectively with randomized variability.
 - Hot orbit option in the Random World Generator is now locked, and Auto selects a random unlocked orbit preset.
+- Random World Generator UI now respects the global Celsius setting for temperature displays.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -287,6 +287,8 @@ function renderWorldDetail(res, seedUsed, forcedType) {
   const teqDisplay = cls?.TeqK || (teqCalc ? Math.round(teqCalc) : null);
   // Star summary + parent body if any
   const star = res.star;
+  const toDisplayTemp = typeof toDisplayTemperature === 'function' ? toDisplayTemperature : (v => v);
+  const tempUnit = typeof getTemperatureUnit === 'function' ? getTemperatureUnit() : 'K';
   const starPanel = `
     <div class="rwg-card">
       <h3>Star: ${star.name}</h3>
@@ -294,7 +296,7 @@ function renderWorldDetail(res, seedUsed, forcedType) {
         <div class="rwg-chip"><div class="label">Spectral</div><div class="value">${star.spectralType}</div></div>
         <div class="rwg-chip"><div class="label">Luminosity</div><div class="value">${(star.luminositySolar).toFixed(3)} L☉</div></div>
         <div class="rwg-chip"><div class="label">Mass</div><div class="value">${(star.massSolar).toFixed(3)} M☉</div></div>
-        <div class="rwg-chip"><div class="label">Temp</div><div class="value">${fmt(star.temperatureK)} K</div></div>
+        <div class="rwg-chip"><div class="label">Temp</div><div class="value">${fmt(toDisplayTemp(star.temperatureK))} ${tempUnit}</div></div>
         <div class="rwg-chip"><div class="label">Habitable Zone</div><div class="value">${star.habitableZone.inner.toFixed(2)}–${star.habitableZone.outer.toFixed(2)} AU</div></div>
       </div>
     </div>`;
@@ -334,10 +336,10 @@ function renderWorldDetail(res, seedUsed, forcedType) {
         <div class="rwg-chip"><div class="label">Rotation</div><div class="value">${fmt(c.rotationPeriod)} h</div></div>
         <div class="rwg-chip"><div class="label">Flux</div><div class="value">${fmt((fluxWm2).toFixed ? fluxWm2.toFixed(0) : fluxWm2)} W/m²</div></div>
         <div class="rwg-chip"><div class="label">Type</div><div class="value">${forcedType && forcedType !== 'auto' ? forcedType : (cls?.archetype || '—')}</div></div>
-        <div class="rwg-chip"><div class="label">Teq</div><div class="value">${teqDisplay ? fmt(teqDisplay) + ' K' : '—'}</div></div>
-        ${temps ? `<div class="rwg-chip"><div class="label">Mean T</div><div class="value">${fmt(temps.mean.toFixed ? temps.mean.toFixed(0) : temps.mean)} K</div></div>` : ''}
-        ${temps ? `<div class="rwg-chip"><div class="label">Day T</div><div class="value">${fmt(temps.day.toFixed ? temps.day.toFixed(0) : temps.day)} K</div></div>` : ''}
-        ${temps ? `<div class="rwg-chip"><div class="label">Night T</div><div class="value">${fmt(temps.night.toFixed ? temps.night.toFixed(0) : temps.night)} K</div></div>` : ''}
+        <div class="rwg-chip"><div class="label">Teq</div><div class="value">${teqDisplay ? fmt(toDisplayTemp(teqDisplay)) + ' ' + tempUnit : '—'}</div></div>
+        ${temps ? `<div class="rwg-chip"><div class="label">Mean T</div><div class="value">${fmt(Math.round(toDisplayTemp(temps.mean)))} ${tempUnit}</div></div>` : ''}
+        ${temps ? `<div class="rwg-chip"><div class="label">Day T</div><div class="value">${fmt(Math.round(toDisplayTemp(temps.day)))} ${tempUnit}</div></div>` : ''}
+        ${temps ? `<div class="rwg-chip"><div class="label">Night T</div><div class="value">${fmt(Math.round(toDisplayTemp(temps.night)))} ${tempUnit}</div></div>` : ''}
       </div>
       <div class="rwg-columns" style="margin-top:10px;">
         <div>

--- a/tests/rwgCelsiusDisplay.test.js
+++ b/tests/rwgCelsiusDisplay.test.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const physics = require('../src/js/physics.js');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+global.EffectableEntity = require('../src/js/effectable-entity.js');
+const SpaceManager = require('../src/js/space.js');
+
+// minimal globals for rwgUI
+global.document = { addEventListener: () => {} };
+global.formatNumber = numbers.formatNumber;
+global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+global.dayNightTemperaturesModel = () => ({ mean: 300, day: 310, night: 290 });
+
+const { renderWorldDetail } = require('../src/js/rwgUI.js');
+
+describe('rwgUI temperature display', () => {
+  test('uses global Celsius setting', () => {
+    global.gameSettings = { useCelsius: true };
+    global.toDisplayTemperature = numbers.toDisplayTemperature;
+    global.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    const sm = new SpaceManager(planetParameters);
+    const res = sm.getCurrentWorldOriginal();
+    const html = renderWorldDetail(res);
+    const dom = new JSDOM(html);
+    const chips = Array.from(dom.window.document.querySelectorAll('.rwg-chip'));
+    const meanChip = chips.find(ch => ch.querySelector('.label')?.textContent === 'Mean T');
+    expect(meanChip).toBeTruthy();
+    expect(meanChip.querySelector('.value').textContent).toMatch(/°C/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- display Random World Generator temperatures using the global Celsius preference
- add regression test ensuring RWG UI honors Celsius setting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6899359435688327886b1c1d3dcfcd92