### PR TITLE
Preserve alien artifacts across planet travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,3 +427,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator UI now reads day/night/mean temperatures directly from the physics model instead of estimating them separately.
 - Solar luminosity for Random World Generator worlds now persists through saves and reloads.
 - Random World Generator equilibration window now displays refinement counts and simulated time.
+- Alien artifact resource values now persist across planet travel, mirroring advanced research.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -115,6 +115,7 @@ function initializeGameState(options = {}) {
   const preserveJournal = options.preserveJournal || false;
   const skipStoryInitialization = options.skipStoryInitialization || false;
   let savedAdvancedResearch = null;
+  let savedAlienArtifact = null;
   let savedProjectTravelState = null;
   if (preserveManagers && typeof projectManager !== 'undefined' && typeof projectManager.saveTravelState === 'function') {
     savedProjectTravelState = projectManager.saveTravelState();
@@ -126,6 +127,12 @@ function initializeGameState(options = {}) {
     savedAdvancedResearch = {
       value: resources.colony.advancedResearch.value,
       unlocked: resources.colony.advancedResearch.unlocked,
+    };
+  }
+  if (preserveManagers && resources && resources.special && resources.special.alienArtifact) {
+    savedAlienArtifact = {
+      value: resources.special.alienArtifact.value,
+      unlocked: resources.special.alienArtifact.unlocked,
     };
   }
   tabManager = new TabManager({
@@ -157,6 +164,10 @@ function initializeGameState(options = {}) {
   if (savedAdvancedResearch) {
     resources.colony.advancedResearch.value = savedAdvancedResearch.value;
     resources.colony.advancedResearch.unlocked = savedAdvancedResearch.unlocked;
+  }
+  if (savedAlienArtifact) {
+    resources.special.alienArtifact.value = savedAlienArtifact.value;
+    resources.special.alienArtifact.unlocked = savedAlienArtifact.unlocked;
   }
   buildings = initializeBuildings(buildingsParameters);
   projectManager = new ProjectManager();

--- a/tests/alienArtifactTravelPersistence.test.js
+++ b/tests/alienArtifactTravelPersistence.test.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Alien artifacts persist across planet travel', () => {
+  test('traveling does not reset alien artifact resource', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      return new Proxy(function () {}, {
+        get: () => createNullElement(),
+        apply: () => createNullElement(),
+        set: () => true,
+      });
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = {
+      AUTO: 'AUTO',
+      Game: function (config) { this.config = config; },
+    };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      addEffect=()=>{};
+      removeEffect=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('resources.special.alienArtifact.unlocked = true; resources.special.alienArtifact.value = 7;', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const value = vm.runInContext('resources.special.alienArtifact.value', ctx);
+    const unlocked = vm.runInContext('resources.special.alienArtifact.unlocked', ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(value).toBe(7);
+    expect(unlocked).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- keep alien artifact resource when switching planets by saving and restoring its state during game initialization
- document artifact travel persistence
- test that alien artifacts remain after planet travel

## Testing
- `npm test` *(fails: tests/rwgEquilibrate.test.js)*
- `npm test tests/rwgEquilibrate.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689a3a718a848327a2cab0e8dda00526