### PR TITLE
Enable continuous resource flow for high-capacity spaceship projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,3 +182,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Advanced research production scales with the number of terraformed worlds.
 - Planetary thrusters adjust day-night cycle duration when spin changes.
 - Surface flow rates scale with planet radius, so larger planets experience faster hydrological movement.
+- Spaceship projects in continuous mode display "Continuous" or "Stopped" instead of a progress bar.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,3 +184,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Planetary thrusters adjust day-night cycle duration when spin changes.
 - Surface flow rates scale with planet radius, so larger planets experience faster hydrological movement.
 - Spaceship projects in continuous mode display "Continuous" or "Stopped" instead of a progress bar.
+- Continuous spaceship projects revert to discrete timing when assignments fall to 100 ships or fewer.
+- Gas-importing space mining caps per-tick transfers at the configured pressure limit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,3 +187,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Continuous spaceship projects revert to discrete timing when assignments fall to 100 ships or fewer.
 - Continuous spaceship projects display total gains as per-second rates.
 - Gas-importing space mining caps per-tick transfers at the configured pressure limit.
+- Dynamic water-import space mining projects scale per-second gains with the assigned ship count.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Continuous spaceship projects display total gains as per-second rates.
 - Gas-importing space mining caps per-tick transfers at the configured pressure limit.
 - Dynamic water-import space mining projects scale per-second gains with the assigned ship count.
+- Space Storage project only marks ship transfers as continuous, leaving expansion progress discrete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Moon-based planetary thrusters show an Escape Δv row and hide spiral Δv when bound to a parent body.
 - Escaped bodies keep their parent reference but set `hasEscapedParent` to track the event.
 - ProjectManager applies project gains each tick via `applyCostAndGain`, keeping `estimateCostAndGain` as a pure rate estimate.
+- Spaceship projects now switch to proportional, per-ship continuous resource flow when 100 or more spaceships are assigned; smaller fleets resolve costs on start and gains on completion.
 - Ore and geothermal satellite UI split Amount and Deposits into separate columns with aligned controls and fonts matching space mining projects.
 - Space Disposal project displays the expected temperature reduction when jettisoning greenhouse gases.
 - Infrared Vision research immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Moon-based planetary thrusters show an Escape Δv row and hide spiral Δv when bound to a parent body.
 - Escaped bodies keep their parent reference but set `hasEscapedParent` to track the event.
 - ProjectManager applies project gains each tick via `applyCostAndGain`, keeping `estimateCostAndGain` as a pure rate estimate.
-- Spaceship projects now switch to proportional, per-ship continuous resource flow when 100 or more spaceships are assigned; smaller fleets resolve costs on start and gains on completion.
+- Spaceship projects now switch to proportional, per-ship continuous resource flow when more than 100 spaceships are assigned; smaller fleets resolve costs on start and gains on completion, and rates match at the 100-ship transition.
 - Ore and geothermal satellite UI split Amount and Deposits into separate columns with aligned controls and fonts matching space mining projects.
 - Space Disposal project displays the expected temperature reduction when jettisoning greenhouse gases.
 - Infrared Vision research immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,4 +185,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Surface flow rates scale with planet radius, so larger planets experience faster hydrological movement.
 - Spaceship projects in continuous mode display "Continuous" or "Stopped" instead of a progress bar.
 - Continuous spaceship projects revert to discrete timing when assignments fall to 100 ships or fewer.
+- Continuous spaceship projects display total gains as per-second rates.
 - Gas-importing space mining caps per-tick transfers at the configured pressure limit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Escaped bodies keep their parent reference but set `hasEscapedParent` to track the event.
 - ProjectManager applies project gains each tick via `applyCostAndGain`, keeping `estimateCostAndGain` as a pure rate estimate.
 - Spaceship projects now switch to proportional, per-ship continuous resource flow when more than 100 spaceships are assigned; smaller fleets resolve costs on start and gains on completion, and rates match at the 100-ship transition.
+- Automation checkboxes pause continuous spaceship projects when resources or environmental thresholds fail and resume them once conditions recover.
 - Ore and geothermal satellite UI split Amount and Deposits into separate columns with aligned controls and fonts matching space mining projects.
 - Space Disposal project displays the expected temperature reduction when jettisoning greenhouse gases.
 - Infrared Vision research immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -237,6 +237,18 @@ class SpaceExportBaseProject extends SpaceshipProject {
     };
   }
 
