### PR TITLE
Use RWG star luminosity for solar flux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,3 +420,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Hot orbit option in the Random World Generator is now locked, and Auto selects a random unlocked orbit preset.
 - Random World Generator UI now respects the global Celsius setting for temperature displays.
 - Random World Generator is now handled by a manager extending EffectableEntity and tracks locked options internally.
+- Solar flux now accounts for the generating star's luminosity when visiting random worlds.

--- a/src/js/rwgEquilibrate.js
+++ b/src/js/rwgEquilibrate.js
@@ -154,6 +154,10 @@
     const minRunMs = options.minRunMs ?? (options.sync ? 0 : 10000);
 
     return new Promise((resolve, reject) => {
+      const prevLum = typeof getStarLuminosity === 'function' ? getStarLuminosity() : 1;
+      if (typeof setStarLuminosity === 'function') {
+        setStarLuminosity(options.star?.luminositySolar || 1);
+      }
       try {
         const TF = TerraformingCtor || (typeof Terraforming === 'function' ? Terraforming : undefined);
         if (typeof TF !== 'function') {
@@ -188,6 +192,9 @@
 
         function finalize(ok) {
           clearTimeout(timeoutHandle);
+          if (typeof setStarLuminosity === 'function') {
+            setStarLuminosity(prevLum);
+          }
           // Restore globals without leaking sandbox
           if (cppDesc) {
             Object.defineProperty(globalThis, 'currentPlanetParameters', cppDesc);
@@ -268,6 +275,9 @@
 
         if (options.sync) loopChunk(); else setTimeout(loopChunk, 0);
       } catch (e) {
+        if (typeof setStarLuminosity === 'function') {
+          setStarLuminosity(prevLum);
+        }
         reject(e);
       }
     });

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -226,7 +226,8 @@ function attachEquilibrateHandler(res, sStr, archetype, box) {
           absTol: 1,
           relTol: 1e-6,
           chunkSteps: 20,
-          cancelToken
+          cancelToken,
+          star: res.star
         }, (p, info) => {
           const label = document.getElementById('rwg-progress-label');
           if (label && info?.label) label.textContent = info.label;

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -243,6 +243,9 @@ class SpaceManager extends EffectableEntity {
                 this.currentRandomSeed = null;
                 this.currentRandomName = '';
                 console.log(`SpaceManager: Current planet set to: ${this.currentPlanetKey}`);
+                if (typeof setStarLuminosity === 'function') {
+                    setStarLuminosity(SOL_STAR.luminositySolar);
+                }
             }
              // Ensure status object exists for the new current planet
              if (!this.planetStatuses[key]) {
@@ -360,6 +363,9 @@ class SpaceManager extends EffectableEntity {
         }
         const storageState = projectManager?.projects?.spaceStorage?.saveTravelState
             ? projectManager.projects.spaceStorage.saveTravelState() : null;
+        if (typeof setStarLuminosity === 'function') {
+            setStarLuminosity(res?.star?.luminositySolar || 1);
+        }
         globalThis.currentPlanetParameters = res?.merged;
         if (typeof initializeGameState === 'function') {
             initializeGameState({ preserveManagers: true, preserveJournal: true });

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1,4 +1,11 @@
-let solarLuminosity = 3.828e26; // Solar luminosity (W)
+const SOLAR_LUMINOSITY_W = 3.828e26; // Base solar luminosity (W)
+let starLuminosityMultiplier = 1; // Multiplier relative to Sol
+function setStarLuminosity(multiplier) {
+  starLuminosityMultiplier = multiplier || 1;
+}
+function getStarLuminosity() {
+  return starLuminosityMultiplier;
+}
 const C_P_AIR = 1004; // J/kg·K
 const EPSILON = 0.622; // Molecular weight ratio
 const AU_METER = 149597870700;
@@ -1203,8 +1210,9 @@ class Terraforming extends EffectableEntity{
     }
 
     calculateSolarFlux(distanceFromSun){
-      return solarLuminosity / (4*Math.PI * Math.pow(distanceFromSun, 2)); // W/m²
-    }    
+      const lum = SOLAR_LUMINOSITY_W * starLuminosityMultiplier;
+      return lum / (4*Math.PI * Math.pow(distanceFromSun, 2)); // W/m²
+    }
 
     calculateModifiedSolarFlux(distanceFromSunInMeters){
       const baseFlux = this.calculateSolarFlux(distanceFromSunInMeters);
@@ -1643,5 +1651,10 @@ synchronizeGlobalResources() {
 
 if (typeof module !== "undefined" && module.exports) {
   module.exports = Terraforming;
+  module.exports.setStarLuminosity = setStarLuminosity;
+  module.exports.getStarLuminosity = getStarLuminosity;
+} else {
+  globalThis.setStarLuminosity = setStarLuminosity;
+  globalThis.getStarLuminosity = getStarLuminosity;
 }
 

--- a/tests/starLuminosityFlux.test.js
+++ b/tests/starLuminosityFlux.test.js
@@ -1,0 +1,28 @@
+const { getZoneRatio, getZonePercentage } = require('../src/js/zones.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const lifeParameters = require('../src/js/life-parameters.js');
+
+global.getZoneRatio = getZoneRatio;
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+global.resources = { atmospheric: {} };
+
+const Terraforming = require('../src/js/terraforming.js');
+
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+Terraforming.prototype.calculateLanternFlux = function(){ return 0; };
+
+describe('star luminosity affects solar flux', () => {
+  afterEach(() => {
+    Terraforming.setStarLuminosity(1);
+  });
+
+  test('flux scales with star luminosity multiplier', () => {
+    Terraforming.setStarLuminosity(2);
+    const terra = new Terraforming({}, { radius: 1, distanceFromSun: 1, albedo: 0, gravity: 1 });
+    const flux = terra.calculateSolarFlux(149597870700);
+    expect(flux).toBeCloseTo(2722, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- compute solar flux using a configurable star luminosity
- set star luminosity when changing planets or equilibrating random worlds
- cover star-driven flux scaling with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689937e251988327a66e11c78bf9afb7