### PR TITLE
Grant focused mirror melt freeze immunity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,3 +430,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Innovation Initiative now boosts android research output.
 - Alien artifact resource values now persist across planet travel, mirroring advanced research.
 - Resource tooltip time line now reserves space with a blank line when no time to full or empty is shown, preventing flicker.
+- Focused mirror melting now grants liquid water freeze immunity, fully protecting 50× the melted amount and partially shielding another 50× based on freezing intensity.


### PR DESCRIPTION
## Summary
- allow focused mirror melting to protect 50× water from freezing and partially shield another 50× with exponential scaling
- track per-zone melt protection in `applyFocusedMelt` and adjust freezing logic
- test focused melt freeze immunity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a6f387a788327b2b445983743d38a