### PR TITLE
Add orbital ring megastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,3 +237,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Underground Land Expansion project now operates even without androids, shows land expansion progress, and adds 0.1% of the planet's starting land per completion.
 - Underground Land Expansion android speed scales with initial land and features a distinct tooltip from Deeper mining.
 - Random World Generator temperature fields (Mean/Day/Night T) display '-' until the world is equilibrated.
+- Added Orbital Rings advanced research unlocking a repeatable orbital ring megastructure that counts as additional terraformed worlds and can draw from space storage resources.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -403,6 +403,24 @@ const projectParameters = {
     treatAsBuilding: true,
     attributes: { canUseSpaceStorage: true }
   },
+  orbitalRing: {
+    type: 'OrbitalRingProject',
+    name: 'Orbital Ring',
+    category: 'mega',
+    cost: {
+      colony: {
+        metal: 1000000000,
+        components: 10000000,
+        superalloys: 100000
+      }
+    },
+    duration: 1800000,
+    description: 'Construct a planetary ring that counts as a terraformed world.',
+    repeatable: true,
+    maxRepeatCount: Infinity,
+    unlocked: false,
+    attributes: { canUseSpaceStorage: true }
+  },
   spaceStorage : {
     type: 'SpaceStorageProject',
     name : 'Space Storage',

--- a/src/js/projects/OrbitalRingProject.js
+++ b/src/js/projects/OrbitalRingProject.js
@@ -1,0 +1,87 @@
+class OrbitalRingProject extends TerraformingDurationProject {
+  constructor(config, name) {
+    super(config, name);
+    this.ringCount = 0;
+    this.currentWorldHasRing = false;
+  }
+
+  renderUI(container) {
+    projectElements[this.name] = projectElements[this.name] || {};
+    const els = projectElements[this.name];
+    const topSection = document.createElement('div');
+    topSection.classList.add('project-top-section');
+    const grid = document.createElement('div');
+    grid.classList.add('project-details-grid');
+    const status = document.createElement('div');
+    status.id = `${this.name}-ring-status`;
+    grid.appendChild(status);
+    const effect = document.createElement('div');
+    effect.innerHTML = 'Orbital rings count as additional terraformed worlds <span class="info-tooltip-icon" title="Each orbital ring increases the terraformed world count.">&#9432;</span>';
+    grid.appendChild(effect);
+    topSection.appendChild(grid);
+    container.appendChild(topSection);
+    els.statusElement = status;
+    this.updateUI();
+  }
+
+  updateUI() {
+    const els = projectElements[this.name];
+    if (els?.statusElement) {
+      els.statusElement.textContent = `Current World Ring: ${this.currentWorldHasRing ? 'Yes' : 'No'}`;
+    }
+  }
+
+  canStart() {
+    if (!super.canStart()) return false;
+    if (this.currentWorldHasRing) return false;
+    if (
+      typeof spaceManager === 'undefined' ||
+      typeof spaceManager.getUnmodifiedTerraformedWorldCount !== 'function'
+    ) {
+      return true;
+    }
+    return this.ringCount < spaceManager.getUnmodifiedTerraformedWorldCount();
+  }
+
+  complete() {
+    super.complete();
+    this.ringCount += 1;
+    if (!this.currentWorldHasRing) {
+      this.currentWorldHasRing = true;
+      if (typeof spaceManager !== 'undefined' && typeof spaceManager.setCurrentWorldHasOrbitalRing === 'function') {
+        spaceManager.setCurrentWorldHasOrbitalRing(true);
+      }
+      const initialLand = currentPlanetParameters?.resources?.colony?.land?.initialValue || 0;
+      if (resources?.colony?.land) {
+        resources.colony.land.value += initialLand;
+      }
+    }
+  }
+
+  saveState() {
+    return { ...super.saveState(), ringCount: this.ringCount, currentWorldHasRing: this.currentWorldHasRing };
+  }
+
+  loadState(state) {
+    super.loadState(state);
+    this.ringCount = state.ringCount || 0;
+    this.currentWorldHasRing = state.currentWorldHasRing || false;
+  }
+
+  saveTravelState() {
+    return { ringCount: this.ringCount };
+  }
+
+  loadTravelState(state = {}) {
+    this.ringCount = state.ringCount || 0;
+    this.currentWorldHasRing = false;
+  }
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.OrbitalRingProject = OrbitalRingProject;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = OrbitalRingProject;
+}

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1413,6 +1413,11 @@ const researchParameters = {
             type: 'booleanFlag',
             flagId: 'orbitalRingsResearchUnlocked',
             value: true
+          },
+          {
+            target: 'project',
+            targetId: 'orbitalRing',
+            type: 'enable'
           }
         ]
       },

