### PR TITLE
Show placeholder temps before RWG equilibration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,3 +235,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Random World Generator UI indicates whether a world has a magnetosphere.
 - Added Underground Land Expansion research and android-assisted project for subterranean land growth.
 - Underground Land Expansion project now operates even without androids, shows land expansion progress, and adds 0.1% of the planet's starting land per completion.
+- Random World Generator temperature fields (Mean/Day/Night T) display '-' until the world is equilibrated.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -378,6 +378,16 @@ function renderWorldDetail(res, seedUsed, forcedType) {
     ? globalThis.spaceManager.isSeedTerraformed(seedUsed)
     : false;
   const travelDisabled = !eqDone || alreadyTerraformed;
+  const showTemps = !seedUsed || eqDone;
+  const meanTVal = (showTemps && temps)
+    ? `${fmt(Math.round(toDisplayTemp(temps.mean)))} ${tempUnit}`
+    : '—';
+  const dayTVal = (showTemps && temps)
+    ? `${fmt(Math.round(toDisplayTemp(temps.day)))} ${tempUnit}`
+    : '—';
+  const nightTVal = (showTemps && temps)
+    ? `${fmt(Math.round(toDisplayTemp(temps.night)))} ${tempUnit}`
+    : '—';
   const warningMsg = !eqDone
     ? 'Press Equilibrate at least once before traveling.'
     : (alreadyTerraformed ? 'This world has already been terraformed.' : '');
@@ -404,9 +414,9 @@ function renderWorldDetail(res, seedUsed, forcedType) {
         <div class="rwg-chip"><div class="label">Magnetosphere</div><div class="value">${c.hasNaturalMagnetosphere ? 'Yes' : 'No'}</div></div>
         <div class="rwg-chip"><div class="label">Type</div><div class="value">${forcedType && forcedType !== 'auto' ? forcedType : (cls?.archetype || '—')}</div></div>
         <div class="rwg-chip"><div class="label">Teq</div><div class="value">${teqDisplay ? fmt(toDisplayTemp(teqDisplay)) + ' ' + tempUnit : '—'}</div></div>
-        ${temps ? `<div class="rwg-chip"><div class="label">Mean T</div><div class="value">${fmt(Math.round(toDisplayTemp(temps.mean)))} ${tempUnit}</div></div>` : ''}
-        ${temps ? `<div class="rwg-chip"><div class="label">Day T</div><div class="value">${fmt(Math.round(toDisplayTemp(temps.day)))} ${tempUnit}</div></div>` : ''}
-        ${temps ? `<div class="rwg-chip"><div class="label">Night T</div><div class="value">${fmt(Math.round(toDisplayTemp(temps.night)))} ${tempUnit}</div></div>` : ''}
+        <div class="rwg-chip"><div class="label">Mean T</div><div class="value">${meanTVal}</div></div>
+        <div class="rwg-chip"><div class="label">Day T</div><div class="value">${dayTVal}</div></div>
+        <div class="rwg-chip"><div class="label">Night T</div><div class="value">${nightTVal}</div></div>
       </div>
       <div class="rwg-columns" style="margin-top:10px;">
         <div>

--- a/tests/rwgEquilibrateTempsUpdate.test.js
+++ b/tests/rwgEquilibrateTempsUpdate.test.js
@@ -66,9 +66,9 @@ describe('Random World Generator equilibrate updates temperatures', () => {
     attachEquilibrateHandler(res, 'seed', 'mars-like', box);
 
     expect(findChipValue('Teq')).toBe('100 K');
-    expect(findChipValue('Mean T')).toBe('250 K');
-    expect(findChipValue('Day T')).toBe('260 K');
-    expect(findChipValue('Night T')).toBe('240 K');
+    expect(findChipValue('Mean T')).toBe('—');
+    expect(findChipValue('Day T')).toBe('—');
+    expect(findChipValue('Night T')).toBe('—');
 
     document.getElementById('rwg-equilibrate-btn').click();
     await new Promise(setImmediate);


### PR DESCRIPTION
## Summary
- Show '-' for Mean, Day, and Night temperatures in random world generator until equilibration runs
- Document RWG temperature placeholder behavior
- Adjust equilibrate test to expect placeholder temps before simulation

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0e38308e08327928161f77be96e33