### PR TITLE
Scale colony upgrade costs based on existing buildings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,3 +214,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Self-replicating ship cap counts ships assigned to projects.
 - Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.
 - Colony upgrades can be performed with fewer than ten buildings remaining, charging full cost for the final upgrade.
+- Colony upgrade costs scale with missing lower-tier buildings, adding proportional water and land costs and increasing metal and glass requirements accordingly.

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -253,15 +253,18 @@ class Colony extends Building {
     const cost = {};
     const amount = upgradeCount * 10;
     const removeCount = Math.min(amount, this.count);
+    const missingRatio = (amount - removeCount) / amount;
 
     for (const category in nextCost) {
       for (const resource in nextCost[category]) {
-        const baseAmount = nextCost[category][resource];
+        const baseAmount = nextCost[category][resource] * upgradeCount;
         let value = 0;
         if (nextName === 't7_colony' && resource === 'superalloys') {
-          value = baseAmount * upgradeCount;
+          value = baseAmount;
         } else if (resource === 'metal' || resource === 'glass') {
-          value = 0.5 * baseAmount * upgradeCount;
+          value = baseAmount * (0.5 + 0.5 * missingRatio);
+        } else if (resource === 'water') {
+          value = baseAmount * missingRatio;
         }
         if (value > 0) {
           if (!cost[category]) cost[category] = {};

--- a/tests/colonyUpgrade.test.js
+++ b/tests/colonyUpgrade.test.js
@@ -109,6 +109,7 @@ describe('colony upgrade', () => {
     t1.count = t1.active = 10;
     ctx.resources.colony.metal.value = 125;
     ctx.resources.colony.glass.value = 125;
+    ctx.resources.colony.water.value = 0;
 
     ctx.createColonyButtons(ctx.colonies);
     ctx.updateStructureDisplay(ctx.colonies);
@@ -121,18 +122,20 @@ describe('colony upgrade', () => {
     expect(t2.count).toBe(1);
     expect(ctx.resources.colony.metal.value).toBe(0);
     expect(ctx.resources.colony.glass.value).toBe(0);
+    expect(ctx.resources.colony.water.value).toBe(0);
     expect(ctx.resources.surface.land.reserved).toBe(0);
   });
 
-  test('upgrade works with fewer than ten buildings at full cost', () => {
+  test('upgrade scales cost when fewer than ten buildings', () => {
     const { dom, ctx } = setupContext('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
     const t1 = ctx.colonies.t1_colony;
     const t2 = ctx.colonies.t2_colony;
     t1.unlocked = true;
     t2.unlocked = true;
     t1.count = t1.active = 8;
-    ctx.resources.colony.metal.value = 125;
-    ctx.resources.colony.glass.value = 125;
+    ctx.resources.colony.metal.value = 150;
+    ctx.resources.colony.glass.value = 150;
+    ctx.resources.colony.water.value = 100;
 
     ctx.createColonyButtons(ctx.colonies);
     ctx.updateStructureDisplay(ctx.colonies);
@@ -145,7 +148,30 @@ describe('colony upgrade', () => {
     expect(t2.count).toBe(1);
     expect(ctx.resources.colony.metal.value).toBe(0);
     expect(ctx.resources.colony.glass.value).toBe(0);
+    expect(ctx.resources.colony.water.value).toBe(0);
     expect(ctx.resources.surface.land.reserved).toBe(2);
+  });
+
+  test('upgrade cost scales with available lower tier buildings', () => {
+    const { ctx } = setupContext();
+    const t1 = ctx.colonies.t1_colony;
+    const t2 = ctx.colonies.t2_colony;
+    t1.unlocked = true;
+    t2.unlocked = true;
+
+    t1.count = t1.active = 5;
+    let cost = t1.getUpgradeCost(1);
+    expect(cost.colony.metal).toBeCloseTo(187.5);
+    expect(cost.colony.glass).toBeCloseTo(187.5);
+    expect(cost.colony.water).toBeCloseTo(250);
+    expect(cost.surface.land).toBeCloseTo(5);
+
+    t1.count = t1.active = 1;
+    cost = t1.getUpgradeCost(1);
+    expect(cost.colony.metal).toBeCloseTo(237.5);
+    expect(cost.colony.glass).toBeCloseTo(237.5);
+    expect(cost.colony.water).toBeCloseTo(450);
+    expect(cost.surface.land).toBeCloseTo(9);
   });
 
   test('upgrade button colors unaffordable cost parts red', () => {


### PR DESCRIPTION
## Summary
- Scale colony upgrade costs with missing lower-tier buildings
- Charge proportional water and land and adjust metal/glass costs
- Test colony upgrade cost scaling and update changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f7008b9048327b968e41348113b08