### PR TITLE
Hide non-auto-start project rates in resource tooltips

### DIFF
--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -162,10 +162,23 @@ class Resource extends EffectableEntity {
     this.productionRateBySource = {}; // Keep this for potential UI use, sum across types
     this.consumptionRateBySource = {}; // Keep this for potential UI use, sum across types
 
+    const hiddenProjects = new Set();
+    if (typeof projectManager !== 'undefined' && projectManager.projects) {
+        for (const key in projectManager.projects) {
+            const p = projectManager.projects[key];
+            if (p && p.displayName && p.autoStart === false && !p.treatAsBuilding) {
+                hiddenProjects.add(p.displayName);
+            }
+        }
+    }
+
     for (const type in this.productionRateByType) {
         for (const source in this.productionRateByType[type]) {
             const rate = this.productionRateByType[type][source];
-                this.productionRate += rate; // Exclude overflow from total production
+            if (type === 'project' && hiddenProjects.has(source)) {
+                continue;
+            }
+            this.productionRate += rate; // Exclude overflow from total production
             if (!this.productionRateBySource[source]) this.productionRateBySource[source] = 0;
             this.productionRateBySource[source] += rate;
         }
@@ -174,11 +187,14 @@ class Resource extends EffectableEntity {
     for (const type in this.consumptionRateByType) {
         for (const source in this.consumptionRateByType[type]) {
             const rate = this.consumptionRateByType[type][source];
-            if (type !== 'overflow') {
+            const hidden = type === 'project' && hiddenProjects.has(source);
+            if (type !== 'overflow' && !hidden) {
                 this.consumptionRate += rate; // Exclude overflow from total consumption
             }
-            if (!this.consumptionRateBySource[source]) this.consumptionRateBySource[source] = 0;
-            this.consumptionRateBySource[source] += rate;
+            if (!hidden) {
+                if (!this.consumptionRateBySource[source]) this.consumptionRateBySource[source] = 0;
+                this.consumptionRateBySource[source] += rate;
+            }
         }
     }
   }

--- a/tests/projectAutoStartTooltip.test.js
+++ b/tests/projectAutoStartTooltip.test.js
@@ -1,0 +1,129 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Resource, produceResources } = require('../src/js/resource.js');
+
+describe('resource tooltip hides non-auto-start project rates', () => {
+  function setupGlobals(energy) {
+    global.resources = { colony: { energy } };
+    global.structures = {};
+    global.dayNightCycle = { isDay: () => true };
+    global.fundingModule = null;
+    global.terraforming = null;
+    global.lifeManager = null;
+    global.researchManager = null;
+    global.updateShipReplication = null;
+    global.updateAndroidResearch = null;
+    global.globalEffects = {};
+  }
+
+  test('project without auto start hidden', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 200 });
+    setupGlobals(energy);
+    const project = {
+      displayName: 'Dummy',
+      isActive: true,
+      isCompleted: false,
+      autoStart: false,
+      estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
+        const cost = { colony: { energy: 100 } };
+        if (applyRates) {
+          resources.colony.energy.modifyRate(-100 * productivity, this.displayName, 'project');
+        }
+        return { cost, gain: {} };
+      },
+      applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
+        accumulatedChanges.colony.energy -= 100 * productivity;
+      }
+    };
+    global.projectManager = { projectOrder: ['dummy'], projects: { dummy: project } };
+
+    produceResources(1000, {});
+
+    expect(energy.consumptionRate).toBeCloseTo(0);
+    expect(energy.consumptionRateBySource.Dummy).toBeUndefined();
+    expect(energy.value).toBeCloseTo(100);
+  });
+
+  test('project production without auto start hidden', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 0 });
+    setupGlobals(energy);
+    const project = {
+      displayName: 'Dummy',
+      isActive: true,
+      isCompleted: false,
+      autoStart: false,
+      estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
+        const gain = { colony: { energy: 100 } };
+        if (applyRates) {
+          resources.colony.energy.modifyRate(100 * productivity, this.displayName, 'project');
+        }
+        return { cost: {}, gain };
+      },
+      applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
+        accumulatedChanges.colony.energy += 100 * productivity;
+      }
+    };
+    global.projectManager = { projectOrder: ['dummy'], projects: { dummy: project } };
+
+    produceResources(1000, {});
+
+    expect(energy.productionRate).toBeCloseTo(0);
+    expect(energy.productionRateBySource.Dummy).toBeUndefined();
+    expect(energy.value).toBeCloseTo(100);
+  });
+
+  test('project with auto start shown', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 200 });
+    setupGlobals(energy);
+    const project = {
+      displayName: 'Dummy',
+      isActive: true,
+      isCompleted: false,
+      autoStart: true,
+      estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
+        const cost = { colony: { energy: 100 } };
+        if (applyRates) {
+          resources.colony.energy.modifyRate(-100 * productivity, this.displayName, 'project');
+        }
+        return { cost, gain: {} };
+      },
+      applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
+        accumulatedChanges.colony.energy -= 100 * productivity;
+      }
+    };
+    global.projectManager = { projectOrder: ['dummy'], projects: { dummy: project } };
+
+    produceResources(1000, {});
+
+    expect(energy.consumptionRate).toBeCloseTo(100);
+    expect(energy.consumptionRateBySource.Dummy).toBeCloseTo(100);
+  });
+
+  test('treat-as-building project shown without auto start', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 200 });
+    setupGlobals(energy);
+    const project = {
+      displayName: 'Dummy',
+      isActive: true,
+      isCompleted: false,
+      autoStart: false,
+      treatAsBuilding: true,
+      estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
+        const cost = { colony: { energy: 100 } };
+        if (applyRates) {
+          resources.colony.energy.modifyRate(-100 * productivity, this.displayName, 'project');
+        }
+        return { cost, gain: {} };
+      },
+      applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
+        accumulatedChanges.colony.energy -= 100 * productivity;
+      }
+    };
+    global.projectManager = { projectOrder: ['dummy'], projects: { dummy: project } };
+
+    produceResources(1000, {});
+
+    expect(energy.consumptionRate).toBeCloseTo(100);
+    expect(energy.consumptionRateBySource.Dummy).toBeCloseTo(100);
+  });
+});


### PR DESCRIPTION
## Summary
- omit non-auto-start project sources from resource rate totals and breakdowns
- test project production/consumption hidden without auto-start while auto-start and treat-as-building remain visible

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a01aa5da1483278f2a2dfc352edba4