### PR TITLE
Recompute project productivity using global resource ratios

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,8 +215,8 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Colony upgrade button scales with selected build count, showing 10 → 1 by default with costs and effects adjusted accordingly.
 - Continuous spaceship and Dyson Swarm projects apply resource changes through resource.js accumulatedChanges.
 - Continuous spaceship projects start without stored energy and scale resource flow to available amounts.
-- Project productivity now calculates per-project efficiency based on the worst resource ratio, so projects without costs (like the Dyson Swarm) run at full output even when others are limited.
-- Project resource rates in tooltips now reflect productivity-adjusted values.
+- Project productivity now sums costs and gains across all active projects and scales each by the worst resource ratio, so projects without costs (like the Dyson Swarm) still run at full output and ordering no longer matters.
+- Project resource rates in tooltips display productivity-adjusted values.
 - Continuous projects display "Stopped" when their auto-start checkbox is disabled.
 - Auto start checkbox shows 'Run' when spaceship projects enter continuous mode and reverts when they return to discrete operation.
 - Colony upgrades can be performed with fewer than ten buildings remaining, charging full cost for the final upgrade.

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -394,8 +394,8 @@ function produceResources(deltaTime, buildings) {
       if (!data) continue;
       const { project } = data;
       const productivity = productivityMap[name] ?? 1;
-      project.applyCostAndGain(deltaTime, accumulatedChanges, productivity);
       project.estimateCostAndGain(deltaTime, true, productivity);
+      project.applyCostAndGain(deltaTime, accumulatedChanges, productivity);
     }
   }
 

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -378,6 +378,7 @@ function produceResources(deltaTime, buildings) {
 
   if (projectManager) {
     const names = projectManager.projectOrder || Object.keys(projectManager.projects || {});
+    const projectData = {};
     for (const name of names) {
       const project = projectManager.projects?.[name];
       if (!project) continue;
@@ -385,7 +386,14 @@ function produceResources(deltaTime, buildings) {
         continue;
       }
       const { cost = {}, gain = {} } = project.estimateCostAndGain(deltaTime, false) || {};
-      const productivity = calculateProjectProductivity(resources, accumulatedChanges, cost, gain);
+      projectData[name] = { project, cost, gain };
+    }
+    const productivityMap = calculateProjectProductivities(resources, accumulatedChanges, projectData);
+    for (const name of names) {
+      const data = projectData[name];
+      if (!data) continue;
+      const { project } = data;
+      const productivity = productivityMap[name] ?? 1;
       project.applyCostAndGain(deltaTime, accumulatedChanges, productivity);
       project.estimateCostAndGain(deltaTime, true, productivity);
     }
@@ -453,23 +461,55 @@ function produceResources(deltaTime, buildings) {
   recalculateTotalRates();
 }
 
-function calculateProjectProductivity(resources, accumulatedChanges, cost = {}, gain = {}) {
-  let productivity = 1;
-  for (const category in cost) {
-    for (const resource in cost[category]) {
-      const required = cost[category][resource] || 0;
-      const produced = gain[category]?.[resource] || 0;
-      const net = Math.max(required - produced, 0);
-      if (net > 0) {
-        const available =
-          (resources[category]?.[resource]?.value || 0) +
-          (accumulatedChanges[category]?.[resource] || 0);
-        const ratio = available / net;
-        productivity = Math.min(productivity, ratio);
+function calculateProjectProductivities(resources, accumulatedChanges, projectData = {}) {
+  const totalNet = {};
+  for (const name in projectData) {
+    const { cost = {}, gain = {} } = projectData[name];
+    for (const category in cost) {
+      for (const resource in cost[category]) {
+        const required = cost[category][resource] || 0;
+        const produced = gain[category]?.[resource] || 0;
+        const net = Math.max(required - produced, 0);
+        if (net > 0) {
+          if (!totalNet[category]) totalNet[category] = {};
+          totalNet[category][resource] = (totalNet[category][resource] || 0) + net;
+        }
       }
     }
   }
-  return Math.max(0, Math.min(1, productivity));
+
+  const ratios = {};
+  for (const category in totalNet) {
+    for (const resource in totalNet[category]) {
+      const available =
+        (resources[category]?.[resource]?.value || 0) +
+        (accumulatedChanges[category]?.[resource] || 0);
+      const net = totalNet[category][resource];
+      const ratio = net > 0 ? Math.min(available / net, 1) : 1;
+      if (!ratios[category]) ratios[category] = {};
+      ratios[category][resource] = Math.max(0, ratio);
+    }
+  }
+
+  const productivityMap = {};
+  for (const name in projectData) {
+    const { cost = {}, gain = {} } = projectData[name];
+    let productivity = 1;
+    for (const category in cost) {
+      for (const resource in cost[category]) {
+        const required = cost[category][resource] || 0;
+        const produced = gain[category]?.[resource] || 0;
+        const net = Math.max(required - produced, 0);
+        if (net > 0) {
+          const ratio = ratios[category]?.[resource] ?? 1;
+          productivity = Math.min(productivity, ratio);
+        }
+      }
+    }
+    productivityMap[name] = Math.max(0, Math.min(1, productivity));
+  }
+
+  return productivityMap;
 }
 
 function recalculateTotalRates(){
@@ -487,7 +527,7 @@ if (typeof module !== 'undefined' && module.exports) {
     checkResourceAvailability,
     createResources,
     produceResources,
-    calculateProjectProductivity,
+    calculateProjectProductivities,
     recalculateTotalRates,
   };
 }

--- a/tests/projectProductivityScaling.test.js
+++ b/tests/projectProductivityScaling.test.js
@@ -1,6 +1,6 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
-const { calculateProjectProductivity } = require('../src/js/resource.js');
+const { calculateProjectProductivities } = require('../src/js/resource.js');
 
 describe('project productivity', () => {
   test('uses worst ratio and leaves cost-free projects unaffected', () => {
@@ -12,18 +12,18 @@ describe('project productivity', () => {
     };
     const changes = { colony: { energy: 10, metal: 0 } };
 
-    const costA = { colony: { energy: 200, metal: 30 } };
-    const gainA = { colony: { metal: 10 } };
-    const prodA = calculateProjectProductivity(resources, changes, costA, gainA);
-    expect(prodA).toBeCloseTo(110 / 200);
-    changes.colony.energy -= costA.colony.energy * prodA;
-    changes.colony.metal -= costA.colony.metal * prodA;
-    changes.colony.metal += gainA.colony.metal * prodA;
+    const projectData = {
+      A: { cost: { colony: { energy: 200, metal: 30 } }, gain: { colony: { metal: 10 } } },
+      B: { cost: {}, gain: { colony: { energy: 10 } } },
+    };
+    const productivities = calculateProjectProductivities(resources, changes, projectData);
+    expect(productivities.A).toBeCloseTo(110 / 200);
+    expect(productivities.B).toBe(1);
+    changes.colony.energy -= projectData.A.cost.colony.energy * productivities.A;
+    changes.colony.metal -= projectData.A.cost.colony.metal * productivities.A;
+    changes.colony.metal += projectData.A.gain.colony.metal * productivities.A;
 
-    const gainB = { colony: { energy: 10 } };
-    const prodB = calculateProjectProductivity(resources, changes, {}, gainB);
-    expect(prodB).toBe(1);
-    changes.colony.energy += gainB.colony.energy * prodB;
+    changes.colony.energy += projectData.B.gain.colony.energy * productivities.B;
 
     const finalEnergy = resources.colony.energy.value + changes.colony.energy;
     const finalMetal = resources.colony.metal.value + changes.colony.metal;

--- a/tests/spaceshipProjectContinuous.test.js
+++ b/tests/spaceshipProjectContinuous.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const vm = require('vm');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
-const { calculateProjectProductivity } = require('../src/js/resource.js');
+const { calculateProjectProductivities } = require('../src/js/resource.js');
 
 function stubResource(value) {
   return {
@@ -79,7 +79,8 @@ describe('SpaceshipProject continuous cost and gain', () => {
     const changes = createChanges(ctx.resources);
     changes.colony.energy = 200;
     const totals = project.estimateCostAndGain(duration / 2);
-    const prod = calculateProjectProductivity(ctx.resources, changes, totals.cost, totals.gain);
+    const prodMap = calculateProjectProductivities(ctx.resources, changes, { p: totals });
+    const prod = prodMap.p;
     project.applyCostAndGain(duration / 2, changes, prod);
     expect(changes.colony.energy).toBeCloseTo(0);
     expect(changes.colony.metal).toBeCloseTo(400);
@@ -126,7 +127,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.update(duration / 2);
     let changes = createChanges(ctx.resources);
     let totals = project.estimateCostAndGain(duration / 2);
-    let prod = calculateProjectProductivity(ctx.resources, changes, totals.cost, totals.gain);
+    let prod = calculateProjectProductivities(ctx.resources, changes, { p: totals }).p;
     project.applyCostAndGain(duration / 2, changes, prod);
     applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.energy.value).toBeCloseTo(495);
@@ -175,7 +176,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.update(duration / 2);
     let changes = createChanges(ctx.resources);
     let totals = project.estimateCostAndGain(duration / 2);
-    let prod = calculateProjectProductivity(ctx.resources, changes, totals.cost, totals.gain);
+    let prod = calculateProjectProductivities(ctx.resources, changes, { p: totals }).p;
     project.applyCostAndGain(duration / 2, changes, prod);
     applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.energy.value).toBeCloseTo(990);
@@ -183,7 +184,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.update(duration / 2);
     changes = createChanges(ctx.resources);
     totals = project.estimateCostAndGain(duration / 2);
-    prod = calculateProjectProductivity(ctx.resources, changes, totals.cost, totals.gain);
+    prod = calculateProjectProductivities(ctx.resources, changes, { p: totals }).p;
     project.applyCostAndGain(duration / 2, changes, prod);
     applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.metal.value).toBeCloseTo(20);


### PR DESCRIPTION
## Summary
- Rework project productivity to sum all project costs and gains and scale each by the worst resource ratio
- Restore project tooltip resource rates to show productivity-adjusted values
- Document and test new productivity handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f777f67748327839cf35447fa95cd