+  shouldAutomationDisable() {
+    if (this.disableBelowTemperature) {
+      if (typeof terraforming !== 'undefined' && terraforming.temperature) {
+        const temp = terraforming.temperature.value || 0;
+        if (temp <= this.disableTemperatureThreshold) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   canStart() {
     if (!super.canStart()) return false;
 

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -211,6 +211,35 @@ class SpaceMiningProject extends SpaceshipProject {
       }
       return;
     }
+    if (this.disableAbovePressure && gain.atmospheric) {
+      const gas = this.getTargetAtmosphericResource();
+      const entry = gain.atmospheric;
+      if (
+        gas &&
+        typeof entry[gas] === 'number' &&
+        typeof terraforming !== 'undefined' &&
+        resources.atmospheric &&
+        resources.atmospheric[gas]
+      ) {
+        const currentAmount = resources.atmospheric[gas].value || 0;
+        const gSurface = terraforming.celestialParameters.gravity;
+        const radius = terraforming.celestialParameters.radius;
+        const surfaceArea = 4 * Math.PI * Math.pow(radius * 1000, 2);
+        const limitPa = this.disablePressureThreshold * 1000;
+        const maxMass = (limitPa * surfaceArea) / (1000 * gSurface);
+        const remaining = Math.max(0, maxMass - currentAmount);
+        const desired = entry[gas] * fraction;
+        const applied = Math.min(desired, remaining);
+        if (applied <= 0) {
+          delete entry[gas];
+          if (Object.keys(entry).length === 0) {
+            delete gain.atmospheric;
+          }
+        } else {
+          entry[gas] = applied / fraction;
+        }
+      }
+    }
     super.applySpaceshipResourceGain(gain, fraction);
   }
 }

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -175,14 +175,16 @@ class SpaceMiningProject extends SpaceshipProject {
     return super.calculateSpaceshipGainPerShip();
   }
 
-  calculateSpaceshipTotalResourceGain() {
+  calculateSpaceshipTotalResourceGain(perSecond = false) {
     if (this.attributes.dynamicWaterImport && this.attributes.resourceGainPerShip?.surface?.ice) {
-    const gainPerShip = this.calculateSpaceshipGainPerShip();
-    const resource = Object.keys(gainPerShip.surface)[0];
-    const amount = gainPerShip.surface[resource];
-      return { surface: { [resource]: amount } };
+      const gainPerShip = this.calculateSpaceshipGainPerShip();
+      const resource = Object.keys(gainPerShip.surface)[0];
+      const multiplier = perSecond
+        ? this.assignedSpaceships * (1000 / this.getEffectiveDuration())
+        : this.assignedSpaceships;
+      return { surface: { [resource]: gainPerShip.surface[resource] * multiplier } };
     }
-    return super.calculateSpaceshipTotalResourceGain();
+    return super.calculateSpaceshipTotalResourceGain(perSecond);
   }
 
   applySpaceshipResourceGain(gain, fraction) {

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -109,6 +109,25 @@ class SpaceMiningProject extends SpaceshipProject {
     return null;
   }
 
+  shouldAutomationDisable() {
+    if (this.disableAbovePressure) {
+      const gas = this.getTargetAtmosphericResource();
+      if (gas && typeof terraforming !== 'undefined' && resources.atmospheric && resources.atmospheric[gas]) {
+        const amount = resources.atmospheric[gas].value || 0;
+        const pressurePa = calculateAtmosphericPressure(
+          amount,
+          terraforming.celestialParameters.gravity,
+          terraforming.celestialParameters.radius
+        );
+        const pressureKPa = pressurePa / 1000;
+        if (pressureKPa >= this.disablePressureThreshold) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   canStart() {
     if (!super.canStart()) return false;
 

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -33,12 +33,15 @@ class SpaceStorageProject extends SpaceshipProject {
 
   calculateTransferAmount() {
     const base = this.attributes.transportPerShip || 0;
-    const scalingFactor = this.assignedSpaceships > 100 ? this.assignedSpaceships / 100 : 1;
+    const scalingFactor = this.assignedSpaceships >= 100 ? this.assignedSpaceships / 100 : 1;
     return base * scalingFactor;
   }
 
   calculateSpaceshipAdjustedDuration() {
     const maxShipsForDurationReduction = 100;
+    if (this.assignedSpaceships >= 100) {
+      return this.baseDuration;
+    }
     const ships = Math.min(Math.max(this.assignedSpaceships, 1), maxShipsForDurationReduction);
     return this.baseDuration / ships;
   }

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -31,15 +31,25 @@ class SpaceStorageProject extends SpaceshipProject {
     return this.repeatCount * this.capacityPerCompletion;
   }
 
+  isContinuous() {
+    return false;
+  }
+
+  isShipOperationContinuous() {
+    return this.assignedSpaceships > 100;
+  }
+
   calculateTransferAmount() {
     const base = this.attributes.transportPerShip || 0;
-    const scalingFactor = this.assignedSpaceships >= 100 ? this.assignedSpaceships / 100 : 1;
+    const scalingFactor = this.isShipOperationContinuous()
+      ? this.assignedSpaceships / 100
+      : 1;
     return base * scalingFactor;
   }
 
   calculateSpaceshipAdjustedDuration() {
     const maxShipsForDurationReduction = 100;
-    if (this.assignedSpaceships >= 100) {
+    if (this.isShipOperationContinuous()) {
       return this.baseDuration;
     }
     const ships = Math.min(Math.max(this.assignedSpaceships, 1), maxShipsForDurationReduction);

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -16,11 +16,29 @@ class SpaceshipProject extends Project {
   }
 
  assignSpaceships(count) {
+    const wasContinuous = this.isContinuous();
     const availableSpaceships = Math.floor(resources.special.spaceships.value);
     this.assignedSpaceships = this.assignedSpaceships || 0;
     const adjustedCount = Math.max(-this.assignedSpaceships, Math.min(count, availableSpaceships));
     this.assignedSpaceships += adjustedCount;
     resources.special.spaceships.value -= adjustedCount;
+    const nowContinuous = this.isContinuous();
+    if (this.isActive && wasContinuous !== nowContinuous) {
+      if (nowContinuous) {
+        this.startingDuration = Infinity;
+        this.remainingTime = Infinity;
+        this.pendingGain = null;
+      } else {
+        this.isActive = false;
+        this.isCompleted = false;
+        this.isPaused = false;
+        const duration = this.getEffectiveDuration();
+        this.startingDuration = duration;
+        this.remainingTime = duration;
+        this.pendingGain = null;
+        this.start(resources);
+      }
+    }
   }
 
   calculateSpaceshipCost() {

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -414,7 +414,10 @@ class SpaceshipProject extends Project {
     const started = super.start(resources);
     if (!started) return false;
 
-    if (!this.isContinuous() && this.attributes.spaceMining) {
+    if (this.isContinuous()) {
+      this.startingDuration = Infinity;
+      this.remainingTime = Infinity;
+    } else if (this.attributes.spaceMining) {
       let gain = this.calculateSpaceshipTotalResourceGain();
       if (this.applyMetalCostPenalty) {
         this.applyMetalCostPenalty(gain);

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -113,9 +113,10 @@ class SpaceshipProject extends Project {
     }
 
     if (elements.totalGainElement && this.assignedSpaceships != null) {
-      const totalGain = this.calculateSpaceshipTotalResourceGain();
+      const perSecond = this.isContinuous();
+      const totalGain = this.calculateSpaceshipTotalResourceGain(perSecond);
       if (Object.keys(totalGain).length > 0) {
-        elements.totalGainElement.textContent = formatTotalResourceGainDisplay(totalGain);
+        elements.totalGainElement.textContent = formatTotalResourceGainDisplay(totalGain, perSecond);
         elements.totalGainElement.style.display = 'block';
       } else {
         elements.totalGainElement.style.display = 'none';
@@ -328,14 +329,16 @@ class SpaceshipProject extends Project {
     return totalCost;
   }
 
-  calculateSpaceshipTotalResourceGain() {
+  calculateSpaceshipTotalResourceGain(perSecond = false) {
     const totalResourceGain = {};
-    const resourceGainPerShip = this.attributes.resourceGainPerShip || {};
-    const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
-    for (const category in resourceGainPerShip) {
+    const gainPerShip = this.calculateSpaceshipGainPerShip() || {};
+    const multiplier = perSecond
+      ? this.assignedSpaceships * (1000 / this.getEffectiveDuration())
+      : 1;
+    for (const category in gainPerShip) {
       totalResourceGain[category] = {};
-      for (const resource in resourceGainPerShip[category]) {
-        totalResourceGain[category][resource] = resourceGainPerShip[category][resource] * efficiency;
+      for (const resource in gainPerShip[category]) {
+        totalResourceGain[category][resource] = gainPerShip[category][resource] * multiplier;
       }
     }
     return totalResourceGain;

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -304,21 +304,31 @@ function updateSpaceStorageUI(project) {
     els.updateModeButtons();
   }
   if (els.shipProgressButton) {
-    const duration = project.getEffectiveDuration();
-    const timeRemaining = Math.ceil(project.shipOperationRemainingTime / 1000);
-    if (project.shipOperationIsActive) {
-      const progressPercent = ((project.shipOperationStartingDuration - project.shipOperationRemainingTime) / project.shipOperationStartingDuration) * 100;
-      els.shipProgressButton.textContent = `In Progress: ${timeRemaining} seconds remaining (${progressPercent.toFixed(2)}%)`;
-      els.shipProgressButton.style.background = `linear-gradient(to right, #4caf50 ${progressPercent}%, #ccc ${progressPercent}%)`;
-    } else if (project.shipOperationIsPaused) {
-      els.shipProgressButton.textContent = `Resume ship transfers (${timeRemaining}s left)`;
-      els.shipProgressButton.style.background = project.canStartShipOperation() ? '#4caf50' : '#f44336';
-    } else if (project.canStartShipOperation && project.canStartShipOperation()) {
-      els.shipProgressButton.textContent = `Start ship transfers (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
-      els.shipProgressButton.style.background = '#4caf50';
+    if (project.isShipOperationContinuous()) {
+      if (project.shipOperationIsActive && !project.shipOperationIsPaused) {
+        els.shipProgressButton.textContent = 'Continuous';
+        els.shipProgressButton.style.background = '#4caf50';
+      } else {
+        els.shipProgressButton.textContent = 'Stopped';
+        els.shipProgressButton.style.background = '#f44336';
+      }
     } else {
-      els.shipProgressButton.textContent = `Start ship transfers (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
-      els.shipProgressButton.style.background = '#f44336';
+      const duration = project.getEffectiveDuration();
+      const timeRemaining = Math.ceil(project.shipOperationRemainingTime / 1000);
+      if (project.shipOperationIsActive) {
+        const progressPercent = ((project.shipOperationStartingDuration - project.shipOperationRemainingTime) / project.shipOperationStartingDuration) * 100;
+        els.shipProgressButton.textContent = `In Progress: ${timeRemaining} seconds remaining (${progressPercent.toFixed(2)}%)`;
+        els.shipProgressButton.style.background = `linear-gradient(to right, #4caf50 ${progressPercent}%, #ccc ${progressPercent}%)`;
+      } else if (project.shipOperationIsPaused) {
+        els.shipProgressButton.textContent = `Resume ship transfers (${timeRemaining}s left)`;
+        els.shipProgressButton.style.background = project.canStartShipOperation() ? '#4caf50' : '#f44336';
+      } else if (project.canStartShipOperation && project.canStartShipOperation()) {
+        els.shipProgressButton.textContent = `Start ship transfers (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
+        els.shipProgressButton.style.background = '#4caf50';
+      } else {
+        els.shipProgressButton.textContent = `Start ship transfers (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
+        els.shipProgressButton.style.background = '#f44336';
+      }
     }
   }
 }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -518,7 +518,15 @@ function updateProjectUI(projectName) {
 
       // Update the duration in the progress bar display
       if (elements.progressButton) {
-        if (project.isActive) {
+        if (typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject && project.isContinuous()) {
+          if (project.isActive && !project.isPaused) {
+            elements.progressButton.textContent = 'Continuous';
+            elements.progressButton.style.background = '#4caf50';
+          } else {
+            elements.progressButton.textContent = 'Stopped';
+            elements.progressButton.style.background = '#f44336';
+          }
+        } else if (project.isActive) {
           const timeRemaining = Math.max(0, project.remainingTime / 1000).toFixed(2);
           const progressPercent = project.getProgress();
           if (project.startingDuration < 1000) {
@@ -549,11 +557,12 @@ function updateProjectUI(projectName) {
             elements.progressButton.textContent = `Start ${project.displayName} (Duration: ${(duration / 1000).toFixed(2)} seconds)`;
           }
 
-        // Set background color based on whether the project can start
-        if (project.canStart()) {
-          elements.progressButton.style.background = '#4caf50'; // Green if it can be started
-        } else {
-          elements.progressButton.style.background = '#f44336'; // Red if it cannot be started
+          // Set background color based on whether the project can start
+          if (project.canStart()) {
+            elements.progressButton.style.background = '#4caf50'; // Green if it can be started
+          } else {
+            elements.progressButton.style.background = '#f44336'; // Red if it cannot be started
+          }
         }
       }
     }
@@ -567,8 +576,6 @@ function updateProjectUI(projectName) {
       // Wait capacity visibility handled by project subclass
     }
   }
-}
-
   if (typeof project.updateUI === 'function') {
     project.updateUI();
   }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -693,13 +693,14 @@ function formatTotalCostDisplay(totalCost, project) {
 
 
 
-function formatTotalResourceGainDisplay(totalResourceGain) {
+function formatTotalResourceGainDisplay(totalResourceGain, perSecond = false) {
   const gainArray = [];
+  const suffix = perSecond ? '/s' : '';
   for (const category in totalResourceGain) {
     for (const resource in totalResourceGain[category]) {
       const resourceDisplayName = resources[category][resource].displayName ||
         resource.charAt(0).toUpperCase() + resource.slice(1);
-      gainArray.push(`${resourceDisplayName}: ${formatNumber(totalResourceGain[category][resource], true)}`);
+      gainArray.push(`${resourceDisplayName}: ${formatNumber(totalResourceGain[category][resource], true)}${suffix}`);
     }
   }
   return `Total Gain: ${gainArray.join(', ')}`;

--- a/tests/spaceDisposalProject.test.js
+++ b/tests/spaceDisposalProject.test.js
@@ -29,6 +29,6 @@ describe('SpaceDisposalProject', () => {
     project.selectedDisposalResource = { category: 'surface', resource: 'liquidWater' };
     const disposal = project.calculateSpaceshipTotalDisposal();
 
-    expect(disposal.surface.liquidWater).toBeCloseTo(2 * config.attributes.disposalAmount);
+    expect(disposal.surface.liquidWater).toBeCloseTo(config.attributes.disposalAmount);
   });
 });

--- a/tests/spaceExportProject.test.js
+++ b/tests/spaceExportProject.test.js
@@ -28,8 +28,8 @@ describe('SpaceExportProject', () => {
     project.assignedSpaceships = 200;
     const totalCost = project.calculateSpaceshipTotalCost();
 
-    expect(totalCost.colony.metal).toBeCloseTo(2 * config.attributes.costPerShip.colony.metal);
-    expect(totalCost.colony.energy).toBeCloseTo(2 * config.attributes.costPerShip.colony.energy);
+    expect(totalCost.colony.metal).toBeCloseTo(config.attributes.costPerShip.colony.metal);
+    expect(totalCost.colony.energy).toBeCloseTo(config.attributes.costPerShip.colony.energy);
   });
 
   test('assignSpaceships respects export cap', () => {

--- a/tests/spaceMiningMetalPenalty.test.js
+++ b/tests/spaceMiningMetalPenalty.test.js
@@ -61,9 +61,9 @@ describe('metal production penalty without space elevator', () => {
     project.assignedSpaceships = 1;
     expect(project.canStart()).toBe(true);
     project.start(context.resources);
-    expect(project.pendingResourceGains).toEqual([
-      { category: 'colony', resource: 'metal', quantity: 90 }
-    ]);
+    const duration = project.getEffectiveDuration();
+    project.update(duration);
+    expect(context.resources.colony.metal.increase).toHaveBeenCalledWith(90);
     expect(context.resources.colony.metal.decrease).not.toHaveBeenCalled();
   });
 
@@ -93,8 +93,8 @@ describe('metal production penalty without space elevator', () => {
     });
     expect(project.canStart()).toBe(true);
     project.start(context.resources);
-    expect(project.pendingResourceGains).toEqual([
-      { category: 'colony', resource: 'metal', quantity: 100 }
-    ]);
+    const duration = project.getEffectiveDuration();
+    project.update(duration);
+    expect(context.resources.colony.metal.increase).toHaveBeenCalledWith(100);
   });
 });

--- a/tests/spaceMiningPressureLimit.test.js
+++ b/tests/spaceMiningPressureLimit.test.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const physics = require('../src/js/physics.js');
+
+function stubResource(value) {
+  return {
+    value,
+    decrease(amount) { this.value = Math.max(this.value - amount, 0); },
+    increase(amount) { this.value += amount; },
+    modifyRate: jest.fn(),
+    updateStorageCap: () => {}
+  };
+}
+
+describe('SpaceMiningProject pressure limit capping', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = {
+      console,
+      EffectableEntity,
+      shipEfficiency: 1,
+      resources: {},
+      projectManager: { projects: {}, durationMultiplier: 1 },
+      terraforming: { celestialParameters: { gravity: 1, radius: 0.01 } },
+      calculateAtmosphericPressure: physics.calculateAtmosphericPressure,
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+    global.resources = ctx.resources;
+    global.projectManager = ctx.projectManager;
+    global.terraforming = ctx.terraforming;
+    global.shipEfficiency = ctx.shipEfficiency;
+    global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+  });
+
+  function massForPressure(kPa, gravity, radius) {
+    const pa = kPa * 1000;
+    const area = 4 * Math.PI * Math.pow(radius * 1000, 2);
+    return (pa * area) / (1000 * gravity);
+  }
+
+  test('imports only up to pressure threshold', () => {
+    const threshold = 0.01; // kPa
+    const massLimit = massForPressure(threshold, ctx.terraforming.celestialParameters.gravity, ctx.terraforming.celestialParameters.radius);
+    ctx.resources = {
+      colony: { energy: stubResource(1000) },
+      special: { spaceships: { value: 200 } },
+      atmospheric: { inertGas: stubResource(massLimit - 1) },
+      surface: {},
+      underground: {}
+    };
+    global.resources = ctx.resources;
+    const config = {
+      name: 'Mine',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { energy: 0 } },
+        resourceGainPerShip: { atmospheric: { inertGas: 10 } }
+      }
+    };
+    const project = new ctx.SpaceMiningProject(config, 'mine');
+    project.disableAbovePressure = true;
+    project.disablePressureThreshold = threshold;
+    project.assignSpaceships(200);
+    project.start(ctx.resources);
+    const duration = project.getEffectiveDuration();
+    project.update(duration);
+    project.applyCostAndGain(duration);
+    expect(ctx.resources.atmospheric.inertGas.value).toBeCloseTo(massLimit);
+  });
+});

--- a/tests/spaceProjectAutomation.test.js
+++ b/tests/spaceProjectAutomation.test.js
@@ -1,0 +1,138 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+function stubResource(value) {
+  return {
+    value,
+    decrease(amount) { this.value = Math.max(this.value - amount, 0); },
+    increase(amount) { this.value += amount; },
+    modifyRate: jest.fn(),
+    updateStorageCap: () => {}
+  };
+}
+
+describe('continuous spaceship project automation', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    ctx.resources = {
+      colony: {
+        energy: stubResource(100000),
+        metal: stubResource(0),
+        funding: stubResource(0)
+      },
+      atmospheric: {
+        carbonDioxide: stubResource(5),
+        greenhouseGas: stubResource(10000)
+      },
+      special: { spaceships: { value: 200 } },
+      surface: { liquidWater: stubResource(0) }
+    };
+    ctx.terraforming = {
+      temperature: { value: 400 },
+      celestialParameters: { gravity: 1, radius: 1 }
+    };
+    ctx.calculateAtmosphericPressure = (amount) => amount * 1000;
+    ctx.projectManager = { projects: {}, durationMultiplier: 1 };
+    vm.createContext(ctx);
+    const projCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projCode + '; this.Project = Project;', ctx);
+    const shipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(shipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+    const exportBaseCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBaseCode + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const disposalCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceDisposalProject.js'), 'utf8');
+    vm.runInContext(disposalCode + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+    global.resources = ctx.resources;
+    global.terraforming = ctx.terraforming;
+    global.calculateAtmosphericPressure = ctx.calculateAtmosphericPressure;
+    global.shipEfficiency = ctx.shipEfficiency;
+    global.projectManager = ctx.projectManager;
+  });
+
+  test('space mining halts and resumes based on pressure automation', () => {
+    const config = {
+      name: 'Import Carbon',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { energy: 10 } },
+        resourceGainPerShip: { colony: { metal: 20 }, atmospheric: { carbonDioxide: 1 } }
+      }
+    };
+    const project = new ctx.SpaceMiningProject(config, 'importCarbon');
+    project.assignedSpaceships = 150;
+    project.autoStart = true;
+    project.disableAbovePressure = true;
+    project.disablePressureThreshold = 6; // kPa
+    expect(project.canStart()).toBe(true);
+    project.start(ctx.resources);
+    project.update(1000);
+    project.applyCostAndGain(1000);
+    expect(ctx.resources.colony.metal.value).toBeGreaterThan(0);
+    ctx.resources.atmospheric.carbonDioxide.value = 7; // exceed threshold
+    project.update(1000);
+    project.applyCostAndGain(1000);
+    expect(project.isActive).toBe(false);
+    const metalAfterStop = ctx.resources.colony.metal.value;
+    ctx.resources.atmospheric.carbonDioxide.value = 5; // below threshold
+    if (project.autoStart && !project.isActive && project.canStart()) {
+      project.start(ctx.resources);
+    }
+    project.update(1000);
+    project.applyCostAndGain(1000);
+    expect(ctx.resources.colony.metal.value).toBeGreaterThan(metalAfterStop);
+  });
+
+  test('space disposal halts and resumes based on temperature automation', () => {
+    const config = {
+      name: 'Disposal',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        disposalAmount: 10,
+        fundingGainAmount: 1,
+        costPerShip: { colony: { energy: 5 } },
+        disposable: { atmospheric: ['greenhouseGas'] },
+        defaultDisposal: { category: 'atmospheric', resource: 'greenhouseGas' }
+      }
+    };
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    project.assignedSpaceships = 150;
+    project.autoStart = true;
+    project.disableBelowTemperature = true;
+    project.disableTemperatureThreshold = 350;
+    project.selectedDisposalResource = { category: 'atmospheric', resource: 'greenhouseGas' };
+    expect(project.canStart()).toBe(true);
+    project.start(ctx.resources);
+    project.update(1000);
+    project.applyCostAndGain(1000);
+    expect(ctx.resources.atmospheric.greenhouseGas.value).toBeLessThan(10000);
+    ctx.terraforming.temperature.value = 300; // below threshold
+    project.update(1000);
+    project.applyCostAndGain(1000);
+    expect(project.isActive).toBe(false);
+    const ghgAfterStop = ctx.resources.atmospheric.greenhouseGas.value;
+    ctx.terraforming.temperature.value = 400; // above threshold
+    if (project.autoStart && !project.isActive && project.canStart()) {
+      project.start(ctx.resources);
+    }
+    project.update(1000);
+    project.applyCostAndGain(1000);
+    expect(ctx.resources.atmospheric.greenhouseGas.value).toBeLessThan(ghgAfterStop);
+  });
+});

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -51,7 +51,7 @@ describe('Space Storage project', () => {
     const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
     expect(project.getBaseDuration()).toBeCloseTo(100000);
     project.assignedSpaceships = 150;
-    expect(project.getBaseDuration()).toBeCloseTo(1000);
+    expect(project.getBaseDuration()).toBeCloseTo(100000);
     expect(project.calculateTransferAmount()).toBe(1_500_000_000);
     project.repeatCount = 2;
     expect(project.maxStorage).toBe(2000000000000);

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -49,6 +49,7 @@ describe('Space Storage project', () => {
     const attrs = { costPerShip: { colony: { energy: 1_000_000_000 } }, transportPerShip: 1_000_000_000 };
     const params = { name: 'spaceStorage', category: 'mega', cost: {}, duration: 300000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: attrs };
     const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
+    project.repeatCount = 1;
     expect(project.getBaseDuration()).toBeCloseTo(100000);
     project.assignedSpaceships = 150;
     expect(project.getBaseDuration()).toBeCloseTo(100000);
@@ -377,7 +378,7 @@ describe('Space Storage project', () => {
       console,
       document: dom.window.document,
       projectElements: {},
-      projectManager: {},
+      projectManager: { isBooleanFlagSet: function() { return false; } },
       formatNumber: numbers.formatNumber,
       formatBigInteger: numbers.formatBigInteger,
       formatTotalCostDisplay: () => '',
@@ -460,5 +461,74 @@ describe('Space Storage project', () => {
     expect(loaded.repeatCount).toBe(4);
     expect(loaded.usedStorage).toBe(500);
     expect(loaded.resourceUsage.metal).toBe(300);
+  });
+
+  test('only ship progress shows continuous status with >100 ships', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div class="projects-subtab-content-wrapper"></div>');
+    const ctx = {
+      console,
+      document: dom.window.document,
+      projectElements: {},
+      projectManager: {},
+      formatNumber: numbers.formatNumber,
+      formatBigInteger: numbers.formatBigInteger,
+      formatTotalCostDisplay: () => '',
+      formatTotalResourceGainDisplay: () => '',
+      resources: {
+        special: { spaceships: { value: 200 } },
+        colony: {
+          metal: { displayName: 'Metal', value: 1000, cap: Infinity, decrease(v){ this.value -= v; }, increase(v){ this.value += v; } }
+        },
+        surface: {},
+        atmospheric: {}
+      },
+      buildings: {},
+      colonies: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      capitalizeFirstLetter: s => s.charAt(0).toUpperCase() + s.slice(1),
+      SpaceMiningProject: function () {},
+      SpaceExportBaseProject: function () {},
+      SpaceExportProject: function () {},
+      SpaceDisposalProject: function () {},
+      spaceManager: {
+        getTerraformedPlanetCount: () => 0,
+        getTerraformedPlanetCountIncludingCurrent: () => 1
+      }
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const shipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(shipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const storageCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceStorageProject.js'), 'utf8');
+    vm.runInContext(storageCode + '; this.SpaceStorageProject = SpaceStorageProject;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.projectElements = projectElements;', ctx);
+    const storageUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
+    vm.runInContext(storageUICode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
+
+    const attrs = { costPerShip: {}, transportPerShip: 1000 };
+    const params = { name: 'spaceStorage', displayName: 'Space Storage', category: 'mega', cost: {}, duration: 1000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: attrs };
+    const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
+
+    ctx.createProjectItem(project);
+    project.updateCostAndGains = () => {};
+    project.selectedResources = [{ category: 'colony', resource: 'metal' }];
+    project.assignSpaceships(101);
+
+    const mainBtn = ctx.projectElements.spaceStorage.progressButton;
+    mainBtn.textContent = 'Start storage expansion (Duration: 1.00 seconds)';
+    const shipBtn = ctx.projectElements.spaceStorage.shipProgressButton;
+
+    ctx.updateSpaceStorageUI(project);
+
+    expect(mainBtn.textContent).toBe('Start storage expansion (Duration: 1.00 seconds)');
+    expect(shipBtn.textContent).toBe('Stopped');
+
+    project.shipOperationIsActive = true;
+    ctx.updateSpaceStorageUI(project);
+    expect(shipBtn.textContent).toBe('Continuous');
   });
 });

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -30,6 +30,7 @@ describe('Space Storage UI', () => {
       shipOperationStartingDuration: 0,
       shipOperationIsActive: false,
       shipWithdrawMode: false,
+      isShipOperationContinuous: () => false,
       getEffectiveDuration: () => 1000,
       createSpaceshipAssignmentUI(container) {
         const doc = container.ownerDocument;
@@ -113,6 +114,7 @@ describe('Space Storage UI', () => {
       shipOperationStartingDuration: 0,
       shipOperationIsActive: false,
       shipWithdrawMode: false,
+      isShipOperationContinuous: () => false,
       getEffectiveDuration: () => 1000,
       createSpaceshipAssignmentUI() {},
       createProjectDetailsGridUI() {},

--- a/tests/spaceshipProjectContinuous.test.js
+++ b/tests/spaceshipProjectContinuous.test.js
@@ -14,14 +14,14 @@ function stubResource(value) {
 }
 
 describe('SpaceshipProject continuous cost and gain', () => {
-  test('applies proportional cost and gain over time when at least 100 ships', () => {
+  test('applies proportional cost and gain over time when more than 100 ships', () => {
     const ctx = { console, EffectableEntity, shipEfficiency: 1 };
     ctx.resources = {
       colony: {
-        energy: stubResource(50),
+        energy: stubResource(1000),
         metal: stubResource(0)
       },
-      special: { spaceships: { value: 100 } }
+      special: { spaceships: { value: 101 } }
     };
     vm.createContext(ctx);
     const projectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -47,21 +47,21 @@ describe('SpaceshipProject continuous cost and gain', () => {
       }
     };
     const project = new ctx.SpaceshipProject(config, 'test');
-    project.assignedSpaceships = 100;
+    project.assignedSpaceships = 101;
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
     const duration = project.getEffectiveDuration();
     project.update(duration / 2);
     project.applyCostAndGain(duration / 2);
-    expect(ctx.resources.colony.energy.value).toBeCloseTo(49.5);
-    expect(ctx.resources.colony.metal.value).toBeCloseTo(1);
+    expect(ctx.resources.colony.energy.value).toBeCloseTo(495);
+    expect(ctx.resources.colony.metal.value).toBeCloseTo(1010);
   });
 
-  test('uses discrete mode below 100 ships', () => {
+  test('uses discrete mode at or below 100 ships', () => {
     const ctx = { console, EffectableEntity, shipEfficiency: 1 };
     ctx.resources = {
       colony: {
-        energy: stubResource(50),
+        energy: stubResource(1000),
         metal: stubResource(0)
       },
       special: { spaceships: { value: 99 } }
@@ -94,13 +94,46 @@ describe('SpaceshipProject continuous cost and gain', () => {
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
     const duration = project.getEffectiveDuration();
-    expect(ctx.resources.colony.energy.value).toBeCloseTo(40);
+    expect(ctx.resources.colony.energy.value).toBeCloseTo(990);
     project.update(duration / 2);
     project.applyCostAndGain(duration / 2);
-    expect(ctx.resources.colony.energy.value).toBeCloseTo(40);
+    expect(ctx.resources.colony.energy.value).toBeCloseTo(990);
     expect(ctx.resources.colony.metal.value).toBeCloseTo(0);
     project.update(duration / 2);
     expect(ctx.resources.colony.metal.value).toBeCloseTo(20);
+  });
+
+  test('production rate matches at 100-ship transition', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    vm.createContext(ctx);
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+
+    const config = {
+      name: 'Test',
+      category: 'resources',
+      cost: {},
+      duration: 100000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { energy: 10 } },
+        resourceGainPerShip: { colony: { metal: 20 } }
+      }
+    };
+    const project = new ctx.SpaceshipProject(config, 'test');
+    project.assignedSpaceships = 100;
+    const discreteDuration = project.getEffectiveDuration();
+    const discreteGain = project.calculateSpaceshipTotalResourceGain().colony.metal;
+    const discreteRate = discreteGain * 1000 / discreteDuration;
+    const perShipGain = project.calculateSpaceshipGainPerShip().colony.metal;
+    const continuousRate = perShipGain * 100 * 1000 / project.duration;
+    expect(discreteRate).toBeCloseTo(continuousRate);
   });
 });
 

--- a/tests/spaceshipProjectContinuous.test.js
+++ b/tests/spaceshipProjectContinuous.test.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+function stubResource(value) {
+  return {
+    value,
+    decrease(amount) { this.value = Math.max(this.value - amount, 0); },
+    increase(amount) { this.value += amount; },
+    modifyRate: jest.fn(),
+    updateStorageCap: () => {}
+  };
+}
+
+describe('SpaceshipProject continuous cost and gain', () => {
+  test('applies proportional cost and gain over time when at least 100 ships', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    ctx.resources = {
+      colony: {
+        energy: stubResource(50),
+        metal: stubResource(0)
+      },
+      special: { spaceships: { value: 100 } }
+    };
+    vm.createContext(ctx);
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+
+    global.resources = ctx.resources;
+
+    const config = {
+      name: 'Test',
+      category: 'resources',
+      cost: {},
+      duration: 100000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { energy: 10 } },
+        resourceGainPerShip: { colony: { metal: 20 } }
+      }
+    };
+    const project = new ctx.SpaceshipProject(config, 'test');
+    project.assignedSpaceships = 100;
+    expect(project.canStart()).toBe(true);
+    project.start(ctx.resources);
+    const duration = project.getEffectiveDuration();
+    project.update(duration / 2);
+    project.applyCostAndGain(duration / 2);
+    expect(ctx.resources.colony.energy.value).toBeCloseTo(49.5);
+    expect(ctx.resources.colony.metal.value).toBeCloseTo(1);
+  });
+
+  test('uses discrete mode below 100 ships', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    ctx.resources = {
+      colony: {
+        energy: stubResource(50),
+        metal: stubResource(0)
+      },
+      special: { spaceships: { value: 99 } }
+    };
+    vm.createContext(ctx);
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+
+    global.resources = ctx.resources;
+
+    const config = {
+      name: 'Test',
+      category: 'resources',
+      cost: {},
+      duration: 100000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { energy: 10 } },
+        resourceGainPerShip: { colony: { metal: 20 } }
+      }
+    };
+    const project = new ctx.SpaceshipProject(config, 'test');
+    project.assignedSpaceships = 99;
+    expect(project.canStart()).toBe(true);
+    project.start(ctx.resources);
+    const duration = project.getEffectiveDuration();
+    expect(ctx.resources.colony.energy.value).toBeCloseTo(40);
+    project.update(duration / 2);
+    project.applyCostAndGain(duration / 2);
+    expect(ctx.resources.colony.energy.value).toBeCloseTo(40);
+    expect(ctx.resources.colony.metal.value).toBeCloseTo(0);
+    project.update(duration / 2);
+    expect(ctx.resources.colony.metal.value).toBeCloseTo(20);
+  });
+});
+

--- a/tests/spaceshipProjectContinuousGainDisplay.test.js
+++ b/tests/spaceshipProjectContinuousGainDisplay.test.js
@@ -57,4 +57,59 @@ describe('SpaceshipProject continuous total gain UI', () => {
     const text = ctx.projectElements.test.totalGainElement.textContent;
     expect(text).toBe('Total Gain: Metal: 1010000/s');
   });
+
+  test('dynamic water import gain scales with ships', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = n => n.toString();
+    ctx.formatBigInteger = n => n.toString();
+    ctx.projectElements = {};
+    ctx.resources = {
+      surface: {
+        ice: { displayName: 'Ice', value: 0, increase() {}, decrease() {} }
+      },
+      special: { spaceships: { value: 200 } }
+    };
+    ctx.shipEfficiency = 1;
+    ctx.terraforming = { temperature: { zones: { tropical: { value: 200 }, temperate: { value: 200 }, polar: { value: 200 } } }, zonalWater: { tropical: {}, temperate: {}, polar: {} } };
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+
+    const config = {
+      name: 'waterImport',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: { spaceMining: true, dynamicWaterImport: true, costPerShip: {}, resourceGainPerShip: { surface: { ice: 10000 } } }
+    };
+    const project = new ctx.SpaceMiningProject(config, 'waterImport');
+    ctx.projectManager = { projects: { waterImport: project }, isBooleanFlagSet: () => false, getProjectStatuses: () => Object.values({ waterImport: project }) };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.assignSpaceships(200);
+    ctx.updateProjectUI('waterImport');
+
+    const text = ctx.projectElements.waterImport.totalGainElement.textContent;
+    expect(text).toBe('Total Gain: Ice: 2000000/s');
+  });
 });

--- a/tests/spaceshipProjectContinuousGainDisplay.test.js
+++ b/tests/spaceshipProjectContinuousGainDisplay.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceshipProject continuous total gain UI', () => {
+  test('shows per-second total gain', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = n => n.toString();
+    ctx.formatBigInteger = n => n.toString();
+    ctx.projectElements = {};
+    ctx.resources = {
+      colony: {
+        metal: { value: 0, increase() {}, decrease() {} },
+      },
+      special: { spaceships: { value: 101 } }
+    };
+    ctx.shipEfficiency = 1;
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+
+    const config = {
+      name: 'test',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: { spaceMining: true, costPerShip: {}, resourceGainPerShip: { colony: { metal: 10000 } } }
+    };
+    const project = new ctx.SpaceshipProject(config, 'test');
+    ctx.projectManager = { projects: { test: project }, isBooleanFlagSet: () => false, getProjectStatuses: () => Object.values({ test: project }) };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.assignSpaceships(101);
+    ctx.updateProjectUI('test');
+
+    const text = ctx.projectElements.test.totalGainElement.textContent;
+    expect(text).toBe('Total Gain: Metal: 1010000/s');
+  });
+});

--- a/tests/spaceshipProjectContinuousUI.test.js
+++ b/tests/spaceshipProjectContinuousUI.test.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceshipProject continuous progress UI', () => {
+  test('displays Continuous or Stopped without progress bar', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper">
+        <div id="resources-projects-list" class="projects-list"></div>
+      </div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = () => '';
+    ctx.formatBigInteger = () => '';
+    ctx.projectElements = {};
+    ctx.resources = { colony: {}, special: {} };
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+
+    class DummySpaceshipProject extends ctx.Project {
+      isContinuous() { return true; }
+    }
+    ctx.SpaceshipProject = DummySpaceshipProject;
+
+    const config = {
+      name: 'test',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: {}
+    };
+    const project = new ctx.SpaceshipProject(config, 'test');
+
+    ctx.projectManager = {
+      projects: { test: project },
+      isBooleanFlagSet: () => false,
+      getProjectStatuses: () => Object.values({ test: project })
+    };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.isActive = true;
+    ctx.updateProjectUI('test');
+    let btn = ctx.projectElements.test.progressButton;
+    expect(btn.textContent).toBe('Continuous');
+    expect(btn.style.background).toBe('rgb(76, 175, 80)');
+
+    project.isActive = false;
+    ctx.updateProjectUI('test');
+    btn = ctx.projectElements.test.progressButton;
+    expect(btn.textContent).toBe('Stopped');
+    expect(btn.style.background).toBe('rgb(244, 67, 54)');
+  });
+});

--- a/tests/waterSpaceMiningReturn.test.js
+++ b/tests/waterSpaceMiningReturn.test.js
@@ -65,7 +65,8 @@ describe('waterSpaceMining dynamic returns', () => {
     const project = createProject(ctx);
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
-    project.complete();
+    const duration = project.getEffectiveDuration();
+    project.update(duration);
     const tropExp = 100 * getZonePercentage('tropical');
     const tempExp = 100 * getZonePercentage('temperate');
     const polarExp = 100 * getZonePercentage('polar');
@@ -79,7 +80,8 @@ describe('waterSpaceMining dynamic returns', () => {
     const project = createProject(ctx);
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
-    project.complete();
+    const duration = project.getEffectiveDuration();
+    project.update(duration);
     expect(ctx.terraforming.zonalWater.tropical.liquid).toBeCloseTo(100);
     expect(ctx.terraforming.zonalWater.temperate.liquid).toBe(0);
     expect(ctx.terraforming.zonalWater.polar.liquid).toBe(0);


### PR DESCRIPTION
## Summary
- Run spaceship projects continuously when assigned 100+ ships, with per-ship costs and gains applied each tick
- Keep smaller fleets discrete and leave their costs and gains until start/completion
- Align space storage and mining logic with the new per-ship continuous model and update tests

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d084774708327b923a3771789b52a