### PR TITLE
Route continuous project resources through accumulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - The "Wait for full capacity" option only requires resources to fill a single ship.
 - Self-replicating ship cap counts ships assigned to projects.
 - Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.
+- Continuous spaceship and Dyson Swarm projects apply resource changes through resource.js accumulatedChanges.
+- Continuous spaceship projects start without stored energy and scale resource flow to available amounts.
+- Project productivity now calculates per-project efficiency based on the worst resource ratio, so projects without costs (like the Dyson Swarm) run at full output even when others are limited.
+- Project resource rates in tooltips now reflect productivity-adjusted values.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -308,8 +308,8 @@ class CargoRocketProject extends Project {
     }
   }
 
-  estimateCostAndGain() {
-    this.estimateProjectCostAndGain();
+  estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
+    this.estimateProjectCostAndGain(deltaTime, applyRates, productivity);
   }
 }
 

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -535,13 +535,15 @@ class PlanetaryThrustersProject extends Project{
     }
   }
 
-  estimateCostAndGain(){
-    if(!this.isCompleted) return;
-    if((!this.spinInvest && !this.motionInvest) || this.power<=0) return;
-    if(resources && resources.colony && resources.colony.energy &&
-       typeof resources.colony.energy.modifyRate === 'function'){
-      resources.colony.energy.modifyRate(-this.power, 'Planetary Thrusters', 'project');
+  estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1){
+    const totals = { cost: {}, gain: {} };
+    if(!this.isCompleted) return totals;
+    if((!this.spinInvest && !this.motionInvest) || this.power<=0) return totals;
+    if (applyRates && resources?.colony?.energy && typeof resources.colony.energy.modifyRate === 'function') {
+      resources.colony.energy.modifyRate(-this.power * productivity, 'Planetary Thrusters', 'project');
     }
+    totals.cost.colony = { energy: this.power * (deltaTime / 1000) };
+    return totals;
   }
 
   saveState(){

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -192,7 +192,7 @@ class SpaceMiningProject extends SpaceshipProject {
     return super.calculateSpaceshipTotalResourceGain(perSecond);
   }
 
-  applySpaceshipResourceGain(gain, fraction) {
+  applySpaceshipResourceGain(gain, fraction, accumulatedChanges = null, productivity = 1) {
     if (this.attributes.dynamicWaterImport && gain.surface) {
       const entry = gain.surface;
       const resource = Object.keys(entry)[0];
@@ -247,7 +247,7 @@ class SpaceMiningProject extends SpaceshipProject {
         }
       }
     }
-    super.applySpaceshipResourceGain(gain, fraction);
+    super.applySpaceshipResourceGain(gain, fraction, accumulatedChanges, productivity);
   }
 }
 

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -116,18 +116,27 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
     }
   }
 
-  estimateCostAndGain(deltaTime = 1000) {
+  estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
+    const totals = { cost: {}, gain: {} };
     if (this.isCompleted && this.collectors > 0) {
       const rate = this.collectors * this.energyPerCollector;
-      resources.colony.energy.modifyRate(rate, 'Dyson Swarm', 'project');
+      if (applyRates && resources.colony?.energy?.modifyRate) {
+        resources.colony.energy.modifyRate(rate * productivity, 'Dyson Swarm', 'project');
+      }
+      totals.gain.colony = { energy: rate * (deltaTime / 1000) };
     }
+    return totals;
   }
 
-  applyCostAndGain(deltaTime = 1000) {
+  applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
     if (this.isCompleted && this.collectors > 0) {
       const rate = this.collectors * this.energyPerCollector;
-      const energyGain = rate * (deltaTime / 1000);
-      resources.colony.energy.increase(energyGain);
+      const energyGain = rate * (deltaTime / 1000) * productivity;
+      if (accumulatedChanges) {
+        accumulatedChanges.colony.energy += energyGain;
+      } else if (resources.colony?.energy) {
+        resources.colony.energy.increase(energyGain);
+      }
     }
   }
 

