### PR TITLE
Add collapsible resource headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,3 +238,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Underground Land Expansion android speed scales with initial land and features a distinct tooltip from Deeper mining.
 - Random World Generator temperature fields (Mean/Day/Night T) display '-' until the world is equilibrated.
 - Added Orbital Rings advanced research unlocking a repeatable orbital ring megastructure that counts as additional terraformed worlds and can draw from space storage resources.
+- Resource category headers include collapse triangles like special project cards.

--- a/src/css/resource.css
+++ b/src/css/resource.css
@@ -1,4 +1,9 @@
-  
+
+  .collapse-arrow {
+    margin-right: 6px;
+    cursor: pointer;
+  }
+
   .resource-row {
     display: grid;
     grid-template-columns: 32% 21% 3% 21% 23%; /* Default layout with cap */

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -10,15 +10,30 @@ function createResourceContainers(resourcesData) {
 
     // Create and append the header for the category
     const header = document.createElement('h3');
-    header.textContent = `${capitalizeFirstLetter(category)} Resources`;
     header.id = `${category}-resources-header`;
     header.style.display = 'none'; // Initially hidden
+    header.style.cursor = 'pointer';
+
+    const arrow = document.createElement('span');
+    arrow.classList.add('collapse-arrow');
+    arrow.innerHTML = '&#9660;';
+    header.appendChild(arrow);
+
+    const label = document.createElement('span');
+    label.textContent = `${capitalizeFirstLetter(category)} Resources`;
+    header.appendChild(label);
     categoryContainer.appendChild(header);
 
     // Create and append the resource list container
     const resourceList = document.createElement('div');
     resourceList.id = `${category}-resources-resources-container`;
     categoryContainer.appendChild(resourceList);
+
+    header.addEventListener('click', () => {
+      const hidden = resourceList.style.display === 'none';
+      resourceList.style.display = hidden ? '' : 'none';
+      arrow.innerHTML = hidden ? '&#9660;' : '&#9654;';
+    });
 
     // Append the complete category container to the main container
     resourcesContainer.appendChild(categoryContainer);

--- a/tests/resourceCollapse.test.js
+++ b/tests/resourceCollapse.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('resource header collapse', () => {
+  test('header toggles resource list and arrow', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.console = console;
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createResourceContainers = createResourceContainers;', ctx);
+
+    ctx.createResourceContainers({ surface: {} });
+
+    const doc = dom.window.document;
+    const categoryContainer = doc.querySelector('.resource-display');
+    const header = doc.getElementById('surface-resources-header');
+    const resourceList = doc.getElementById('surface-resources-resources-container');
+
+    // Unhide for testing
+    categoryContainer.style.display = 'block';
+    header.style.display = 'block';
+
+    const arrow = header.querySelector('.collapse-arrow');
+    expect(arrow.innerHTML).toBe('▼');
+
+    header.dispatchEvent(new dom.window.Event('click'));
+    expect(resourceList.style.display).toBe('none');
+    expect(arrow.innerHTML).toBe('▶');
+
+    header.dispatchEvent(new dom.window.Event('click'));
+    expect(resourceList.style.display === '' || resourceList.style.display === 'block').toBe(true);
+    expect(arrow.innerHTML).toBe('▼');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Add collapsible triangles to resource category headers for colony, surface, underground, atmospheric and special resources
- Style resource header arrows and document feature
- Test resource header collapse behaviour

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a108cb838c8327bacfc58504e092b0