### PR TITLE
Use planet parameters to set star luminosity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,3 +434,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Radiation penalty values below 0.01% are hidden from the UI.
 - Radiation display in the terraforming UI now shows mSv/day without formatNumber and values below 0.01 mSv/day appear as 0.
 - Water overflow now counts as production and is included in resource totals instead of showing a separate overflow line.
+- Star luminosity is now a celestial parameter set during Terraforming construction, ensuring new games have correct solar flux.

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -90,6 +90,7 @@ const defaultPlanetParameters = {
     mass: 6.417e23, // kg
     albedo: 0.25, // Default (Mars)
     rotationPeriod: 24.6, // hours, Default (Mars)
+    starLuminosity: 1, // Multiplier relative to Sol
   }
 };
 
@@ -258,6 +259,7 @@ const titanOverrides = {
     mass: 1.345e23, // kg
     albedo: 0.15,
     rotationPeriod: 382.7,
+    starLuminosity: 1,
     parentBody: {
       name: 'Saturn',
       radius: 60268,        // km
@@ -362,6 +364,7 @@ const callistoOverrides = {
     mass: 1.076e23,            // kg
     albedo: 0.17,              // Bond albedo estimate :contentReference[oaicite:5]{index=5}
     rotationPeriod: 400.8,     // hours (16 .7 days tidally‑locked) :contentReference[oaicite:6]{index=6}
+    starLuminosity: 1,
     parentBody: {
       name: 'Jupiter',
       radius: 71492,       // km
@@ -458,6 +461,7 @@ const ganymedeOverrides = {
     mass: 1.482e23,            // kg
     albedo: 0.21,              // Bond albedo estimate
     rotationPeriod: 171.7,     // hours (7.155 days, tidally locked)
+    starLuminosity: 1,
     parentBody: {
       name: 'Jupiter',
       radius: 71492,      // km

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -669,6 +669,7 @@ function hashStringToInt(str) {
         mass: bulk.mass,
         albedo,
         rotationPeriod: rotation,
+        starLuminosity: star.luminositySolar,
         parentBody,
         surfaceArea,
         temperature: { day: temps.day, night: temps.night, mean: temps.mean },

--- a/src/js/rwgEquilibrate.js
+++ b/src/js/rwgEquilibrate.js
@@ -194,9 +194,6 @@
 
     return new Promise((resolve, reject) => {
       const prevLum = typeof getStarLuminosity === 'function' ? getStarLuminosity() : 1;
-      if (typeof setStarLuminosity === 'function') {
-        setStarLuminosity(options.star?.luminositySolar || 1);
-      }
       try {
         const TF = TerraformingCtor || (typeof Terraforming === 'function' ? Terraforming : undefined);
         if (typeof TF !== 'function') {

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -276,8 +276,7 @@ function attachEquilibrateHandler(res, sStr, archetype, box) {
       eqBtn.disabled = true;
       try {
         const result = await runEquilibration(res.merged, {
-          cancelToken,
-          star: res.star
+          cancelToken
         }, (p, info) => {
           const label = document.getElementById('rwg-progress-label');
           if (label && info?.label) label.textContent = info.label;

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -67,10 +67,6 @@ function loadGame(slotOrCustomString) {
             currentPlanetParameters = planetParameters[key];
           }
         }
-        if (typeof setStarLuminosity === 'function') {
-          setStarLuminosity(worldOriginal?.star?.luminositySolar || 1);
-        }
-
         // Clear previously applied story effects so they don't carry over
         if (storyManager) {
           storyManager.appliedEffects = [];

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -243,9 +243,6 @@ class SpaceManager extends EffectableEntity {
                 this.currentRandomSeed = null;
                 this.currentRandomName = '';
                 console.log(`SpaceManager: Current planet set to: ${this.currentPlanetKey}`);
-                if (typeof setStarLuminosity === 'function') {
-                    setStarLuminosity(SOL_STAR.luminositySolar);
-                }
             }
              // Ensure status object exists for the new current planet
              if (!this.planetStatuses[key]) {
@@ -363,9 +360,6 @@ class SpaceManager extends EffectableEntity {
         }
         const storageState = projectManager?.projects?.spaceStorage?.saveTravelState
             ? projectManager.projects.spaceStorage.saveTravelState() : null;
-        if (typeof setStarLuminosity === 'function') {
-            setStarLuminosity(res?.star?.luminositySolar || 1);
-        }
         globalThis.currentPlanetParameters = res?.merged;
         if (typeof initializeGameState === 'function') {
             initializeGameState({ preserveManagers: true, preserveJournal: true });

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -113,6 +113,11 @@ class Terraforming extends EffectableEntity{
         this.initialCelestialParameters.crossSectionArea = Math.PI * Math.pow(initRadiusMeters, 2);
     }
 
+    const starLuminosity = this.celestialParameters.starLuminosity || 1;
+    this.celestialParameters.starLuminosity = starLuminosity;
+    this.initialCelestialParameters.starLuminosity = starLuminosity;
+    setStarLuminosity(starLuminosity);
+
     this.lifeParameters = lifeParameters; // Load external life parameters
     this.zonalCoverageCache = {};
 

--- a/tests/rwgLuminositySave.test.js
+++ b/tests/rwgLuminositySave.test.js
@@ -24,7 +24,9 @@ describe('RWG solar luminosity persistence', () => {
     sandbox.resources = { colony: { colonists: { value: 0 } } };
     sandbox.saveGameToSlot = () => {};
     sandbox.projectManager = { projects: { spaceStorage: { saveTravelState: () => null, loadTravelState: () => {} } } };
-    sandbox.initializeGameState = () => {};
+    sandbox.initializeGameState = () => {
+      sandbox.setStarLuminosity(sandbox.currentPlanetParameters?.celestialParameters?.starLuminosity || 1);
+    };
     sandbox.updateProjectUI = () => {};
     sandbox.updateSpaceUI = () => {};
     sandbox.skillManager = null;
@@ -57,7 +59,7 @@ describe('RWG solar luminosity persistence', () => {
 
     const sm = new sandbox.SpaceManager({ mars: { name: 'Mars' } });
     sandbox.spaceManager = sm;
-    sm.travelToRandomWorld({ merged: { name: 'Alpha' }, star: { luminositySolar: 2 } }, '42');
+    sm.travelToRandomWorld({ merged: { name: 'Alpha', celestialParameters: { starLuminosity: 2 } }, star: { luminositySolar: 2 } }, '42');
     expect(sandbox.getStarLuminosity()).toBe(2);
 
     const saved = JSON.stringify({ spaceManager: sm.saveState() });

--- a/tests/starLuminosityFlux.test.js
+++ b/tests/starLuminosityFlux.test.js
@@ -20,8 +20,7 @@ describe('star luminosity affects solar flux', () => {
   });
 
   test('flux scales with star luminosity multiplier', () => {
-    Terraforming.setStarLuminosity(2);
-    const terra = new Terraforming({}, { radius: 1, distanceFromSun: 1, albedo: 0, gravity: 1 });
+    const terra = new Terraforming({}, { radius: 1, distanceFromSun: 1, albedo: 0, gravity: 1, starLuminosity: 2 });
     const flux = terra.calculateSolarFlux(149597870700);
     expect(flux).toBeCloseTo(2722, 0);
   });


### PR DESCRIPTION
## Summary
- Store star luminosity on each planet's `celestialParameters`
- Initialize Terraforming with planet star luminosity instead of changing it on travel
- Pass generated star luminosity from the Random World Generator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c03ac14dc8327ad468d73b4f62e15