### PR TITLE
Fix Space Storage scaling and tooltip display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,3 +199,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo Rocket project cannot start without selecting any resources.
 - Space Storage continuous mode transfers resources each tick and is toggled by the Auto Start Ships checkbox.
 - Space Storage displays transfer rate under Cost & Gain.
+- Space Storage ship transfers scale with assigned ships, matching rates across the 100-ship transition.
+- Space Storage transfers appear in resource tooltips as production or consumption.


### PR DESCRIPTION
## Summary
- Match ship transfer rates at the 100-ship transition for Space Storage
- Show Space Storage transfers in resource tooltips and add coverage tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e5df62c80832791e56518c5ef5d4c