### PR TITLE
Add gravity warning and happiness penalty for high-gravity worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,3 +230,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Life designer shift-clicking ±1/±10 buttons spends or removes all available points.
 - Projects with auto-start disabled skip cost/gain estimation, simplifying resource rate handling.
 - Life designer ±1/±10 buttons include tooltips noting Shift spends or recovers all points.
+- High-gravity worlds (>10 m/s²) show a warning in the random world generator and reduce colony happiness by 10% per m/s² above 10, capped at 100%.

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -187,12 +187,16 @@ class Colony extends Building {
     totalLuxuryHappiness = Math.min(foodNeed, energyNeed) * totalLuxuryHappiness;
 
     const milestoneHappiness = milestonesManager.getHappinessBonus();
-  
-    // Calculate the target happiness
-    const targetHappiness = nonLuxuryHappiness + comfortHappiness + totalLuxuryHappiness + milestoneHappiness;
-  
-    // Adjust the happiness towards the target value
-    this.happiness = this.adjustToTarget(this.happiness, targetHappiness / 100, deltaTime);
+
+    // Apply gravity penalty: every m/s² above 10 reduces happiness by 10%, capped at 100%
+    const gravity = globalThis.terraforming?.celestialParameters?.gravity || 0;
+    const gravityPenalty = gravity > 10 ? Math.min((gravity - 10) * 0.1, 1) : 0;
+
+    // Calculate the target happiness after gravity penalty
+    const targetHappiness = (nonLuxuryHappiness + comfortHappiness + totalLuxuryHappiness + milestoneHappiness) * (1 - gravityPenalty);
+
+    // Adjust the happiness towards the target value and ensure it doesn't drop below 0
+    this.happiness = this.adjustToTarget(this.happiness, Math.max(0, targetHappiness) / 100, deltaTime);
   }
 
   // Override calculateBaseMinRatio to exclude luxury resources from productivity calculation

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -321,13 +321,16 @@ function renderPlanetCard(p, index) {
   const fmt = typeof formatNumber === 'function' ? formatNumber : (n => n);
   const c = p.merged?.celestialParameters || {};
   const cls = p.classification || p.merged?.classification;
+  const gWarn = c.gravity > 10
+    ? '<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 10%, for a maximum of a 100% reduction">⚠</span>'
+    : '';
   return `
     <div class="rwg-planet-card">
       <div class="rwg-planet-title">${p.name || p.merged?.name || 'Planet ' + (index + 1)}</div>
       <div class="rwg-grid">
         <div><strong>Orbit</strong><div>${(p.orbitAU ?? c.distanceFromSun)?.toFixed ? (p.orbitAU ?? c.distanceFromSun).toFixed(2) : (p.orbitAU ?? c.distanceFromSun)} AU</div></div>
         <div><strong>Radius</strong><div>${fmt((c.radius ?? 0).toFixed ? c.radius.toFixed(0) : c.radius)} km</div></div>
-        <div><strong>Gravity</strong><div>${fmt((c.gravity ?? 0).toFixed ? c.gravity.toFixed(2) : c.gravity)} m/s²</div></div>
+        <div><strong>Gravity</strong><div>${fmt((c.gravity ?? 0).toFixed ? c.gravity.toFixed(2) : c.gravity)} m/s²${gWarn}</div></div>
         <div><strong>Albedo</strong><div>${(c.albedo ?? 0)}</div></div>
         <div><strong>Type</strong><div>${cls?.archetype || '—'}</div></div>
       </div>
@@ -378,6 +381,9 @@ function renderWorldDetail(res, seedUsed, forcedType) {
   const warningMsg = !eqDone
     ? 'Press Equilibrate at least once before traveling.'
     : (alreadyTerraformed ? 'This world has already been terraformed.' : '');
+  const gWarn = c.gravity > 10
+    ? '<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 10%, for a maximum of a 100% reduction">⚠</span>'
+    : '';
   const worldPanel = `
     <div class="rwg-card">
       <h3>${res.merged?.name || 'Generated World'}</h3>
@@ -391,7 +397,7 @@ function renderWorldDetail(res, seedUsed, forcedType) {
         <div class="rwg-chip"><div class="label">Seed</div><div class="value">${seedString}</div></div>
         <div class="rwg-chip"><div class="label">Orbit</div><div class="value">${(res.orbitAU ?? c.distanceFromSun)?.toFixed ? (res.orbitAU ?? c.distanceFromSun).toFixed(2) : (res.orbitAU ?? c.distanceFromSun)} AU</div></div>
         <div class="rwg-chip"><div class="label">Radius</div><div class="value">${fmt(c.radius)} km</div></div>
-        <div class="rwg-chip"><div class="label">Gravity</div><div class="value">${fmt(c.gravity)} m/s²</div></div>
+        <div class="rwg-chip"><div class="label">Gravity</div><div class="value">${fmt(c.gravity)} m/s²${gWarn}</div></div>
         <div class="rwg-chip"><div class="label">Albedo</div><div class="value">${c.albedo}</div></div>
         <div class="rwg-chip"><div class="label">Rotation</div><div class="value">${fmt(c.rotationPeriod)} h</div></div>
         <div class="rwg-chip"><div class="label">Flux</div><div class="value">${fmt((fluxWm2).toFixed ? fluxWm2.toFixed(0) : fluxWm2)} W/m²</div></div>

--- a/tests/gravityHappinessPenalty.test.js
+++ b/tests/gravityHappinessPenalty.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function setup(gravity) {
+  const ctx = { console };
+  ctx.milestonesManager = { getHappinessBonus: () => 0 };
+  ctx.resources = { colony: { metal: { updateStorageCap: () => {}, maintenanceMultiplier: 1 } } };
+  ctx.buildings = {};
+  ctx.terraforming = { celestialParameters: { gravity } };
+  ctx.maintenanceFraction = 0;
+  vm.createContext(ctx);
+
+  const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+  vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+  const buildingCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'building.js'), 'utf8');
+  vm.runInContext(buildingCode + '; this.Building = Building;', ctx);
+  const colonyCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colony.js'), 'utf8');
+  vm.runInContext(colonyCode + '; this.Colony = Colony;', ctx);
+
+  const config = {
+    name: 'Base',
+    category: 'Colony',
+    cost: { colony: { metal: 1 } },
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: false,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true,
+    baseComfort: 0
+  };
+
+  const colony = new ctx.Colony(config, 'base');
+  colony.updateNeedsRatio = () => {};
+  colony.filledNeeds.food = 1;
+  colony.filledNeeds.energy = 1;
+  return colony;
+}
+
+describe('gravity happiness penalty', () => {
+  test('reduces happiness above 10 m/s²', () => {
+    const colony = setup(12);
+    colony.updateHappiness(1);
+    expect(colony.happiness).toBeCloseTo(0.4);
+  });
+
+  test('caps happiness at zero when penalty reaches 100%', () => {
+    const colony = setup(25);
+    colony.updateHappiness(1);
+    expect(colony.happiness).toBe(0);
+  });
+});
+

