### PR TITLE
Fix autobuild cost averaging to preserve overflow time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,3 +225,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Colony upgrade costs scale with missing lower-tier buildings, adding proportional water and land costs and increasing metal and glass requirements accordingly.
 - Added a `treatAsBuilding` flag for certain projects like the Dyson Swarm Receiver so they contribute to building productivity and resource production loops.
 - Population growth skill multiplier displays as 'Awakening' in the growth rate tooltip.
+- Autobuild cost tracker preserves overflow milliseconds for accurate 10-second spending averages.

--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -20,14 +20,14 @@ const autobuildCostTracker = {
     },
     update(delta) {
         this.elapsed += delta;
-        if (this.elapsed >= 1000) {
+        while (this.elapsed >= 1000) {
             this.costQueue.push(this.currentCosts);
             this.buildingCostQueue.push(this.currentBuildingCosts);
             if (this.costQueue.length > 10) this.costQueue.shift();
             if (this.buildingCostQueue.length > 10) this.buildingCostQueue.shift();
             this.currentCosts = {};
             this.currentBuildingCosts = {};
-            this.elapsed = 0;
+            this.elapsed -= 1000;
         }
     },
     getAverageCost(category, resource) {

--- a/tests/autobuildCostAverage.test.js
+++ b/tests/autobuildCostAverage.test.js
@@ -1,0 +1,20 @@
+const { autobuildCostTracker } = require('../src/js/autobuild.js');
+
+describe('autobuild cost tracker averaging', () => {
+  beforeEach(() => {
+    autobuildCostTracker.elapsed = 0;
+    autobuildCostTracker.currentCosts = {};
+    autobuildCostTracker.currentBuildingCosts = {};
+    autobuildCostTracker.costQueue = [];
+    autobuildCostTracker.buildingCostQueue = [];
+  });
+
+  test('carries over elapsed overflow for accurate average', () => {
+    autobuildCostTracker.recordCost('Habitat', { colony: { metal: 5 } });
+    autobuildCostTracker.update(1001);
+    autobuildCostTracker.recordCost('Habitat', { colony: { metal: 15 } });
+    autobuildCostTracker.update(999);
+    expect(autobuildCostTracker.costQueue.length).toBe(2);
+    expect(autobuildCostTracker.getAverageCost('colony', 'metal')).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- carry over overflow milliseconds in autobuild cost tracker so 10-second window stays accurate
- test cost tracker for overflow handling
- document autobuild cost tracker update in AGENTS

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f982ed6a88327a1eea2a2d5868dd0