### PR TITLE
Fix space storage tests for updated UI structure

### DIFF
--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -109,8 +109,10 @@ describe('Space Storage project', () => {
     const checkboxes = container.querySelectorAll('#ss-resource-grid input[type="checkbox"]');
     expect(checkboxes.length).toBe(9);
     const items = container.querySelectorAll('#ss-resource-grid .storage-resource-item');
-    expect(items[0].children.length).toBe(4);
-    expect(items[0].children[2].classList.contains('info-tooltip-icon')).toBe(true);
+    expect(items[0].children.length).toBe(3);
+    const label = items[0].children[1];
+    const fullIcon = label.querySelector('.storage-full-icon');
+    expect(fullIcon).toBeDefined();
     checkboxes[0].checked = true;
     checkboxes[0].dispatchEvent(new dom.window.Event('change'));
     expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -64,10 +64,11 @@ describe('Space Storage UI', () => {
     const items = els.resourceGrid.querySelectorAll('.storage-resource-item');
     expect(items.length).toBe(9);
     const firstItem = items[0];
-    const fullIcon = firstItem.children[2];
-    expect(fullIcon.classList.contains('info-tooltip-icon')).toBe(true);
+    const label = firstItem.children[1];
+    const fullIcon = label.querySelector('.storage-full-icon');
+    expect(fullIcon).toBeDefined();
     expect(fullIcon.style.display).toBe('none');
-    expect(firstItem.children[3].textContent).toBe(String(numbers.formatNumber(0, false, 0)));
+    expect(firstItem.children[2].textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.shipProgressButton).toBeDefined();
     expect(els.withdrawButton).toBeDefined();
     expect(els.storeButton).toBeDefined();
@@ -83,7 +84,7 @@ describe('Space Storage UI', () => {
     const updatedItems = els.resourceGrid.querySelectorAll('.storage-resource-item');
     expect(updatedItems.length).toBe(9);
     const metalItem = updatedItems[0];
-    expect(metalItem.children[3].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
+    expect(metalItem.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
 
     const topSection = container.querySelector('.project-top-section');
     const titles = Array.from(topSection.querySelectorAll('.section-title')).map(e => e.textContent);
@@ -124,7 +125,7 @@ describe('Space Storage UI', () => {
     ctx.updateSpaceStorageUI(project);
 
     const els = ctx.projectElements[project.name];
-    const icon = els.resourceGrid.querySelector('.storage-resource-item .info-tooltip-icon');
+    const icon = els.resourceGrid.querySelector('.storage-resource-item .storage-full-icon');
     expect(icon.style.display).toBe('none');
 
     project.shipWithdrawMode = true;


### PR DESCRIPTION
## Summary
- Align space storage tests with current UI markup
- Verify full storage indicator via `.storage-full-icon`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d5720ae748327898d4255003f3e10