### PR TITLE
Reduce RWG dropdown flicker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,3 +422,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator is now handled by a manager extending EffectableEntity and tracks locked options internally.
 - Solar flux now accounts for the generating star's luminosity when visiting random worlds.
 - Random World Generator UI now reflects manager-locked orbit and type options during regular UI updates.
+- Random World Generator dropdowns now only change when their lock state changes, preventing flicker.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -108,9 +108,11 @@ function updateRandomWorldUI() {
     Array.from(orbitSel.options).forEach(opt => {
       if (opt.value === 'auto') return;
       const locked = typeof mgr.isOrbitLocked === 'function' ? mgr.isOrbitLocked(opt.value) : false;
-      const base = opt.textContent.replace(' (Locked)', '');
-      opt.disabled = locked;
-      opt.textContent = locked ? base + ' (Locked)' : base;
+      const base = opt.dataset.baseText || opt.textContent.replace(' (Locked)', '');
+      opt.dataset.baseText = base;
+      const newText = locked ? base + ' (Locked)' : base;
+      if (opt.disabled !== locked) opt.disabled = locked;
+      if (opt.textContent !== newText) opt.textContent = newText;
     });
   }
 
@@ -120,9 +122,11 @@ function updateRandomWorldUI() {
       if (opt.value === 'auto') return;
       const key = opt.value === 'rocky' ? 'hot-rocky' : opt.value;
       const locked = typeof mgr.isTypeLocked === 'function' ? mgr.isTypeLocked(key) : false;
-      const base = opt.textContent.replace(' (Locked)', '');
-      opt.disabled = locked;
-      opt.textContent = locked ? base + ' (Locked)' : base;
+      const base = opt.dataset.baseText || opt.textContent.replace(' (Locked)', '');
+      opt.dataset.baseText = base;
+      const newText = locked ? base + ' (Locked)' : base;
+      if (opt.disabled !== locked) opt.disabled = locked;
+      if (opt.textContent !== newText) opt.textContent = newText;
     });
   }
 }


### PR DESCRIPTION
## Summary
- Only change Random World Generator dropdown options when their lock state changes
- Document dropdown update behavior in AGENTS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68993ad425e08327b8b02ea4b115f785