### PR TITLE
Display per-second cost for continuous spaceship projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Spaceship projects in continuous mode display "Continuous" or "Stopped" instead of a progress bar.
 - Continuous spaceship projects revert to discrete timing when assignments fall to 100 ships or fewer.
 - Continuous spaceship projects display total gains as per-second rates.
+- Continuous spaceship projects display total costs as per-second rates.
 - Gas-importing space mining caps per-tick transfers at the configured pressure limit.
 - Dynamic water-import space mining projects scale per-second gains with the assigned ship count.
 - Space Storage project only marks ship transfers as continuous, leaving expansion progress discrete.

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -93,8 +93,9 @@ class SpaceshipProject extends Project {
     }
 
     if (elements.totalCostElement && this.assignedSpaceships != null) {
-      const totalCost = this.calculateSpaceshipTotalCost();
-      elements.totalCostElement.innerHTML = formatTotalCostDisplay(totalCost, this);
+      const perSecond = this.isContinuous();
+      const totalCost = this.calculateSpaceshipTotalCost(perSecond);
+      elements.totalCostElement.innerHTML = formatTotalCostDisplay(totalCost, this, perSecond);
     }
 
     if (elements.resourceGainPerShipElement && this.attributes.resourceGainPerShip) {
@@ -320,11 +321,17 @@ class SpaceshipProject extends Project {
     }
   }
 
-  calculateSpaceshipTotalCost() {
+  calculateSpaceshipTotalCost(perSecond = false) {
     const totalCost = {};
     const costPerShip = this.calculateSpaceshipCost();
+    const multiplier = perSecond
+      ? this.assignedSpaceships * (1000 / this.getEffectiveDuration())
+      : 1;
     for (const category in costPerShip) {
-      totalCost[category] = { ...costPerShip[category] };
+      totalCost[category] = {};
+      for (const resource in costPerShip[category]) {
+        totalCost[category][resource] = costPerShip[category][resource] * multiplier;
+      }
     }
     return totalCost;
   }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -653,8 +653,9 @@ function startProjectWithSelectedResources(project) {
   }
 }
 
-function formatTotalCostDisplay(totalCost, project) {
+function formatTotalCostDisplay(totalCost, project, perSecond = false) {
   const costArray = [];
+  const suffix = perSecond ? '/s' : '';
   for (const category in totalCost) {
     for (const resource in totalCost[category]) {
       const requiredAmount = totalCost[category][resource];
@@ -664,7 +665,7 @@ function formatTotalCostDisplay(totalCost, project) {
         resource.charAt(0).toUpperCase() + resource.slice(1);
 
       // Check if the player has enough of this resource
-      const resourceText = `${resourceDisplayName}: ${formatNumber(requiredAmount, true)}`;
+      const resourceText = `${resourceDisplayName}: ${formatNumber(requiredAmount, true)}${suffix}`;
       const highlight = availableAmount < requiredAmount &&
         !(project && project.ignoreCostForResource && project.ignoreCostForResource(category, resource));
       const formattedResourceText = highlight

--- a/tests/spaceshipProjectContinuousCostDisplay.test.js
+++ b/tests/spaceshipProjectContinuousCostDisplay.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceshipProject continuous total cost UI', () => {
+  test('shows per-second total cost', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = n => n.toString();
+    ctx.formatBigInteger = n => n.toString();
+    ctx.projectElements = {};
+    ctx.resources = {
+      colony: {
+        energy: { value: 0, increase() {}, decrease() {} },
+      },
+      special: { spaceships: { value: 101 } }
+    };
+    ctx.shipEfficiency = 1;
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+
+    const config = {
+      name: 'testCost',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: { spaceMining: true, costPerShip: { colony: { energy: 10 } }, resourceGainPerShip: {} }
+    };
+    const project = new ctx.SpaceshipProject(config, 'testCost');
+    ctx.projectManager = { projects: { testCost: project }, isBooleanFlagSet: () => false, getProjectStatuses: () => Object.values({ testCost: project }) };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.assignSpaceships(101);
+    ctx.updateProjectUI('testCost');
+
+    const text = ctx.projectElements.testCost.totalCostElement.textContent;
+    expect(text).toBe('Total Cost: Energy: 1010/s');
+  });
+});


### PR DESCRIPTION
## Summary
- show per-second cost for spaceship projects when running continuously
- support per-second formatting in project UI cost helper
- test that continuous projects reveal total cost per second

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f355c9fc08327820ec06313e5ee14