### PR TITLE
Hide zero maintenance costs

### DIFF
--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -852,9 +852,15 @@ function updateDecreaseButtonText(button, buildCount) {
     }
 
     if (structure.requiresMaintenance && Object.keys(structure.maintenanceCost).length > 0) {
-      const maintenanceKeys = Object.keys(structure.maintenanceCost).map(r => `colony.${r}`);
+      const filteredMaintenance = Object.entries(structure.maintenanceCost)
+        .filter(([_, cost]) => cost > 0)
+        .reduce((acc, [res, cost]) => {
+          acc[res] = cost;
+          return acc;
+        }, {});
+      const maintenanceKeys = Object.keys(filteredMaintenance).map(r => `colony.${r}`);
       if (maintenanceKeys.length > 0) {
-        sections.push({ key: 'maintenance', label: 'Maintenance', data: structure.maintenanceCost, keys: maintenanceKeys });
+        sections.push({ key: 'maintenance', label: 'Maintenance', data: filteredMaintenance, keys: maintenanceKeys });
       }
     }
 
@@ -1029,3 +1035,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getProdConsSections, formatMaintenanceDetails };
+}

--- a/tests/noZeroMaintenanceDisplay.test.js
+++ b/tests/noZeroMaintenanceDisplay.test.js
@@ -1,0 +1,25 @@
+const { getProdConsSections } = (() => {
+  global.document = { addEventListener: () => {} };
+  return require('../src/js/structuresUI.js');
+})();
+
+describe('maintenance cost display', () => {
+  test('getProdConsSections excludes zero maintenance costs', () => {
+    const structure = {
+      requiresMaintenance: true,
+      maintenanceCost: { metal: 0, components: 5 },
+      getModifiedStorage: () => ({}),
+      powerPerBuilding: null,
+      active: 1,
+      productivity: 1,
+      name: 'testStruct',
+      getModifiedProduction: () => ({}),
+      getModifiedConsumption: () => ({})
+    };
+
+    const sections = getProdConsSections(structure);
+    const maintSection = sections.find(sec => sec.key === 'maintenance');
+    expect(maintSection.keys).toEqual(['colony.components']);
+    expect(maintSection.data).toEqual({ components: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- filter maintenance entries with zero cost so UI doesn't display them
- export utilities for testing and cover zero-cost maintenance case

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f35fbfcc483278beeb83e06733793