### PR TITLE
Add tooltip for Solis point reward scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,9 +417,10 @@
                             <div id="solis-quest-text">No quest available</div>
                             <div id="solis-cooldown" class="hidden"></div>
                         </div>
-                        <div class="solis-controls">
+                            <div class="solis-controls">
                             <div class="solis-reward-control">
                                 <span>Reward: <span id="solis-reward">1.00</span> point(s)</span>
+                                <span class="info-tooltip-icon" title="Multiplied by square root of worlds terraformed">&#9432;</span>
                                 <button id="solis-multiply-button" class="solis-multiplier-button">+</button>
                                 <button id="solis-divide-button" class="solis-multiplier-button">-</button>
                             </div>

--- a/tests/solisRewardTooltip.test.js
+++ b/tests/solisRewardTooltip.test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Solis reward tooltip', () => {
+  test('explains reward scaling', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const control = dom.window.document.querySelector('.solis-reward-control');
+    const icon = control && control.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    expect(icon.getAttribute('title')).toBe('Multiplied by square root of worlds terraformed');
+  });
+});


### PR DESCRIPTION
## Summary
- add info tooltip beside Solis quest reward explaining square-root world multiplier
- test for tooltip presence in Solis reward control

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f961957fc8327937f57ebfaa1a1af