### PR TITLE
Add Superalloy space storage option gated by research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Fixed Dyson Swarm collectors resetting after planet travel; collector counts persist across worlds while the receiver must be rebuilt on each planet.
 - Collector persistence is managed through ProjectManager travel state so only the Dyson Swarm's collector count carries over between planets.
 - Space Storage allows storing glass and preserves its capacity and stored resources across planet travel using travel state save/load.
+- Space Storage allows storing superalloys when the Superalloys research is completed.
 - Skill points are granted only when traveling from a fully terraformed planet to one not yet terraformed.
 - `getTerraformedPlanetCountIncludingCurrent` in SpaceManager avoids double counting the current planet when applying terraforming bonuses.
 - Autosave slot can be manually overwritten through the Save button.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -4,6 +4,7 @@ const storageResourceOptions = [
   { label: 'Components', category: 'colony', resource: 'components' },
   { label: 'Electronics', category: 'colony', resource: 'electronics' },
   { label: 'Superconductors', category: 'colony', resource: 'superconductors' },
+  { label: 'Superalloys', category: 'colony', resource: 'superalloys', requiresFlag: 'superalloyResearchUnlocked' },
   { label: 'Oxygen', category: 'atmospheric', resource: 'oxygen' },
   { label: 'Carbon Dioxide', category: 'atmospheric', resource: 'carbonDioxide' },
   { label: 'Water', category: 'surface', resource: 'liquidWater' },
@@ -145,6 +146,13 @@ function renderSpaceStorageUI(project, container) {
     resourceItem.append(checkbox, label, usage);
     resourceGrid.appendChild(resourceItem);
 
+    if (opt.requiresFlag) {
+      const hasFlag = typeof researchManager === 'undefined'
+        || (typeof researchManager.isBooleanFlagSet === 'function'
+          && researchManager.isBooleanFlagSet(opt.requiresFlag));
+      resourceItem.style.display = hasFlag ? '' : 'none';
+    }
+
     projectElements[project.name] = {
       ...projectElements[project.name],
       resourceCheckboxes: {
@@ -158,6 +166,10 @@ function renderSpaceStorageUI(project, container) {
       fullIcons: {
         ...(projectElements[project.name]?.fullIcons || {}),
         [opt.resource]: fullIcon
+      },
+      resourceItems: {
+        ...(projectElements[project.name]?.resourceItems || {}),
+        [opt.resource]: resourceItem
       }
     };
   });
@@ -280,6 +292,20 @@ function updateSpaceStorageUI(project) {
           r => r.category === opt.category && r.resource === opt.resource
         );
         cb.checked = checked;
+      }
+    });
+  }
+  if (els.resourceItems) {
+    storageResourceOptions.forEach(opt => {
+      const item = els.resourceItems[opt.resource];
+      if (item && opt.requiresFlag) {
+        const hasFlag = typeof researchManager === 'undefined'
+          || (typeof researchManager.isBooleanFlagSet === 'function'
+            && researchManager.isBooleanFlagSet(opt.requiresFlag));
+        item.style.display = hasFlag ? '' : 'none';
+        if (!hasFlag) {
+          project.toggleResourceSelection(opt.category, opt.resource, false);
+        }
       }
     });
   }

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -104,17 +104,22 @@ describe('Space Storage project', () => {
     const params = { name: 'spaceStorage', category: 'mega', cost: {}, duration: 300000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: attrs };
     const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
     const container = dom.window.document.getElementById('root');
+    ctx.researchManager = { isBooleanFlagSet: () => false };
     project.updateCostAndGains = () => {};
     project.renderUI(container);
     const checkboxes = container.querySelectorAll('#ss-resource-grid input[type="checkbox"]');
-    expect(checkboxes.length).toBe(9);
+    expect(checkboxes.length).toBe(10);
+    const superCheckbox = container.querySelector('#spaceStorage-res-superalloys');
+    expect(superCheckbox.parentElement.style.display).toBe('none');
+    const visibleCheckboxes = Array.from(checkboxes).filter(cb => cb.parentElement.style.display !== 'none');
+    expect(visibleCheckboxes.length).toBe(9);
     const items = container.querySelectorAll('#ss-resource-grid .storage-resource-item');
     expect(items[0].children.length).toBe(3);
     const label = items[0].children[1];
     const fullIcon = label.querySelector('.storage-full-icon');
     expect(fullIcon).toBeDefined();
-    checkboxes[0].checked = true;
-    checkboxes[0].dispatchEvent(new dom.window.Event('change'));
+    visibleCheckboxes[0].checked = true;
+    visibleCheckboxes[0].dispatchEvent(new dom.window.Event('change'));
     expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });
   });
 

