### PR TITLE
Display population growth skill effect as 'Awakening'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,3 +224,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Colony upgrades can be performed with fewer than ten buildings remaining, charging full cost for the final upgrade.
 - Colony upgrade costs scale with missing lower-tier buildings, adding proportional water and land costs and increasing metal and glass requirements accordingly.
 - Added a `treatAsBuilding` flag for certain projects like the Dyson Swarm Receiver so they contribute to building productivity and resource production loops.
+- Population growth skill multiplier displays as 'Awakening' in the growth rate tooltip.

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -304,16 +304,17 @@ class EffectableEntity {
       }
     }
 
-    applyGlobalPopulationGrowth(effect) {
-      const multiplier = 1 + effect.value;
-      this.addAndReplace({
-        type: 'growthMultiplier',
-        value: multiplier,
-        effectId: `${effect.effectId}-growthMultiplier`,
-        sourceId: effect.sourceId,
-        onLoad: effect.onLoad
-      });
-    }
+  applyGlobalPopulationGrowth(effect) {
+    const multiplier = 1 + effect.value;
+    this.addAndReplace({
+      type: 'growthMultiplier',
+      value: multiplier,
+      effectId: `${effect.effectId}-growthMultiplier`,
+      sourceId: effect.sourceId,
+      onLoad: effect.onLoad,
+      name: effect.name
+    });
+  }
 
     applyGlobalWorkerReduction(effect) {
       const multiplier = 1 - effect.value;

--- a/src/js/skills-parameters.js
+++ b/src/js/skills-parameters.js
@@ -22,6 +22,7 @@ const skillParameters = {
     effect: {
       target: 'population',
       type: 'globalPopulationGrowth',
+      name: 'Awakening',
       baseValue: 0.2,
       perRank: true
     },

--- a/tests/globalPopulationGrowth.test.js
+++ b/tests/globalPopulationGrowth.test.js
@@ -35,4 +35,17 @@ describe('globalPopulationGrowth effect', () => {
     const count = pop.activeEffects.filter(e => e.type === 'growthMultiplier').length;
     expect(count).toBe(1);
   });
+
+  test('uses provided name for multiplier effect', () => {
+    const pop = new TestPopulation();
+    pop.addAndReplace({
+      type: 'globalPopulationGrowth',
+      value: 0.1,
+      effectId: 'skill',
+      sourceId: 'skill',
+      name: 'Awakening'
+    });
+    const gm = pop.activeEffects.find(e => e.type === 'growthMultiplier');
+    expect(gm.name).toBe('Awakening');
+  });
 });


### PR DESCRIPTION
## Summary
- name population growth skill effect 'Awakening'
- propagate effect name to growth multiplier so tooltip shows new display name
- test growth multiplier retains effect name

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f968ac9408327a92a2f5853e254c3