### PR TITLE
Count random worlds in terraformed tally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - SpaceManager stores the random world seed as `currentPlanetKey` when visiting procedural planets, unifying key handling for story and procedural worlds.
 - Optical depth tooltip lists contributions from each gas.
 - Optical depth tooltip refreshes its gas contributions in real time while hovered.
+- `getTerraformedPlanetCount` now counts terraformed procedural worlds via `getAllPlanetStatuses`.

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -67,7 +67,7 @@ class SpaceManager extends EffectableEntity {
      * @returns {boolean} - True if terraformed, false otherwise. Returns false if planet not found.
      */
     isPlanetTerraformed(planetKey) {
-        return this.planetStatuses[planetKey]?.terraformed || false;
+        return this.getPlanetStatus(planetKey)?.terraformed || false;
     }
 
     /**
@@ -80,12 +80,20 @@ class SpaceManager extends EffectableEntity {
     }
 
     /**
+     * Returns a combined object of story planet statuses and random world statuses.
+     * @returns {Object}
+     */
+    getAllPlanetStatuses() {
+        return { ...this.planetStatuses, ...this.randomWorldStatuses };
+    }
+
+    /**
      * Counts how many planets have been fully terraformed.
      * The current planet only contributes if it is terraformed.
      * @returns {number}
      */
     getTerraformedPlanetCount() {
-        return Object.values(this.planetStatuses)
+        return Object.values(this.getAllPlanetStatuses())
             .filter(status => status.terraformed).length;
     }
 
@@ -209,7 +217,7 @@ class SpaceManager extends EffectableEntity {
      * @returns {object | null} - The status object or null if planet not found.
      */
     getPlanetStatus(planetKey) {
-        return this.planetStatuses[planetKey] || null;
+        return this.planetStatuses[planetKey] || this.randomWorldStatuses[planetKey] || null;
     }
 
     // --- Setters / Updates ---

--- a/tests/spaceManagerTerraformedCount.test.js
+++ b/tests/spaceManagerTerraformedCount.test.js
@@ -23,6 +23,20 @@ describe('SpaceManager terraformed planet counting', () => {
     sm.planetStatuses.titan.terraformed = false;
     expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(0);
   });
+
+  test('counts terraformed random worlds', () => {
+    const sm = new SpaceManager({ mars: {}, titan: {} });
+    sm.randomWorldStatuses['123'] = { terraformed: true, visited: true, colonists: 0, name: 'Seed 123' };
+
+    expect(sm.getTerraformedPlanetCount()).toBe(1);
+    expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(2);
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(1);
+
+    sm.currentRandomSeed = '123';
+    sm.currentPlanetKey = '123';
+    expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(1);
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(0);
+  });
 });
 
 delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- track random world statuses alongside story planets
- include procedural worlds in `getTerraformedPlanetCount`
- test counting terraformed random worlds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c94cbc3d483278f46ac595dd0d4f3