### PR TITLE
Add shift-click to max life design points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,3 +226,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added a `treatAsBuilding` flag for certain projects like the Dyson Swarm Receiver so they contribute to building productivity and resource production loops.
 - Population growth skill multiplier displays as 'Awakening' in the growth rate tooltip.
 - Autobuild cost tracker preserves overflow milliseconds for accurate 10-second spending averages.
+- Life designer shift-clicking ±1/±10 buttons spends or removes all available points.

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -276,15 +276,32 @@ function initializeLifeTerraformingDesignerUI() {
             lifeDesigner.tentativeDesign.getDesignCost() +
             Math.abs(lifeDesigner.tentativeDesign[attributeName].value);
 
-          let newValue = currentTentativeValue + changeAmount;
+          let costExcludingCurrent, available;
+          if (attributeName === 'optimalGrowthTemperature') {
+              costExcludingCurrent =
+                lifeDesigner.tentativeDesign.getDesignCost() -
+                Math.abs(lifeDesigner.tentativeDesign[attributeName].value);
+              available =
+                lifeDesigner.maxLifeDesignPoints() - costExcludingCurrent;
+          }
+
+          let newValue;
+          if (event.shiftKey) {
+              if (changeAmount > 0) {
+                  if (attributeName === 'optimalGrowthTemperature') {
+                      newValue = Math.min(15, available);
+                  } else {
+                      newValue = remainingPoints;
+                  }
+              } else {
+                  newValue = 0;
+              }
+          } else {
+              newValue = currentTentativeValue + changeAmount;
+          }
 
           if (attributeName === 'optimalGrowthTemperature') {
               newValue = Math.max(-15, Math.min(15, newValue));
-              const costExcludingCurrent =
-                lifeDesigner.tentativeDesign.getDesignCost() -
-                Math.abs(lifeDesigner.tentativeDesign[attributeName].value);
-              const available =
-                lifeDesigner.maxLifeDesignPoints() - costExcludingCurrent;
               const allowed = Math.min(Math.abs(newValue), Math.max(0, available));
               newValue = Math.sign(newValue) * allowed;
           } else {

--- a/tests/lifeShiftSpendRemove.test.js
+++ b/tests/lifeShiftSpendRemove.test.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const physics = require('../src/js/physics.js');
+const numbers = require('../src/js/numbers.js');
+
+describe('life designer shift click', () => {
+  test('shift-clicking spend/remove allocates all points', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+    ctx.terraforming = {
+      temperature: { zones: { tropical: { day: 280, night: 280 }, temperate: { day: 280, night: 280 }, polar: { day: 280, night: 280 } } },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const zonesCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'zones.js'), 'utf8');
+    vm.runInContext(zonesCode, ctx);
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,0,0,0,0,0,0);
+    ctx.lifeDesigner.baseMaxPoints = 20;
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    const plusBtn = dom.window.document.querySelector('.life-tentative-btn.life-tentative-plus[data-attribute="minTemperatureTolerance"][data-change="1"]');
+    plusBtn.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, shiftKey: true }));
+    expect(ctx.lifeDesigner.tentativeDesign.minTemperatureTolerance.value).toBe(20);
+
+    const minusBtn = dom.window.document.querySelector('.life-tentative-btn.life-tentative-minus[data-attribute="minTemperatureTolerance"][data-change="-1"]');
+    minusBtn.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, shiftKey: true }));
+    expect(ctx.lifeDesigner.tentativeDesign.minTemperatureTolerance.value).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow holding Shift when adjusting Life Designer attributes to spend all remaining points or remove them entirely
- Cover shift-click point allocation with tests
- Document new Life Designer shortcut in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a008132fa083279b9874e598fac288