### PR TITLE
Hide rate display when hideRate enabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,3 +243,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource category headers include collapse triangles like special project cards.
 - Orbital Ring project retains active status and remaining time through planet travel, continuing construction mid-journey.
 - Worker resource can display negative values and hides its rate when `hideRate` is enabled in planet parameters.
+- Resources with `hideRate` enabled no longer display a per-second rate in the resource list.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -539,7 +539,11 @@ function updateResourceDisplay(resources) {
 
 function updateResourceRateDisplay(resource){
   const ppsElement = document.getElementById(`${resource.name}-pps-resources-container`);
-  if (ppsElement) {
+  if (resource.hideRate) {
+    if (ppsElement) {
+      ppsElement.remove();
+    }
+  } else if (ppsElement) {
     const netRate = resource.productionRate - resource.consumptionRate;
     if (Math.abs(netRate) < 1e-3) {
       ppsElement.textContent = `0/s`;

--- a/tests/resourceHideRateDisplayToggle.test.js
+++ b/tests/resourceHideRateDisplayToggle.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('resource rate display hide', () => {
+  test('rate element removed when hideRate becomes true', () => {
+    const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+    const { JSDOM } = require(jsdomPath);
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.resources = { colony: {} };
+    ctx.buildings = {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const res = {
+      name: 'testResource',
+      displayName: 'Test',
+      category: 'colony',
+      value: 0,
+      cap: 0,
+      hasCap: true,
+      unlocked: true,
+      hideRate: false,
+      reserved: 0,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      unit: null,
+      isBooleanFlagSet: () => false,
+    };
+
+    ctx.createResourceDisplay({ colony: { testResource: res } });
+    ctx.updateResourceDisplay({ colony: { testResource: res } });
+
+    expect(dom.window.document.getElementById('testResource-pps-resources-container')).not.toBeNull();
+
+    res.hideRate = true;
+    ctx.updateResourceDisplay({ colony: { testResource: res } });
+
+    expect(dom.window.document.getElementById('testResource-pps-resources-container')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- remove per-second rate display for resources marked `hideRate`
- test hiding rate when `hideRate` toggles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a1df400668832781319011e76e2e53