### PR TITLE
Enable Underground Land Expansion without androids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,3 +234,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Worlds generated with a natural magnetosphere start with the magnetic shield effect and display as "Natural magnetosphere" in the terraforming summary.
 - Random World Generator UI indicates whether a world has a magnetosphere.
 - Added Underground Land Expansion research and android-assisted project for subterranean land growth.
+- Underground Land Expansion project now operates even without androids, shows land expansion progress, and adds 0.1% of the planet's starting land per completion.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -180,6 +180,7 @@ const projectParameters = {
     duration: 120000,
     description: "Build subterranean habitats to slightly expand usable land. Each completion increases land by a small amount.",
     repeatable: true,
+    maxRepeatCount: 1000,
     unlocked: false,
     attributes: {}
   },

--- a/src/js/projects/UndergroundExpansionProject.js
+++ b/src/js/projects/UndergroundExpansionProject.js
@@ -15,9 +15,30 @@ class UndergroundExpansionProject extends AndroidProject {
     return scaledCost;
   }
 
+  canStart() {
+    if (this.repeatCount >= this.maxRepeatCount) {
+      return false;
+    }
+    return Project.prototype.canStart.call(this);
+  }
+
+  updateUI() {
+    super.updateUI();
+    const elements = projectElements[this.name];
+    if (elements?.repeatCountElement && typeof terraforming !== 'undefined') {
+      const maxLand = terraforming.initialLand || 0;
+      const perCompletion = maxLand / 1000;
+      const expanded = Math.min(this.repeatCount * perCompletion, maxLand);
+      elements.repeatCountElement.textContent = `Land Expansion: ${formatNumber(expanded, true)} / ${formatNumber(maxLand, true)}`;
+    }
+  }
+
   complete() {
     super.complete();
-    // Completion effect to increase land will be implemented later.
+    if (typeof terraforming !== 'undefined' && resources?.surface?.land) {
+      const increase = (terraforming.initialLand || 0) / 1000;
+      resources.surface.land.increase(increase);
+    }
   }
 }
 

--- a/tests/undergroundExpansionProject.test.js
+++ b/tests/undergroundExpansionProject.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Underground Land Expansion project', () => {
+  const projectsPath = path.join(__dirname, '..', 'src/js', 'projects.js');
+  const androidPath = path.join(__dirname, '..', 'src/js/projects', 'AndroidProject.js');
+  const ugPath = path.join(__dirname, '..', 'src/js/projects', 'UndergroundExpansionProject.js');
+
+  function createContext() {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = { colony: { androids: { value: 0 } }, surface: { land: { value: 1000, increase(amount){ this.value += amount; } } } };
+    ctx.buildings = { oreMine: { count: 1 } };
+    ctx.terraforming = { initialLand: 1000 };
+    vm.createContext(ctx);
+    vm.runInContext(fs.readFileSync(projectsPath, 'utf8') + '; this.Project = Project;', ctx);
+    vm.runInContext(fs.readFileSync(androidPath, 'utf8') + '; this.AndroidProject = AndroidProject;', ctx);
+    vm.runInContext(fs.readFileSync(ugPath, 'utf8') + '; this.UndergroundExpansionProject = UndergroundExpansionProject;', ctx);
+    return ctx;
+  }
+
+  test('can start without androids', () => {
+    const ctx = createContext();
+    const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
+    const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
+    project.booleanFlags.add('androidAssist');
+    expect(project.canStart()).toBe(true);
+    expect(project.getAndroidSpeedMultiplier()).toBe(1);
+  });
+
+  test('completion increases land by 1/1000 of initial land', () => {
+    const ctx = createContext();
+    const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
+    const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
+    project.complete();
+    expect(ctx.resources.surface.land.value).toBeCloseTo(1001, 5);
+    expect(project.repeatCount).toBe(1);
+  });
+
+  test('cannot start after reaching max repeat count', () => {
+    const ctx = createContext();
+    const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
+    const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
+    project.repeatCount = 1000;
+    expect(project.canStart()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Let Underground Land Expansion run even with zero androids and expand land by 0.1% of the planet's initial area per completion
- Show Land Expansion progress under cost using the planet's initial land value as the cap
- Add tests covering android-free start, land gain, and repeat limit

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0e0db8938832785bcb63b4026efc1