### PR TITLE
Display magnetosphere status in RWG UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,3 +230,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Life designer shift-clicking ±1/±10 buttons spends or removes all available points.
 - Projects with auto-start disabled skip cost/gain estimation, simplifying resource rate handling.
 - Life designer ±1/±10 buttons include tooltips noting Shift spends or recovers all points.
+- Random World Generator UI indicates whether a world has a magnetosphere.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -395,6 +395,7 @@ function renderWorldDetail(res, seedUsed, forcedType) {
         <div class="rwg-chip"><div class="label">Albedo</div><div class="value">${c.albedo}</div></div>
         <div class="rwg-chip"><div class="label">Rotation</div><div class="value">${fmt(c.rotationPeriod)} h</div></div>
         <div class="rwg-chip"><div class="label">Flux</div><div class="value">${fmt((fluxWm2).toFixed ? fluxWm2.toFixed(0) : fluxWm2)} W/m²</div></div>
+        <div class="rwg-chip"><div class="label">Magnetosphere</div><div class="value">${c.hasNaturalMagnetosphere ? 'Yes' : 'No'}</div></div>
         <div class="rwg-chip"><div class="label">Type</div><div class="value">${forcedType && forcedType !== 'auto' ? forcedType : (cls?.archetype || '—')}</div></div>
         <div class="rwg-chip"><div class="label">Teq</div><div class="value">${teqDisplay ? fmt(toDisplayTemp(teqDisplay)) + ' ' + tempUnit : '—'}</div></div>
         ${temps ? `<div class="rwg-chip"><div class="label">Mean T</div><div class="value">${fmt(Math.round(toDisplayTemp(temps.mean)))} ${tempUnit}</div></div>` : ''}

--- a/tests/rwgMagnetosphereDisplay.test.js
+++ b/tests/rwgMagnetosphereDisplay.test.js
@@ -1,0 +1,66 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const physics = require('../src/js/physics.js');
+
+describe('Random World Generator magnetosphere display', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    global.document = { addEventListener: () => {} };
+    global.formatNumber = numbers.formatNumber;
+    global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    global.dayNightTemperaturesModel = () => ({ mean: 300, day: 310, night: 290 });
+  });
+
+  function buildRes(hasMag) {
+    return {
+      star: { name: 'Sun', spectralType: 'G', luminositySolar: 1, massSolar: 1, temperatureK: 5800 },
+      seedString: '1',
+      orbitAU: 1,
+      merged: {
+        celestialParameters: {
+          distanceFromSun: 1,
+          radius: 6000,
+          gravity: 9.8,
+          albedo: 0.3,
+          rotationPeriod: 24,
+          hasNaturalMagnetosphere: hasMag
+        },
+        resources: {
+          atmospheric: {
+            carbonDioxide: { initialValue: 1 },
+            inertGas: { initialValue: 1 },
+            oxygen: { initialValue: 0 },
+            atmosphericWater: { initialValue: 0 },
+            atmosphericMethane: { initialValue: 0 }
+          },
+          surface: {}
+        },
+        classification: { archetype: 'mars-like' }
+      }
+    };
+  }
+
+  test('shows when a world has a magnetosphere', () => {
+    const { renderWorldDetail } = require('../src/js/rwgUI.js');
+    const res = buildRes(true);
+    const html = renderWorldDetail(res, 'seed', 'mars-like');
+    const dom = new JSDOM(html);
+    const chips = Array.from(dom.window.document.querySelectorAll('.rwg-chip'));
+    const chip = chips.find(ch => ch.querySelector('.label')?.textContent === 'Magnetosphere');
+    expect(chip).toBeTruthy();
+    expect(chip.querySelector('.value').textContent).toBe('Yes');
+  });
+
+  test('shows when a world lacks a magnetosphere', () => {
+    const { renderWorldDetail } = require('../src/js/rwgUI.js');
+    const res = buildRes(false);
+    const html = renderWorldDetail(res, 'seed', 'mars-like');
+    const dom = new JSDOM(html);
+    const chips = Array.from(dom.window.document.querySelectorAll('.rwg-chip'));
+    const chip = chips.find(ch => ch.querySelector('.label')?.textContent === 'Magnetosphere');
+    expect(chip).toBeTruthy();
+    expect(chip.querySelector('.value').textContent).toBe('No');
+  });
+});


### PR DESCRIPTION
## Summary
- Show whether generated worlds have a magnetosphere in the Random World Generator UI
- Add tests for magnetosphere display
- Document magnetosphere UI in AGENTS instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0d81fd0d08327a3c4fc8ab81f000b