### PR TITLE
Fix Solis water upgrade applying storage before increase

### DIFF
--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -243,9 +243,6 @@ class SolisManager extends EffectableEntity {
       const res = resources && resources.colony && resources.colony[key];
       if (upgrade && upgrade.purchases > 0 && res && typeof res.increase === 'function') {
         const amount = RESOURCE_UPGRADE_AMOUNTS[key] * upgrade.purchases;
-        if (!globalGameIsLoadingFromSave) {
-          res.increase(amount);
-        }
         if (typeof addEffect === 'function' && res.hasCap) {
           addEffect({
             target: 'resource',
@@ -256,6 +253,9 @@ class SolisManager extends EffectableEntity {
             effectId: `solisStorage-${key}`,
             sourceId: 'solisShop'
           });
+        }
+        if (!globalGameIsLoadingFromSave) {
+          res.increase(amount);
         }
       }
     }

--- a/tests/solisResourceUpgrades.test.js
+++ b/tests/solisResourceUpgrades.test.js
@@ -28,7 +28,9 @@ describe('Solis resource upgrades', () => {
         .reduce((s, e) => s + e.value, 0);
       this.cap = this.baseCap + bonus;
     }
-    increase(v) { this.value += v; }
+    increase(v) {
+      this.value = Math.min(this.value + v, this.cap);
+    }
   }
 
   function makeResource() {
@@ -67,13 +69,16 @@ describe('Solis resource upgrades', () => {
     global.globalGameIsLoadingFromSave = false;
     const manager = new SolisManager();
     for (const k of Object.keys(amounts)) {
-      manager.shopUpgrades[k].purchases = k === 'metal' ? 2 : 1;
+      manager.shopUpgrades[k].purchases =
+        k === 'metal' ? 2 : k === 'water' ? 5 : 1;
     }
     manager.reapplyEffects();
     expect(cols.metal.value).toBe(2 * amounts.metal);
     expect(cols.metal.cap).toBe(2 * amounts.metal);
+    expect(cols.water.value).toBe(5 * amounts.water);
+    expect(cols.water.cap).toBe(5 * amounts.water);
     for (const k of Object.keys(amounts)) {
-      if (k !== 'metal') {
+      if (k !== 'metal' && k !== 'water') {
         expect(cols[k].value).toBe(amounts[k]);
         expect(cols[k].cap).toBe(amounts[k]);
       }


### PR DESCRIPTION
## Summary
- Apply Solis resource storage bonus before increasing starting amounts to avoid clamping
- Strengthen Solis resource upgrade tests to enforce storage caps and check multiple purchases, especially water

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a687a45288327a9318ab2f2025703