--- a/tests/spaceStorageSuperalloyVisibility.test.js
+++ b/tests/spaceStorageSuperalloyVisibility.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('Space Storage superalloy option visibility', () => {
+  test('option appears only after superalloy research', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.projectElements = {};
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.resources = { colony: { metal: { displayName: 'Metal', value: 0 } } };
+    ctx.researchManager = {
+      unlocked: false,
+      isBooleanFlagSet(flag) {
+        return flag === 'superalloyResearchUnlocked' && this.unlocked;
+      }
+    };
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
+    const project = {
+      name: 'spaceStorage',
+      cost: { colony: { metal: 1 } },
+      getScaledCost() { return this.cost; },
+      usedStorage: 0,
+      maxStorage: 100,
+      resourceUsage: {},
+      selectedResources: [],
+      shipOperationAutoStart: false,
+      shipOperationRemainingTime: 0,
+      shipOperationStartingDuration: 0,
+      shipOperationIsActive: false,
+      shipWithdrawMode: false,
+      isShipOperationContinuous: () => false,
+      getEffectiveDuration: () => 1000,
+      createSpaceshipAssignmentUI() {},
+      createProjectDetailsGridUI() {},
+      toggleResourceSelection() {}
+    };
+    const container = dom.window.document.getElementById('container');
+    ctx.renderSpaceStorageUI(project, container);
+    ctx.updateSpaceStorageUI(project);
+    const item = dom.window.document.getElementById('spaceStorage-res-superalloys').parentElement;
+    expect(item.style.display).toBe('none');
+    ctx.researchManager.unlocked = true;
+    ctx.updateSpaceStorageUI(project);
+    expect(item.style.display).not.toBe('none');
+  });
+});

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -12,6 +12,7 @@ describe('Space Storage UI', () => {
     ctx.projectElements = {};
     ctx.formatNumber = numbers.formatNumber;
     ctx.resources = { colony: { metal: { displayName: 'Metal' } } };
+    ctx.researchManager = { isBooleanFlagSet: () => false };
 
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
     vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
@@ -52,6 +53,7 @@ describe('Space Storage UI', () => {
         section.appendChild(title);
         container.appendChild(section);
       },
+      toggleResourceSelection() {},
     };
     const container = dom.window.document.getElementById('container');
     ctx.renderSpaceStorageUI(project, container);
@@ -61,9 +63,13 @@ describe('Space Storage UI', () => {
     expect(els.usedDisplay.textContent).toBe(String(numbers.formatNumber(0, false, 0)));
     expect(els.maxDisplay.textContent).toBe(String(numbers.formatNumber(1000000000000, false, 0)));
     expect(els.expansionCostDisplay.textContent).toBe(`Metal: ${numbers.formatNumber(metalCost, true)}`);
-    const items = els.resourceGrid.querySelectorAll('.storage-resource-item');
-    expect(items.length).toBe(9);
-    const firstItem = items[0];
+    const items = Array.from(els.resourceGrid.querySelectorAll('.storage-resource-item'));
+    expect(items.length).toBe(10);
+    const superItem = dom.window.document.getElementById('spaceStorage-res-superalloys').parentElement;
+    expect(superItem.style.display).toBe('none');
+    const visibleItems = items.filter(i => i.style.display !== 'none');
+    expect(visibleItems.length).toBe(9);
+    const firstItem = visibleItems[0];
     const label = firstItem.children[1];
     const fullIcon = label.querySelector('.storage-full-icon');
     expect(fullIcon).toBeDefined();
@@ -81,9 +87,10 @@ describe('Space Storage UI', () => {
     project.resourceUsage = { metal: 500 };
     project.usedStorage = 500;
     ctx.updateSpaceStorageUI(project);
-    const updatedItems = els.resourceGrid.querySelectorAll('.storage-resource-item');
-    expect(updatedItems.length).toBe(9);
-    const metalItem = updatedItems[0];
+    const updatedItems = Array.from(els.resourceGrid.querySelectorAll('.storage-resource-item'));
+    const updatedVisible = updatedItems.filter(i => i.style.display !== 'none');
+    expect(updatedVisible.length).toBe(9);
+    const metalItem = updatedVisible[0];
     expect(metalItem.children[2].textContent).toBe(String(numbers.formatNumber(500, false, 0)));
 
     const topSection = container.querySelector('.project-top-section');
@@ -98,6 +105,7 @@ describe('Space Storage UI', () => {
     ctx.projectElements = {};
     ctx.formatNumber = numbers.formatNumber;
     ctx.resources = { colony: { metal: { displayName: 'Metal', hasCap: true, value: 10, cap: 10 } } };
+    ctx.researchManager = { isBooleanFlagSet: () => false };
 
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
     vm.runInContext(uiCode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
@@ -119,6 +127,7 @@ describe('Space Storage UI', () => {
       getEffectiveDuration: () => 1000,
       createSpaceshipAssignmentUI() {},
       createProjectDetailsGridUI() {},
+      toggleResourceSelection() {},
     };
     const container = dom.window.document.getElementById('container');
     ctx.renderSpaceStorageUI(project, container);


### PR DESCRIPTION
## Summary
- allow Space Storage to store Superalloys
- hide Superalloys option until Superalloys research is unlocked
- test superalloy visibility in Space Storage UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f2c1c0d6083278a96c7db2398c752