### PR TITLE
Use physics model temperatures in Random World Generator UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,3 +424,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator UI now reflects manager-locked orbit and type options during regular UI updates.
 - Random World Generator dropdowns now only change when their lock state changes, preventing flicker.
 - Random World Generator now precomputes zonal coverages and derives temperatures using physics.js.
+- Random World Generator UI now reads day/night/mean temperatures directly from the physics model instead of estimating them separately.


### PR DESCRIPTION
## Summary
- Remove redundant temperature estimation in `rwgUI.js`
- Display day, night, and mean temperatures from `dayNightTemperaturesModel`
- Document change in AGENTS notes

## Testing
- `npm test` *(fails: Cannot find module '/root/.local/share/mise/installs/node/22.18.0/lib/node_modules/jsdom')*


------
https://chatgpt.com/codex/tasks/task_b_68994023a6108327be678f477df78c37