### PR TITLE
Use star mass for planetary thrusters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,3 +435,4 @@ second time they speak in a chapter to help clarify who is talking.
 - Radiation display in the terraforming UI now shows mSv/day without formatNumber and values below 0.01 mSv/day appear as 0.
 - Water overflow now counts as production and is included in resource totals instead of showing a separate overflow line.
 - Star luminosity is now a celestial parameter set during Terraforming construction, ensuring new games have correct solar flux.
+- Planetary thrusters now use the host star's mass for orbital calculations on random worlds.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -267,7 +267,8 @@ class PlanetaryThrustersProject extends Project{
       this.el.distTargetRow.style.display="block";
       this.el.distDvRow.style.display="block";
       this.el.escRow.style.display=this.el.parentRow.style.display=this.el.moonWarn.style.display=this.el.hillRow.style.display="none";
-      const dv=spiralDeltaV(p.distanceFromSun||this.tgtAU,this.tgtAU);
+      const starM = (p.starMass || SOLAR_MASS);
+      const dv=spiralDeltaV(p.distanceFromSun||this.tgtAU,this.tgtAU, G*starM);
       this.el.distDv.textContent=fmt(dv,false,3)+" m/s";
       this.el.distE.textContent=formatEnergy(translationalEnergyRemaining(p,dv,this.getThrustPowerRatio()));
       if(changed){
@@ -324,7 +325,8 @@ class PlanetaryThrustersProject extends Project{
       }else{
         this.escapePhase=false;
         if(resetDV || this.startAU===null) this.startAU=p.distanceFromSun;
-        this.dVreq=spiralDeltaV(this.startAU,this.tgtAU);
+        const starM = (p.starMass || SOLAR_MASS);
+        this.dVreq=spiralDeltaV(this.startAU,this.tgtAU, G*starM);
       }
     }
   }
@@ -410,7 +412,8 @@ class PlanetaryThrustersProject extends Project{
         this.el.distDvRow.style.display="block";
         this.el.escRow.style.display=this.el.parentRow.style.display=this.el.moonWarn.style.display=this.el.hillRow.style.display="none";
         const curAU=p.distanceFromSun||tgtAU;
-        const dvPreview=spiralDeltaV(curAU,tgtAU);
+        const starM = (p.starMass || SOLAR_MASS);
+        const dvPreview=spiralDeltaV(curAU,tgtAU, G*starM);
         this.el.distDv.textContent=fmt(dvPreview,false,3)+" m/s";
         // For heliocentric moves, show remaining dv based on job when active
         const usingJob  = this.motionInvest && this.dVreq > 0;
@@ -495,13 +498,14 @@ class PlanetaryThrustersProject extends Project{
           this.startAU = p.distanceFromSun; // stays on the planet per your model
           this.dVdone = 0;
           this.energySpentMotion = 0;    // optional reset for clarity
-          this.dVreq = spiralDeltaV(this.startAU, this.tgtAU);
+          const starM = (p.starMass || SOLAR_MASS);
+          this.dVreq = spiralDeltaV(this.startAU, this.tgtAU, G*starM);
           this.calcMotionCost();
           this.updateUI();
           return;
         }
       } else {
-        const mu=G*SOLAR_MASS;
+        const mu=G*(p.starMass || SOLAR_MASS);
         let a_sma=p.distanceFromSun*AU_IN_METERS;
         const v=Math.sqrt(mu/a_sma);
         let E=-mu/(2*a_sma)+v*a*dt*(this.tgtAU>this.startAU?+1:-1);

--- a/tests/planetaryThrustersStarMass.test.js
+++ b/tests/planetaryThrustersStarMass.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+const thrusterCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'PlanetaryThrustersProject.js'), 'utf8');
+const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+
+describe('Planetary Thrusters star mass', () => {
+  test('heliocentric Δv uses current star mass', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(thrusterCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const G = 6.67430e-11;
+    const AU_IN_METERS = 1.496e11;
+    const starMass = 2 * 1.989e30;
+    ctx.terraforming = {
+      celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 10, distanceFromSun: 1, starMass }
+    };
+    ctx.resources = { colony: { energy: { value: 1e40, decrease(v){ this.value -= v; }, updateStorageCap(){} } } };
+
+    const config = ctx.projectParameters.planetaryThruster;
+    const project = new ctx.PlanetaryThrustersProject(config, 'thruster');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    project.complete();
+
+    project.el.distTarget.value = 2;
+    project.calcMotionCost();
+
+    const dvText = project.el.distDv.textContent;
+    const actual = parseFloat(dvText.replace(/[^\d.-]/g, ''));
+    const expected = Math.abs(Math.sqrt(G*starMass/(1*AU_IN_METERS)) - Math.sqrt(G*starMass/(2*AU_IN_METERS)));
+
+    expect(actual).toBeCloseTo(expected, 3);
+  });
+});
+


### PR DESCRIPTION
## Summary
- make planetary thrusters account for the current star's mass when calculating orbital motion
- document the planetary thruster improvement
- add test for star-mass-dependent Δv

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c06b202ec8327bd6fd1a8b36bb855