### PR TITLE
Adjust tests for underground expansion and Dyson Swarm collector

### DIFF
--- a/tests/dysonSwarmCollector.test.js
+++ b/tests/dysonSwarmCollector.test.js
@@ -10,10 +10,10 @@ describe('Dyson Swarm collector behaviour', () => {
       EffectableEntity,
       resources: {
         colony: {
-          metal: { value: 1000000, decrease: () => {}, updateStorageCap: () => {} },
-          glass: { value: 500000, decrease: () => {}, updateStorageCap: () => {} },
-          electronics: { value: 500000, decrease: () => {}, updateStorageCap: () => {} },
-          components: { value: 100000, decrease: () => {}, updateStorageCap: () => {} },
+          metal: { value: 5000000, decrease: () => {}, updateStorageCap: () => {} },
+          glass: { value: 80000, decrease: () => {}, updateStorageCap: () => {} },
+          electronics: { value: 2500000, decrease: () => {}, updateStorageCap: () => {} },
+          components: { value: 400000, decrease: () => {}, updateStorageCap: () => {} },
           energy: { value: 0, modifyRate: () => {}, updateStorageCap: () => {} }
         }
       },
@@ -37,7 +37,8 @@ describe('Dyson Swarm collector behaviour', () => {
     project.isCompleted = true;
     ctx.projectManager.projects.dyson = project;
 
-    project.startCollector();
+    const started = project.startCollector();
+    expect(started).toBe(true);
     expect(project.collectorProgress).toBe(project.collectorDuration);
     ctx.projectManager.updateProjects(1000);
     expect(project.collectorProgress).toBe(project.collectorDuration - 1000);

--- a/tests/undergroundExpansionCostScaling.test.js
+++ b/tests/undergroundExpansionCostScaling.test.js
@@ -7,6 +7,7 @@ describe('Underground Land Expansion cost scaling', () => {
   test('cost scales with land', () => {
     const ctx = { console, EffectableEntity };
     ctx.resources = { surface: { land: { value: 5 } } };
+    ctx.terraforming = { initialLand: 5 };
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);

--- a/tests/undergroundExpansionProject.test.js
+++ b/tests/undergroundExpansionProject.test.js
@@ -49,12 +49,12 @@ describe('Underground Land Expansion project', () => {
     expect(project.getAndroidSpeedMultiplier()).toBe(1);
   });
 
-  test('completion increases land by 1/1000 of initial land', () => {
+  test('completion increases land by 1/10000 of initial land', () => {
     const ctx = createContext();
     const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
     const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
     project.complete();
-    expect(ctx.resources.surface.land.value).toBeCloseTo(1001, 5);
+    expect(ctx.resources.surface.land.value).toBeCloseTo(1000.1, 5);
     expect(project.repeatCount).toBe(1);
   });
 
@@ -71,7 +71,7 @@ describe('Underground Land Expansion project', () => {
     const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
     const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
     project.assignedAndroids = 100;
-    const expected = 1 + Math.sqrt(100 / ctx.terraforming.initialLand);
+    const expected = 1 + Math.sqrt(10000 * 100 / ctx.terraforming.initialLand);
     expect(project.getAndroidSpeedMultiplier()).toBeCloseTo(expected, 5);
   });
 
@@ -81,7 +81,7 @@ describe('Underground Land Expansion project', () => {
     const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
     project.renderUI(container);
     const title = ctx.projectElements.undergroundExpansion.androidSpeedDisplay.title;
-    expect(title).toBe('1 + sqrt(androids assigned / initial land)');
+    expect(title).toBe('1 + sqrt(10000*androids assigned / initial land)');
     expect(title).not.toBe('1 + sqrt(androids assigned / ore mines built)');
   });
 });


### PR DESCRIPTION
## Summary
- Align Underground Expansion project tests with 1/10000 land increase and updated android speed formula
- Provide initial land context for cost-scaling test
- Ensure Dyson Swarm collector test has sufficient resources and verifies start success

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0f8ea47808327ab0271f5389c0073