### PR TITLE
Sync RWG option locks with manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,3 +420,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Hot orbit option in the Random World Generator is now locked, and Auto selects a random unlocked orbit preset.
 - Random World Generator UI now respects the global Celsius setting for temperature displays.
 - Random World Generator is now handled by a manager extending EffectableEntity and tracks locked options internally.
+- Random World Generator UI now reflects manager-locked orbit and type options during regular UI updates.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -99,6 +99,34 @@ function ensureRandomWorldUI() {
   }
 }
 
+function updateRandomWorldUI() {
+  const mgr = typeof rwgManager !== 'undefined' ? rwgManager : globalThis.rwgManager;
+  if (!mgr) return;
+
+  const orbitSel = /** @type {HTMLSelectElement|null} */(document.getElementById('rwg-orbit'));
+  if (orbitSel) {
+    Array.from(orbitSel.options).forEach(opt => {
+      if (opt.value === 'auto') return;
+      const locked = typeof mgr.isOrbitLocked === 'function' ? mgr.isOrbitLocked(opt.value) : false;
+      const base = opt.textContent.replace(' (Locked)', '');
+      opt.disabled = locked;
+      opt.textContent = locked ? base + ' (Locked)' : base;
+    });
+  }
+
+  const typeSel = /** @type {HTMLSelectElement|null} */(document.getElementById('rwg-type'));
+  if (typeSel) {
+    Array.from(typeSel.options).forEach(opt => {
+      if (opt.value === 'auto') return;
+      const key = opt.value === 'rocky' ? 'hot-rocky' : opt.value;
+      const locked = typeof mgr.isTypeLocked === 'function' ? mgr.isTypeLocked(key) : false;
+      const base = opt.textContent.replace(' (Locked)', '');
+      opt.disabled = locked;
+      opt.textContent = locked ? base + ' (Locked)' : base;
+    });
+  }
+}
+
 function attachTravelHandler(res, sStr) {
   const travelBtn = document.getElementById('rwg-travel-btn');
   if (!travelBtn) return;
@@ -490,7 +518,15 @@ if (typeof showSpaceRandomTab === 'function') {
   };
 }
 
+if (typeof updateSpaceUI === 'function') {
+  const originalUpdateSpaceUI = updateSpaceUI;
+  updateSpaceUI = function(...args) {
+    originalUpdateSpaceUI.apply(this, args);
+    updateRandomWorldUI();
+  };
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { initializeRandomWorldUI, ensureRandomWorldUI, renderWorldDetail, attachEquilibrateHandler, attachTravelHandler };
+  module.exports = { initializeRandomWorldUI, ensureRandomWorldUI, updateRandomWorldUI, renderWorldDetail, attachEquilibrateHandler, attachTravelHandler };
 }
 

--- a/tests/rwgUILockStateSync.test.js
+++ b/tests/rwgUILockStateSync.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Random World Generator lock UI sync', () => {
+  test('dropdown options reflect manager lock state', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="space-random"></div>` , { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+
+    const spaceUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'spaceUI.js'), 'utf8');
+    const rwgCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwg.js'), 'utf8');
+    const rwgUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+    vm.runInContext(`
+      function isObject(o){ return o && typeof o === 'object' && !Array.isArray(o); }
+      function deepMerge(a,b){
+        if(!isObject(a) || !isObject(b)) return { ...(a||{}), ...(b||{}) };
+        const out = { ...a };
+        Object.keys(b).forEach(k => { out[k] = isObject(a[k]) && isObject(b[k]) ? deepMerge(a[k], b[k]) : b[k]; });
+        return out;
+      }
+      const defaultPlanetParameters = { name:'Default', resources:{ colony:{}, surface:{}, underground:{}, atmospheric:{}, special:{} }, buildingParameters:{}, populationParameters:{}, celestialParameters:{} };
+      ${spaceUICode}
+      ${rwgCode}
+      ${rwgUICode}
+      initializeRandomWorldUI();
+    `, ctx);
+
+    const hotOpt = dom.window.document.querySelector('#rwg-orbit option[value="hot"]');
+    const coldOpt = dom.window.document.querySelector('#rwg-orbit option[value="cold"]');
+    const venusOpt = dom.window.document.querySelector('#rwg-type option[value="venus-like"]');
+    const marsOpt = dom.window.document.querySelector('#rwg-type option[value="mars-like"]');
+
+    expect(hotOpt.disabled).toBe(true);
+    expect(venusOpt.disabled).toBe(true);
+
+    vm.runInContext('rwgManager.unlockOrbit("hot"); rwgManager.unlockType("venus-like"); updateSpaceUI();', ctx);
+    expect(hotOpt.disabled).toBe(false);
+    expect(hotOpt.textContent.includes("Locked")).toBe(false);
+    expect(venusOpt.disabled).toBe(false);
+    expect(venusOpt.textContent.includes("Locked")).toBe(false);
+
+    vm.runInContext('rwgManager.lockOrbit("cold"); rwgManager.lockType("mars-like"); updateSpaceUI();', ctx);
+    expect(coldOpt.disabled).toBe(true);
+    expect(coldOpt.textContent.includes("Locked")).toBe(true);
+    expect(marsOpt.disabled).toBe(true);
+    expect(marsOpt.textContent.includes("Locked")).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Update Random World Generator UI each render to enable or disable orbit and type options based on the manager's lock state
- Hook updateSpaceUI to invoke the new RWG update routine during the regular UI loop
- Add regression test for RWG lock state syncing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689938063890832785fb229c20c7ea3e