### PR TITLE
Consume active colonies before inactive during upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Auto start checkbox shows 'Run' when spaceship projects enter continuous mode and reverts when they return to discrete operation.
 - Colony upgrades can be performed with fewer than ten buildings remaining, charging full cost for the final upgrade.
 - Colony upgrade costs scale with missing lower-tier buildings, adding proportional water and land costs and increasing metal and glass requirements accordingly.
+- Colony upgrades consume active colonies before inactive ones and require land for inactive replacements.
 - Added a `treatAsBuilding` flag for certain projects like the Dyson Swarm Receiver so they contribute to building productivity and resource production loops.
 - Population growth skill multiplier displays as 'Awakening' in the growth rate tooltip.
 - Autobuild cost tracker preserves overflow milliseconds for accurate 10-second spending averages.


### PR DESCRIPTION
## Summary
- Remove active colonies before inactive during upgrades
- Charge land when inactive colonies are consumed
- Test active-first removal, inactive land cost, and active count bounds

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a1bbf51c1c8327b1991073f37b14a1