### PR TITLE
feat: signal full colony storage in Space Storage withdraw mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,3 +176,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Optical depth tooltip lists contributions from each gas.
 - Optical depth tooltip refreshes its gas contributions in real time while hovered.
 - `getTerraformedPlanetCount` now counts terraformed procedural worlds via `getAllPlanetStatuses`.
+- Space Storage withdraw mode shows an icon when colony storage is full.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -131,11 +131,17 @@ function renderSpaceStorageUI(project, container) {
     label.htmlFor = checkbox.id;
     label.textContent = opt.label;
 
+    const fullIcon = document.createElement('span');
+    fullIcon.classList.add('info-tooltip-icon');
+    fullIcon.innerHTML = '&#9432;';
+    fullIcon.title = 'Colony storage full';
+    fullIcon.style.display = 'none';
+
     const usage = document.createElement('span');
     usage.id = `${project.name}-usage-${opt.resource}`;
     usage.textContent = '0';
 
-    resourceItem.append(checkbox, label, usage);
+    resourceItem.append(checkbox, label, fullIcon, usage);
     resourceGrid.appendChild(resourceItem);
 
     projectElements[project.name] = {
@@ -147,6 +153,10 @@ function renderSpaceStorageUI(project, container) {
       usageCells: {
         ...(projectElements[project.name]?.usageCells || {}),
         [opt.resource]: usage
+      },
+      fullIcons: {
+        ...(projectElements[project.name]?.fullIcons || {}),
+        [opt.resource]: fullIcon
       }
     };
   });
@@ -268,6 +278,19 @@ function updateSpaceStorageUI(project) {
           r => r.category === opt.category && r.resource === opt.resource
         );
         cb.checked = checked;
+      }
+    });
+  }
+  if (els.fullIcons) {
+    storageResourceOptions.forEach(opt => {
+      const icon = els.fullIcons[opt.resource];
+      const res = resources[opt.category]?.[opt.resource];
+      if (icon) {
+        if (project.shipWithdrawMode && res && res.hasCap && res.value >= res.cap) {
+          icon.style.display = 'inline';
+        } else {
+          icon.style.display = 'none';
+        }
       }
     });
   }

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -108,7 +108,8 @@ describe('Space Storage project', () => {
     const checkboxes = container.querySelectorAll('#ss-resource-grid input[type="checkbox"]');
     expect(checkboxes.length).toBe(9);
     const items = container.querySelectorAll('#ss-resource-grid .storage-resource-item');
-    expect(items[0].children.length).toBe(3);
+    expect(items[0].children.length).toBe(4);
+    expect(items[0].children[2].classList.contains('info-tooltip-icon')).toBe(true);
     checkboxes[0].checked = true;
     checkboxes[0].dispatchEvent(new dom.window.Event('change'));
     expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -62,7 +62,11 @@ describe('Space Storage UI', () => {
     expect(els.expansionCostDisplay.textContent).toBe(`Metal: ${numbers.formatNumber(metalCost, true)}`);
     const items = els.resourceGrid.querySelectorAll('.storage-resource-item');
     expect(items.length).toBe(9);
-    expect(items[0].children[2].textContent).toBe(String(numbers.formatNumber(0, false, 0)));
+    const firstItem = items[0];
+    const fullIcon = firstItem.children[2];
+    expect(fullIcon.classList.contains('info-tooltip-icon')).toBe(true);
+    expect(fullIcon.style.display).toBe('none');
+    expect(firstItem.children[3].textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();
     expect(els.withdrawButton).toBeDefined();
     expect(els.storeButton).toBeDefined();
@@ -78,10 +82,52 @@ describe('Space Storage UI', () => {
     const updatedItems = els.resourceGrid.querySelectorAll('.storage-resource-item');
     expect(updatedItems.length).toBe(9);
     const metalItem = updatedItems[0];
-    expect(metalItem.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
+    expect(metalItem.children[3].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
 
     const topSection = container.querySelector('.project-top-section');
     const titles = Array.from(topSection.querySelectorAll('.section-title')).map(e => e.textContent);
     expect(titles).toEqual(expect.arrayContaining(['Assignment', 'Cost & Gain', 'Expansion']));
+  });
+
+  test('shows full icon when withdrawing to full colony storage', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.projectElements = {};
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.resources = { colony: { metal: { displayName: 'Metal', hasCap: true, value: 10, cap: 10 } } };
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
+
+    const project = {
+      name: 'spaceStorage',
+      cost: { colony: { metal: 1 } },
+      getScaledCost() { return this.cost; },
+      usedStorage: 0,
+      maxStorage: 100,
+      resourceUsage: {},
+      selectedResources: [],
+      shipOperationAutoStart: false,
+      shipOperationRemainingTime: 0,
+      shipOperationStartingDuration: 0,
+      shipOperationIsActive: false,
+      shipWithdrawMode: false,
+      getEffectiveDuration: () => 1000,
+      createSpaceshipAssignmentUI() {},
+      createProjectDetailsGridUI() {},
+    };
+    const container = dom.window.document.getElementById('container');
+    ctx.renderSpaceStorageUI(project, container);
+    ctx.updateSpaceStorageUI(project);
+
+    const els = ctx.projectElements[project.name];
+    const icon = els.resourceGrid.querySelector('.storage-resource-item .info-tooltip-icon');
+    expect(icon.style.display).toBe('none');
+
+    project.shipWithdrawMode = true;
+    ctx.updateSpaceStorageUI(project);
+    expect(icon.style.display).toBe('inline');
+    expect(icon.title).toBe('Colony storage full');
   });
 });


### PR DESCRIPTION
## Summary
- show an info icon when withdrawing resources to a full colony storage
- test Space Storage UI for the new colony storage full indicator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cab27d4148327a73443b3268a5689