### PR TITLE
Scale advanced research with terraformed worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,3 +177,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Optical depth tooltip refreshes its gas contributions in real time while hovered.
 - `getTerraformedPlanetCount` now counts terraformed procedural worlds via `getAllPlanetStatuses`.
 - Space Storage withdraw mode shows an icon when colony storage is full.
+- Advanced research production scales with the number of terraformed worlds.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -132,17 +132,16 @@ function renderSpaceStorageUI(project, container) {
     label.textContent = opt.label;
 
     const fullIcon = document.createElement('span');
-    fullIcon.classList.add('storage-full-icon');
-    fullIcon.innerHTML = ' &#9888;&#xFE0E;';
+    fullIcon.classList.add('info-tooltip-icon');
+    fullIcon.innerHTML = '&#9432;';
     fullIcon.title = 'Colony storage full';
     fullIcon.style.display = 'none';
-    label.appendChild(fullIcon);
 
     const usage = document.createElement('span');
     usage.id = `${project.name}-usage-${opt.resource}`;
     usage.textContent = '0';
 
-    resourceItem.append(checkbox, label, usage);
+    resourceItem.append(checkbox, label, fullIcon, usage);
     resourceGrid.appendChild(resourceItem);
 
     projectElements[project.name] = {

--- a/src/js/research.js
+++ b/src/js/research.js
@@ -47,13 +47,13 @@ class Research {
       if (!resources || !resources.colony || !resources.colony.advancedResearch) return;
       if (!resources.colony.advancedResearch.unlocked) return;
       if (typeof spaceManager === 'undefined') return;
+      if (typeof spaceManager.getTerraformedPlanetCount !== 'function') return;
 
-      const statuses = spaceManager.planetStatuses || {};
-      const count = Object.values(statuses).filter(s => s.terraformed).length;
+      const count = spaceManager.getTerraformedPlanetCount();
       if (count <= 0) return;
 
       const rate = count; // 1 per second per terraformed planet
-      resources.colony.advancedResearch.increase(rate * deltaTime / 1000);
+      resources.colony.advancedResearch.increase((rate * deltaTime) / 1000);
       resources.colony.advancedResearch.modifyRate(rate, 'Research Manager', 'research');
     }
 

--- a/tests/advancedResearchProduction.test.js
+++ b/tests/advancedResearchProduction.test.js
@@ -20,11 +20,7 @@ describe('advanced research production', () => {
         }
       },
       spaceManager: {
-        planetStatuses: {
-          mars: { terraformed: true },
-          venus: { terraformed: true },
-          titan: { terraformed: false }
-        }
+        getTerraformedPlanetCount: jest.fn().mockReturnValue(2)
       },
       buildings: {},
       colonies: {},
@@ -40,6 +36,7 @@ describe('advanced research production', () => {
 
     manager.update(1000);
 
+    expect(ctx.spaceManager.getTerraformedPlanetCount).toHaveBeenCalled();
     expect(ctx.resources.colony.advancedResearch.value).toBe(2);
     expect(ctx.resources.colony.advancedResearch.modifyRate).toHaveBeenCalledWith(2, 'Research Manager', 'research');
   });


### PR DESCRIPTION
## Summary
- Scale advanced research generation by terraformed worlds via SpaceManager
- Verify advanced research scaling in tests
- Add tooltip icons for Space Storage full storage indicators

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689ccaa2e0f88327b57fc621b8d74b26