### PR TITLE
Skip cost estimation for disabled auto-start projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,3 +227,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Population growth skill multiplier displays as 'Awakening' in the growth rate tooltip.
 - Autobuild cost tracker preserves overflow milliseconds for accurate 10-second spending averages.
 - Life designer shift-clicking ±1/±10 buttons spends or removes all available points.
+- Projects with auto-start disabled skip cost/gain estimation, simplifying resource rate handling.


### PR DESCRIPTION
## Summary
- simplify resource rate calculation by removing project auto-start filtering
- avoid estimating cost/gain for projects with auto-start disabled
- test auto-start disabled projects skip rate estimation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a0825015d8832787ec8a5ed7e0e607