### PR TITLE
Add android storage to Ecumenopolis District

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - WGC shop offers a Superalloy production multiplier upgrade unlocked by Superalloys research, capped at 900 purchases, and increasing production by 100% per purchase.
 - Added a maintenanceMultiplier attribute for resources; superalloys use a multiplier of 0 and maintenance costs scale with each resource's multiplier.
 - Added placeholder Nanotechnology Stage I advanced research costing 125k.
+- Ecumenopolis District now provides 100M android storage.

--- a/src/js/colony-parameters.js
+++ b/src/js/colony-parameters.js
@@ -104,7 +104,7 @@ const colonyParameters = {
       cost: { colony: { metal: 50000000, water: 50000000, glass: 50000000, superalloys: 1000000 } },
       consumption: { colony: { energy: 25000000000, food: 1000000, electronics: 10000, androids: 100 } },
       production: { colony: { research: 1000000 } },
-      storage: { colony: { colonists: 10000000 } },
+      storage: { colony: { colonists: 10000000, androids: 100000000 } },
       baseComfort: 1,
       dayNightActivity: false,
       canBeToggled: true,

--- a/tests/ecumenopolisAndroidStorage.test.js
+++ b/tests/ecumenopolisAndroidStorage.test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Ecumenopolis District storage', () => {
+  test('provides 100M android storage', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colony-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.colonyParameters = colonyParameters;', ctx);
+    const params = ctx.colonyParameters;
+    const t7 = params.t7_colony;
+    expect(t7.storage.colony.androids).toBe(100000000);
+  });
+});


### PR DESCRIPTION
## Summary
- Expand Ecumenopolis District to store up to 100M androids
- Document new android storage capacity
- Cover Ecumenopolis android storage with dedicated test

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f3b300ee08327b891c08147869d4f