--- a/tests/rwgGravityWarning.test.js
+++ b/tests/rwgGravityWarning.test.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+function setup() {
+  const ctx = {
+    console,
+    document: { addEventListener: () => {} },
+    formatNumber: n => n,
+    calculateAtmosphericPressure: () => 0,
+    dayNightTemperaturesModel: () => ({ mean: 0, day: 0, night: 0 }),
+    toDisplayTemperature: v => v,
+    getTemperatureUnit: () => 'K',
+    equilibratedWorlds: new Set(['seed'])
+  };
+  vm.createContext(ctx);
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+  return ctx;
+}
+
+describe('RWG gravity warning icon', () => {
+  test('renderWorldDetail shows warning for high gravity and not for low', () => {
+    const ctx = setup();
+    const baseRes = {
+      merged: { celestialParameters: { gravity: 12, radius: 6000, albedo: 0 }, name: 'Test', resources: {} },
+      orbitAU: 1,
+      star: { name: 'Sun', spectralType: 'G', luminositySolar: 1, massSolar: 1, temperatureK: 5800 }
+    };
+    let html = ctx.renderWorldDetail(baseRes, 'seed');
+    let dom = new JSDOM(html);
+    let chip = Array.from(dom.window.document.querySelectorAll('.rwg-chip')).find(ch => ch.querySelector('.label')?.textContent === 'Gravity');
+    let icon = chip.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    expect(icon.textContent).toBe('⚠');
+
+    baseRes.merged.celestialParameters.gravity = 9;
+    html = ctx.renderWorldDetail(baseRes, 'seed');
+    dom = new JSDOM(html);
+    chip = Array.from(dom.window.document.querySelectorAll('.rwg-chip')).find(ch => ch.querySelector('.label')?.textContent === 'Gravity');
+    icon = chip.querySelector('.info-tooltip-icon');
+    expect(icon).toBeNull();
+  });
+
+  test('renderPlanetCard warns for high gravity only', () => {
+    const ctx = setup();
+    const cardHtml = ctx.renderPlanetCard({ merged: { celestialParameters: { gravity: 12, radius: 1, albedo: 0 }, name: 'A' } }, 0);
+    let dom = new JSDOM(cardHtml);
+    let icon = dom.window.document.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    expect(icon.textContent).toBe('⚠');
+
+    const safeHtml = ctx.renderPlanetCard({ merged: { celestialParameters: { gravity: 9, radius: 1, albedo: 0 }, name: 'B' } }, 0);
+    dom = new JSDOM(safeHtml);
+    icon = dom.window.document.querySelector('.info-tooltip-icon');
+    expect(icon).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Show warning icon with tooltip for RWG planets exceeding 10 m/s² gravity
- Reduce colony happiness by 10% per m/s² above 10, capped at 100%
- Test gravity warning rendering and happiness reduction logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a0d904fab48327ab32f4e772a93027