### PR TITLE
Refresh optical depth tooltip in real time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,3 +172,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Water overflow counts as production and is included in resource totals instead of showing a separate overflow line.
 - Star luminosity is a celestial parameter set during Terraforming construction, ensuring new games have correct solar flux.
 - Optical depth tooltip lists contributions from each gas.
+- Optical depth tooltip refreshes its gas contributions in real time while hovered.

--- a/src/css/terraforming.css
+++ b/src/css/terraforming.css
@@ -65,3 +65,15 @@
   .status-cross {
     color: red;
   }
+
+  #optical-depth-info {
+    position: relative;
+  }
+
+  #optical-depth-info .resource-tooltip {
+    text-align: left;
+  }
+
+  #optical-depth-info:hover .resource-tooltip {
+    display: block;
+  }

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -285,7 +285,7 @@ function createTemperatureBox(row) {
     innerHTML += `
         </tbody>
       </table>
-      <p class="no-margin">Optical depth: <span id="optical-depth"></span> <span id="optical-depth-info" class="info-tooltip-icon" title="">&#9432;</span></p>
+      <p class="no-margin">Optical depth: <span id="optical-depth"></span> <span id="optical-depth-info" class="info-tooltip-icon" title="">&#9432;<span id="optical-depth-tooltip" class="resource-tooltip"></span></span></p>
       <p class="no-margin">Wind turbine multiplier: <span id="wind-turbine-multiplier">${(terraforming.calculateWindTurbineMultiplier()*100).toFixed(2)}</span>%</p>
     `;
   
@@ -320,6 +320,10 @@ function createTemperatureBox(row) {
       const lines = Object.entries(contributions)
         .map(([gas, val]) => `${gas.toUpperCase()}: ${val.toFixed(2)}`);
       opticalDepthInfo.title = lines.join('\n');
+      const tooltip = document.getElementById('optical-depth-tooltip');
+      if (tooltip) {
+        tooltip.innerHTML = lines.join('<br>');
+      }
     }
 
 

--- a/tests/atmosphereOpticalDepthUI.test.js
+++ b/tests/atmosphereOpticalDepthUI.test.js
@@ -55,9 +55,62 @@ describe('atmosphere UI optical depth', () => {
     expect(info).not.toBeNull();
     expect(info.title).toContain('CO2: 0.30');
     expect(info.title).toContain('H2O: 0.20');
+    const tooltip = pEls[1].querySelector('#optical-depth-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.textContent).toContain('CO2: 0.30');
+    expect(tooltip.textContent).toContain('H2O: 0.20');
     expect(box.querySelector('#emissivity')).toBeNull();
     expect(pEls[2].querySelector('#wind-turbine-multiplier')).not.toBeNull();
     expect(pEls[1].classList.contains('no-margin')).toBe(true);
     expect(pEls[2].classList.contains('no-margin')).toBe(true);
+  });
+
+  test('optical depth tooltip updates in real time', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="summary-terraforming"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const numbers = require('../src/js/numbers.js');
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
+    const physics = require('../src/js/physics.js');
+    ctx.DEFAULT_SURFACE_ALBEDO = physics.DEFAULT_SURFACE_ALBEDO;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+
+    ctx.resources = { atmospheric: { o2: { displayName: 'O2' } } };
+    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.terraformingGasTargets = { o2: { min: 0, max: 100 } };
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    ctx.terraforming = {
+      temperature: { name: 'Temp', value: 0, emissivity: 1, opticalDepth: 0.5, opticalDepthContributions: { co2: 0.3, h2o: 0.2 }, effectiveTempNoAtmosphere: 0,
+        zones: { tropical: { value: 0, day: 0, night: 0 }, temperate: { value: 0, day: 0, night: 0 }, polar: { value: 0, day: 0, night: 0 } } },
+      atmosphere: { name: 'Atm' },
+      water: {}, luminosity: { name: 'Lum', albedo: 0, solarFlux: 0, modifiedSolarFlux: 0, calculateSolarPanelMultiplier: () => 1 },
+      life: { name: 'Life' }, magnetosphere: { name: 'Mag' },
+      celestialParameters: { albedo: 0, gravity: 1, radius: 1 },
+      calculateSolarPanelMultiplier: () => 1,
+      calculateWindTurbineMultiplier: () => 1,
+      calculateTotalPressure: () => 1,
+      getAtmosphereStatus: () => true,
+      getLuminosityStatus: () => true,
+      getMagnetosphereStatus: () => true,
+      getWaterStatus: () => true,
+      getLifeStatus: () => true,
+      isBooleanFlagSet: () => false
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.createTerraformingSummaryUI();
+    ctx.updateAtmosphereBox();
+
+    const tooltip = dom.window.document.getElementById('optical-depth-tooltip');
+    expect(tooltip.textContent).toContain('CO2: 0.30');
+    ctx.terraforming.temperature.opticalDepthContributions = { co2: 0.1, h2o: 0.4 };
+    ctx.updateAtmosphereBox();
+    expect(tooltip.textContent).toContain('CO2: 0.10');
+    expect(tooltip.textContent).toContain('H2O: 0.40');
   });
 });


### PR DESCRIPTION
## Summary
- Show an info tooltip for atmospheric optical depth that updates continuously while hovered
- Style optical depth tooltip and document feature
- Test that optical depth tooltip contents refresh on each update

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c9138c9388327ba7490ffccec19a5