### PR TITLE
Add autobuilder controls to Construction Office

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resources with `hideRate` enabled no longer display a per-second rate in the resource list.
 - Construction Office UI card unlocks with research and sits to the right of colony sliders.
 - Construction Office card manages autobuilder status and strategic reserve, persisting settings through saves and travel.
+- Construction Office visibility updates dynamically based on research unlocks.
+- Autobuilder respects a strategic reserve percentage, preventing builds that would dip resources below the configured reserve.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,3 +244,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Orbital Ring project retains active status and remaining time through planet travel, continuing construction mid-journey.
 - Worker resource can display negative values and hides its rate when `hideRate` is enabled in planet parameters.
 - Resources with `hideRate` enabled no longer display a per-second rate in the resource list.
+- Construction Office UI card unlocks with research and sits to the right of colony sliders.
+- Construction Office card manages autobuilder status and strategic reserve, persisting settings through saves and travel.

--- a/index.html
+++ b/index.html
@@ -280,6 +280,7 @@
               </div>
               <div id="colony-controls-container">
                 <div id="colony-sliders-container"></div>
+                <div id="construction-office-container" class="invisible"></div>
               </div>
               <div class="building-list" id="colony-buildings-buttons"></div>
             </div>

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -596,6 +596,10 @@
     flex: 2; /* Makes the management card wider */
 }
 
+#construction-office-container {
+    flex: 0 0 auto; /* Same width behavior as growth rate card */
+}
+
 #unhide-obsolete-container {
     margin-left: auto; /* Pushes the button to the right */
 }

--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -60,6 +60,124 @@ const autobuildCostTracker = {
     }
 };
 
