### PR TITLE
Add Nanotechnology Stage I advanced research placeholder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space Storage transfers appear in resource tooltips as production or consumption.
 - WGC shop offers a Superalloy production multiplier upgrade unlocked by Superalloys research, capped at 900 purchases, and increasing production by 100% per purchase.
 - Added a maintenanceMultiplier attribute for resources; superalloys use a multiplier of 0 and maintenance costs scale with each resource's multiplier.
+- Added placeholder Nanotechnology Stage I advanced research costing 125k.

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1352,6 +1352,21 @@ const researchParameters = {
         ]
       },
       {
+        id: 'nanotechnology_stage_1',
+        name: 'Nanotechnology Stage I',
+        description: 'Placeholder for future nanotechnology research.',
+        cost: { advancedResearch: 125000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'researchManager',
+            type: 'booleanFlag',
+            flagId: 'nanotechnologyStage1',
+            value: true
+          }
+        ]
+      },
+      {
         id: 'tractor_beams',
         name: 'Tractor Beams',
         description: 'Seriously?  Tractor Beams?  Sets planetary thrusters to a thrust-to-power ratio of 1, greatly reducing energy needs.',

--- a/tests/nanotechnologyStage1Research.test.js
+++ b/tests/nanotechnologyStage1Research.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Nanotechnology Stage I advanced research', () => {
+  test('exists with correct cost and flag', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const adv = ctx.researchParameters.advanced;
+    const research = adv.find(r => r.id === 'nanotechnology_stage_1');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(125000);
+    const flag = research.effects.find(
+      e => e.type === 'booleanFlag' && e.flagId === 'nanotechnologyStage1' && e.target === 'researchManager' && e.value === true
+    );
+    expect(flag).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add placeholder Nanotechnology Stage I advanced research costing 125k advanced research and setting a future-use flag
- document new research in AGENTS changelog
- test presence and cost of Nanotechnology Stage I advanced research

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e6aa86fb08327819fa47e65478689