### PR TITLE
feat: add default pressure limits for gas import projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,3 +193,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added a setting to preserve project auto-start selections between worlds.
 - Water overflow no longer contributes to resource totals but remains displayed in tooltips.
 - Project auto-start now runs within ProjectManager and requires the `automateSpecialProjects` flag.
+- Carbon and nitrogen importation projects now start with configurable default pressure limits.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -196,7 +196,8 @@ const projectParameters = {
     attributes: {
       spaceMining : true,
       costPerShip : {colony : {metal : 100000, energy : 100000000000}},
-      resourceGainPerShip : {atmospheric: {carbonDioxide : 1000000}}
+      resourceGainPerShip : {atmospheric: {carbonDioxide : 1000000}},
+      maxPressure: 10
     }
   },
   waterSpaceMining: {
@@ -229,7 +230,8 @@ const projectParameters = {
     attributes: {
       spaceMining : true,
       costPerShip : {colony : {metal : 100000, energy : 100000000000}},
-      resourceGainPerShip : {atmospheric: {inertGas : 1000000}}
+      resourceGainPerShip : {atmospheric: {inertGas : 1000000}},
+      maxPressure: 100
     }
   },
   spaceElevator: {

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -3,6 +3,11 @@ class SpaceMiningProject extends SpaceshipProject {
     super(config, name);
     this.disableAbovePressure = false;
     this.disablePressureThreshold = 0;
+    const maxPressure = config.attributes?.maxPressure;
+    if (typeof maxPressure === 'number') {
+      this.disableAbovePressure = true;
+      this.disablePressureThreshold = maxPressure;
+    }
   }
 
   shouldPenalizeMetalProduction() {

--- a/tests/spaceMiningDefaultPressure.test.js
+++ b/tests/spaceMiningDefaultPressure.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceMiningProject default pressure threshold', () => {
+  test('constructor initializes pressure limit from attributes', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+
+    ctx.resources = { colony: {}, special: { spaceships: { value: 0 } }, atmospheric: {}, surface: {}, underground: {} };
+    ctx.projectManager = new ctx.ProjectManager();
+    const params = {
+      mine: {
+        type: 'SpaceMiningProject',
+        name: 'Mine',
+        category: 'resources',
+        cost: {},
+        duration: 1,
+        description: '',
+        repeatable: true,
+        maxRepeatCount: Infinity,
+        unlocked: true,
+        attributes: { spaceMining: true, maxPressure: 0.1 }
+      }
+    };
+    ctx.projectManager.initializeProjects(params);
+    const project = ctx.projectManager.projects.mine;
+    expect(project.disableAbovePressure).toBe(true);
+    expect(project.disablePressureThreshold).toBe(0.1);
+  });
+});


### PR DESCRIPTION
## Summary
- allow SpaceMiningProject to read max pressure from parameters
- add default pressure caps for carbon and nitrogen import projects
- test pressure threshold initialization

## Testing
- `npm test` *(fails: waterLeak.test.js, overflowTotals.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_689d6212232883279ba4a8c60120e982