### PR TITLE
Show 'Stopped' when continuous projects disabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - The "Wait for full capacity" option only requires resources to fill a single ship.
 - Self-replicating ship cap counts ships assigned to projects.
 - Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.
+- Continuous projects display "Stopped" when their auto-start checkbox is disabled.

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -519,7 +519,7 @@ function updateProjectUI(projectName) {
       // Update the duration in the progress bar display
       if (elements.progressButton) {
         if (typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject && project.isContinuous()) {
-          if (project.isActive && !project.isPaused) {
+          if (project.autoStart && project.isActive && !project.isPaused) {
             elements.progressButton.textContent = 'Continuous';
             elements.progressButton.style.background = '#4caf50';
           } else {

--- a/tests/spaceshipProjectContinuousUI.test.js
+++ b/tests/spaceshipProjectContinuousUI.test.js
@@ -56,13 +56,15 @@ describe('SpaceshipProject continuous progress UI', () => {
     ctx.createProjectItem(project);
     ctx.projectElements = vm.runInContext('projectElements', ctx);
 
+    project.autoStart = true;
     project.isActive = true;
     ctx.updateProjectUI('test');
     let btn = ctx.projectElements.test.progressButton;
     expect(btn.textContent).toBe('Continuous');
     expect(btn.style.background).toBe('rgb(76, 175, 80)');
 
-    project.isActive = false;
+    project.autoStart = false;
+    project.isActive = true;
     ctx.updateProjectUI('test');
     btn = ctx.projectElements.test.progressButton;
     expect(btn.textContent).toBe('Stopped');


### PR DESCRIPTION
## Summary
- Show "Stopped" when a continuous spaceship project's auto-start checkbox is unchecked
- Cover checkbox behavior in tests
- Document change in AGENTS

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f6d698af8832796a444a6e4623eab