### PR TITLE
Adjust life targets for ecumenopolis districts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - WGC shop offers a Superalloy production multiplier upgrade unlocked by Superalloys research, capped at 900 purchases, and increasing production by 100% per purchase.
 - Added a maintenanceMultiplier attribute for resources; superalloys use a multiplier of 0 and maintenance costs scale with each resource's multiplier.
 - Added placeholder Nanotechnology Stage I advanced research costing 125k.
+- Ecumenopolis District coverage now reduces land available for life, lowers life terraforming requirements, and updates the life UI accordingly.

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
     <script src="src/js/day-night-setting.js"></script>
     <script src="src/js/advanced-research/self-replicating-ships.js"></script>
     <script src="src/js/advanced-research/hive-mind-androids.js"></script>
+    <script src="src/js/advanced-research/ecumenopolis.js"></script>
     <script src="src/js/resource.js"></script>
     <script src="src/js/resourceUI.js"></script>
     <script src="src/js/building.js"></script>

--- a/src/js/advanced-research/ecumenopolis.js
+++ b/src/js/advanced-research/ecumenopolis.js
@@ -1,0 +1,13 @@
+function getEcumenopolisLandFraction(terraforming) {
+  const eco = typeof colonies !== 'undefined' ? colonies?.t7_colony : globalThis.colonies?.t7_colony;
+  if (!eco || !terraforming?.initialLand) return 0;
+  return (eco.active * eco.requiresLand) / terraforming.initialLand;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getEcumenopolisLandFraction };
+}
+
+if (typeof window !== 'undefined') {
+  window.getEcumenopolisLandFraction = getEcumenopolisLandFraction;
+}

