### PR TITLE
Remove duplicate optical depth tooltip

### DIFF
--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -285,7 +285,7 @@ function createTemperatureBox(row) {
     innerHTML += `
         </tbody>
       </table>
-      <p class="no-margin">Optical depth: <span id="optical-depth"></span> <span id="optical-depth-info" class="info-tooltip-icon" title="">&#9432;<span id="optical-depth-tooltip" class="resource-tooltip"></span></span></p>
+      <p class="no-margin">Optical depth: <span id="optical-depth"></span> <span id="optical-depth-info" class="info-tooltip-icon">&#9432;<span id="optical-depth-tooltip" class="resource-tooltip"></span></span></p>
       <p class="no-margin">Wind turbine multiplier: <span id="wind-turbine-multiplier">${(terraforming.calculateWindTurbineMultiplier()*100).toFixed(2)}</span>%</p>
     `;
   
@@ -319,7 +319,6 @@ function createTemperatureBox(row) {
       const contributions = terraforming.temperature.opticalDepthContributions || {};
       const lines = Object.entries(contributions)
         .map(([gas, val]) => `${gas.toUpperCase()}: ${val.toFixed(2)}`);
-      opticalDepthInfo.title = lines.join('\n');
       const tooltip = document.getElementById('optical-depth-tooltip');
       if (tooltip) {
         tooltip.innerHTML = lines.join('<br>');

--- a/tests/atmosphereOpticalDepthUI.test.js
+++ b/tests/atmosphereOpticalDepthUI.test.js
@@ -53,8 +53,7 @@ describe('atmosphere UI optical depth', () => {
     expect(pEls[1].querySelector('#optical-depth')).not.toBeNull();
     const info = pEls[1].querySelector('#optical-depth-info');
     expect(info).not.toBeNull();
-    expect(info.title).toContain('CO2: 0.30');
-    expect(info.title).toContain('H2O: 0.20');
+    expect(info.getAttribute('title')).toBeNull();
     const tooltip = pEls[1].querySelector('#optical-depth-tooltip');
     expect(tooltip).not.toBeNull();
     expect(tooltip.textContent).toContain('CO2: 0.30');


### PR DESCRIPTION
## Summary
- remove non-updating optical depth tooltip and rely on dynamic tooltip
- adjust tests for single optical depth tooltip

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c936d69f0832795c9dac4818bf989