### PR TITLE
Add placeholder Orbital Rings advanced research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space Storage transfers appear in resource tooltips as production or consumption.
 - WGC shop offers a Superalloy production multiplier upgrade unlocked by Superalloys research, capped at 900 purchases, and increasing production by 100% per purchase.
 - Added a maintenanceMultiplier attribute for resources; superalloys use a multiplier of 0 and maintenance costs scale with each resource's multiplier.
+- Added placeholder Orbital Rings advanced research costing 150k.

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1352,6 +1352,21 @@ const researchParameters = {
         ]
       },
       {
+        id: 'orbital_rings',
+        name: 'Orbital Rings',
+        description: 'Placeholder for orbital ring megastructure research.',
+        cost: { advancedResearch: 150000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'researchManager',
+            type: 'booleanFlag',
+            flagId: 'orbitalRingsResearchUnlocked',
+            value: true
+          }
+        ]
+      },
+      {
         id: 'tractor_beams',
         name: 'Tractor Beams',
         description: 'Seriously?  Tractor Beams?  Sets planetary thrusters to a thrust-to-power ratio of 1, greatly reducing energy needs.',

--- a/tests/orbitalRingsResearch.test.js
+++ b/tests/orbitalRingsResearch.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Orbital Rings research', () => {
+  test('exists in advanced research with correct cost and effect', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const advanced = ctx.researchParameters.advanced;
+    const research = advanced.find(r => r.id === 'orbital_rings');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(150000);
+    const effect = research.effects.find(e => e.target === 'researchManager' && e.type === 'booleanFlag' && e.flagId === 'orbitalRingsResearchUnlocked' && e.value === true);
+    expect(effect).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add placeholder Orbital Rings advanced research priced at 150k with flag effect
- document Orbital Rings research in AGENTS changelog
- test for new Orbital Rings advanced research

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e6a8ee0d08327a833beee76c80d60