--- a/src/js/colony-parameters.js
+++ b/src/js/colony-parameters.js
@@ -100,7 +100,7 @@ const colonyParameters = {
     t7_colony: {
       name: 'Ecumenopolis District',
       category: 'Colony',
-      description: 'A planet-spanning city offering unparalleled comfort and capacity.',
+      description: 'A planet-spanning city offering unparalleled comfort and capacity. Reduces land for life growth and lowers life terraforming requirements.',
       cost: { colony: { metal: 50000000, water: 50000000, glass: 50000000, superalloys: 1000000 } },
       consumption: { colony: { energy: 25000000000, food: 1000000, electronics: 10000, androids: 100 } },
       production: { colony: { research: 1000000 } },

--- a/src/js/life.js
+++ b/src/js/life.js
@@ -16,6 +16,10 @@ const BASE_MAX_BIOMASS_DENSITY = 0.1; // Base max biomass in tons per m^2
 const RADIATION_TOLERANCE_THRESHOLD = 25; // Points needed for full mitigation
 const MINIMUM_BIOMASS_DECAY_RATE = 1; // Minimum decay in tons per second when conditions are lethal
 
+if (typeof module !== 'undefined' && module.exports) {
+  ({ getEcumenopolisLandFraction } = require('./advanced-research/ecumenopolis.js'));
+}
+
 class LifeAttribute {
   constructor(name, value, displayName, description, maxUpgrades) {
     this.name = name;
@@ -571,7 +575,8 @@ class LifeManager extends EffectableEntity {
           if (canGrowHere) {
               // --- Growth Calculation ---
               // Calculate land area and biomass capacity first
-              const zoneArea = terraforming.celestialParameters.surfaceArea * getZonePercentage(zoneName);
+              const landMultiplier = Math.max(0, 1 - getEcumenopolisLandFraction(terraforming));
+              const zoneArea = terraforming.celestialParameters.surfaceArea * getZonePercentage(zoneName) * landMultiplier;
               const liquidWaterCoverage = terraforming.zonalCoverageCache[zoneName]?.liquidWater ?? 0;
               const iceCoverage = terraforming.zonalCoverageCache[zoneName]?.ice ?? 0;
               // const availableLandArea = Math.max(0, zoneArea * (1 - liquidWaterCoverage - iceCoverage)); // Land area calculation no longer used for biomass limit

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -62,6 +62,18 @@ if (typeof module !== 'undefined' && module.exports) {
     }
 }
 
+var getEcumenopolisLandFraction;
+if (typeof module !== 'undefined' && module.exports) {
+    ({ getEcumenopolisLandFraction } = require('./advanced-research/ecumenopolis.js'));
+} else {
+    getEcumenopolisLandFraction = globalThis.getEcumenopolisLandFraction;
+}
+
+function getEffectiveLifeFraction(terraforming) {
+    const fraction = getEcumenopolisLandFraction(terraforming);
+    return Math.max(0, (terraforming.life?.target || 0) - fraction);
+}
+
 const SOLAR_PANEL_BASE_LUMINOSITY = 1000;
 const BASE_COMFORTABLE_TEMPERATURE = 295.15;
 const KPA_PER_ATM = 101.325;
@@ -92,6 +104,7 @@ class Terraforming extends EffectableEntity{
     super({ description: 'This module manages all terraforming compononents' });
 
     this.resources = resources;
+    this.initialLand = resources.surface?.land?.value || 0;
 
     // Clone so config values remain immutable
     this.celestialParameters = structuredClone(celestialParameters);
@@ -321,7 +334,7 @@ class Terraforming extends EffectableEntity{
 
   getLifeStatus() {
      // Compare average biomass coverage to the global target
-    return (calculateAverageCoverage(this, 'biomass') > this.life.target);
+    return (calculateAverageCoverage(this, 'biomass') > getEffectiveLifeFraction(this));
   }
 
   getTerraformingStatus() {
@@ -1700,6 +1713,7 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports = Terraforming;
   module.exports.setStarLuminosity = setStarLuminosity;
   module.exports.getStarLuminosity = getStarLuminosity;
+  module.exports.getEffectiveLifeFraction = getEffectiveLifeFraction;
 } else {
   globalThis.setStarLuminosity = setStarLuminosity;
   globalThis.getStarLuminosity = getStarLuminosity;

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -581,14 +581,15 @@ function updateLifeBox() {
     // Calculate average biomass coverage percentage using the centralized helper function
     const avgBiomassCoverage = calculateAverageCoverage(terraforming, 'biomass');
 
-    // Update border based on average biomass coverage vs target
-    // TODO: The getLifeStatus function itself needs updating in terraforming.js
-    //       to use the new avgBiomassCoverage calculation. For now, we replicate the check.
-    if (avgBiomassCoverage > terraforming.life.target) {
+    const effectiveTarget = getEffectiveLifeFraction(terraforming);
+    if (avgBiomassCoverage > effectiveTarget) {
         lifeBox.style.borderColor = 'green';
     } else {
         lifeBox.style.borderColor = 'red';
     }
+
+    const targetSpan = lifeBox.querySelector('.terraforming-target');
+    if (targetSpan) targetSpan.textContent = `Target : Life coverage above ${(effectiveTarget * 100).toFixed(0)}%.`;
 
     // Calculate zonal coverage percentages
     const polarCov = terraforming.zonalCoverageCache['polar']?.biomass ?? 0;

--- a/tests/ecumenopolisLifeTarget.test.js
+++ b/tests/ecumenopolisLifeTarget.test.js
@@ -1,0 +1,41 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = {};
+const Terraforming = require('../src/js/terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+Terraforming.prototype.updateSurfaceRadiation = function(){};
+const { getEcumenopolisLandFraction } = require('../src/js/advanced-research/ecumenopolis.js');
+const { getEffectiveLifeFraction } = require('../src/js/terraforming.js');
+
+describe('Ecumenopolis land effect on life target', () => {
+  test('life target scales with ecumenopolis coverage', () => {
+    global.resources = {
+      surface: { land: { value: 1000000 } },
+      atmospheric: {},
+      special: { albedoUpgrades: { value: 0 } }
+    };
+    global.buildings = {};
+    global.colonies = { t7_colony: { active: 0, requiresLand: 100000 } };
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, { distanceFromSun: 1, radius: 1, gravity: 1, albedo: 0 });
+
+    expect(getEcumenopolisLandFraction(tf)).toBe(0);
+    expect(getEffectiveLifeFraction(tf)).toBeCloseTo(0.5);
+
+    global.colonies.t7_colony.active = 2; // 20% coverage
+    expect(getEcumenopolisLandFraction(tf)).toBeCloseTo(0.2);
+    expect(getEffectiveLifeFraction(tf)).toBeCloseTo(0.3);
+
+    global.colonies.t7_colony.active = 5; // 50% coverage
+    expect(getEcumenopolisLandFraction(tf)).toBeCloseTo(0.5);
+    expect(getEffectiveLifeFraction(tf)).toBe(0);
+  });
+});

--- a/tests/geologicalBurialCO2.test.js
+++ b/tests/geologicalBurialCO2.test.js
@@ -14,6 +14,7 @@ describe('geological burial slows when CO2 depleted', () => {
     ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
     ctx.getZonePercentage = () => 1;
     ctx.calculateZonalCoverage = () => 0;
+    ctx.getEcumenopolisLandFraction = () => 0;
     ctx.terraforming = {
       zonalCoverageCache: {
         tropical: { liquidWater: 0.1, ice: 0 },
@@ -37,7 +38,9 @@ describe('geological burial slows when CO2 depleted', () => {
       },
       getMagnetosphereStatus: () => true,
       celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 },
-      calculateZonalSolarPanelMultiplier: () => 1
+      calculateZonalSolarPanelMultiplier: () => 1,
+      getEcumenopolisLandFraction: () => 0,
+      getEffectiveLifeFraction: () => 0.5
     };
     ctx.resources = {
       surface: { biomass: { value: 0, modifyRate: jest.fn() } },

--- a/tests/lifeCoverageTable.test.js
+++ b/tests/lifeCoverageTable.test.js
@@ -34,6 +34,7 @@ describe('life coverage table', () => {
       celestialParameters: { surfaceArea: 1 },
       calculateZonalSolarPanelMultiplier: () => 1
     };
+    ctx.getEffectiveLifeFraction = () => 0.5;
     ctx.projectManager = { isBooleanFlagSet: () => false };
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');

--- a/tests/lifeLuminosityTable.test.js
+++ b/tests/lifeLuminosityTable.test.js
@@ -33,6 +33,7 @@ describe('life luminosity table', () => {
       }
     };
     ctx.projectManager = { isBooleanFlagSet: () => false };
+    ctx.getEffectiveLifeFraction = () => 0.5;
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');
     vm.runInContext(code, ctx);


### PR DESCRIPTION
## Summary
- Move Ecumenopolis land coverage helper into its own module
- Keep effective life target calculation in `terraforming.js`
- Update UI and tests to use `getEffectiveLifeFraction`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f3c3943988327886f17d27a1ae41f