### PR TITLE
Rename auto-start to Run for continuous spaceship projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - The "Wait for full capacity" option only requires resources to fill a single ship.
 - Self-replicating ship cap counts ships assigned to projects.
 - Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.
+- Auto start checkbox shows 'Run' when spaceship projects enter continuous mode and reverts when they return to discrete operation.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -257,6 +257,14 @@ function updateSpaceStorageUI(project) {
     els.shipAutoStartContainer.style.display = display;
     els.prioritizeMegaContainer.style.display = display;
   }
+  if (els.shipAutoStartContainer) {
+    const label = els.shipAutoStartContainer.querySelector('label');
+    if (label) {
+      label.textContent = project.isShipOperationContinuous()
+        ? 'Run'
+        : 'Auto Start Ships';
+    }
+  }
   if (els.usedDisplay) {
     els.usedDisplay.textContent = formatNumber(project.usedStorage, false, 0);
   }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -251,6 +251,7 @@ function createProjectItem(project) {
     progressButton: progressButton,
     autoStartCheckbox: autoStartCheckbox,
     autoStartCheckboxContainer: autoStartCheckboxContainer,
+    autoStartLabel: autoStartLabel,
     automationSettingsContainer: automationSettingsContainer,
     cardFooter: cardFooter,
     upButton: upButton,
@@ -455,6 +456,15 @@ function updateProjectUI(projectName) {
   // Set the auto-start checkbox state based on the project data
   if (elements.autoStartCheckbox) {
     elements.autoStartCheckbox.checked = project.autoStart || false;
+  }
+  if (
+    elements.autoStartLabel &&
+    typeof SpaceshipProject !== 'undefined' &&
+    project instanceof SpaceshipProject
+  ) {
+    elements.autoStartLabel.textContent = project.isContinuous()
+      ? 'Run'
+      : 'Auto start';
   }
 
 

--- a/tests/spaceshipProjectAutoStartLabel.test.js
+++ b/tests/spaceshipProjectAutoStartLabel.test.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceshipProject auto-start label', () => {
+  test('renames to Run in continuous mode and reverts otherwise', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper">
+        <div id="resources-projects-list" class="projects-list"></div>
+      </div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = () => '';
+    ctx.formatBigInteger = () => '';
+    ctx.projectElements = {};
+    ctx.resources = { colony: {}, special: {} };
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+
+    class DummySpaceshipProject extends ctx.Project {
+      constructor(config, name) {
+        super(config, name);
+        this.continuous = false;
+      }
+      isContinuous() { return this.continuous; }
+    }
+    ctx.SpaceshipProject = DummySpaceshipProject;
+
+    const config = {
+      name: 'test',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: {}
+    };
+    const project = new ctx.SpaceshipProject(config, 'test');
+
+    ctx.projectManager = {
+      projects: { test: project },
+      isBooleanFlagSet: () => true,
+      getProjectStatuses: () => [project]
+    };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.continuous = true;
+    ctx.updateProjectUI('test');
+    let label = ctx.projectElements.test.autoStartCheckboxContainer.querySelector('label');
+    expect(label.textContent).toBe('Run');
+
+    project.continuous = false;
+    ctx.updateProjectUI('test');
+    label = ctx.projectElements.test.autoStartCheckboxContainer.querySelector('label');
+    expect(label.textContent).toBe('Auto start');
+  });
+});


### PR DESCRIPTION
## Summary
- Label auto-start checkboxes as **Run** when spaceship projects enter continuous mode
- Extend Space Storage ship auto-start to display **Run** in continuous mode
- Test auto-start label transitions for continuous spaceship operations

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f6d2dc1a483279cae1ccd162d9171