### PR TITLE
Show per-second temperature drop for continuous disposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Spaceship projects now switch to proportional, per-ship continuous resource flow when more than 100 spaceships are assigned; smaller fleets resolve costs on start and gains on completion, and rates match at the 100-ship transition.
 - Automation checkboxes pause continuous spaceship projects when resources or environmental thresholds fail and resume them once conditions recover.
 - Ore and geothermal satellite UI split Amount and Deposits into separate columns with aligned controls and fonts matching space mining projects.
-- Space Disposal project displays the expected temperature reduction when jettisoning greenhouse gases.
+- Space Disposal project displays the expected temperature reduction when jettisoning greenhouse gases and shows per-second rates in continuous mode.
 - Infrared Vision research immediately removes the day-night penalty on Ice Harvesters when the cycle is disabled.
 - Android project assignments keep androids in storage and tooltips show worker and project usage.
 - Androids above their storage cap no longer contribute workers, and excess project assignments are reduced.

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -65,7 +65,7 @@ describe('SkillManager save/load', () => {
     global.addEffect.mockClear();
     manager.reapplyEffects();
     expect(global.addEffect).toHaveBeenCalledWith(
-      expect.objectContaining({ value: 2, sourceId: 'test' })
+      expect.objectContaining({ value: 2, effectId: 'test' })
     );
   });
 
@@ -75,19 +75,19 @@ describe('SkillManager save/load', () => {
     const manager = new SkillManager(data);
     manager.unlockSkill('android_efficiency');
     expect(global.addEffect).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 1.4, sourceId: 'android_efficiency' })
+      expect.objectContaining({ value: 1.4, effectId: 'android_efficiency' })
     );
 
     global.addEffect.mockClear();
     manager.upgradeSkill('android_efficiency');
     expect(global.addEffect).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 1.8, sourceId: 'android_efficiency' })
+      expect.objectContaining({ value: 1.8, effectId: 'android_efficiency' })
     );
 
     global.addEffect.mockClear();
     manager.upgradeSkill('android_efficiency');
     expect(global.addEffect).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 2.2, sourceId: 'android_efficiency' })
+      expect.objectContaining({ value: 2.2, effectId: 'android_efficiency' })
     );
   });
 

--- a/tests/spaceDisposalTemperatureReduction.test.js
+++ b/tests/spaceDisposalTemperatureReduction.test.js
@@ -215,4 +215,116 @@ describe('SpaceDisposalProject temperature reduction display', () => {
       global.gameSettings = originalGlobals.gameSettings;
     }
   });
+
+  test('shows per-second reduction in continuous mode', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectElements = {};
+
+    const numbersCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'numbers.js'), 'utf8');
+    vm.runInContext(
+      numbersCode + '; this.formatNumber = formatNumber; this.toDisplayTemperature = toDisplayTemperature; this.toDisplayTemperatureDelta = toDisplayTemperatureDelta; this.getTemperatureUnit = getTemperatureUnit;',
+      ctx,
+    );
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.gameSettings = {};
+
+    ctx.formatTotalCostDisplay = () => '';
+    ctx.formatTotalResourceGainDisplay = () => '';
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    const originalGlobals = {
+      resources: global.resources,
+      terraforming: global.terraforming,
+      projectElements: global.projectElements,
+      formatNumber: global.formatNumber,
+      toDisplayTemperature: global.toDisplayTemperature,
+      toDisplayTemperatureDelta: global.toDisplayTemperatureDelta,
+      getTemperatureUnit: global.getTemperatureUnit,
+      formatTotalCostDisplay: global.formatTotalCostDisplay,
+      formatTotalResourceGainDisplay: global.formatTotalResourceGainDisplay,
+      projectManager: global.projectManager,
+      gameSettings: global.gameSettings,
+    };
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const disposalSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceDisposalProject.js'), 'utf8');
+    vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+
+    ctx.resources = {
+      atmospheric: { greenhouseGas: { value: 1000 } },
+      special: { spaceships: { value: 200 } },
+      colony: {},
+      surface: {},
+      underground: {},
+    };
+    ctx.shipEfficiency = 1;
+
+    const baseTemp = 250;
+    const factor = 0.001;
+    ctx.terraforming = {
+      temperature: { value: baseTemp },
+      updateSurfaceTemperature: function () {
+        this.temperature.value = baseTemp + ctx.resources.atmospheric.greenhouseGas.value * factor;
+      },
+    };
+    ctx.terraforming.updateSurfaceTemperature();
+
+    global.resources = ctx.resources;
+    global.terraforming = ctx.terraforming;
+    global.projectElements = ctx.projectElements;
+    global.formatNumber = ctx.formatNumber;
+    global.toDisplayTemperature = ctx.toDisplayTemperature;
+    global.toDisplayTemperatureDelta = ctx.toDisplayTemperatureDelta;
+    global.getTemperatureUnit = ctx.getTemperatureUnit;
+    global.formatTotalCostDisplay = ctx.formatTotalCostDisplay;
+    global.formatTotalResourceGainDisplay = ctx.formatTotalResourceGainDisplay;
+    global.projectManager = ctx.projectManager;
+    global.gameSettings = ctx.gameSettings;
+
+    const config = {
+      name: 'dispose',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { spaceExport: true, disposalAmount: 1, disposable: { atmospheric: ['greenhouseGas'] } },
+    };
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    project.assignedSpaceships = 150;
+    project.selectedDisposalResource = { category: 'atmospheric', resource: 'greenhouseGas' };
+
+    try {
+      const container = dom.window.document.getElementById('container');
+      project.renderUI(container);
+      project.updateUI();
+      const elem = ctx.projectElements['dispose'].temperatureReductionElement;
+      expect(elem.textContent).toBe('Temperature will reduce by: 0.15K/s');
+      ctx.gameSettings.useCelsius = true;
+      project.updateUI();
+      expect(elem.textContent).toBe('Temperature will reduce by: 0.15°C/s');
+    } finally {
+      global.resources = originalGlobals.resources;
+      global.terraforming = originalGlobals.terraforming;
+      global.projectElements = originalGlobals.projectElements;
+      global.formatNumber = originalGlobals.formatNumber;
+      global.toDisplayTemperature = originalGlobals.toDisplayTemperature;
+      global.toDisplayTemperatureDelta = originalGlobals.toDisplayTemperatureDelta;
+      global.getTemperatureUnit = originalGlobals.getTemperatureUnit;
+      global.formatTotalCostDisplay = originalGlobals.formatTotalCostDisplay;
+      global.formatTotalResourceGainDisplay = originalGlobals.formatTotalResourceGainDisplay;
+      global.projectManager = originalGlobals.projectManager;
+      global.gameSettings = originalGlobals.gameSettings;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Display per-second temperature reduction when the space disposal project runs in continuous mode
- Add tests for continuous disposal temperature estimates and align skill effect tests with effect IDs
- Document continuous-mode behavior in project notes

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f941b1ae083278da958312e90e640