### PR TITLE
Scale colony upgrade button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Ecumenopolis District coverage now reduces land available for life, lowers life terraforming requirements, and updates the life UI accordingly.
 - Ecumenopolis District now provides 100M android storage.
 - Colonies can upgrade to the Ecumenopolis District via the upgrade button and require full superalloy cost.
+- Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.

--- a/tests/colonyUpgrade.test.js
+++ b/tests/colonyUpgrade.test.js
@@ -124,7 +124,7 @@ describe('colony upgrade', () => {
     expect(ctx.resources.surface.land.reserved).toBe(0);
   });
 
-  test('upgrade scales costs when fewer than ten buildings', () => {
+  test('upgrade requires at least ten buildings', () => {
     const { dom, ctx } = setupContext('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
     const t1 = ctx.colonies.t1_colony;
     const t2 = ctx.colonies.t2_colony;
@@ -139,15 +139,15 @@ describe('colony upgrade', () => {
     ctx.updateStructureDisplay(ctx.colonies);
 
     const button = dom.window.document.getElementById('t1_colony-upgrade-button');
-    expect(button.disabled).toBe(false);
+    expect(button.disabled).toBe(true);
     button.click();
 
-    expect(t1.count).toBe(0);
-    expect(t2.count).toBe(1);
-    expect(ctx.resources.colony.metal.value).toBeCloseTo(0);
-    expect(ctx.resources.colony.glass.value).toBeCloseTo(0);
-    expect(ctx.resources.colony.water.value).toBeCloseTo(0);
-    expect(ctx.resources.surface.land.reserved).toBe(9);
+    expect(t1.count).toBe(1);
+    expect(t2.count).toBe(0);
+    expect(ctx.resources.colony.metal.value).toBe(237.5);
+    expect(ctx.resources.colony.glass.value).toBe(237.5);
+    expect(ctx.resources.colony.water.value).toBe(450);
+    expect(ctx.resources.surface.land.reserved).toBe(0);
   });
 
   test('upgrade button colors unaffordable cost parts red', () => {

--- a/tests/ecumenopolisUpgrade.test.js
+++ b/tests/ecumenopolisUpgrade.test.js
@@ -129,5 +129,36 @@ describe('Ecumenopolis upgrade', () => {
     expect(t7.count).toBe(1);
     expect(ctx.resources.colony.superalloys.value).toBe(0);
   });
+
+  test('Metropolis upgrades multiple districts based on build count', () => {
+    const { dom, ctx } = setupContext();
+    const t6 = ctx.colonies.t6_colony;
+    const t7 = ctx.colonies.t7_colony;
+    t6.unlocked = true;
+    t7.unlocked = true;
+    t6.count = t6.active = 20;
+
+    ctx.resources.colony.metal.value = 50000000;
+    ctx.resources.colony.glass.value = 50000000;
+    ctx.resources.colony.superalloys.value = 2000000;
+
+    ctx.createColonyButtons(ctx.colonies);
+    vm.runInContext("selectedBuildCounts['t6_colony'] = 2;", ctx);
+    ctx.updateStructureDisplay(ctx.colonies);
+
+    const button = dom.window.document.getElementById('t6_colony-upgrade-button');
+    expect(button.disabled).toBe(false);
+
+    const cost = t6.getUpgradeCost(2);
+    expect(cost.colony.superalloys).toBe(2000000);
+
+    button.click();
+
+    expect(t6.count).toBe(0);
+    expect(t7.count).toBe(2);
+    expect(ctx.resources.colony.superalloys.value).toBe(0);
+    expect(ctx.resources.colony.metal.value).toBe(0);
+    expect(ctx.resources.colony.glass.value).toBe(0);
+  });
 });
 


### PR DESCRIPTION
## Summary
- scale colony upgrades by selected build count with minimum 10
- show upgrade button as `10 → 1` by default and adjust cost/effect accordingly
- document colony upgrade scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f46fb88448327a1043215579fe182