### PR TITLE
Move project auto-start logic into manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,3 +191,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Dynamic water-import space mining projects scale per-second gains with the assigned ship count.
 - Space Storage project only marks ship transfers as continuous, leaving expansion progress discrete.
 - Added a setting to preserve project auto-start selections between worlds.
+- Project auto-start now runs within ProjectManager and requires the `automateSpecialProjects` flag.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -514,6 +514,22 @@ class ProjectManager extends EffectableEntity {
       if (typeof project.applyCostAndGain === 'function') {
         project.applyCostAndGain(deltaTime);
       }
+
+      if (
+        this.isBooleanFlagSet('automateSpecialProjects') &&
+        project.autoStart &&
+        !project.isActive &&
+        !project.isCompleted &&
+        project.canStart()
+      ) {
+        if (project.isPaused) {
+          if (project.resume() && typeof updateProjectUI === 'function') {
+            updateProjectUI(project.name);
+          }
+        } else {
+          this.startProject(project.name);
+        }
+      }
     }
   }
 

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -591,10 +591,6 @@ function updateProjectUI(projectName) {
 
 
 
-  // Check if the auto-start checkbox is checked and attempt to start the project automatically
-  if (elements.autoStartCheckbox?.checked && !project.isActive && !project.isCompleted && project.canStart()) {
-    checkAndStartProjectAutomatically(project);
-  }
   // Final visibility check for the footer and its contents
   const footer = elements.cardFooter;
   if (footer) {
@@ -654,16 +650,6 @@ function startProjectWithSelectedResources(project) {
   } else if (project.canStart()) {
     projectManager.startProject(project.name);
   } else {
-  }
-}
-
-function checkAndStartProjectAutomatically(project) {
-  if (project.isPaused) {
-    if (project.canStart()) {
-      startProjectWithSelectedResources(project);
-    }
-  } else if (project.canStart()) {
-    startProjectWithSelectedResources(project);
   }
 }
 


### PR DESCRIPTION
## Summary
- Handle project auto-start within `ProjectManager.updateProjects`
- Remove UI-based auto-start calls and close helper function properly
- Document auto-start behavior relying on `automateSpecialProjects` flag

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d59be22208327b56240f25d6d57ef