### PR TITLE
Hide negligible radiation penalty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,3 +430,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Innovation Initiative now boosts android research output.
 - Alien artifact resource values now persist across planet travel, mirroring advanced research.
 - Resource tooltip time line now reserves space with a blank line when no time to full or empty is shown, preventing flicker.
+- Radiation penalty values below 0.01% are hidden from the UI.

--- a/src/js/life.js
+++ b/src/js/life.js
@@ -204,6 +204,9 @@ class LifeDesign {
             const mitigation = this.getRadiationMitigationRatio();
             finalPenalty = basePenalty * (1 - mitigation);
         }
+        if (finalPenalty < 0.0001) {
+            finalPenalty = 0;
+        }
 
         const pass = finalPenalty === 0;
         const reason = pass ? null : "High radiation";

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -637,7 +637,10 @@ function updateLifeStatusTable() {
                 : (terraforming.calculateZonalSolarPanelMultiplier ? terraforming.calculateZonalSolarPanelMultiplier(zone) : 1);
             const tempMult = growthTempResults[zone]?.multiplier || 0;
               const radMitigation = designToCheck.getRadiationMitigationRatio();
-              const radPenalty = terraforming.getMagnetosphereStatus() ? 0 : (terraforming.radiationPenalty || 0) * (1 - radMitigation);
+              let radPenalty = terraforming.getMagnetosphereStatus() ? 0 : (terraforming.radiationPenalty || 0) * (1 - radMitigation);
+              if (radPenalty < 0.0001) {
+                  radPenalty = 0;
+              }
               const radMult = 1 - radPenalty;
             const waterMult = (terraforming.zonalWater[zone]?.liquid || 0) > 1e-9 ? 1 : 0;
             const otherMult = (typeof lifeManager !== 'undefined' && lifeManager.getEffectiveLifeGrowthMultiplier) ? lifeManager.getEffectiveLifeGrowthMultiplier() : 1;

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -616,8 +616,12 @@ function updateLifeBox() {
       <p>Magnetosphere: <span id="magnetosphere-status">${magnetosphereStatusText}</span></p>
         <p>Orbital radiation: <span id="orbital-radiation">${formatNumber(orbRad, false, 2)}</span> mSv/day</p>
         <p>Surface radiation: <span id="surface-radiation">${formatNumber(rad, false, 2)}</span> mSv/day</p>
-        <p>Radiation penalty: <span id="surface-radiation-penalty">${formatNumber(radPenalty * 100, false, 0)}</span>%</p>
+        <p id="radiation-penalty-row">Radiation penalty: <span id="surface-radiation-penalty">${formatNumber(radPenalty * 100, false, 0)}</span>%</p>
       `;
+    if ((radPenalty || 0) < 0.0001) {
+      const penaltyRow = magnetosphereBox.querySelector('#radiation-penalty-row');
+      if (penaltyRow) penaltyRow.style.display = 'none';
+    }
     const magnetosphereHeading = magnetosphereBox.querySelector('h3');
     if (magnetosphereHeading) {
       magnetosphereHeading.appendChild(magInfo);
@@ -648,7 +652,14 @@ function updateLifeBox() {
         surfaceRadiation.textContent = formatNumber(terraforming.surfaceRadiation || 0, false, 2);
       }
       if (surfaceRadiationPenalty) {
-        surfaceRadiationPenalty.textContent = formatNumber((terraforming.radiationPenalty || 0) * 100, false, 0);
+        const penaltyRow = surfaceRadiationPenalty.parentElement;
+        const penaltyValue = terraforming.radiationPenalty || 0;
+        if (penaltyValue < 0.0001) {
+          penaltyRow.style.display = 'none';
+        } else {
+          penaltyRow.style.display = '';
+          surfaceRadiationPenalty.textContent = formatNumber(penaltyValue * 100, false, 0);
+        }
       }
 
     if(terraforming.getMagnetosphereStatus()){

--- a/tests/radiationDisplay.test.js
+++ b/tests/radiationDisplay.test.js
@@ -67,4 +67,59 @@ describe('radiation display', () => {
     expect(penEl).not.toBeNull();
     expect(penEl.textContent).toBe(numbers.formatNumber(0.1234 * 100, false, 0));
   });
+
+  test('radiation penalty hidden when below threshold', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="summary-terraforming"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const numbers = require('../src/js/numbers.js');
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
+    ctx.DEFAULT_SURFACE_ALBEDO = require('../src/js/physics.js').DEFAULT_SURFACE_ALBEDO;
+
+    ctx.resources = { atmospheric: { o2: { displayName: 'O2', value: 0 } } };
+    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.terraformingGasTargets = { o2: { min: 0, max: 100 } };
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    ctx.terraforming = {
+      temperature: { name: 'Temp', value: 0, emissivity: 1, effectiveTempNoAtmosphere: 0,
+        zones: { tropical: { value: 0, day: 0, night: 0 },
+                temperate: { value: 0, day: 0, night: 0 },
+                polar: { value: 0, day: 0, night: 0 } } },
+      atmosphere: { name: 'Atm' },
+      water: {},
+      luminosity: { name: 'Lum', albedo: 0, solarFlux: 0, modifiedSolarFlux: 0 },
+      life: { name: 'Life', target: 0.5 },
+      magnetosphere: { name: 'Mag' },
+      surfaceRadiation: 0.1,
+      orbitalRadiation: 0.2,
+      radiationPenalty: 0.00005,
+      celestialParameters: { albedo: 0, gravity: 1, radius: 1, surfaceArea: 1 },
+      calculateSolarPanelMultiplier: () => 1,
+      calculateWindTurbineMultiplier: () => 1,
+      getAtmosphereStatus: () => true,
+      getLuminosityStatus: () => true,
+      getMagnetosphereStatus: () => true,
+      waterTarget: 0.2,
+      totalEvaporationRate: 0,
+      totalWaterSublimationRate: 0,
+      totalRainfallRate: 0,
+      totalSnowfallRate: 0,
+      totalMeltRate: 0,
+      totalFreezeRate: 0,
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: {}, temperate: {}, polar: {} }
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.createTerraformingSummaryUI();
+
+    const penEl = dom.window.document.getElementById('surface-radiation-penalty');
+    expect(penEl).not.toBeNull();
+    expect(penEl.parentElement.style.display).toBe('none');
+  });
 });


### PR DESCRIPTION
## Summary
- Hide magnetosphere radiation penalty line when below 0.01%
- Treat tiny radiation penalties as zero in life checks and growth calculations
- Document radiation penalty display change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a6d6755008327b6d88b6de9e0b029