--- a/tests/orbitalRingCanStartLimit.test.js
+++ b/tests/orbitalRingCanStartLimit.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Orbital Ring project start limits', () => {
+  function setup() {
+    const ctx = { console, projectElements: {} };
+    ctx.EffectableEntity = require('../src/js/effectable-entity.js');
+    ctx.resources = { colony: { metal: { value: 1 }, components: { value: 1 }, superalloys: { value: 1 } } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const tdpCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'TerraformingDurationProject.js'), 'utf8');
+    const orbCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'OrbitalRingProject.js'), 'utf8');
+    const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
+    vm.runInContext(tdpCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
+    vm.runInContext(orbCode + '; this.OrbitalRingProject = OrbitalRingProject;', ctx);
+    vm.runInContext(spaceCode + '; this.SpaceManager = SpaceManager;', ctx);
+    ctx.spaceManager = new ctx.SpaceManager({ mars: {} });
+    ctx.globalThis = ctx;
+    return ctx;
+  }
+
+  test('cannot exceed terraformed worlds or build twice on same world', () => {
+    const ctx = setup();
+    ctx.spaceManager.planetStatuses.mars.terraformed = true;
+    const config = { name: 'orbitalRing', category: 'mega', cost: {}, duration: 1, description: '', repeatable: true, unlocked: true, attributes: {} };
+    const project = new ctx.OrbitalRingProject(config, 'orbitalRing');
+    expect(project.canStart()).toBe(true);
+    project.ringCount = 1;
+    expect(project.canStart()).toBe(false);
+    project.ringCount = 0;
+    project.currentWorldHasRing = true;
+    expect(project.canStart()).toBe(false);
+  });
+});

--- a/tests/orbitalRingLandIncrease.test.js
+++ b/tests/orbitalRingLandIncrease.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Orbital Ring project land effect', () => {
+  function setup() {
+    const ctx = { console, projectElements: {} };
+    ctx.EffectableEntity = require('../src/js/effectable-entity.js');
+    ctx.resources = { colony: { land: { value: 100 } } };
+    ctx.currentPlanetParameters = { resources: { colony: { land: { initialValue: 100 } } } };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const tdpCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'TerraformingDurationProject.js'), 'utf8');
+    const orbCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'OrbitalRingProject.js'), 'utf8');
+    const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
+    vm.runInContext(tdpCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
+    vm.runInContext(orbCode + '; this.OrbitalRingProject = OrbitalRingProject;', ctx);
+    vm.runInContext(spaceCode + '; this.SpaceManager = SpaceManager;', ctx);
+    ctx.spaceManager = new ctx.SpaceManager({ mars: {} });
+    ctx.spaceManager.planetStatuses.mars.terraformed = true;
+    ctx.globalThis = ctx;
+    return ctx;
+  }
+
+  test('completion adds initial land and sets flag', () => {
+    const ctx = setup();
+    const config = { name: 'orbitalRing', category: 'mega', cost: {}, duration: 1, description: '', repeatable: true, unlocked: true, attributes: {} };
+    const project = new ctx.OrbitalRingProject(config, 'orbitalRing');
+    project.complete();
+    expect(project.ringCount).toBe(1);
+    expect(project.currentWorldHasRing).toBe(true);
+    expect(ctx.spaceManager.planetStatuses.mars.orbitalRing).toBe(true);
+    expect(ctx.resources.colony.land.value).toBe(200);
+  });
+});

--- a/tests/orbitalRingProjectParameters.test.js
+++ b/tests/orbitalRingProjectParameters.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Orbital Ring project parameters', () => {
+  test('defined correctly', () => {
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+    const project = ctx.projectParameters.orbitalRing;
+    expect(project).toBeDefined();
+    expect(project.type).toBe('OrbitalRingProject');
+    expect(project.category).toBe('mega');
+    expect(project.cost.colony.metal).toBe(1000000000);
+    expect(project.duration).toBe(1800000);
+    expect(project.repeatable).toBe(true);
+    expect(project.attributes.canUseSpaceStorage).toBe(true);
+  });
+});

--- a/tests/spaceManagerOrbitalRingCount.test.js
+++ b/tests/spaceManagerOrbitalRingCount.test.js
@@ -1,0 +1,19 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('SpaceManager orbital ring counting', () => {
+  test('orbital rings add to terraformed count', () => {
+    const sm = new SpaceManager({ mars: {}, titan: {} });
+    sm.planetStatuses.titan.terraformed = true;
+    sm.planetStatuses.titan.orbitalRing = true;
+    global.projectManager = { projects: { orbitalRing: { ringCount: 1 } } };
+    expect(sm.getUnmodifiedTerraformedWorldCount()).toBe(1);
+    expect(sm.getTerraformedPlanetCount()).toBe(2);
+    expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(3);
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(2);
+    delete global.projectManager;
+  });
+});
+
+delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- add Orbital Ring mega project unlocked by new advanced research
- count orbital rings as terraformed worlds and limit builds to existing terraformed planets
- track ring presence per world and grant initial land on first completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0fd222fa08327a2cbb5ba4d8a82f8