### PR TITLE
Prefix colony upgrade button text and adjust ecumenopolis upgrade test

### DIFF
--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -517,6 +517,7 @@ function updateDecreaseButtonText(button, buildCount) {
       button.dataset.keys = keyString;
       button.dataset.amount = amountString;
       button.textContent = '';
+      button.append('Upgrade ');
       button.append(`${formatNumber(amount, true)} \u2192 ${formatNumber(upgradeCount, true)} `);
       list = document.createElement('span');
       button.appendChild(list);

--- a/tests/ecumenopolisUpgrade.test.js
+++ b/tests/ecumenopolisUpgrade.test.js
@@ -143,7 +143,7 @@ describe('Ecumenopolis upgrade', () => {
     ctx.resources.colony.superalloys.value = 2000000;
 
     ctx.createColonyButtons(ctx.colonies);
-    vm.runInContext("selectedBuildCounts['t6_colony'] = 2;", ctx);
+    vm.runInContext("selectedBuildCounts['t6_colony'] = 20;", ctx);
     ctx.updateStructureDisplay(ctx.colonies);
 
     const button = dom.window.document.getElementById('t6_colony-upgrade-button');


### PR DESCRIPTION
## Summary
- Add "Upgrade" prefix to colony upgrade button labels
- Update ecumenopolis upgrade test to match build count behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a1cc96a0c0832789be047edc16a5d4