### PR TITLE
Add superalloy multiplier to WGC shop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,3 +202,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added Superalloys advanced research unlocking Superalloy Foundry, Superalloy Fusion Reactor, and Ecumenopolis District.
 - Space Storage ship transfers scale with assigned ships, matching rates across the 100-ship transition.
 - Space Storage transfers appear in resource tooltips as production or consumption.
+- WGC shop offers a Superalloy production multiplier upgrade unlocked by Superalloys research, capped at 900 purchases, and increasing production by 100% per purchase.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -51,6 +51,7 @@ class WarpGateCommand extends EffectableEntity {
       electronicsEfficiency: { purchases: 0, max: 400 },
       superconductorEfficiency: { purchases: 0, max: 400 },
       androidsEfficiency: { purchases: 0, max: 400 },
+      superalloyEfficiency: { purchases: 0, max: 900, enabled: false },
       foodProduction: { purchases: 0, max: 400 },
     };
     this.facilities = {
@@ -275,12 +276,20 @@ class WarpGateCommand extends EffectableEntity {
   getMultiplier(key) {
     const up = this.rdUpgrades[key];
     if (!up) return 1;
+    if (key === 'superalloyEfficiency') {
+      return 1 + up.purchases;
+    }
     return 1 + (up.purchases / 100);
   }
 
   purchaseUpgrade(key) {
     const up = this.rdUpgrades[key];
     if (!up) return false;
+    if (key === 'superalloyEfficiency') {
+      if (!researchManager || typeof researchManager.isBooleanFlagSet !== 'function' || !researchManager.isBooleanFlagSet('superalloyResearchUnlocked')) {
+        return false;
+      }
+    }
     if (up.max && up.purchases >= up.max) return false;
     const cost = this.getUpgradeCost(key);
     const art = resources && resources.special && resources.special.alienArtifact;
@@ -308,6 +317,7 @@ class WarpGateCommand extends EffectableEntity {
       electronicsEfficiency: 'electronicsFactory',
       superconductorEfficiency: 'superconductorFactory',
       androidsEfficiency: 'androidFactory',
+      superalloyEfficiency: 'superalloyFoundry',
       foodProduction: 'hydroponicFarm',
     };
     if (mapping[key]) {

--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -16,6 +16,7 @@ const rdItems = {
   electronicsEfficiency: 'Electronics production efficiency',
   superconductorEfficiency: 'Superconductor production efficiency',
   androidsEfficiency: 'Androids production efficiency',
+  superalloyEfficiency: 'Superalloy production efficiency',
   foodProduction: 'Food production efficiency'
 };
 const rdDescriptions = {
@@ -178,7 +179,7 @@ function createRDItem(key, label) {
   });
   div.appendChild(button);
 
-  rdElements[key] = { button, mult: multSpan };
+  rdElements[key] = { button, mult: multSpan, container: div };
   return div;
 }
 
@@ -616,6 +617,13 @@ function updateWGCUI() {
   for (const key in rdElements) {
     const el = rdElements[key];
     if (!el) continue;
+    if (key === 'superalloyEfficiency') {
+      const hasResearch = typeof researchManager !== 'undefined' && typeof researchManager.isBooleanFlagSet === 'function' && researchManager.isBooleanFlagSet('superalloyResearchUnlocked');
+      warpGateCommand.rdUpgrades.superalloyEfficiency.enabled = hasResearch;
+      const enabled = warpGateCommand.rdUpgrades.superalloyEfficiency.enabled;
+      if (el.container) el.container.classList.toggle('hidden', !enabled);
+      if (!enabled) continue;
+    }
     const cost = warpGateCommand.getUpgradeCost(key);
     if (el.button) {
       el.button.textContent = `Buy (${cost})`;

--- a/tests/wgcSuperalloyUpgrade.test.js
+++ b/tests/wgcSuperalloyUpgrade.test.js
@@ -1,0 +1,50 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC superalloy upgrade', () => {
+  class MockResource extends EffectableEntity {
+    constructor(v=0){
+      super({description:'aa'});
+      this.value = v;
+    }
+    decrease(v){ this.value -= v; }
+  }
+
+  function makeFoundry(){
+    const config = {
+      name:'Superalloy Foundry', category:'production', cost:{colony:{}}, consumption:{},
+      production:{ colony:{ superalloys:1 }}, storage:{}, dayNightActivity:false,
+      canBeToggled:true, requiresMaintenance:true, maintenanceFactor:1,
+      requiresDeposit:null, requiresWorker:0, unlocked:true
+    };
+    return new Building(config,'superalloyFoundry');
+  }
+
+  beforeEach(() => {
+    global.resources = { special: { alienArtifact: new MockResource(5) } };
+    global.buildings = { superalloyFoundry: makeFoundry() };
+    global.addEffect = effect => {
+      const b = global.buildings[effect.targetId];
+      if(b) b.addAndReplace(effect);
+    };
+    global.researchManager = { isBooleanFlagSet: () => false };
+  });
+
+  test('requires superalloy research and is capped at 900 purchases', () => {
+    const wgc = new WarpGateCommand();
+    expect(wgc.purchaseUpgrade('superalloyEfficiency')).toBe(false);
+    global.researchManager.isBooleanFlagSet = f => f === 'superalloyResearchUnlocked';
+    wgc.rdUpgrades.superalloyEfficiency.enabled = true;
+    expect(wgc.purchaseUpgrade('superalloyEfficiency')).toBe(true);
+    const effect = global.buildings.superalloyFoundry.activeEffects.find(e=>e.effectId==='wgc-superalloyEfficiency');
+    expect(effect).toBeDefined();
+    expect(effect.value).toBeCloseTo(2);
+    expect(wgc.purchaseUpgrade('superalloyEfficiency')).toBe(true);
+    const effect2 = global.buildings.superalloyFoundry.activeEffects.find(e=>e.effectId==='wgc-superalloyEfficiency');
+    expect(effect2.value).toBeCloseTo(3);
+    wgc.rdUpgrades.superalloyEfficiency.purchases = 900;
+    expect(wgc.purchaseUpgrade('superalloyEfficiency')).toBe(false);
+  });
+});

--- a/tests/wgcSuperalloyUpgradeVisibility.test.js
+++ b/tests/wgcSuperalloyUpgradeVisibility.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC superalloy upgrade visibility', () => {
+  test('upgrade appears only after superalloy research', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    ctx.researchManager = { isBooleanFlagSet: () => false };
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.updateWGCUI();
+    const item = dom.window.document.getElementById('wgc-superalloyEfficiency-button').parentElement;
+    expect(item.classList.contains('hidden')).toBe(true);
+    expect(ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled).toBe(false);
+    ctx.researchManager.isBooleanFlagSet = f => f === 'superalloyResearchUnlocked';
+    ctx.updateWGCUI();
+    expect(ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled).toBe(true);
+    expect(item.classList.contains('hidden')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add superalloy production multiplier upgrade to Warp Gate Command shop with 900 purchase cap
- Hide the upgrade unless Superalloys advanced research is completed
- Document the new upgrade and add tests for purchasing and UI visibility
- Ensure the upgrade grants +100% production per purchase and updates its tests accordingly

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e62ff2b9c8327880b067664308329