### PR TITLE
feat: show optical depth breakdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Radiation penalty values below 0.01% are hidden from the UI, and radiation display in the terraforming UI shows mSv/day without `formatNumber`, with values below 0.01 mSv/day appearing as 0.
 - Water overflow counts as production and is included in resource totals instead of showing a separate overflow line.
 - Star luminosity is a celestial parameter set during Terraforming construction, ensuring new games have correct solar flux.
+- Optical depth tooltip lists contributions from each gas.

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -194,6 +194,7 @@ class Terraforming extends EffectableEntity{
       equilibriumTemperature: 0,
       emissivity: 0,
       opticalDepth: 0,
+      opticalDepthContributions: {},
       unlocked: false,
       zones: {
         tropical: {
@@ -1009,10 +1010,10 @@ class Terraforming extends EffectableEntity{
       const surfacePressurePa = calculateAtmosphericPressure(totalMass / 1000, gSurface, this.celestialParameters.radius);
       const surfacePressureBar = surfacePressurePa / 100000;
 
-      const emissivity = calculateEmissivity(composition, surfacePressureBar, gSurface);
+      const { emissivity, tau, contributions } = calculateEmissivity(composition, surfacePressureBar, gSurface);
       this.temperature.emissivity = emissivity;
-      const tau = emissivity < 1 ? -Math.log(1 - emissivity) : Infinity;
       this.temperature.opticalDepth = tau;
+      this.temperature.opticalDepthContributions = contributions;
 
       const baseParams = {
         groundAlbedo: groundAlbedo,
@@ -1633,6 +1634,7 @@ synchronizeGlobalResources() {
           this.temperature.emissivity = terraformingState.temperature.emissivity || 0;
           this.temperature.effectiveTempNoAtmosphere = terraformingState.temperature.effectiveTempNoAtmosphere || 0;
           this.temperature.opticalDepth = terraformingState.temperature.opticalDepth || 0;
+          this.temperature.opticalDepthContributions = terraformingState.temperature.opticalDepthContributions || {};
           this.temperature.unlocked = terraformingState.temperature.unlocked || false;
           if (terraformingState.temperature.zones) {
               for (const zone of ['tropical', 'temperate', 'polar']) {

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -285,7 +285,7 @@ function createTemperatureBox(row) {
     innerHTML += `
         </tbody>
       </table>
-      <p class="no-margin">Optical depth: <span id="optical-depth"></span></p>
+      <p class="no-margin">Optical depth: <span id="optical-depth"></span> <span id="optical-depth-info" class="info-tooltip-icon" title="">&#9432;</span></p>
       <p class="no-margin">Wind turbine multiplier: <span id="wind-turbine-multiplier">${(terraforming.calculateWindTurbineMultiplier()*100).toFixed(2)}</span>%</p>
     `;
   
@@ -313,6 +313,13 @@ function createTemperatureBox(row) {
     const opticalDepth = document.getElementById('optical-depth');
     if (opticalDepth) {
       opticalDepth.textContent = terraforming.temperature.opticalDepth.toFixed(2);
+    }
+    const opticalDepthInfo = document.getElementById('optical-depth-info');
+    if (opticalDepthInfo) {
+      const contributions = terraforming.temperature.opticalDepthContributions || {};
+      const lines = Object.entries(contributions)
+        .map(([gas, val]) => `${gas.toUpperCase()}: ${val.toFixed(2)}`);
+      opticalDepthInfo.title = lines.join('\n');
     }
 
 

--- a/tests/physics.test.js
+++ b/tests/physics.test.js
@@ -1,4 +1,4 @@
-const { calculateAtmosphericPressure, effectiveTemp, calculateEmissivity, calculateActualAlbedoPhysics } = require('../src/js/physics.js');
+const { calculateAtmosphericPressure, effectiveTemp, calculateEmissivity, calculateActualAlbedoPhysics, opticalDepth, opticalDepthSat } = require('../src/js/physics.js');
 
 describe('physics helpers', () => {
   test('calculateAtmosphericPressure basic case', () => {
@@ -11,10 +11,17 @@ describe('physics helpers', () => {
     expect(T).toBeCloseTo(216.6828649, 5);
   });
 
-  test('calculateEmissivity uses optical depth', () => {
-    const e = calculateEmissivity({ co2: 0.5 }, 1, 9.81);
-    expect(e).toBeGreaterThan(0);
-    expect(e).toBeLessThan(1);
+  test('calculateEmissivity uses saturated optical depth', () => {
+    const comp = { ch4: 0.5 };
+    const pBar = 2;
+    const { total: tauUnsat } = opticalDepth(comp, pBar, 9.81);
+    const { total: tauSat } = opticalDepthSat(comp, pBar, 9.81);
+    const { emissivity, tau, contributions } = calculateEmissivity(comp, pBar, 9.81);
+    expect(emissivity).toBeGreaterThan(0);
+    expect(emissivity).toBeLessThan(1);
+    expect(tau).toBeCloseTo(tauSat);
+    expect(tau).toBeLessThan(tauUnsat);
+    expect(contributions.ch4).toBeCloseTo(tauSat);
   });
 
   test('calculateActualAlbedoPhysics includes clouds and haze', () => {


### PR DESCRIPTION
## Summary
- expose per-gas optical depth values from physics helpers
- refresh atmosphere UI with tooltip listing optical depth contributions
- base optical depth and tooltip on saturated value used for temperature
- cover optical depth tooltip and physics helpers in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c8da5896c8327b5d36c9f53b3eb92