### PR TITLE
Toggle WGC superalloy upgrade row by flag

### DIFF
--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -618,8 +618,6 @@ function updateWGCUI() {
     const el = rdElements[key];
     if (!el) continue;
     if (key === 'superalloyEfficiency') {
-      const hasResearch = typeof researchManager !== 'undefined' && typeof researchManager.isBooleanFlagSet === 'function' && researchManager.isBooleanFlagSet('superalloyResearchUnlocked');
-      warpGateCommand.rdUpgrades.superalloyEfficiency.enabled = hasResearch;
       const enabled = warpGateCommand.rdUpgrades.superalloyEfficiency.enabled;
       if (el.container) el.container.classList.toggle('hidden', !enabled);
       if (!enabled) continue;

--- a/tests/wgcSuperalloyUpgradeVisibility.test.js
+++ b/tests/wgcSuperalloyUpgradeVisibility.test.js
@@ -14,7 +14,6 @@ describe('WGC superalloy upgrade visibility', () => {
     ctx.console = console;
     ctx.EffectableEntity = EffectableEntity;
     ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
-    ctx.researchManager = { isBooleanFlagSet: () => false };
     vm.createContext(ctx);
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
     vm.runInContext(code, ctx);
@@ -24,7 +23,7 @@ describe('WGC superalloy upgrade visibility', () => {
     const item = dom.window.document.getElementById('wgc-superalloyEfficiency-button').parentElement;
     expect(item.classList.contains('hidden')).toBe(true);
     expect(ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled).toBe(false);
-    ctx.researchManager.isBooleanFlagSet = f => f === 'superalloyResearchUnlocked';
+    ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled = true;
     ctx.updateWGCUI();
     expect(ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled).toBe(true);
     expect(item.classList.contains('hidden')).toBe(false);


### PR DESCRIPTION
## Summary
- show or hide WGC superalloy production efficiency row based on its enabled flag
- update superalloy upgrade visibility test to reflect new flag-based behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e6ae285608327bb9f2deb72b9a30f