### PR TITLE
Persist orbital ring project across travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,3 +239,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Random World Generator temperature fields (Mean/Day/Night T) display '-' until the world is equilibrated.
 - Added Orbital Rings advanced research unlocking a repeatable orbital ring megastructure that counts as additional terraformed worlds and can draw from space storage resources.
 - Resource category headers include collapse triangles like special project cards.
+- Orbital Ring project retains active status and remaining time through planet travel, continuing construction mid-journey.

--- a/src/js/projects/OrbitalRingProject.js
+++ b/src/js/projects/OrbitalRingProject.js
@@ -54,12 +54,23 @@ class OrbitalRingProject extends TerraformingDurationProject {
   }
 
   saveTravelState() {
-    return { ringCount: this.ringCount };
+    const state = { ringCount: this.ringCount };
+    if (this.isActive) {
+      state.isActive = true;
+      state.remainingTime = this.remainingTime;
+      state.startingDuration = this.startingDuration;
+    }
+    return state;
   }
 
   loadTravelState(state = {}) {
     this.ringCount = state.ringCount || 0;
     this.currentWorldHasRing = false;
+    if (state.isActive) {
+      this.isActive = true;
+      this.remainingTime = state.remainingTime || this.remainingTime;
+      this.startingDuration = state.startingDuration || this.getEffectiveDuration();
+    }
   }
 }
 

--- a/tests/orbitalRingTravelPersistence.test.js
+++ b/tests/orbitalRingTravelPersistence.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Orbital Ring travel persistence', () => {
+  function setup() {
+    const ctx = { console, projectElements: {} };
+    ctx.EffectableEntity = require('../src/js/effectable-entity.js');
+    ctx.resources = { colony: {}, surface: {} };
+    ctx.spaceManager = {
+      getUnmodifiedTerraformedWorldCount: () => 2,
+      getCurrentPlanetKey: () => 'mars',
+      isPlanetTerraformed: () => true,
+      setCurrentWorldHasOrbitalRing: () => {}
+    };
+    ctx.terraforming = { initialLand: 0 };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const tdpCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'TerraformingDurationProject.js'), 'utf8');
+    const orbCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'OrbitalRingProject.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
+    vm.runInContext(tdpCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
+    vm.runInContext(orbCode + '; this.OrbitalRingProject = OrbitalRingProject;', ctx);
+    ctx.globalThis = ctx;
+    return ctx;
+  }
+
+  test('active state and remaining time persist through travel', () => {
+    const ctx = setup();
+    const config = {
+      name: 'orbitalRing',
+      category: 'mega',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      unlocked: true,
+      attributes: {}
+    };
+    const project = new ctx.OrbitalRingProject(config, 'orbitalRing');
+    project.start(ctx.resources);
+    project.update(200);
+    const saved = project.saveTravelState();
+    const project2 = new ctx.OrbitalRingProject(config, 'orbitalRing');
+    project2.loadTravelState(saved);
+    expect(project2.isActive).toBe(true);
+    expect(project2.remainingTime).toBe(800);
+    project2.update(200);
+    expect(project2.remainingTime).toBe(600);
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve Orbital Ring project progress across planet travel, restoring active status and remaining time after arriving
- Document Orbital Ring travel persistence in AGENTS notes
- Test Orbital Ring travel state to ensure ongoing construction resumes

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a1243683c8832786f5dc5be57941d0