### PR TITLE
Prevent starting cargo rockets without payload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,3 +196,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Water overflow no longer contributes to resource totals but remains displayed in tooltips.
 - Project auto-start now runs within ProjectManager and requires the `automateSpecialProjects` flag.
 - Carbon and nitrogen importation projects now start with configurable default pressure limits.
+- Cargo Rocket project cannot start without selecting any resources.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -212,21 +212,22 @@ class CargoRocketProject extends Project {
 
   canStart() {
     if (!super.canStart()) return false;
+    if (!this.selectedResources || this.selectedResources.length === 0) {
+      return false;
+    }
 
-    if (this.selectedResources && this.selectedResources.length > 0) {
-      let totalFundingCost = 0;
-      this.selectedResources.forEach(({ category, resource, quantity }) => {
-        const basePrice = this.attributes.resourceChoiceGainCost[category][resource];
-        if (resource === 'spaceships') {
-          totalFundingCost += this.getSpaceshipTotalCost(quantity, basePrice);
-        } else {
-          totalFundingCost += basePrice * quantity;
-        }
-      });
-
-      if (resources.colony.funding.value < totalFundingCost) {
-        return false;
+    let totalFundingCost = 0;
+    this.selectedResources.forEach(({ category, resource, quantity }) => {
+      const basePrice = this.attributes.resourceChoiceGainCost[category][resource];
+      if (resource === 'spaceships') {
+        totalFundingCost += this.getSpaceshipTotalCost(quantity, basePrice);
+      } else {
+        totalFundingCost += basePrice * quantity;
       }
+    });
+
+    if (resources.colony.funding.value < totalFundingCost) {
+      return false;
     }
 
     return true;

--- a/tests/cargoRocketProject.test.js
+++ b/tests/cargoRocketProject.test.js
@@ -72,4 +72,40 @@ describe('Cargo Rocket project', () => {
 
     expect(ctx.resources.special.spaceships.increase).toHaveBeenCalledWith(1);
   });
+
+  test('cannot start without selecting resources', () => {
+    const ctx = {
+      console,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      resources: {
+        colony: { funding: { value: 1e9, decrease: jest.fn(), modifyRate: jest.fn() } },
+        special: { spaceships: { value: 0, increase: jest.fn(), modifyRate: jest.fn() } }
+      },
+      projectManager: { projects: {}, durationMultiplier: 1 },
+    };
+    vm.createContext(ctx);
+    global.resources = ctx.resources;
+    global.projectManager = ctx.projectManager;
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+
+    const config = {
+      name: 'Cargo Rocket',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { resourceChoiceGainCost: { special: { spaceships: 5 } } }
+    };
+
+    const project = new ctx.CargoRocketProject(config, 'cargo_rocket');
+    project.selectedResources = [];
+    expect(project.canStart()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure Cargo Rocket project cannot launch when no resources are selected
- Document cargo rocket start restriction
- Test that cargo rockets require a resource selection

## Testing
- `npm test` *(fails: tests/waterLeak.test.js, tests/overflowTotals.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_689d667e46dc8327a4f0238f9b9bdfd3