### PR TITLE
Allow colony upgrades below ten

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - The "Wait for full capacity" option only requires resources to fill a single ship.
 - Self-replicating ship cap counts ships assigned to projects.
 - Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.
+- Colony upgrades can be performed with fewer than ten buildings remaining, charging full cost for the final upgrade.

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -252,6 +252,7 @@ class Colony extends Building {
     const nextCost = next.getEffectiveCost(1);
     const cost = {};
     const amount = upgradeCount * 10;
+    const removeCount = Math.min(amount, this.count);
 
     for (const category in nextCost) {
       for (const resource in nextCost[category]) {
@@ -269,7 +270,7 @@ class Colony extends Building {
       }
     }
 
-    const landNeeded = upgradeCount * next.requiresLand - amount * (this.requiresLand || 0);
+    const landNeeded = upgradeCount * next.requiresLand - removeCount * (this.requiresLand || 0);
     if (landNeeded > 0) {
       if (!cost.surface) cost.surface = {};
       cost.surface.land = landNeeded;
@@ -279,8 +280,8 @@ class Colony extends Building {
   }
 
   canAffordUpgrade(upgradeCount = 1) {
-    const amount = upgradeCount * 10;
-    if (this.count < amount) return false;
+    const maxUpgrades = Math.ceil(this.count / 10);
+    if (maxUpgrades === 0 || upgradeCount > maxUpgrades) return false;
     const cost = this.getUpgradeCost(upgradeCount);
     if (!cost) return false;
     for (const category in cost) {
@@ -306,6 +307,7 @@ class Colony extends Building {
     if (!this.canAffordUpgrade(upgradeCount)) return false;
     const cost = this.getUpgradeCost(upgradeCount);
     const amount = upgradeCount * 10;
+    const removeCount = Math.min(amount, this.count);
 
     // Pay cost
     for (const category in cost) {
@@ -316,12 +318,12 @@ class Colony extends Building {
     }
 
     // Adjust land usage
-    if (this.requiresLand) this.adjustLand(-amount);
+    if (this.requiresLand) this.adjustLand(-removeCount);
     if (next.requiresLand) next.adjustLand(upgradeCount);
 
     // Remove lower tier buildings
-    this.count -= amount;
-    this.active -= amount;
+    this.count -= removeCount;
+    this.active -= removeCount;
     this.updateResourceStorage();
 
     // Add upgraded building

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -488,7 +488,7 @@ function updateDecreaseButtonText(button, buildCount) {
     }
 
     const upgradeCount = Math.max(1, selectedBuildCounts[colony.name] || 1);
-    const amount = upgradeCount * 10;
+    const amount = Math.min(upgradeCount * 10, colony.count);
     const cost = colony.getUpgradeCost(upgradeCount);
     if (!cost) {
       button.style.display = 'none';

--- a/tests/colonyUpgrade.test.js
+++ b/tests/colonyUpgrade.test.js
@@ -124,30 +124,28 @@ describe('colony upgrade', () => {
     expect(ctx.resources.surface.land.reserved).toBe(0);
   });
 
-  test('upgrade requires at least ten buildings', () => {
+  test('upgrade works with fewer than ten buildings at full cost', () => {
     const { dom, ctx } = setupContext('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
     const t1 = ctx.colonies.t1_colony;
     const t2 = ctx.colonies.t2_colony;
     t1.unlocked = true;
     t2.unlocked = true;
-    t1.count = t1.active = 1;
-    ctx.resources.colony.metal.value = 237.5;
-    ctx.resources.colony.glass.value = 237.5;
-    ctx.resources.colony.water.value = 450;
+    t1.count = t1.active = 8;
+    ctx.resources.colony.metal.value = 125;
+    ctx.resources.colony.glass.value = 125;
 
     ctx.createColonyButtons(ctx.colonies);
     ctx.updateStructureDisplay(ctx.colonies);
 
     const button = dom.window.document.getElementById('t1_colony-upgrade-button');
-    expect(button.disabled).toBe(true);
+    expect(button.disabled).toBe(false);
     button.click();
 
-    expect(t1.count).toBe(1);
-    expect(t2.count).toBe(0);
-    expect(ctx.resources.colony.metal.value).toBe(237.5);
-    expect(ctx.resources.colony.glass.value).toBe(237.5);
-    expect(ctx.resources.colony.water.value).toBe(450);
-    expect(ctx.resources.surface.land.reserved).toBe(0);
+    expect(t1.count).toBe(0);
+    expect(t2.count).toBe(1);
+    expect(ctx.resources.colony.metal.value).toBe(0);
+    expect(ctx.resources.colony.glass.value).toBe(0);
+    expect(ctx.resources.surface.land.reserved).toBe(2);
   });
 
   test('upgrade button colors unaffordable cost parts red', () => {


### PR DESCRIPTION
## Summary
- permit colony upgrades when fewer than ten buildings remain
- adjust upgrade UI to show actual converted buildings
- add test for upgrading partial colonies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f6c4dc044832786a911d72e06751c