### PR TITLE
Refine underground land expansion android scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,4 +235,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Random World Generator UI indicates whether a world has a magnetosphere.
 - Added Underground Land Expansion research and android-assisted project for subterranean land growth.
 - Underground Land Expansion project now operates even without androids, shows land expansion progress, and adds 0.1% of the planet's starting land per completion.
+- Underground Land Expansion android speed scales with initial land and features a distinct tooltip from Deeper mining.
 - Random World Generator temperature fields (Mean/Day/Night T) display '-' until the world is equilibrated.

--- a/src/js/projects/UndergroundExpansionProject.js
+++ b/src/js/projects/UndergroundExpansionProject.js
@@ -22,6 +22,19 @@ class UndergroundExpansionProject extends AndroidProject {
     return Project.prototype.canStart.call(this);
   }
 
+  getAndroidSpeedMultiplier() {
+    const initialLand = Math.max((typeof terraforming !== 'undefined' ? terraforming.initialLand : 0), 1);
+    return 1 + Math.sqrt((this.assignedAndroids || 0) / initialLand);
+  }
+
+  renderUI(container) {
+    super.renderUI(container);
+    const elements = projectElements[this.name];
+    if (elements?.androidSpeedDisplay) {
+      elements.androidSpeedDisplay.title = '1 + sqrt(androids assigned / initial land)';
+    }
+  }
+
   updateUI() {
     super.updateUI();
     const elements = projectElements[this.name];

--- a/tests/undergroundExpansionProject.test.js
+++ b/tests/undergroundExpansionProject.test.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const numbers = require('../src/js/numbers.js');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('Underground Land Expansion project', () => {
@@ -18,6 +20,24 @@ describe('Underground Land Expansion project', () => {
     vm.runInContext(fs.readFileSync(androidPath, 'utf8') + '; this.AndroidProject = AndroidProject;', ctx);
     vm.runInContext(fs.readFileSync(ugPath, 'utf8') + '; this.UndergroundExpansionProject = UndergroundExpansionProject;', ctx);
     return ctx;
+  }
+
+  function createDomContext() {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatBigInteger = numbers.formatBigInteger;
+    ctx.projectElements = {};
+    ctx.resources = { colony: { androids: { value: 0 } }, surface: { land: { value: 1000, increase(amount){ this.value += amount; } } } };
+    ctx.buildings = { oreMine: { count: 1 } };
+    ctx.terraforming = { initialLand: 1000 };
+    ctx.EffectableEntity = EffectableEntity;
+    vm.runInContext(fs.readFileSync(projectsPath, 'utf8') + '; this.Project = Project;', ctx);
+    vm.runInContext(fs.readFileSync(androidPath, 'utf8') + '; this.AndroidProject = AndroidProject;', ctx);
+    vm.runInContext(fs.readFileSync(ugPath, 'utf8') + '; this.UndergroundExpansionProject = UndergroundExpansionProject;', ctx);
+    return { ctx, container: dom.window.document.getElementById('container') };
   }
 
   test('can start without androids', () => {
@@ -44,5 +64,24 @@ describe('Underground Land Expansion project', () => {
     const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
     project.repeatCount = 1000;
     expect(project.canStart()).toBe(false);
+  });
+
+  test('android speed multiplier scales with initial land', () => {
+    const ctx = createContext();
+    const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
+    const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
+    project.assignedAndroids = 100;
+    const expected = 1 + Math.sqrt(100 / ctx.terraforming.initialLand);
+    expect(project.getAndroidSpeedMultiplier()).toBeCloseTo(expected, 5);
+  });
+
+  test('android speed tooltip references initial land', () => {
+    const { ctx, container } = createDomContext();
+    const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
+    const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
+    project.renderUI(container);
+    const title = ctx.projectElements.undergroundExpansion.androidSpeedDisplay.title;
+    expect(title).toBe('1 + sqrt(androids assigned / initial land)');
+    expect(title).not.toBe('1 + sqrt(androids assigned / ore mines built)');
   });
 });


### PR DESCRIPTION
## Summary
- Customise underground land expansion android speed to scale with initial land
- Give underground expansion a dedicated android tooltip separate from deeper mining
- Cover new scaling and tooltip behaviour with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a0e71ac1588327ab2b63b042959dba