### PR TITLE
Return random world key from SpaceManager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Radiation penalty values below 0.01% are hidden from the UI, and radiation display in the terraforming UI shows mSv/day without `formatNumber`, with values below 0.01 mSv/day appearing as 0.
 - Water overflow counts as production and is included in resource totals instead of showing a separate overflow line.
 - Star luminosity is a celestial parameter set during Terraforming construction, ensuring new games have correct solar flux.
+- SpaceManager stores the random world seed as `currentPlanetKey` when visiting procedural planets, unifying key handling for story and procedural worlds.

--- a/tests/randomWorldKey.test.js
+++ b/tests/randomWorldKey.test.js
@@ -1,0 +1,46 @@
+describe('SpaceManager random world key', () => {
+  let SpaceManager;
+  let originals = {};
+
+  beforeEach(() => {
+    originals = {
+      saveGameToSlot: global.saveGameToSlot,
+      projectManager: global.projectManager,
+      initializeGameState: global.initializeGameState,
+      updateProjectUI: global.updateProjectUI,
+      updateSpaceUI: global.updateSpaceUI,
+      skillManager: global.skillManager,
+      EffectableEntity: global.EffectableEntity,
+    };
+    global.saveGameToSlot = () => {};
+    global.projectManager = { projects: { spaceStorage: { saveTravelState: () => null, loadTravelState: () => {} } } };
+    global.initializeGameState = () => {};
+    global.updateProjectUI = () => {};
+    global.updateSpaceUI = () => {};
+    global.skillManager = { skillPoints: 0 };
+    global.EffectableEntity = class {};
+    SpaceManager = require('../src/js/space.js');
+  });
+
+  afterEach(() => {
+    Object.entries(originals).forEach(([key, value]) => {
+      if (value === undefined) {
+        delete global[key];
+      } else {
+      global[key] = value;
+      }
+    });
+    jest.resetModules();
+  });
+
+  test('current planet key tracks story and random worlds', () => {
+    const sm = new SpaceManager({ mars: { name: 'Mars' }, titan: { name: 'Titan' } });
+    expect(sm.getCurrentPlanetKey()).toBe('mars');
+    const result = { merged: { name: 'Randomia' } };
+    const seed = 42;
+    sm.travelToRandomWorld(result, seed);
+    expect(sm.getCurrentPlanetKey()).toBe(String(seed));
+    sm.changeCurrentPlanet('titan');
+    expect(sm.getCurrentPlanetKey()).toBe('titan');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure SpaceManager records the current random world's seed directly in `currentPlanetKey`
- handle saved state and terraformed counts when current planet is procedural
- verify key switches between random and story worlds

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_689c8e4a55f083279a8ede91867af3c4