### PR TITLE
Add Underground Land Expansion research and project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,3 +233,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - High-gravity worlds (>10 m/s²) show a warning in the random world generator and reduce colony happiness by 10% per m/s² above 10, capped at 100%.
 - Worlds generated with a natural magnetosphere start with the magnetic shield effect and display as "Natural magnetosphere" in the terraforming summary.
 - Random World Generator UI indicates whether a world has a magnetosphere.
+- Added Underground Land Expansion research and android-assisted project for subterranean land growth.

--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
     <script src="src/js/projects/SpaceDisposalProject.js"></script>
     <script src="src/js/projects/AndroidProject.js"></script>
     <script src="src/js/projects/DeeperMiningProject.js"></script>
+    <script src="src/js/projects/UndergroundExpansionProject.js"></script>
     <script src="src/js/projects/PlanetaryThrustersProject.js"></script>
     <script src="src/js/projects/SpaceStorageProject.js"></script>
     <script src="src/js/projects/spaceStorageUI.js"></script>

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -167,6 +167,22 @@ const projectParameters = {
       ]
     }
   },
+  undergroundExpansion: {
+    type: 'UndergroundExpansionProject',
+    name: "Underground Land Expansion",
+    category: "infrastructure",
+    cost: {
+      colony: {
+        metal: 10,
+        components: 10
+      }
+    },
+    duration: 120000,
+    description: "Build subterranean habitats to slightly expand usable land. Each completion increases land by a small amount.",
+    repeatable: true,
+    unlocked: false,
+    attributes: {}
+  },
   oreSpaceMining: {
     type: 'SpaceMiningProject',
     name: "Metal Asteroid Mining",

--- a/src/js/projects/UndergroundExpansionProject.js
+++ b/src/js/projects/UndergroundExpansionProject.js
@@ -1,0 +1,30 @@
+class UndergroundExpansionProject extends AndroidProject {
+  getScaledCost() {
+    const cost = super.getScaledCost();
+    const land = (resources?.surface?.land?.value) || 0;
+    if (!land) {
+      return cost;
+    }
+    const scaledCost = {};
+    for (const category in cost) {
+      scaledCost[category] = {};
+      for (const resource in cost[category]) {
+        scaledCost[category][resource] = cost[category][resource] * land;
+      }
+    }
+    return scaledCost;
+  }
+
+  complete() {
+    super.complete();
+    // Completion effect to increase land will be implemented later.
+  }
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.UndergroundExpansionProject = UndergroundExpansionProject;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = UndergroundExpansionProject;
+}

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -378,6 +378,29 @@ const researchParameters = {
         ],
       },
       {
+        id: 'underground_land_expansion',
+        name: 'Underground Land Expansion',
+        description: 'Unlocks a repeatable android project to expand usable land via subterranean construction.',
+        cost: { research: 2000000 },
+        prerequisites: ['android_factory'],
+        requiredFlags: ['undergroundHabitatsResearchUnlocked'],
+        effects: [
+          {
+            target: 'project',
+            targetId: 'undergroundExpansion',
+            type: 'enable',
+            value: true,
+          },
+          {
+            target: 'project',
+            targetId: 'undergroundExpansion',
+            type: 'booleanFlag',
+            flagId: 'androidAssist',
+            value: true
+          }
+        ],
+      },
+      {
         id: 'superconductor_factory',
         name: 'Superconductor Factory',
         description: 'Enables the fabrication of superconductors locally.',
@@ -1305,10 +1328,16 @@ const researchParameters = {
       {
         id: 'underground_habitats',
         name: 'Underground habitats',
-        description: 'TBA',
+        description: 'Opens research into expanding land through subterranean construction.',
         cost: { advancedResearch: 50000 },
         prerequisites: [],
         effects: [
+          {
+            target: 'researchManager',
+            type: 'booleanFlag',
+            flagId: 'undergroundHabitatsResearchUnlocked',
+            value: true
+          }
         ]
       },
       {

--- a/tests/undergroundExpansionCostScaling.test.js
+++ b/tests/undergroundExpansionCostScaling.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Underground Land Expansion cost scaling', () => {
+  test('cost scales with land', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = { surface: { land: { value: 5 } } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const androidCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js'), 'utf8');
+    vm.runInContext(androidCode + '; this.AndroidProject = AndroidProject;', ctx);
+    const ugCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'UndergroundExpansionProject.js'), 'utf8');
+    vm.runInContext(ugCode + '; this.UndergroundExpansionProject = UndergroundExpansionProject;', ctx);
+    const config = {
+      name: 'undergroundExpansion',
+      category: 'infrastructure',
+      cost: { colony: { metal: 10, components: 10 } },
+      duration: 1,
+      description: '',
+      repeatable: true,
+      unlocked: true,
+      attributes: {}
+    };
+    const p = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
+    const cost = p.getScaledCost();
+    expect(cost.colony.metal).toBe(50);
+    expect(cost.colony.components).toBe(50);
+  });
+});

--- a/tests/undergroundHabitatsResearch.test.js
+++ b/tests/undergroundHabitatsResearch.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Underground habitats advanced research', () => {
+  test('exists with correct cost and flag', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const adv = ctx.researchParameters.advanced;
+    const research = adv.find(r => r.id === 'underground_habitats');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(50000);
+    const flagEffect = research.effects.find(
+      e => e.type === 'booleanFlag' && e.flagId === 'undergroundHabitatsResearchUnlocked' && e.value === true
+    );
+    expect(flagEffect).toBeDefined();
+  });
+});

--- a/tests/undergroundLandExpansionResearch.test.js
+++ b/tests/undergroundLandExpansionResearch.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Underground Land Expansion research', () => {
+  test('exists with correct cost and effects', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const industry = ctx.researchParameters.industry;
+    const research = industry.find(r => r.id === 'underground_land_expansion');
+    expect(research).toBeDefined();
+    expect(research.cost.research).toBe(2000000);
+    expect(research.prerequisites).toContain('android_factory');
+    expect(research.requiredFlags).toContain('undergroundHabitatsResearchUnlocked');
+    const enableEffect = research.effects.find(e =>
+      e.target === 'project' && e.targetId === 'undergroundExpansion' && e.type === 'enable' && e.value === true
+    );
+    expect(enableEffect).toBeDefined();
+    const flagEffect = research.effects.find(e =>
+      e.target === 'project' && e.targetId === 'undergroundExpansion' && e.type === 'booleanFlag' && e.flagId === 'androidAssist' && e.value === true
+    );
+    expect(flagEffect).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add advanced research flag for underground habitats to unlock land expansion tech
- introduce Underground Land Expansion research unlocking android-run underground expansion project
- implement UndergroundExpansionProject with land-scaling costs and placeholder completion effect

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0dd709b688327b90b177e3e89a117