### PR TITLE
Keep resource tooltip time line visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,3 +429,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Random World Generator equilibration window now displays refinement counts and simulated time.
 - Innovation Initiative now boosts android research output.
 - Alien artifact resource values now persist across planet travel, mirroring advanced research.
+- Resource tooltip time line now reserves space with a blank line when no time to full or empty is shown, preventing flicker.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -598,10 +598,10 @@ function updateResourceRateDisplay(resource){
         const time = resource.value / Math.abs(netRate);
         timeDiv.textContent = `Time to empty: ${formatDuration(Math.max(time, 0))}`;
       } else {
-        timeDiv.textContent = '';
+        timeDiv.innerHTML = '&nbsp;';
       }
     } else {
-      timeDiv.textContent = '';
+      timeDiv.innerHTML = '&nbsp;';
     }
   }
 

--- a/tests/resourceTooltipTime.test.js
+++ b/tests/resourceTooltipTime.test.js
@@ -110,4 +110,18 @@ describe('resource tooltip time remaining', () => {
     expect(html).toContain('Time to empty');
     expect(html).toContain('2 years');
   });
+
+  test('shows blank line when rate is zero', () => {
+    const { dom, ctx } = setup();
+    const resource = {
+      name: 'silicon', displayName: 'Silicon', category: 'colony',
+      value: 50, cap: 100, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 2, consumptionRate: 2,
+      productionRateBySource: {}, consumptionRateBySource: {}, unit: 'kg'
+    };
+    ctx.createResourceDisplay({ colony: { silicon: resource } });
+    ctx.updateResourceRateDisplay(resource);
+    const timeDiv = dom.window.document.getElementById('silicon-tooltip-time');
+    expect(timeDiv.innerHTML).toBe('&nbsp;');
+  });
 });


### PR DESCRIPTION
## Summary
- Prevent resource tooltip text flicker by reserving a blank line when no time to empty/full is shown
- Test coverage to ensure blank line presence when rates balance
- Document resource tooltip spacing improvement in AGENTS changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a6a5918f48327a9d9f048edc4b349