+// Construction Office state and UI
+const constructionOfficeState = {
+    autobuilderActive: true,
+    strategicReserve: 0,
+};
+
+function updateConstructionOfficeUI() {
+    const statusSpan = typeof document !== 'undefined' ? document.getElementById('autobuilder-status') : null;
+    const pauseBtn = typeof document !== 'undefined' ? document.getElementById('autobuilder-pause-btn') : null;
+    const reserveInput = typeof document !== 'undefined' ? document.getElementById('strategic-reserve-input') : null;
+    if (statusSpan) {
+        statusSpan.textContent = constructionOfficeState.autobuilderActive ? 'active' : 'disabled';
+    }
+    if (pauseBtn) {
+        pauseBtn.textContent = constructionOfficeState.autobuilderActive ? 'Pause' : 'Resume';
+    }
+    if (reserveInput) {
+        reserveInput.value = constructionOfficeState.strategicReserve;
+    }
+}
+
+function setAutobuilderActive(active) {
+    constructionOfficeState.autobuilderActive = !!active;
+    updateConstructionOfficeUI();
+}
+
+function toggleAutobuilder() {
+    setAutobuilderActive(!constructionOfficeState.autobuilderActive);
+}
+
+function setStrategicReserve(value) {
+    let val = parseInt(value, 10);
+    if (isNaN(val)) val = 0;
+    val = Math.max(0, Math.min(100, val));
+    constructionOfficeState.strategicReserve = val;
+    updateConstructionOfficeUI();
+}
+
+function saveConstructionOfficeState() {
+    return { ...constructionOfficeState };
+}
+
+function loadConstructionOfficeState(state) {
+    if (!state) return;
+    setAutobuilderActive(state.autobuilderActive);
+    setStrategicReserve(state.strategicReserve);
+}
+
+function captureConstructionOfficeSettings() {
+    return saveConstructionOfficeState();
+}
+
+function restoreConstructionOfficeSettings(state) {
+    loadConstructionOfficeState(state);
+}
+
+function initializeConstructionOfficeUI() {
+    const container = typeof document !== 'undefined' ? document.getElementById('construction-office-container') : null;
+    if (!container) return;
+
+    container.innerHTML = '';
+    container.classList.add('invisible');
+
+    const card = document.createElement('div');
+    card.classList.add('project-card');
+    card.id = 'construction-office-card';
+
+    const header = document.createElement('div');
+    header.classList.add('card-header');
+    const title = document.createElement('span');
+    title.classList.add('card-title');
+    title.textContent = 'Construction Office';
+    header.appendChild(title);
+    card.appendChild(header);
+
+    const body = document.createElement('div');
+    body.classList.add('card-body');
+
+    const statusDiv = document.createElement('div');
+    const statusLabel = document.createElement('span');
+    statusLabel.textContent = 'Autobuilder: ';
+    const statusValue = document.createElement('span');
+    statusValue.id = 'autobuilder-status';
+    statusDiv.appendChild(statusLabel);
+    statusDiv.appendChild(statusValue);
+    body.appendChild(statusDiv);
+
+    const pauseBtn = document.createElement('button');
+    pauseBtn.id = 'autobuilder-pause-btn';
+    pauseBtn.addEventListener('click', () => {
+        toggleAutobuilder();
+    });
+    body.appendChild(pauseBtn);
+
+    const reserveDiv = document.createElement('div');
+    const reserveLabel = document.createElement('label');
+    reserveLabel.textContent = 'Strategic reserve: ';
+    const reserveInput = document.createElement('input');
+    reserveInput.type = 'number';
+    reserveInput.min = '0';
+    reserveInput.max = '100';
+    reserveInput.id = 'strategic-reserve-input';
+    reserveInput.addEventListener('change', () => {
+        setStrategicReserve(reserveInput.value);
+    });
+    const percentSpan = document.createElement('span');
+    percentSpan.textContent = '%';
+    reserveDiv.appendChild(reserveLabel);
+    reserveDiv.appendChild(reserveInput);
+    reserveDiv.appendChild(percentSpan);
+    body.appendChild(reserveDiv);
+
+    card.appendChild(body);
+    container.appendChild(card);
+
+    updateConstructionOfficeUI();
+}
+
 const savedAutoBuildSettings = {};
 
 function captureAutoBuildSettings(structures) {
@@ -87,6 +205,9 @@ function restoreAutoBuildSettings(structures) {
 }
 
 function autoBuild(buildings, delta = 0) {
+    if (typeof constructionOfficeState !== 'undefined' && !constructionOfficeState.autobuilderActive) {
+        return;
+    }
     autobuildCostTracker.update(delta);
     const population = resources.colony.colonists.value;
     const workerCap = resources.colony.workers?.cap || 0;
@@ -162,7 +283,22 @@ function autoBuild(buildings, delta = 0) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { autoBuild, autobuildCostTracker, captureAutoBuildSettings, restoreAutoBuildSettings };
+    module.exports = {
+        autoBuild,
+        autobuildCostTracker,
+        captureAutoBuildSettings,
+        restoreAutoBuildSettings,
+        constructionOfficeState,
+        setAutobuilderActive,
+        toggleAutobuilder,
+        setStrategicReserve,
+        saveConstructionOfficeState,
+        loadConstructionOfficeState,
+        captureConstructionOfficeSettings,
+        restoreConstructionOfficeSettings,
+        updateConstructionOfficeUI,
+        initializeConstructionOfficeUI,
+    };
 }
 
 if (typeof window !== 'undefined') {
@@ -170,4 +306,14 @@ if (typeof window !== 'undefined') {
     window.autobuildCostTracker = autobuildCostTracker;
     window.captureAutoBuildSettings = captureAutoBuildSettings;
     window.restoreAutoBuildSettings = restoreAutoBuildSettings;
+    window.constructionOfficeState = constructionOfficeState;
+    window.setAutobuilderActive = setAutobuilderActive;
+    window.toggleAutobuilder = toggleAutobuilder;
+    window.setStrategicReserve = setStrategicReserve;
+    window.saveConstructionOfficeState = saveConstructionOfficeState;
+    window.loadConstructionOfficeState = loadConstructionOfficeState;
+    window.captureConstructionOfficeSettings = captureConstructionOfficeSettings;
+    window.restoreConstructionOfficeSettings = restoreConstructionOfficeSettings;
+    window.updateConstructionOfficeUI = updateConstructionOfficeUI;
+    window.initializeConstructionOfficeUI = initializeConstructionOfficeUI;
 }

--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -67,9 +67,15 @@ const constructionOfficeState = {
 };
 
 function updateConstructionOfficeUI() {
+    const container = typeof document !== 'undefined' ? document.getElementById('construction-office-container') : null;
     const statusSpan = typeof document !== 'undefined' ? document.getElementById('autobuilder-status') : null;
     const pauseBtn = typeof document !== 'undefined' ? document.getElementById('autobuilder-pause-btn') : null;
     const reserveInput = typeof document !== 'undefined' ? document.getElementById('strategic-reserve-input') : null;
+
+    if (container && typeof globalEffects !== 'undefined' && typeof globalEffects.isBooleanFlagSet === 'function') {
+        const unlocked = globalEffects.isBooleanFlagSet('automateConstruction');
+        container.classList.toggle('invisible', !unlocked);
+    }
     if (statusSpan) {
         statusSpan.textContent = constructionOfficeState.autobuilderActive ? 'active' : 'disabled';
     }
@@ -242,11 +248,12 @@ function autoBuild(buildings, delta = 0) {
     // Step 3: Efficiently allocate builds
     buildableBuildings.forEach(({ building, requiredAmount }) => {
         let buildCount = 0;
-        const canBuildFull = building.canAfford(requiredAmount);
+        const reserve = constructionOfficeState.strategicReserve;
+        const canBuildFull = building.canAfford(requiredAmount, reserve);
         if (canBuildFull) {
             buildCount = requiredAmount;
         } else {
-            let maxBuildable = building.maxBuildable();
+            let maxBuildable = building.maxBuildable(reserve);
 
             if (building.requiresLand && typeof building.landAffordCount === 'function') {
                 maxBuildable = Math.min(maxBuildable, building.landAffordCount());

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -383,4 +383,5 @@ function initializeColonies(coloniesParameters) {
  
   function updateColonyDisplay(colonies) {
     updateStructureDisplay(colonies);
+    updateConstructionOfficeUI();
   }

--- a/src/js/colonyUI.js
+++ b/src/js/colonyUI.js
@@ -258,4 +258,5 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   createGrowthRateDisplay();
+  initializeConstructionOfficeUI();
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -117,11 +117,15 @@ function initializeGameState(options = {}) {
   let savedAdvancedResearch = null;
   let savedAlienArtifact = null;
   let savedProjectTravelState = null;
+  let savedConstructionOffice = null;
   if (preserveManagers && typeof projectManager !== 'undefined' && typeof projectManager.saveTravelState === 'function') {
     savedProjectTravelState = projectManager.saveTravelState();
   }
   if (preserveManagers && typeof captureAutoBuildSettings === 'function' && typeof structures !== 'undefined') {
     captureAutoBuildSettings(structures);
+  }
+  if (preserveManagers && typeof captureConstructionOfficeSettings === 'function') {
+    savedConstructionOffice = captureConstructionOfficeSettings();
   }
   if (preserveManagers && resources && resources.colony && resources.colony.advancedResearch) {
     savedAdvancedResearch = {
@@ -193,6 +197,9 @@ function initializeGameState(options = {}) {
   structures = { ...buildings, ...colonies };
   if (preserveManagers && typeof restoreAutoBuildSettings === 'function') {
     restoreAutoBuildSettings(structures);
+  }
+  if (savedConstructionOffice && typeof restoreConstructionOfficeSettings === 'function') {
+    restoreConstructionOfficeSettings(savedConstructionOffice);
   }
   if (!preserveManagers || !researchManager) {
     researchManager = new ResearchManager(researchParameters);

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -758,6 +758,11 @@ const researchParameters = {
             flagId: 'automateConstruction',
             value: true
           },
+          {
+            target: 'tabContent',
+            targetId: 'construction-office-container',
+            type: 'enableContent'
+          }
         ],
       },
       {

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -25,6 +25,7 @@ function getGameState() {
     colonySliderSettings: typeof colonySliderSettings !== 'undefined' ? colonySliderSettings : undefined,
     ghgFactorySettings: typeof ghgFactorySettings !== 'undefined' ? ghgFactorySettings : undefined,
     mirrorOversightSettings: typeof globalThis.mirrorOversightSettings !== 'undefined' ? globalThis.mirrorOversightSettings : undefined,
+    constructionOffice: typeof saveConstructionOfficeState === 'function' ? saveConstructionOfficeState() : undefined,
     playTimeSeconds: typeof playTimeSeconds !== 'undefined' ? playTimeSeconds : undefined
   };
 }
@@ -320,6 +321,10 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.mirrorOversightSettings){
       Object.assign(mirrorOversightSettings, gameState.mirrorOversightSettings);
+    }
+
+    if(gameState.constructionOffice && typeof loadConstructionOfficeState === 'function'){
+      loadConstructionOfficeState(gameState.constructionOffice);
     }
 
     if(gameState.playTimeSeconds !== undefined){

--- a/tests/autobuildStrategicReserve.test.js
+++ b/tests/autobuildStrategicReserve.test.js
@@ -1,0 +1,51 @@
+const { autoBuild, setStrategicReserve } = require('../src/js/autobuild.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+global.maintenanceFraction = 0;
+const { Building } = require('../src/js/building.js');
+
+describe('autobuild respects strategic reserve', () => {
+  test('avoids building below reserve', () => {
+    const config = {
+      name: 'Test',
+      category: 'colony',
+      cost: { colony: { metal: 50 } },
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: {},
+      canBeToggled: false,
+      maintenanceFactor: 1,
+      requiresMaintenance: false,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true,
+      surfaceArea: 0,
+      requiresProductivity: true,
+      requiresLand: 0,
+    };
+
+    const b = new Building(config, 'test');
+    b.autoBuildEnabled = true;
+    b.autoBuildPercent = 100;
+
+    global.resources = {
+      colony: {
+        colonists: { value: 100 },
+        metal: { value: 80, cap: 100, decrease(v) { this.value -= v; } },
+      },
+      surface: {},
+      underground: {},
+    };
+
+    setStrategicReserve(50);
+    autoBuild({ t: b });
+    expect(b.count).toBe(0);
+
+    resources.colony.metal.value = 150;
+    resources.colony.metal.cap = 200;
+    autoBuild({ t: b });
+    expect(b.count).toBe(1);
+    expect(resources.colony.metal.value).toBe(100);
+  });
+});

--- a/tests/autobuilderPause.test.js
+++ b/tests/autobuilderPause.test.js
@@ -1,0 +1,26 @@
+const { autoBuild, constructionOfficeState } = require('../src/js/autobuild.js');
+
+describe('autobuilder global pause', () => {
+  test('autoBuild skips when disabled', () => {
+    global.resources = { colony: { colonists: { value: 10 } } };
+    const building = {
+      autoBuildEnabled: true,
+      autoBuildPercent: 10,
+      count: 0,
+      canAfford: () => true,
+      maxBuildable: () => 1,
+      build: jest.fn(() => { building.count += 1; return true; }),
+    };
+
+    constructionOfficeState.autobuilderActive = true;
+    autoBuild({ A: building });
+    expect(building.build).toHaveBeenCalled();
+
+    building.build.mockClear();
+    constructionOfficeState.autobuilderActive = false;
+    autoBuild({ A: building });
+    expect(building.build).not.toHaveBeenCalled();
+
+    constructionOfficeState.autobuilderActive = true; // reset
+  });
+});

--- a/tests/buildingStrategicReserve.test.js
+++ b/tests/buildingStrategicReserve.test.js
@@ -1,0 +1,44 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+global.maintenanceFraction = 0;
+const { Building } = require('../src/js/building.js');
+
+describe('Building reserve-aware affordability', () => {
+  test('canAfford and maxBuildable respect strategic reserve', () => {
+    global.resources = {
+      colony: {
+        metal: { value: 80, cap: 100 },
+      },
+    };
+
+    const config = {
+      name: 'Test',
+      category: 'colony',
+      cost: { colony: { metal: 50 } },
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: {},
+      canBeToggled: false,
+      maintenanceFactor: 1,
+      requiresMaintenance: false,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true,
+      surfaceArea: 0,
+      requiresProductivity: true,
+      requiresLand: 0,
+    };
+
+    const b = new Building(config, 'test');
+
+    expect(b.canAfford(1, 50)).toBe(false);
+    expect(b.maxBuildable(50)).toBe(0);
+
+    resources.colony.metal.value = 150;
+    resources.colony.metal.cap = 200;
+
+    expect(b.canAfford(1, 50)).toBe(true);
+    expect(b.maxBuildable(50)).toBe(1);
+  });
+});

--- a/tests/constructionOfficeState.test.js
+++ b/tests/constructionOfficeState.test.js
@@ -1,0 +1,31 @@
+const {
+  constructionOfficeState,
+  saveConstructionOfficeState,
+  loadConstructionOfficeState,
+  captureConstructionOfficeSettings,
+  restoreConstructionOfficeSettings,
+} = require('../src/js/autobuild.js');
+
+describe('Construction Office state persistence', () => {
+  test('saves and loads state', () => {
+    constructionOfficeState.autobuilderActive = false;
+    constructionOfficeState.strategicReserve = 25;
+    const saved = saveConstructionOfficeState();
+    constructionOfficeState.autobuilderActive = true;
+    constructionOfficeState.strategicReserve = 0;
+    loadConstructionOfficeState(saved);
+    expect(constructionOfficeState.autobuilderActive).toBe(false);
+    expect(constructionOfficeState.strategicReserve).toBe(25);
+  });
+
+  test('persists through travel capture/restore', () => {
+    constructionOfficeState.autobuilderActive = false;
+    constructionOfficeState.strategicReserve = 55;
+    const saved = captureConstructionOfficeSettings();
+    constructionOfficeState.autobuilderActive = true;
+    constructionOfficeState.strategicReserve = 0;
+    restoreConstructionOfficeSettings(saved);
+    expect(constructionOfficeState.autobuilderActive).toBe(false);
+    expect(constructionOfficeState.strategicReserve).toBe(55);
+  });
+});

--- a/tests/constructionOfficeUI.test.js
+++ b/tests/constructionOfficeUI.test.js
@@ -1,10 +1,11 @@
-const { initializeConstructionOfficeUI, constructionOfficeState } = require('../src/js/autobuild.js');
+const { initializeConstructionOfficeUI, constructionOfficeState, updateConstructionOfficeUI } = require('../src/js/autobuild.js');
 
 describe('Construction Office UI', () => {
   test('initializes card and controls', () => {
     const { JSDOM } = require('jsdom');
-    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-controls-container"><div id="colony-sliders-container"></div><div id="construction-office-container" class="invisible"></div></div>` , { runScripts: 'outside-only' });
+    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-controls-container"><div id="colony-sliders-container"></div><div id="construction-office-container" class="invisible"></div></div>`, { runScripts: 'outside-only' });
     global.document = dom.window.document;
+    global.globalEffects = { isBooleanFlagSet: () => false };
 
     initializeConstructionOfficeUI();
 
@@ -32,9 +33,15 @@ describe('Construction Office UI', () => {
     expect(status.textContent).toBe('active');
     expect(constructionOfficeState.autobuilderActive).toBe(true);
 
-    // simulate research unlock
-    container.classList.remove('invisible');
+    // simulate research unlock via global flag
+    global.globalEffects.isBooleanFlagSet = flag => flag === 'automateConstruction';
+    updateConstructionOfficeUI();
     expect(container.classList.contains('invisible')).toBe(false);
+
+    // simulate losing research
+    global.globalEffects.isBooleanFlagSet = () => false;
+    updateConstructionOfficeUI();
+    expect(container.classList.contains('invisible')).toBe(true);
 
     // ensure the container is positioned after the sliders box
     const parentChildren = Array.from(container.parentElement.children);

--- a/tests/constructionOfficeUI.test.js
+++ b/tests/constructionOfficeUI.test.js
@@ -1,0 +1,43 @@
+const { initializeConstructionOfficeUI, constructionOfficeState } = require('../src/js/autobuild.js');
+
+describe('Construction Office UI', () => {
+  test('initializes card and controls', () => {
+    const { JSDOM } = require('jsdom');
+    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-controls-container"><div id="colony-sliders-container"></div><div id="construction-office-container" class="invisible"></div></div>` , { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+
+    initializeConstructionOfficeUI();
+
+    const container = document.getElementById('construction-office-container');
+    expect(container).toBeTruthy();
+    expect(container.classList.contains('invisible')).toBe(true);
+    const title = container.querySelector('.card-title');
+    expect(title && title.textContent).toBe('Construction Office');
+
+    const status = document.getElementById('autobuilder-status');
+    const pauseBtn = document.getElementById('autobuilder-pause-btn');
+    const reserveInput = document.getElementById('strategic-reserve-input');
+
+    expect(status.textContent).toBe('active');
+    expect(pauseBtn.textContent).toBe('Pause');
+    expect(reserveInput.value).toBe('0');
+    expect(reserveInput.nextSibling.textContent).toBe('%');
+
+    pauseBtn.click();
+    expect(status.textContent).toBe('disabled');
+    expect(pauseBtn.textContent).toBe('Resume');
+    expect(constructionOfficeState.autobuilderActive).toBe(false);
+
+    pauseBtn.click();
+    expect(status.textContent).toBe('active');
+    expect(constructionOfficeState.autobuilderActive).toBe(true);
+
+    // simulate research unlock
+    container.classList.remove('invisible');
+    expect(container.classList.contains('invisible')).toBe(false);
+
+    // ensure the container is positioned after the sliders box
+    const parentChildren = Array.from(container.parentElement.children);
+    expect(parentChildren[parentChildren.length - 1]).toBe(container);
+  });
+});


### PR DESCRIPTION
## Summary
- Consolidate Construction Office state management and UI into autobuild.js
- Remove standalone Construction Office scripts and reference the shared module
- Adjust tests and imports to use unified autobuild functions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a20e76c2a08327bbf2a22c947ac352