### PR TITLE
Fix jsdom module resolution for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "jsdom": "^22.1.0"
   },
   "jest": {
-    "setupFiles": ["<rootDir>/tests/jestSetup.js"]
+    "setupFiles": ["<rootDir>/tests/jestSetup.js"],
+    "moduleNameMapper": {
+      ".*/lib/node_modules/jsdom$": "<rootDir>/node_modules/jsdom"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Map absolute jsdom paths to local installation so tests run without global modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689cee159de88327be45fca1e6f14567