### PR TITLE
Only wait for single ship capacity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Ecumenopolis District coverage now reduces land available for life, lowers life terraforming requirements, and updates the life UI accordingly.
 - Ecumenopolis District now provides 100M android storage.
 - Colonies can upgrade to the Ecumenopolis District via the upgrade button and require full superalloy cost.
+- The "Wait for full capacity" option only requires resources to fill a single ship.

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -400,11 +400,12 @@ class SpaceshipProject extends Project {
 
       if (this.attributes.spaceExport && this.selectedDisposalResource) {
         const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
-        const disposalPerTick = (this.attributes.disposalAmount || 0) * this.assignedSpaceships * efficiency * factor;
+        const shipCount = this.waitForCapacity ? 1 : this.assignedSpaceships;
+        const disposalPerTick = (this.attributes.disposalAmount || 0) * shipCount * efficiency * factor;
         const { category, resource } = this.selectedDisposalResource;
         let required = disposalPerTick;
         if (this.waitForCapacity) {
-          required += (totalSpaceshipCost[category]?.[resource] || 0) * this.assignedSpaceships * factor +
+          required += (totalSpaceshipCost[category]?.[resource] || 0) * factor +
             (cost[category]?.[resource] || 0);
         }
         if (resources[category][resource].value < required) {


### PR DESCRIPTION
## Summary
- Ensure the "Wait for full capacity" option requires resources for just one ship, even in continuous projects
- Test continuous export projects only needing one ship filled when waiting for capacity
- Document the new behavior in AGENTS.md

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f490793d88327aa6e97d279e94227