--- a/tests/dysonSwarmEnergyProduction.test.js
+++ b/tests/dysonSwarmEnergyProduction.test.js
@@ -43,7 +43,9 @@ describe('Dyson Swarm energy production', () => {
     project.energyPerCollector = 50;
 
     project.estimateCostAndGain();
-    project.applyCostAndGain(1000);
+    const changes = { colony: { energy: 0 } };
+    project.applyCostAndGain(1000, changes);
+    ctx.resources.colony.energy.value += changes.colony.energy;
 
     expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalledWith(150, 'Dyson Swarm', 'project');
     expect(ctx.resources.colony.energy.value).toBe(150);

--- a/tests/projectProductivityScaling.test.js
+++ b/tests/projectProductivityScaling.test.js
@@ -1,0 +1,33 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { calculateProjectProductivity } = require('../src/js/resource.js');
+
+describe('project productivity', () => {
+  test('uses worst ratio and leaves cost-free projects unaffected', () => {
+    const resources = {
+      colony: {
+        energy: { value: 100 },
+        metal: { value: 50 }
+      }
+    };
+    const changes = { colony: { energy: 10, metal: 0 } };
+
+    const costA = { colony: { energy: 200, metal: 30 } };
+    const gainA = { colony: { metal: 10 } };
+    const prodA = calculateProjectProductivity(resources, changes, costA, gainA);
+    expect(prodA).toBeCloseTo(110 / 200);
+    changes.colony.energy -= costA.colony.energy * prodA;
+    changes.colony.metal -= costA.colony.metal * prodA;
+    changes.colony.metal += gainA.colony.metal * prodA;
+
+    const gainB = { colony: { energy: 10 } };
+    const prodB = calculateProjectProductivity(resources, changes, {}, gainB);
+    expect(prodB).toBe(1);
+    changes.colony.energy += gainB.colony.energy * prodB;
+
+    const finalEnergy = resources.colony.energy.value + changes.colony.energy;
+    const finalMetal = resources.colony.metal.value + changes.colony.metal;
+    expect(finalEnergy).toBeCloseTo(10);
+    expect(finalMetal).toBeCloseTo(39);
+  });
+});

--- a/tests/projectRateProductivityDisplay.test.js
+++ b/tests/projectRateProductivityDisplay.test.js
@@ -1,0 +1,52 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Resource, produceResources } = require('../src/js/resource.js');
+
+describe('project rates reflect productivity', () => {
+  test('resource tooltip rates scale with project productivity', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 100 });
+    const metal = new Resource({ name: 'metal', category: 'colony', initialValue: 0 });
+
+    global.resources = { colony: { energy, metal } };
+    global.structures = {};
+    global.dayNightCycle = { isDay: () => true };
+    global.fundingModule = null;
+    global.terraforming = null;
+    global.lifeManager = null;
+    global.researchManager = null;
+    global.updateShipReplication = null;
+    global.updateAndroidResearch = null;
+    global.globalEffects = {};
+
+    class DummyProject {
+      constructor() {
+        this.displayName = 'Dummy';
+        this.isActive = true;
+        this.isCompleted = false;
+      }
+      estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
+        const cost = { colony: { energy: 200 } };
+        const gain = { colony: { metal: 10 } };
+        if (applyRates) {
+          resources.colony.energy.modifyRate(-200 * productivity, this.displayName, 'project');
+          resources.colony.metal.modifyRate(10 * productivity, this.displayName, 'project');
+        }
+        return { cost, gain };
+      }
+      applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
+        accumulatedChanges.colony.energy -= 200 * productivity;
+        accumulatedChanges.colony.metal += 10 * productivity;
+      }
+    }
+
+    const project = new DummyProject();
+    global.projectManager = { projectOrder: ['dummy'], projects: { dummy: project } };
+
+    produceResources(1000, {});
+
+    expect(energy.value).toBeCloseTo(0);
+    expect(metal.value).toBeCloseTo(5);
+    expect(energy.consumptionRate).toBeCloseTo(100);
+    expect(metal.productionRate).toBeCloseTo(5);
+  });
+});

--- a/tests/spaceMiningPressureLimit.test.js
+++ b/tests/spaceMiningPressureLimit.test.js
@@ -14,6 +14,27 @@ function stubResource(value) {
   };
 }
 
