### PR TITLE
Update overflow tests for resource system

### DIFF
--- a/tests/overflowTotals.test.js
+++ b/tests/overflowTotals.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
-describe('overflow excluded from totals', () => {
+describe('overflow totals handling', () => {
   function loadResource() {
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resource.js'), 'utf8');
     const ctx = { EffectableEntity: class {}, unlockResource: () => {} };
@@ -14,18 +14,18 @@ describe('overflow excluded from totals', () => {
   test('consumption overflow not counted', () => {
     const ctx = loadResource();
     const r = new ctx.Resource({ name: 'water', displayName: 'Water', category: 'colony', hasCap: true, baseCap: 100, unlocked: true });
-    r.modifyRate(-5, 'Overflow', 'overflow');
+    r.modifyRate(-5, 'Overflow (not summed)', 'overflow');
     r.recalculateTotalRates();
     expect(r.consumptionRate).toBe(0);
-    expect(r.consumptionRateBySource.Overflow).toBe(5);
+    expect(r.consumptionRateBySource['Overflow (not summed)']).toBe(5);
   });
 
-  test('production overflow not counted', () => {
+  test('production overflow counted', () => {
     const ctx = loadResource();
     const r = new ctx.Resource({ name: 'ice', displayName: 'Ice', category: 'surface', hasCap: false, baseCap: 0, unlocked: true });
     r.modifyRate(3, 'Overflow', 'overflow');
     r.recalculateTotalRates();
-    expect(r.productionRate).toBe(0);
+    expect(r.productionRate).toBe(3);
     expect(r.productionRateBySource.Overflow).toBe(3);
   });
 });

--- a/tests/waterLeak.test.js
+++ b/tests/waterLeak.test.js
@@ -112,7 +112,7 @@ describe('water leaks when colony storage full', () => {
     expect(ctx.terraforming.zonalWater.polar.liquid).toBe(0);
     expect(ctx.terraforming.zonalWater.polar.ice).toBe(0);
     expect(ctx.resources.colony.water.value).toBe(100);
-    expect(ctx.resources.colony.water.consumptionRateBySource.Overflow).toBeCloseTo(10);
+    expect(ctx.resources.colony.water.consumptionRateBySource['Overflow (not summed)']).toBeCloseTo(10);
     expect(ctx.resources.surface.liquidWater.productionRateBySource.Overflow).toBeCloseTo(10);
     expect(ctx.resources.surface.ice.productionRateBySource.Overflow || 0).toBe(0);
   });
@@ -147,7 +147,7 @@ describe('water leaks when colony storage full', () => {
     expect(ctx.terraforming.zonalWater.temperate.ice).toBeCloseTo(tempExp);
     expect(ctx.terraforming.zonalWater.polar.ice).toBeCloseTo(polarExp);
     expect(ctx.resources.colony.water.value).toBe(100);
-    expect(ctx.resources.colony.water.consumptionRateBySource.Overflow).toBeCloseTo(10);
+    expect(ctx.resources.colony.water.consumptionRateBySource['Overflow (not summed)']).toBeCloseTo(10);
     expect(ctx.resources.surface.ice.productionRateBySource.Overflow).toBeCloseTo(10);
   });
 });


### PR DESCRIPTION
## Summary
- Adjust water leak tests to look for "Overflow (not summed)" consumption source
- Verify production overflow contributes to totals while consumption overflow does not

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d66b2ec788327bb2483875f6143de