### PR TITLE
Fix cargo rocket resource reservation

### DIFF
--- a/tests/cargoRocketProject.test.js
+++ b/tests/cargoRocketProject.test.js
@@ -29,4 +29,47 @@ describe('Cargo Rocket project', () => {
     expect(typeof ctx.CargoRocketProject.prototype.getResourceChoiceGainCost).toBe('function');
     expect(typeof ctx.CargoRocketProject.prototype.applyResourceChoiceGain).toBe('function');
   });
+
+  test('changing selection after start does not increase gains', () => {
+    const ctx = {
+      console,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      resources: {
+        colony: { funding: { value: 1e9, decrease: jest.fn(), modifyRate: jest.fn() } },
+        special: { spaceships: { value: 0, increase: jest.fn(), modifyRate: jest.fn() } }
+      },
+      projectManager: { projects: {}, durationMultiplier: 1 },
+    };
+    vm.createContext(ctx);
+    global.resources = ctx.resources;
+    global.projectManager = ctx.projectManager;
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+
+    const config = {
+      name: 'Cargo Rocket',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { resourceChoiceGainCost: { special: { spaceships: 5 } } }
+    };
+
+    const project = new ctx.CargoRocketProject(config, 'cargo_rocket');
+    project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 1 }];
+    project.start(ctx.resources);
+    project.autoStart = true;
+
+    project.selectedResources = [{ category: 'special', resource: 'spaceships', quantity: 1000000 }];
+    project.estimateProjectCostAndGain();
+    project.complete();
+
+    expect(ctx.resources.special.spaceships.increase).toHaveBeenCalledWith(1);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent cargo rockets from updating pending gains when auto-run estimates cost
- add regression test for mid-flight resource selection changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b2e4c00708327818a02dff0e59191