### PR TITLE
Preserve day-night progress when adjusting spin

### DIFF
--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -474,8 +474,19 @@ class PlanetaryThrustersProject extends Project{
         const dΩ=sign*dvTick/(p.radius*1e3);
         const ω=2*Math.PI/(getRotHours(p)*3600)+dΩ;
         p.rotationPeriod=2*Math.PI/ω/3600;
-        if(typeof dayNightCycle !== 'undefined' && rotationPeriodToDurationFunc){
+        if (typeof dayNightCycle !== 'undefined' && rotationPeriodToDurationFunc) {
+          const oldDur = dayNightCycle.dayDuration;
+          const progress = typeof dayNightCycle.getDayProgress === 'function'
+            ? dayNightCycle.getDayProgress()
+            : 0;
+          const daysElapsed = dayNightCycle.elapsedTime / oldDur;
           dayNightCycle.dayDuration = rotationPeriodToDurationFunc(p.rotationPeriod);
+          dayNightCycle.elapsedTime = daysElapsed * dayNightCycle.dayDuration;
+          if (typeof dayNightCycle.setDayProgress === 'function') {
+            dayNightCycle.setDayProgress(progress);
+          } else {
+            dayNightCycle.dayProgress = progress;
+          }
         }
         if(this.dVdone>=this.dVreq){this.spinInvest=false;this.dVreq=this.dVdone=0;this.activeMode=null;}
         this.updateUI(); return;

--- a/tests/planetaryThrustersDayNightCycle.test.js
+++ b/tests/planetaryThrustersDayNightCycle.test.js
@@ -22,6 +22,9 @@ describe('Planetary Thrusters day-night cycle', () => {
     ctx.rotationPeriodToDuration = rotationPeriodToDuration;
     ctx.DayNightCycle = DayNightCycle;
     ctx.dayNightCycle = new DayNightCycle(rotationPeriodToDuration(20));
+    ctx.dayNightCycle.elapsedTime = ctx.dayNightCycle.dayDuration * 5.25;
+    ctx.dayNightCycle.update(0);
+    const initialProgress = ctx.dayNightCycle.getDayProgress();
     ctx.terraforming = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 20, distanceFromSun: 1 } };
     ctx.resources = { colony: { energy: { value: 1e40, decrease(v){ this.value -= v; }, updateStorageCap(){} } } };
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
@@ -49,6 +52,7 @@ describe('Planetary Thrusters day-night cycle', () => {
     expect(newPeriod).not.toBe(20);
     expect(ctx.dayNightCycle.dayDuration).not.toBe(initialDuration);
     expect(ctx.dayNightCycle.dayDuration).toBeCloseTo(rotationPeriodToDuration(newPeriod), 5);
+    expect(ctx.dayNightCycle.getDayProgress()).toBeCloseTo(initialProgress, 5);
   });
 });
 


### PR DESCRIPTION
## Summary
- keep day/night progress constant when planetary thrusters change rotation
- test planetary thrusters to ensure day/night progress is preserved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a12720e67c83278c422f747368d178