### PR TITLE
Use resource display names in optical depth tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - SpaceManager stores the random world seed as `currentPlanetKey` when visiting procedural planets, unifying key handling for story and procedural worlds.
 - Optical depth tooltip lists contributions from each gas.
 - Optical depth tooltip refreshes its gas contributions in real time while hovered.
+- Optical depth tooltip uses resource display names.
 - `getTerraformedPlanetCount` now counts terraformed procedural worlds via `getAllPlanetStatuses`.
 - Space Storage withdraw mode shows an icon when colony storage is full.
 - Advanced research production scales with the number of terraformed worlds.

--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -318,7 +318,19 @@ function createTemperatureBox(row) {
     if (opticalDepthInfo) {
       const contributions = terraforming.temperature.opticalDepthContributions || {};
       const lines = Object.entries(contributions)
-        .map(([gas, val]) => `${gas.toUpperCase()}: ${val.toFixed(2)}`);
+        .map(([gas, val]) => {
+          const mapping = {
+            co2: 'carbonDioxide',
+            h2o: 'atmosphericWater',
+            ch4: 'atmosphericMethane',
+            greenhousegas: 'greenhouseGas'
+          };
+          const resourceKey = mapping[gas.toLowerCase()];
+          const displayName = resourceKey && resources.atmospheric[resourceKey]
+            ? resources.atmospheric[resourceKey].displayName
+            : gas.toUpperCase();
+          return `${displayName}: ${val.toFixed(2)}`;
+        });
       const tooltip = document.getElementById('optical-depth-tooltip');
       if (tooltip) {
         tooltip.innerHTML = lines.join('<br>');

--- a/tests/atmosphereOpticalDepthUI.test.js
+++ b/tests/atmosphereOpticalDepthUI.test.js
@@ -17,8 +17,22 @@ describe('atmosphere UI optical depth', () => {
     ctx.DEFAULT_SURFACE_ALBEDO = physics.DEFAULT_SURFACE_ALBEDO;
     ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
 
-    ctx.resources = { atmospheric: { o2: { displayName: 'O2' } } };
-    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.resources = {
+      atmospheric: {
+        o2: { displayName: 'O2' },
+        carbonDioxide: { displayName: 'Carbon Dioxide' },
+        atmosphericWater: { displayName: 'Water Vap.' }
+      }
+    };
+    ctx.currentPlanetParameters = {
+      resources: {
+        atmospheric: {
+          o2: { initialValue: 0 },
+          carbonDioxide: { initialValue: 0 },
+          atmosphericWater: { initialValue: 0 }
+        }
+      }
+    };
     ctx.terraformingGasTargets = { o2: { min: 0, max: 100 } };
     ctx.projectManager = { isBooleanFlagSet: () => false };
 
@@ -56,8 +70,8 @@ describe('atmosphere UI optical depth', () => {
     expect(info.getAttribute('title')).toBeNull();
     const tooltip = pEls[1].querySelector('#optical-depth-tooltip');
     expect(tooltip).not.toBeNull();
-    expect(tooltip.textContent).toContain('CO2: 0.30');
-    expect(tooltip.textContent).toContain('H2O: 0.20');
+    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.30');
+    expect(tooltip.textContent).toContain('Water Vap.: 0.20');
     expect(box.querySelector('#emissivity')).toBeNull();
     expect(pEls[2].querySelector('#wind-turbine-multiplier')).not.toBeNull();
     expect(pEls[1].classList.contains('no-margin')).toBe(true);
@@ -76,8 +90,22 @@ describe('atmosphere UI optical depth', () => {
     ctx.DEFAULT_SURFACE_ALBEDO = physics.DEFAULT_SURFACE_ALBEDO;
     ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
 
-    ctx.resources = { atmospheric: { o2: { displayName: 'O2' } } };
-    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.resources = {
+      atmospheric: {
+        o2: { displayName: 'O2' },
+        carbonDioxide: { displayName: 'Carbon Dioxide' },
+        atmosphericWater: { displayName: 'Water Vap.' }
+      }
+    };
+    ctx.currentPlanetParameters = {
+      resources: {
+        atmospheric: {
+          o2: { initialValue: 0 },
+          carbonDioxide: { initialValue: 0 },
+          atmosphericWater: { initialValue: 0 }
+        }
+      }
+    };
     ctx.terraformingGasTargets = { o2: { min: 0, max: 100 } };
     ctx.projectManager = { isBooleanFlagSet: () => false };
 
@@ -106,10 +134,10 @@ describe('atmosphere UI optical depth', () => {
     ctx.updateAtmosphereBox();
 
     const tooltip = dom.window.document.getElementById('optical-depth-tooltip');
-    expect(tooltip.textContent).toContain('CO2: 0.30');
+    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.30');
     ctx.terraforming.temperature.opticalDepthContributions = { co2: 0.1, h2o: 0.4 };
     ctx.updateAtmosphereBox();
-    expect(tooltip.textContent).toContain('CO2: 0.10');
-    expect(tooltip.textContent).toContain('H2O: 0.40');
+    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.10');
+    expect(tooltip.textContent).toContain('Water Vap.: 0.40');
   });
 });


### PR DESCRIPTION
## Summary
- Display optical depth gas contributions using each resource's display name
- Test optical depth tooltip rendering with display names and live updates
- Note update in AGENTS documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a085617458832791639cce3b15cda8