### PR TITLE
feat: preserve project autostart between worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,3 +189,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Gas-importing space mining caps per-tick transfers at the configured pressure limit.
 - Dynamic water-import space mining projects scale per-second gains with the assigned ship count.
 - Space Storage project only marks ship transfers as continuous, leaving expansion progress discrete.
+- Added a setting to preserve project auto-start selections between worlds.

--- a/index.html
+++ b/index.html
@@ -565,6 +565,9 @@
           <label style="display:block;margin-bottom:8px;">
             <input type="checkbox" id="dark-mode-toggle"> Enable Dark Mode
           </label>
+          <label style="display:block;margin-bottom:8px;">
+            <input type="checkbox" id="preserve-project-auto-start-toggle"> Preserve project auto-start between worlds <span class="info-tooltip-icon" title="Keeps project auto-start selections when travelling.">&#9432;</span>
+          </label>
       </div>
     </div>
 
@@ -703,6 +706,14 @@
         darkModeToggle.addEventListener('change', () => {
             gameSettings.darkMode = darkModeToggle.checked;
             document.body.classList.toggle('dark-mode', gameSettings.darkMode);
+        });
+    }
+
+    const preserveAutoStartToggle = document.getElementById('preserve-project-auto-start-toggle');
+    if (preserveAutoStartToggle) {
+        preserveAutoStartToggle.checked = gameSettings.preserveProjectAutoStart;
+        preserveAutoStartToggle.addEventListener('change', () => {
+            gameSettings.preserveProjectAutoStart = preserveAutoStartToggle.checked;
         });
     }
 

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -39,6 +39,7 @@ let gameSettings = {
   silenceMilestoneAlert: false,
   silenceUnlockAlert: false,
   disableDayNightCycle: false,
+  preserveProjectAutoStart: false,
 };
 
 let colonySliderSettings = {

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -661,20 +661,35 @@ class ProjectManager extends EffectableEntity {
 
   saveTravelState() {
     const travelState = {};
+    const preserveAuto = typeof gameSettings !== 'undefined' && gameSettings.preserveProjectAutoStart;
     for (const name in this.projects) {
       const project = this.projects[name];
+      const state = {};
+      if (preserveAuto) {
+        state.autoStart = project.autoStart;
+      }
       if (typeof project.saveTravelState === 'function') {
-        travelState[name] = project.saveTravelState();
+        Object.assign(state, project.saveTravelState());
+      }
+      if (Object.keys(state).length > 0) {
+        travelState[name] = state;
       }
     }
     return travelState;
   }
 
   loadTravelState(travelState = {}) {
+    const preserveAuto = typeof gameSettings !== 'undefined' && gameSettings.preserveProjectAutoStart;
     for (const name in travelState) {
       const project = this.projects[name];
-      if (project && typeof project.loadTravelState === 'function') {
-        project.loadTravelState(travelState[name]);
+      if (!project) continue;
+      const state = travelState[name] || {};
+      if (preserveAuto && typeof state.autoStart !== 'undefined') {
+        project.autoStart = state.autoStart;
+      }
+      if (typeof project.loadTravelState === 'function') {
+        const { autoStart, ...projectState } = state;
+        project.loadTravelState(projectState);
       }
     }
   }

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -278,6 +278,10 @@ function loadGame(slotOrCustomString) {
         darkModeToggle.checked = gameSettings.darkMode;
         document.body.classList.toggle('dark-mode', gameSettings.darkMode);
       }
+      const preserveAutoStartToggle = document.getElementById('preserve-project-auto-start-toggle');
+      if(preserveAutoStartToggle){
+        preserveAutoStartToggle.checked = gameSettings.preserveProjectAutoStart;
+      }
       if (typeof completedResearchHidden !== 'undefined') {
         completedResearchHidden = gameSettings.hideCompletedResearch || false;
         if (typeof updateAllResearchButtons === 'function') {

--- a/tests/preserveProjectAutoStart.test.js
+++ b/tests/preserveProjectAutoStart.test.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('project auto-start preservation setting', () => {
+  function stubResource(value) {
+    return {
+      value,
+      decrease(amount) { this.value = Math.max(this.value - amount, 0); },
+      increase(amount) { this.value += amount; },
+    };
+  }
+
+  const config = {
+    name: 'Test',
+    category: 'resources',
+    cost: {},
+    duration: 1000,
+    description: '',
+    repeatable: true,
+    unlocked: true,
+    attributes: {},
+  };
+
+  function loadProjectContext(settings) {
+    const ctx = { console, EffectableEntity, gameSettings: settings };
+    ctx.resources = { colony: { energy: stubResource(1000) } };
+    vm.createContext(ctx);
+    const projCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projCode + '; this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
+    return ctx;
+  }
+
+  test('autoStart persists across travel when setting enabled and waits for unlock', () => {
+    const ctx = loadProjectContext({ preserveProjectAutoStart: true });
+    const project = new ctx.Project(config, 'test');
+    project.autoStart = true;
+    const pm1 = new ctx.ProjectManager();
+    ctx.projectManager = pm1;
+    pm1.projects.test = project;
+    const saved = pm1.saveTravelState();
+
+    const pm2 = new ctx.ProjectManager();
+    ctx.projectManager = pm2;
+    const newProject = new ctx.Project({ ...config, unlocked: false }, 'test');
+    pm2.projects.test = newProject;
+    pm2.loadTravelState(saved);
+    expect(newProject.autoStart).toBe(true);
+    expect(newProject.isActive).toBe(false);
+    newProject.unlocked = true;
+    if (newProject.autoStart && !newProject.isActive && newProject.canStart()) {
+      newProject.start(ctx.resources);
+    }
+    expect(newProject.isActive).toBe(true);
+  });
+
+  test('autoStart resets across travel when setting disabled', () => {
+    const ctx = loadProjectContext({ preserveProjectAutoStart: false });
+    const project = new ctx.Project(config, 'test');
+    project.autoStart = true;
+    const pm1 = new ctx.ProjectManager();
+    ctx.projectManager = pm1;
+    pm1.projects.test = project;
+    const saved = pm1.saveTravelState();
+
+    const pm2 = new ctx.ProjectManager();
+    ctx.projectManager = pm2;
+    const newProject = new ctx.Project(config, 'test');
+    pm2.projects.test = newProject;
+    pm2.loadTravelState(saved);
+    expect(newProject.autoStart).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add setting to preserve project auto-start across planet travel
- persist project auto-start when enabled and defer until project unlocks
- test project auto-start setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d55654cfc83278b91095a3d154f2d