### PR TITLE
Display RWG day-night temperatures

### DIFF
--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -658,6 +658,7 @@ function hashStringToInt(str) {
       // Initial zonal guesses to seed terraforming models
       ...zonal,
       zonalCoverageCache,
+      finalTemps: { mean: temps.mean, day: temps.day, night: temps.night },
       fundingRate: Math.round(randRange(rng, 5, 15)), // tweak to taste
       buildingParameters: { maintenanceFraction: 0.001 },
       populationParameters: { workerRatio: 0.5 },

--- a/tests/rwgCelsiusDisplay.test.js
+++ b/tests/rwgCelsiusDisplay.test.js
@@ -23,6 +23,8 @@ describe('rwgUI temperature display', () => {
 
     const sm = new SpaceManager(planetParameters);
     const res = sm.getCurrentWorldOriginal();
+    res.override = res.override || {};
+    res.override.finalTemps = global.dayNightTemperaturesModel({});
     const html = renderWorldDetail(res);
     const dom = new JSDOM(html);
     const chips = Array.from(dom.window.document.querySelectorAll('.rwg-chip'));

--- a/tests/rwgEquilibrateTempsUpdate.test.js
+++ b/tests/rwgEquilibrateTempsUpdate.test.js
@@ -56,7 +56,10 @@ describe('Random World Generator equilibrate updates temperatures', () => {
         },
         classification: { archetype: 'mars-like', TeqK: 100 }
       },
-      override: { resources: { atmospheric: {} } }
+      override: {
+        resources: { atmospheric: {} },
+        finalTemps: { mean: 250, day: 260, night: 240 }
+      }
     };
     const box = document.getElementById('rwg-result');
     box.innerHTML = renderWorldDetail(res, 'seed', 'mars-like');

--- a/tests/rwgPhysicsTemperature.test.js
+++ b/tests/rwgPhysicsTemperature.test.js
@@ -20,4 +20,8 @@ test('random world generator uses physics model and precomputes zonal coverage',
   terraObj.zonalCoverageCache = override.zonalCoverageCache;
   expect(cp.temperature.mean).toBeGreaterThan(0);
   expect(typeof cp.actualAlbedo).toBe('number');
+  expect(override.finalTemps).toBeDefined();
+  expect(override.finalTemps.mean).toBeCloseTo(cp.temperature.mean);
+  expect(override.finalTemps.day).toBeCloseTo(cp.temperature.day);
+  expect(override.finalTemps.night).toBeCloseTo(cp.temperature.night);
 });


### PR DESCRIPTION
## Summary
- show day, night, and mean temperatures in Random World Generator results
- verify temperature values through RWG physics tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6899424951e48327804d6f9f43907778