### PR TITLE
Fix superalloy upgrade visibility test

### DIFF
--- a/tests/wgcSuperalloyUpgradeVisibility.test.js
+++ b/tests/wgcSuperalloyUpgradeVisibility.test.js
@@ -14,6 +14,12 @@ describe('WGC superalloy upgrade visibility', () => {
     ctx.console = console;
     ctx.EffectableEntity = EffectableEntity;
     ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    ctx.researchManager = {
+      researchUnlocked: false,
+      isBooleanFlagSet(flag) {
+        return flag === 'superalloyResearchUnlocked' && this.researchUnlocked;
+      },
+    };
     vm.createContext(ctx);
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
     vm.runInContext(code, ctx);
@@ -21,11 +27,10 @@ describe('WGC superalloy upgrade visibility', () => {
     ctx.initializeWGCUI();
     ctx.updateWGCUI();
     const item = dom.window.document.getElementById('wgc-superalloyEfficiency-button').parentElement;
-    expect(item.classList.contains('hidden')).toBe(true);
+    expect(item.style.display).toBe('none');
     expect(ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled).toBe(false);
-    ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled = true;
+    ctx.researchManager.researchUnlocked = true;
     ctx.updateWGCUI();
-    expect(ctx.warpGateCommand.rdUpgrades.superalloyEfficiency.enabled).toBe(true);
-    expect(item.classList.contains('hidden')).toBe(false);
+    expect(item.style.display).not.toBe('none');
   });
 });


### PR DESCRIPTION
## Summary
- ensure WGC superalloy upgrade test hides upgrade until research unlock

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_689e7580814483279ab237c5606ea0d9