### PR TITLE
refactor: use space manager terraformed count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Story world original properties list partial atmospheric pressures for key gases instead of a single total.
 - Cargo rocket ship purchases raise future ship prices based on terraformed planets and decay by 1% per second.
 - Metal export cap counts previously terraformed worlds excluding the current planet.
+- SpaceManager exposes `getTerraformedPlanetCountExcludingCurrent` for modules needing previously terraformed world counts.
 - Life design biodome points scale with active Biodomes instead of total built.
 - Cargo rocket spaceship tooltip appears immediately to the right of the Spaceships label.
 - Pre-travel saves no longer update SpaceManager's current world before travel.

--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -2,18 +2,9 @@ class SpaceExportProject extends SpaceExportBaseProject {
   getExportCap() {
     if (
       typeof spaceManager !== 'undefined' &&
-      typeof spaceManager.getTerraformedPlanetCount === 'function'
+      typeof spaceManager.getTerraformedPlanetCountExcludingCurrent === 'function'
     ) {
-      let count = spaceManager.getTerraformedPlanetCount();
-      if (
-        typeof spaceManager.getCurrentPlanetKey === 'function' &&
-        typeof spaceManager.isPlanetTerraformed === 'function'
-      ) {
-        const currentKey = spaceManager.getCurrentPlanetKey();
-        if (spaceManager.isPlanetTerraformed(currentKey)) {
-          count -= 1;
-        }
-      }
+      const count = spaceManager.getTerraformedPlanetCountExcludingCurrent();
       return Math.max(count, 1) * 1000000000;
     }
     return 1000000000;

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -103,6 +103,19 @@ class SpaceManager extends EffectableEntity {
         return this.isPlanetTerraformed(this.currentPlanetKey) ? count : count + 1;
     }
 
+    /**
+     * Counts how many planets have been terraformed prior to the current world.
+     * The current planet is excluded even if it has already been terraformed.
+     * @returns {number}
+     */
+    getTerraformedPlanetCountExcludingCurrent() {
+        const count = this.getTerraformedPlanetCount();
+        if (this.currentRandomSeed !== null) {
+            return this.isSeedTerraformed(String(this.currentRandomSeed)) ? Math.max(count - 1, 0) : count;
+        }
+        return this.isPlanetTerraformed(this.currentPlanetKey) ? Math.max(count - 1, 0) : count;
+    }
+
     getCurrentWorldName() {
         if (this.currentRandomSeed !== null) {
             return this.currentRandomName || `Seed ${this.currentRandomSeed}`;

--- a/tests/spaceExportProject.test.js
+++ b/tests/spaceExportProject.test.js
@@ -35,7 +35,7 @@ describe('SpaceExportProject', () => {
   test('assignSpaceships respects export cap', () => {
     const ctx = { console, EffectableEntity, shipEfficiency: 1 };
     ctx.resources = { special: { spaceships: { value: 100 } }, colony: { metal: {} } };
-    ctx.spaceManager = { getTerraformedPlanetCount: () => 2 };
+    ctx.spaceManager = { getTerraformedPlanetCountExcludingCurrent: () => 2 };
     vm.createContext(ctx);
 
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -64,9 +64,7 @@ describe('SpaceExportProject', () => {
     const ctx = { console, EffectableEntity, shipEfficiency: 1 };
     ctx.resources = { special: { spaceships: { value: 100 } }, colony: { metal: {} } };
     ctx.spaceManager = {
-      getTerraformedPlanetCount: () => 2,
-      getCurrentPlanetKey: () => 'mars',
-      isPlanetTerraformed: (key) => key === 'mars'
+      getTerraformedPlanetCountExcludingCurrent: () => 1
     };
     vm.createContext(ctx);
 
@@ -87,11 +85,11 @@ describe('SpaceExportProject', () => {
     const config = ctx.projectParameters.exportResources;
     const project = new ctx.SpaceExportProject(config, 'exportResources');
 
-    // current world is terraformed -> one less world counts
+    // export cap uses the provided terraformed count
     expect(project.getExportCap()).toBe(1000000000);
 
-    // now mark current world as unterraformed -> all worlds count
-    ctx.spaceManager.isPlanetTerraformed = () => false;
+    // change the count returned by space manager
+    ctx.spaceManager.getTerraformedPlanetCountExcludingCurrent = () => 2;
     expect(project.getExportCap()).toBe(2000000000);
   });
 });

--- a/tests/spaceManagerTerraformedCount.test.js
+++ b/tests/spaceManagerTerraformedCount.test.js
@@ -9,10 +9,19 @@ describe('SpaceManager terraformed planet counting', () => {
 
     expect(sm.getTerraformedPlanetCount()).toBe(1);
     expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(2);
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(1);
 
     sm.planetStatuses.mars.terraformed = true;
     expect(sm.getTerraformedPlanetCount()).toBe(2);
     expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(2);
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(1);
+
+    sm.currentPlanetKey = 'titan';
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(1);
+
+    sm.currentPlanetKey = 'mars';
+    sm.planetStatuses.titan.terraformed = false;
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `getTerraformedPlanetCountExcludingCurrent` to `SpaceManager`
- use new method in `SpaceExportProject` to compute export cap
- cover new behaviour with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c92a7b99c832796071710dd54409d