### PR TITLE
Route continuous project resources through accumulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - The "Wait for full capacity" option only requires resources to fill a single ship.
 - Self-replicating ship cap counts ships assigned to projects.
 - Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.
+- Continuous spaceship and Dyson Swarm projects apply resource changes through resource.js accumulatedChanges.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -511,10 +511,6 @@ class ProjectManager extends EffectableEntity {
       // Always update so subclasses can run logic after completion
       project.update(deltaTime);
 
-      if (typeof project.applyCostAndGain === 'function') {
-        project.applyCostAndGain(deltaTime);
-      }
-
       if (
         this.isBooleanFlagSet('automateSpecialProjects') &&
         project.autoStart &&
@@ -529,6 +525,15 @@ class ProjectManager extends EffectableEntity {
         } else {
           this.startProject(project.name);
         }
+      }
+    }
+  }
+
+  applyCostAndGain(deltaTime = 1000, accumulatedChanges) {
+    for (const projectName in this.projects) {
+      const project = this.projects[projectName];
+      if (typeof project.applyCostAndGain === 'function') {
+        project.applyCostAndGain(deltaTime, accumulatedChanges);
       }
     }
   }

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -123,11 +123,15 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
     }
   }
 
-  applyCostAndGain(deltaTime = 1000) {
+  applyCostAndGain(deltaTime = 1000, accumulatedChanges) {
     if (this.isCompleted && this.collectors > 0) {
       const rate = this.collectors * this.energyPerCollector;
       const energyGain = rate * (deltaTime / 1000);
-      resources.colony.energy.increase(energyGain);
+      if (accumulatedChanges) {
+        accumulatedChanges.colony.energy += energyGain;
+      } else {
+        resources.colony.energy.increase(energyGain);
+      }
     }
   }
 

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -378,6 +378,9 @@ function produceResources(deltaTime, buildings) {
 
   if(projectManager){
     projectManager.estimateProjects(deltaTime);
+    if (typeof projectManager.applyCostAndGain === 'function') {
+      projectManager.applyCostAndGain(deltaTime, accumulatedChanges);
+    }
   }
 
   // Apply accumulated changes to resources

--- a/tests/dysonSwarmEnergyProduction.test.js
+++ b/tests/dysonSwarmEnergyProduction.test.js
@@ -43,7 +43,9 @@ describe('Dyson Swarm energy production', () => {
     project.energyPerCollector = 50;
 
     project.estimateCostAndGain();
-    project.applyCostAndGain(1000);
+    const changes = { colony: { energy: 0 } };
+    project.applyCostAndGain(1000, changes);
+    ctx.resources.colony.energy.value += changes.colony.energy;
 
     expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalledWith(150, 'Dyson Swarm', 'project');
     expect(ctx.resources.colony.energy.value).toBe(150);

--- a/tests/spaceMiningPressureLimit.test.js
+++ b/tests/spaceMiningPressureLimit.test.js
@@ -14,6 +14,27 @@ function stubResource(value) {
   };
 }
 
+function createChanges(resources) {
+  const changes = {};
+  for (const category in resources) {
+    changes[category] = {};
+    for (const resource in resources[category]) {
+      changes[category][resource] = 0;
+    }
+  }
+  return changes;
+}
+
+function applyChanges(resources, changes) {
+  for (const category in changes) {
+    for (const resource in changes[category]) {
+      if (resources[category]?.[resource]) {
+        resources[category][resource].value += changes[category][resource];
+      }
+    }
+  }
+}
+
 describe('SpaceMiningProject pressure limit capping', () => {
   let ctx;
   beforeEach(() => {
@@ -79,7 +100,9 @@ describe('SpaceMiningProject pressure limit capping', () => {
     project.start(ctx.resources);
     const duration = project.getEffectiveDuration();
     project.update(duration);
-    project.applyCostAndGain(duration);
+    const changes = createChanges(ctx.resources);
+    project.applyCostAndGain(duration, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.atmospheric.inertGas.value).toBeCloseTo(massLimit);
   });
 });

--- a/tests/spaceProjectAutomation.test.js
+++ b/tests/spaceProjectAutomation.test.js
@@ -13,6 +13,27 @@ function stubResource(value) {
   };
 }
 
+function createChanges(resources) {
+  const changes = {};
+  for (const category in resources) {
+    changes[category] = {};
+    for (const resource in resources[category]) {
+      changes[category][resource] = 0;
+    }
+  }
+  return changes;
+}
+
+function applyChanges(resources, changes) {
+  for (const category in changes) {
+    for (const resource in changes[category]) {
+      if (resources[category]?.[resource]) {
+        resources[category][resource].value += changes[category][resource];
+      }
+    }
+  }
+}
+
 describe('continuous spaceship project automation', () => {
   let ctx;
   beforeEach(() => {
@@ -77,11 +98,15 @@ describe('continuous spaceship project automation', () => {
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
     project.update(1000);
-    project.applyCostAndGain(1000);
+    let changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.metal.value).toBeGreaterThan(0);
     ctx.resources.atmospheric.carbonDioxide.value = 7; // exceed threshold
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(project.isActive).toBe(false);
     const metalAfterStop = ctx.resources.colony.metal.value;
     ctx.resources.atmospheric.carbonDioxide.value = 5; // below threshold
@@ -89,7 +114,9 @@ describe('continuous spaceship project automation', () => {
       project.start(ctx.resources);
     }
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.metal.value).toBeGreaterThan(metalAfterStop);
   });
 
@@ -120,11 +147,15 @@ describe('continuous spaceship project automation', () => {
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.atmospheric.greenhouseGas.value).toBeLessThan(10000);
     ctx.terraforming.temperature.value = 300; // below threshold
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(project.isActive).toBe(false);
     const ghgAfterStop = ctx.resources.atmospheric.greenhouseGas.value;
     ctx.terraforming.temperature.value = 400; // above threshold
@@ -132,7 +163,9 @@ describe('continuous spaceship project automation', () => {
       project.start(ctx.resources);
     }
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.atmospheric.greenhouseGas.value).toBeLessThan(ghgAfterStop);
   });
 });

--- a/tests/spaceshipProjectContinuous.test.js
+++ b/tests/spaceshipProjectContinuous.test.js
@@ -13,6 +13,27 @@ function stubResource(value) {
   };
 }
 
+function createChanges(resources) {
+  const changes = {};
+  for (const category in resources) {
+    changes[category] = {};
+    for (const resource in resources[category]) {
+      changes[category][resource] = 0;
+    }
+  }
+  return changes;
+}
+
+function applyChanges(resources, changes) {
+  for (const category in changes) {
+    for (const resource in changes[category]) {
+      if (resources[category]?.[resource]) {
+        resources[category][resource].value += changes[category][resource];
+      }
+    }
+  }
+}
+
 describe('SpaceshipProject continuous cost and gain', () => {
   test('applies proportional cost and gain over time when more than 100 ships', () => {
     const ctx = { console, EffectableEntity, shipEfficiency: 1 };
@@ -52,7 +73,9 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.start(ctx.resources);
     const duration = project.getEffectiveDuration();
     project.update(duration / 2);
-    project.applyCostAndGain(duration / 2);
+    const changes = createChanges(ctx.resources);
+    project.applyCostAndGain(duration / 2, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.energy.value).toBeCloseTo(495);
     expect(ctx.resources.colony.metal.value).toBeCloseTo(1010);
   });
@@ -96,10 +119,15 @@ describe('SpaceshipProject continuous cost and gain', () => {
     const duration = project.getEffectiveDuration();
     expect(ctx.resources.colony.energy.value).toBeCloseTo(990);
     project.update(duration / 2);
-    project.applyCostAndGain(duration / 2);
+    let changes = createChanges(ctx.resources);
+    project.applyCostAndGain(duration / 2, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.energy.value).toBeCloseTo(990);
     expect(ctx.resources.colony.metal.value).toBeCloseTo(0);
     project.update(duration / 2);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(duration / 2, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.metal.value).toBeCloseTo(20);
   });
 


### PR DESCRIPTION
## Summary
- Move continuous project resource flow into `resource.js` using accumulatedChanges for safe application
- Add `applyCostAndGain` hook in `ProjectManager` and update Spaceship/Dyson Swarm projects to modify accumulatedChanges
- Update tests for new resource handling of continuous projects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f530a39448327bdccd4165f5ef235