### PR TITLE
Format Solis points and scale artifact trades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,8 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Solis research upgrade lists upcoming technologies horizontally and crosses out each as it is purchased, clarifying that one tech is unlocked per purchase.
 - Chapter 13.2 reward triggers a one-time alert on the Solis tab.
 - Solis point rewards now scale with the square root of terraformed worlds and display two decimal places.
+- Solis point display now shows two decimal places, and alien artifact trade points scale with the Solis point multiplier.
+- Alien artifact donation UI displays Solis points per artifact based on the current terraformed world bonus.
 - Fixed Dyson Swarm collectors resetting after planet travel; collector counts persist across worlds while the receiver must be rebuilt on each planet.
 - Collector persistence is managed through ProjectManager travel state so only the Dyson Swarm's collector count carries over between planets.
 - Space Storage allows storing glass and preserves its capacity and stored resources across planet travel using travel state save/load.

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -183,6 +183,7 @@ function initializeSolisUI() {
 
     const label = document.createElement('span');
     label.classList.add('solis-shop-item-label');
+    label.id = 'solis-donation-label';
     label.textContent = 'Donate artifacts for 10 Solis points each';
     item.appendChild(label);
 
@@ -282,6 +283,7 @@ function updateSolisUI() {
   const donationCount = document.getElementById('solis-donation-count');
   const donationInput = document.getElementById('solis-donation-input');
   const donationButton = document.getElementById('solis-donation-button');
+  const donationLabel = document.getElementById('solis-donation-label');
   const researchShop = document.getElementById('solis-research-shop');
 
   const flag = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisAlienArtifactUpgrade');
@@ -289,7 +291,10 @@ function updateSolisUI() {
   if (researchShop) researchShop.classList.toggle('hidden', !flag);
 
   if (pointsSpan) {
-    pointsSpan.textContent = solisManager.solisPoints;
+    const format = typeof formatNumber === 'function'
+      ? formatNumber
+      : (n, _s, p = 2) => Number(n).toFixed(p);
+    pointsSpan.textContent = format(solisManager.solisPoints, false, 2);
   }
   if (rewardSpan) {
     const format = typeof formatNumber === 'function'
@@ -352,6 +357,13 @@ function updateSolisUI() {
   if (donationButton && donationInput && resources.special && resources.special.alienArtifact) {
     const amt = parseInt(donationInput.value, 10) || 0;
     donationButton.disabled = amt <= 0 || amt > resources.special.alienArtifact.value;
+  }
+  if (donationLabel) {
+    const format = typeof formatNumber === 'function'
+      ? formatNumber
+      : (n, _s, p = 2) => Number(n).toFixed(p);
+    const per = 10 * (solisManager.getTerraformedWorldBonus ? solisManager.getTerraformedWorldBonus() : 1);
+    donationLabel.textContent = `Donate artifacts for ${format(per, false, 2)} Solis points each`;
   }
 
   for (const key in shopElements) {

--- a/tests/solisArtifactDonationScaling.test.js
+++ b/tests/solisArtifactDonationScaling.test.js
@@ -1,0 +1,19 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis artifact donation scaling', () => {
+  test('donateArtifacts scales with terraformed world bonus', () => {
+    const manager = new SolisManager();
+    const prevResources = global.resources;
+    const prevSpace = global.spaceManager;
+    global.resources = { special: { alienArtifact: { value: 5, decrease(n){ this.value -= n; } } } };
+    global.spaceManager = { getTerraformedPlanetCount: () => 4 };
+
+    const result = manager.donateArtifacts(2);
+    expect(result).toBe(true);
+    expect(manager.solisPoints).toBe(2 * 10 * 2); // sqrt(4) = 2 bonus
+    global.resources = prevResources;
+    global.spaceManager = prevSpace;
+  });
+});

--- a/tests/solisArtifactDonationUI.test.js
+++ b/tests/solisArtifactDonationUI.test.js
@@ -34,4 +34,35 @@ describe('Solis artifact donation UI', () => {
     const count = dom.window.document.getElementById('solis-donation-count').textContent;
     expect(count).toBe('4.00');
   });
+
+  test('shows scaled points per artifact', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="wrapper"><div id="solis-donation-items"></div></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.solisManager = {
+      isBooleanFlagSet: () => true,
+      solisPoints: 0,
+      rewardMultiplier: 5,
+      getTerraformedWorldBonus: () => 2,
+      currentQuest: null,
+      refreshCooldown: 0,
+      lastRefreshTime: 0,
+      postCompletionCooldownUntil: 0,
+      questInterval: 0,
+      shopUpgrades: {},
+      getUpgradeCost: () => 0,
+      donateArtifacts: () => {}
+    };
+    ctx.resources = { special: { alienArtifact: { value: 0 } } };
+
+    const numbersCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'numbers.js'), 'utf8');
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'solisUI.js'), 'utf8');
+    vm.runInContext(numbersCode + '\n' + uiCode, ctx);
+
+    ctx.initializeSolisUI();
+    ctx.updateSolisUI();
+
+    const label = dom.window.document.getElementById('solis-donation-label').textContent;
+    expect(label).toBe('Donate artifacts for 20.00 Solis points each');
+  });
 });

--- a/tests/solisPointsDisplay.test.js
+++ b/tests/solisPointsDisplay.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('Solis points display', () => {
+  test('shows two decimal places', () => {
+    const dom = new JSDOM('<!DOCTYPE html><span id="solis-points-value"></span>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.solisManager = {
+      solisPoints: 1.2345,
+      isBooleanFlagSet: () => false,
+      getCurrentReward: () => 0,
+      refreshCooldown: 0,
+      lastRefreshTime: 0,
+      postCompletionCooldownUntil: 0,
+      questInterval: 0,
+      currentQuest: null,
+      shopUpgrades: {},
+      getUpgradeCost: () => 0,
+    };
+    ctx.resources = { special: { alienArtifact: { value: 0 } }, colony: {} };
+    ctx.formatNumber = numbers.formatNumber;
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'solisUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+
+    ctx.updateSolisUI();
+    expect(dom.window.document.getElementById('solis-points-value').textContent).toBe('1.23');
+  });
+});


### PR DESCRIPTION
## Summary
- Display Solis point totals with two decimal places
- Scale alien artifact donations by the terraformed world bonus and show the correct reward in the donation UI
- Add tests for Solis point formatting, artifact trade scaling, and donation UI text

## Testing
- `npm test` *(fails: waterLeak.test.js, overflowTotals.test.js)*


------
https://chatgpt.com/codex/tasks/task_b_689d628e09b88327bd02185a26115fe0