### PR TITLE
Scale Solis points with terraformed worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Solis artifact donations grant 10 points per artifact instead of 100.
 - Solis research upgrade lists upcoming technologies horizontally and crosses out each as it is purchased, clarifying that one tech is unlocked per purchase.
 - Chapter 13.2 reward triggers a one-time alert on the Solis tab.
+- Solis point rewards now scale with the square root of terraformed worlds and display two decimal places.
 - Fixed Dyson Swarm collectors resetting after planet travel; collector counts persist across worlds while the receiver must be rebuilt on each planet.
 - Collector persistence is managed through ProjectManager travel state so only the Dyson Swarm's collector count carries over between planets.
 - Space Storage allows storing glass and preserves its capacity and stored resources across planet travel using travel state save/load.

--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@
                         </div>
                         <div class="solis-controls">
                             <div class="solis-reward-control">
-                                <span>Reward: <span id="solis-reward">1</span> point(s)</span>
+                                <span>Reward: <span id="solis-reward">1.00</span> point(s)</span>
                                 <button id="solis-multiply-button" class="solis-multiplier-button">+</button>
                                 <button id="solis-divide-button" class="solis-multiplier-button">-</button>
                             </div>

--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -54,6 +54,22 @@ class SolisManager extends EffectableEntity {
     };
   }
 
+  getTerraformedWorldBonus() {
+    if (
+      typeof spaceManager !== 'undefined' &&
+      spaceManager &&
+      typeof spaceManager.getTerraformedPlanetCount === 'function'
+    ) {
+      const count = spaceManager.getTerraformedPlanetCount();
+      return Math.sqrt(count);
+    }
+    return 1;
+  }
+
+  getCurrentReward() {
+    return this.rewardMultiplier * this.getTerraformedWorldBonus();
+  }
+
   availableResources() {
     const list = [];
     for (const name in this.resourceValues) {
@@ -100,7 +116,7 @@ class SolisManager extends EffectableEntity {
     const res = resources.colony[this.currentQuest.resource];
     if (!res || res.value < this.currentQuest.quantity) return false;
     res.decrease(this.currentQuest.quantity);
-    this.solisPoints += this.rewardMultiplier;
+    this.solisPoints += this.getCurrentReward();
     this.currentQuest = null;
     this.lastQuestTime = Date.now();
     this.postCompletionCooldownUntil = this.lastQuestTime + this.questInterval;
@@ -206,7 +222,7 @@ class SolisManager extends EffectableEntity {
     } else {
       res.value -= count;
     }
-    this.solisPoints += count * 10;
+    this.solisPoints += count * 10 * this.getTerraformedWorldBonus();
     return true;
   }
 

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -292,7 +292,10 @@ function updateSolisUI() {
     pointsSpan.textContent = solisManager.solisPoints;
   }
   if (rewardSpan) {
-    rewardSpan.textContent = solisManager.rewardMultiplier;
+    const format = typeof formatNumber === 'function'
+      ? formatNumber
+      : (n, _s, p = 2) => Number(n).toFixed(p);
+    rewardSpan.textContent = format(solisManager.getCurrentReward(), false, 2);
   }
   const quest = solisManager.currentQuest;
   if (questMessage && questDetail && questQuantitySpan && questResourceSpan) {

--- a/tests/solisRewardScaling.test.js
+++ b/tests/solisRewardScaling.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis quest reward scaling', () => {
+  test('multiplies reward by sqrt of terraformed worlds and displays two decimals', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <span id="solis-points-value"></span>
+      <span id="solis-reward"></span>
+      <div id="solis-quest-message"></div>
+      <div id="solis-quest-detail"><span id="solis-quest-quantity"></span><span id="solis-quest-resource"></span></div>
+      <button id="solis-refresh-button"></button>
+      <button id="solis-complete-button"></button>
+      <div id="solis-cooldown"></div>
+      <span id="solis-cooldown-text"></span>
+      <div id="solis-cooldown-bar"></div>
+      <div id="solis-donation-section"></div>
+      <span id="solis-donation-count"></span>
+      <input id="solis-donation-input" value="0" />
+      <button id="solis-donation-button"></button>
+      <div id="solis-research-shop"></div>
+    `, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.solisManager = new SolisManager();
+    ctx.solisManager.currentQuest = { resource: 'metal', quantity: 5 };
+    ctx.resources = { colony: { metal: { value: 10, decrease(q){ this.value -= q; }, unlocked: true } } };
+    global.resources = ctx.resources;
+    global.spaceManager = { getTerraformedPlanetCount: () => 2 };
+    ctx.spaceManager = global.spaceManager;
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'solisUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+    ctx.updateSolisUI();
+
+    const expected = numbers.formatNumber(Math.sqrt(2), false, 2);
+    expect(dom.window.document.getElementById('solis-reward').textContent).toBe(expected);
+
+    ctx.solisManager.completeQuest();
+    expect(ctx.solisManager.solisPoints).toBeCloseTo(Math.sqrt(2));
+  });
+});


### PR DESCRIPTION
## Summary
- Scale Solis point rewards by the square root of the number of terraformed worlds
- Show Solis quest reward to two decimals
- Test quest reward scaling with terraformed worlds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d55244ba88327a9d7fe2020c994e0