### PR TITLE
Fix golden asteroid effect stacking on repeated load

### DIFF
--- a/src/js/gold-asteroid.js
+++ b/src/js/gold-asteroid.js
@@ -206,9 +206,23 @@ class GoldenAsteroid {
     loadState(data) {
       this.despawn();
       this.removeEffects();
-      if (this.countdownElement) {
-        this.countdownElement.remove();
-        this.countdownElement = null;
+
+      // Remove any leftover DOM elements from previous instances
+      const container = document.getElementById('gold-asteroid-container');
+      if (container) {
+        const staleCountdown = container.querySelector('.gold-asteroid-countdown');
+        if (staleCountdown) {
+          staleCountdown.remove();
+        }
+      }
+      this.countdownElement = null;
+
+      const gameContainer = document.getElementById('game-container');
+      if (gameContainer) {
+        const staleAsteroid = gameContainer.querySelector('.golden-asteroid');
+        if (staleAsteroid) {
+          staleAsteroid.remove();
+        }
       }
 
       this.active = data.active;
@@ -219,9 +233,9 @@ class GoldenAsteroid {
       this.lastSpawnTime = 0;
       this.generateNextSpawnTime();
 
-          if (this.countdownActive) {
-              this.addEffects();
-              this.startCountdown(this.countdownRemainingTime);
-          }
+      if (this.countdownActive) {
+        this.addEffects();
+        this.startCountdown(this.countdownRemainingTime);
+      }
     }
   }

--- a/tests/goldenAsteroidReload.test.js
+++ b/tests/goldenAsteroidReload.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('golden asteroid repeated load', () => {
+  test('replaces existing countdown element on subsequent loads', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="gold-asteroid-container"></div><div id="game-container"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.document = dom.window.document;
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'gold-asteroid.js'), 'utf8');
+    vm.runInContext(`${code}; this.GoldenAsteroid = GoldenAsteroid;`, ctx);
+
+    const asteroid1 = new ctx.GoldenAsteroid();
+    asteroid1.startCountdown(1000);
+    const saved = asteroid1.saveState();
+
+    const asteroid2 = new ctx.GoldenAsteroid();
+    asteroid2.loadState(saved);
+
+    const container = dom.window.document.getElementById('gold-asteroid-container');
+    expect(container.children.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- clear leftover golden asteroid visuals before loading state to prevent stacked countdowns
- add regression test ensuring repeated loads only show a single countdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a37b3a0188327a7d8cc1b2ce45f18