### PR TITLE
Allow negative worker counts and hide worker rate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,3 +242,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added Orbital Rings advanced research unlocking a repeatable orbital ring megastructure that counts as additional terraformed worlds and can draw from space storage resources.
 - Resource category headers include collapse triangles like special project cards.
 - Orbital Ring project retains active status and remaining time through planet travel, continuing construction mid-journey.
+- Worker resource can display negative values and hides its rate when `hideRate` is enabled in planet parameters.

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -34,7 +34,7 @@ const defaultPlanetParameters = {
     colony: {
       funding: { name: 'Funding', initialValue: 0, unlocked: false },
       colonists: { name: 'Colonists', initialValue: 0, hasCap: true, baseCap: 0, unlocked:false },
-      workers: { name: 'Workers', initialValue: 0, hasCap: true, baseCap: 0, unlocked:false },
+      workers: { name: 'Workers', initialValue: 0, hasCap: true, baseCap: 0, unlocked:false, hideRate: true },
       energy: { name: 'Energy', initialValue: 0, hasCap: true, baseCap: 50000000, unlocked:false , unit: 'Watt-day' },
       metal: { name: 'Metal', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false, maintenanceConversion : {surface : 'scrapMetal'}, unit: 'ton'},
       silicon: { name: 'Silicon', initialValue: 0, hasCap: true, baseCap: 5000, unlocked:false , unit: 'ton' },

--- a/src/js/population.js
+++ b/src/js/population.js
@@ -132,7 +132,7 @@ class PopulationModule extends EffectableEntity {
     // Update worker cap based on current population and worker ratio
     this.updateWorkerCap();
 
-    this.workerResource.value = Math.max(0, this.workerResource.cap - this.totalWorkersRequired);
+    this.workerResource.value = this.workerResource.cap - this.totalWorkersRequired;
   }
 
   updateWorkerCap() {

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -24,6 +24,7 @@ class Resource extends EffectableEntity {
     this.maintenanceMultiplier = resourceData.maintenanceMultiplier !== undefined ? resourceData.maintenanceMultiplier : 1; // Multiplier for maintenance costs
     this.conversionValue = resourceData.conversionValue || 1; // Default to 1 if not provided
     this.hideWhenSmall = resourceData.hideWhenSmall || false; // Flag to hide when value is very small
+    this.hideRate = resourceData.hideRate || false; // Flag to hide rate display in UI
     this.overflowRate = 0; // Track overflow/leakage rate for tooltip display
   }
 
@@ -58,6 +59,9 @@ class Resource extends EffectableEntity {
     }
     if (config.hideWhenSmall !== undefined) {
       this.hideWhenSmall = config.hideWhenSmall;
+    }
+    if (config.hideRate !== undefined) {
+      this.hideRate = config.hideRate;
     }
 
     if (this.name === 'land' && config.initialValue !== undefined) {

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -342,7 +342,7 @@ function createResourceElement(category, resourceObj, resourceName) {
           <div class="resource-slash">/</div>
           <div class="resource-cap"><span id="${resourceName}-cap-resources-container">${Math.floor(resourceObj.cap)}</span></div>
         ` : ''}
-        <div class="resource-pps" id="${resourceName}-pps-resources-container">+0/s</div>
+        ${resourceObj.hideRate ? '' : `<div class="resource-pps" id="${resourceName}-pps-resources-container">+0/s</div>`}
       </div>
     `;
     resourceElement.appendChild(createTooltipElement(resourceName));
@@ -356,7 +356,7 @@ function createResourceElement(category, resourceObj, resourceName) {
           <div class="resource-slash">/</div>
           <div class="resource-cap"><span id="${resourceName}-total-resources-container">${Math.floor(resourceObj.value)}</span></div>
         ` : ''}
-        <div class="resource-pps"></div>
+        ${resourceObj.hideRate ? '' : '<div class="resource-pps"></div>'}
       </div>
     `;
     if (resourceObj.name === 'land') {
@@ -378,7 +378,7 @@ function createResourceElement(category, resourceObj, resourceName) {
           <div class="resource-slash">/</div>
           <div class="resource-cap"><span id="${resourceName}-cap-resources-container">${resourceObj.cap.toFixed(2)}</span></div>
         ` : ''}
-        <div class="resource-pps" id="${resourceName}-pps-resources-container">+0/s</div>
+        ${resourceObj.hideRate ? '' : `<div class="resource-pps" id="${resourceName}-pps-resources-container">+0/s</div>`}
       </div>
     `;
     resourceElement.appendChild(createTooltipElement(resourceName));

--- a/tests/negativeWorkersDisplay.test.js
+++ b/tests/negativeWorkersDisplay.test.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('worker resource negative display and rate hiding', () => {
+  test('PopulationModule allows negative workers when demand exceeds supply', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = {
+      colony: {
+        colonists: {
+          value: 5,
+          cap: 100,
+          modifyRate: () => {},
+          increase(v) { this.value += v; },
+          decrease(v) { this.value -= v; },
+        },
+        workers: { value: 0, cap: 0 },
+        androids: { value: 0, cap: 0 },
+      },
+    };
+    ctx.buildings = {
+      factory: {
+        active: 1,
+        getTotalWorkerNeed: () => 8,
+        getEffectiveWorkerMultiplier: () => 1,
+      },
+    };
+    ctx.colonies = {
+      base: { active: 1, storage: { colony: { colonists: 100 } }, happiness: 0.5 },
+    };
+    ctx.projectManager = {
+      getAssignedAndroids: () => 0,
+      forceUnassignAndroids: () => {},
+    };
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'population.js'), 'utf8');
+    vm.runInContext(code + '; this.PopulationModule = PopulationModule;', ctx);
+    const module = new ctx.PopulationModule(ctx.resources, { workerRatio: 1 });
+    module.updatePopulation(1000);
+    expect(ctx.resources.colony.workers.value).toBe(-3);
+  });
+
+  test('worker resource displays negative value without rate', () => {
+    const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+    const { JSDOM } = require(jsdomPath);
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.populationModule = { getEffectiveWorkerRatio: () => 0.5 };
+    ctx.resources = { colony: {} };
+    ctx.buildings = {};
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const workers = {
+      name: 'workers',
+      displayName: 'Workers',
+      category: 'colony',
+      value: -5,
+      cap: 60,
+      hasCap: true,
+      unlocked: true,
+      hideRate: true,
+      reserved: 0,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      unit: null,
+      isBooleanFlagSet: () => false,
+    };
+
+    ctx.createResourceDisplay({ colony: { workers } });
+    ctx.updateResourceDisplay({ colony: { workers } });
+
+    const valueEl = dom.window.document.getElementById('workers-resources-container');
+    expect(valueEl.textContent.trim().startsWith('-')).toBe(true);
+    expect(dom.window.document.getElementById('workers-pps-resources-container')).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow workers to show negative values when demand exceeds available
- add `hideRate` option and use it to hide workers' per-second rate
- cover negative worker handling with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a1db1f3d108327ab6f235af7fd7641