+function createChanges(resources) {
+  const changes = {};
+  for (const category in resources) {
+    changes[category] = {};
+    for (const resource in resources[category]) {
+      changes[category][resource] = 0;
+    }
+  }
+  return changes;
+}
+
+function applyChanges(resources, changes) {
+  for (const category in changes) {
+    for (const resource in changes[category]) {
+      if (resources[category]?.[resource]) {
+        resources[category][resource].value += changes[category][resource];
+      }
+    }
+  }
+}
+
 describe('SpaceMiningProject pressure limit capping', () => {
   let ctx;
   beforeEach(() => {
@@ -79,7 +100,9 @@ describe('SpaceMiningProject pressure limit capping', () => {
     project.start(ctx.resources);
     const duration = project.getEffectiveDuration();
     project.update(duration);
-    project.applyCostAndGain(duration);
+    const changes = createChanges(ctx.resources);
+    project.applyCostAndGain(duration, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.atmospheric.inertGas.value).toBeCloseTo(massLimit);
   });
 });

--- a/tests/spaceProjectAutomation.test.js
+++ b/tests/spaceProjectAutomation.test.js
@@ -13,6 +13,27 @@ function stubResource(value) {
   };
 }
 
+function createChanges(resources) {
+  const changes = {};
+  for (const category in resources) {
+    changes[category] = {};
+    for (const resource in resources[category]) {
+      changes[category][resource] = 0;
+    }
+  }
+  return changes;
+}
+
+function applyChanges(resources, changes) {
+  for (const category in changes) {
+    for (const resource in changes[category]) {
+      if (resources[category]?.[resource]) {
+        resources[category][resource].value += changes[category][resource];
+      }
+    }
+  }
+}
+
 describe('continuous spaceship project automation', () => {
   let ctx;
   beforeEach(() => {
@@ -77,11 +98,15 @@ describe('continuous spaceship project automation', () => {
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
     project.update(1000);
-    project.applyCostAndGain(1000);
+    let changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.metal.value).toBeGreaterThan(0);
     ctx.resources.atmospheric.carbonDioxide.value = 7; // exceed threshold
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(project.isActive).toBe(false);
     const metalAfterStop = ctx.resources.colony.metal.value;
     ctx.resources.atmospheric.carbonDioxide.value = 5; // below threshold
@@ -89,7 +114,9 @@ describe('continuous spaceship project automation', () => {
       project.start(ctx.resources);
     }
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.metal.value).toBeGreaterThan(metalAfterStop);
   });
 
@@ -120,11 +147,15 @@ describe('continuous spaceship project automation', () => {
     expect(project.canStart()).toBe(true);
     project.start(ctx.resources);
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.atmospheric.greenhouseGas.value).toBeLessThan(10000);
     ctx.terraforming.temperature.value = 300; // below threshold
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(project.isActive).toBe(false);
     const ghgAfterStop = ctx.resources.atmospheric.greenhouseGas.value;
     ctx.terraforming.temperature.value = 400; // above threshold
@@ -132,7 +163,9 @@ describe('continuous spaceship project automation', () => {
       project.start(ctx.resources);
     }
     project.update(1000);
-    project.applyCostAndGain(1000);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
     expect(ctx.resources.atmospheric.greenhouseGas.value).toBeLessThan(ghgAfterStop);
   });
 });

--- a/tests/waitForCapacity.test.js
+++ b/tests/waitForCapacity.test.js
@@ -123,11 +123,11 @@ describe('waitForCapacity flag', () => {
   test('continuous mode only needs one ship filled', () => {
     const project = createContinuousExportProject();
     project.waitForCapacity = true;
-    global.resources.colony.metal.value = 1000; // one ship disposal (100) * factor (10)
-    global.resources.colony.energy.value = 10100; // baseline cost for assigned ships
+    global.resources.colony.metal.value = 100; // one ship disposal
+    global.resources.colony.energy.value = 0;
     global.resources.special.spaceships.value = 101;
     expect(project.canStart()).toBe(true);
-    global.resources.colony.metal.value = 999; // just below requirement
+    global.resources.colony.metal.value = 99; // just below requirement
     expect(project.canStart()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Allow continuous spaceship projects to start without stored energy and check only the wait-for-capacity requirement
- Scale continuous spaceship costs and gains to available resources via `accumulatedChanges`
- Compute project-specific productivity based on each project's worst resource ratio so cost-free projects like the Dyson Swarm remain at full output
- Recalculate project resource rates after applying productivity so tooltips reflect actual scaled flows

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f530a39448327bdccd4165f5ef235