### PR TITLE
Reduce high-gravity penalty to 5%

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,6 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Life designer shift-clicking ±1/±10 buttons spends or removes all available points.
 - Projects with auto-start disabled skip cost/gain estimation, simplifying resource rate handling.
 - Life designer ±1/±10 buttons include tooltips noting Shift spends or recovers all points.
-- High-gravity worlds (>10 m/s²) show a warning in the random world generator and reduce colony happiness by 10% per m/s² above 10, capped at 100%.
+- High-gravity worlds (>10 m/s²) show a warning in the random world generator and reduce colony happiness by 5% per m/s² above 10, capped at 100%.
 - Worlds generated with a natural magnetosphere start with the magnetic shield effect and display as "Natural magnetosphere" in the terraforming summary.
 - Random World Generator UI indicates whether a world has a magnetosphere.

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -188,9 +188,9 @@ class Colony extends Building {
 
     const milestoneHappiness = milestonesManager.getHappinessBonus();
 
-    // Apply gravity penalty: every m/s² above 10 reduces happiness by 10%, capped at 100%
+    // Apply gravity penalty: every m/s² above 10 reduces happiness by 5%, capped at 100%
     const gravity = globalThis.terraforming?.celestialParameters?.gravity || 0;
-    const gravityPenalty = gravity > 10 ? Math.min((gravity - 10) * 0.1, 1) : 0;
+    const gravityPenalty = gravity > 10 ? Math.min((gravity - 10) * 0.05, 1) : 0;
 
     // Calculate the target happiness after gravity penalty
     const targetHappiness = (nonLuxuryHappiness + comfortHappiness + totalLuxuryHappiness + milestoneHappiness) * (1 - gravityPenalty);

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -322,7 +322,7 @@ function renderPlanetCard(p, index) {
   const c = p.merged?.celestialParameters || {};
   const cls = p.classification || p.merged?.classification;
   const gWarn = c.gravity > 10
-    ? '<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 10%, for a maximum of a 100% reduction">⚠</span>'
+    ? '<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 5%, for a maximum of a 100% reduction">⚠</span>'
     : '';
   return `
     <div class="rwg-planet-card">
@@ -382,7 +382,7 @@ function renderWorldDetail(res, seedUsed, forcedType) {
     ? 'Press Equilibrate at least once before traveling.'
     : (alreadyTerraformed ? 'This world has already been terraformed.' : '');
   const gWarn = c.gravity > 10
-    ? '<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 10% of its value, for a maximum of a 100% reduction">⚠</span>'
+    ? '<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 5% of its value, for a maximum of a 100% reduction">⚠</span>'
     : '';
   const worldPanel = `
     <div class="rwg-card">

--- a/tests/gravityHappinessPenalty.test.js
+++ b/tests/gravityHappinessPenalty.test.js
@@ -46,11 +46,11 @@ describe('gravity happiness penalty', () => {
   test('reduces happiness above 10 m/s²', () => {
     const colony = setup(12);
     colony.updateHappiness(1);
-    expect(colony.happiness).toBeCloseTo(0.4);
+    expect(colony.happiness).toBeCloseTo(0.45);
   });
 
   test('caps happiness at zero when penalty reaches 100%', () => {
-    const colony = setup(25);
+    const colony = setup(35);
     colony.updateHappiness(1);
     expect(colony.happiness).toBe(0);
   });

--- a/tests/rwgGravityWarning.test.js
+++ b/tests/rwgGravityWarning.test.js
@@ -35,6 +35,7 @@ describe('RWG gravity warning icon', () => {
     let icon = chip.querySelector('.info-tooltip-icon');
     expect(icon).not.toBeNull();
     expect(icon.textContent).toBe('⚠');
+    expect(icon.getAttribute('title')).toContain('5%');
 
     baseRes.merged.celestialParameters.gravity = 9;
     html = ctx.renderWorldDetail(baseRes, 'seed');
@@ -51,6 +52,7 @@ describe('RWG gravity warning icon', () => {
     let icon = dom.window.document.querySelector('.info-tooltip-icon');
     expect(icon).not.toBeNull();
     expect(icon.textContent).toBe('⚠');
+    expect(icon.getAttribute('title')).toContain('5%');
 
     const safeHtml = ctx.renderPlanetCard({ merged: { celestialParameters: { gravity: 9, radius: 1, albedo: 0 }, name: 'B' } }, 0);
     dom = new JSDOM(safeHtml);


### PR DESCRIPTION
## Summary
- Reduce colony happiness penalty from gravity above 10 m/s² to 5% per additional m/s²
- Update random world generator gravity tooltip to mention 5% penalty
- Adjust tests for new gravity penalty and tooltip message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0df9af334832795d1be4d3369cddf