### PR TITLE
feat: prioritize workers for buildings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,3 +248,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Construction Office card manages autobuilder status and strategic reserve, persisting settings through saves and travel.
 - Construction Office visibility updates dynamically based on research unlocks.
 - Autobuilder respects a strategic reserve percentage, preventing builds that would dip resources below the configured reserve.
+- Buildings requiring workers can be prioritized via a checkbox, allocating workers to them before others.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -18,6 +18,7 @@ class Building extends EffectableEntity {
     this.autoBuildPercent = 0.1;
     this.autoBuildPriority = false;
     this.autoBuildBasis = 'population';
+    this.workerPriority = false;
 
     this.maintenanceCost = this.calculateMaintenanceCost();
     this.currentProduction = {};
@@ -423,7 +424,7 @@ class Building extends EffectableEntity {
 
     // Calculate minRatio based on worker availability if applicable
     if (this.getTotalWorkerNeed() > 0) {
-      const workerRatio = populationModule.getWorkerAvailabilityRatio();
+      const workerRatio = populationModule.getWorkerAvailabilityRatio(this.workerPriority);
       minRatio = Math.min(minRatio, workerRatio);
     }
 

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -646,8 +646,40 @@ function updateDecreaseButtonText(button, buildCount) {
       const span = costElement._spans.get(item.key);
       if (!span) return;
       const text = `${item.label}: ${formatNumber(requiredAmount, true)}`;
-      if (span.textContent !== text) {
-        span.textContent = text;
+
+      if (item.key === 'colony.workers') {
+        let textSpan = span._textSpan;
+        if (!textSpan) {
+          textSpan = document.createElement('span');
+          span._textSpan = textSpan;
+          span.textContent = '';
+          span.appendChild(textSpan);
+
+          const label = document.createElement('label');
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.checked = structure.workerPriority;
+          checkbox.addEventListener('change', () => {
+            structure.workerPriority = checkbox.checked;
+            if (typeof populationModule !== 'undefined' && typeof populationModule.updateWorkerRequirements === 'function') {
+              populationModule.updateWorkerRequirements();
+              if (populationModule.workerResource) {
+                populationModule.workerResource.value = populationModule.workerResource.cap - populationModule.totalWorkersRequired;
+              }
+            }
+          });
+          label.append(checkbox, ' prioritize');
+          const container = document.createElement('span');
+          container.append(' (', label, ')');
+          span.appendChild(container);
+          span._priorityCheckbox = checkbox;
+        }
+        textSpan.textContent = text;
+        span._priorityCheckbox.checked = structure.workerPriority;
+      } else {
+        if (span.textContent !== text) {
+          span.textContent = text;
+        }
       }
       const hasEnough = item.available >= requiredAmount;
       const color = hasEnough ? '' : item.insufficientColor;

--- a/tests/workerPriorityProductivity.test.js
+++ b/tests/workerPriorityProductivity.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+test('prioritized buildings receive workers first', () => {
+  const dom = new JSDOM(`<!DOCTYPE html>`, { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0, cap: 15 }, androids: { value: 0, cap: 0 } } };
+  const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+  const buildingCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'building.js'), 'utf8');
+  const populationCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'population.js'), 'utf8');
+  vm.runInContext(effectCode + '\n' + buildingCode + '\n' + populationCode + '; this.Building = Building; this.PopulationModule = PopulationModule;', ctx);
+
+  const pop = new ctx.PopulationModule(ctx.resources, { workerRatio: 1 });
+  ctx.populationModule = pop;
+
+  const config = { name: 'A', category: 'resource', description: '', cost: {}, consumption: {}, production: {}, storage: {}, dayNightActivity: true, canBeToggled: false, maintenanceFactor: 0, requiresMaintenance: false, requiresDeposit: false, requiresWorker: 10, unlocked: true, surfaceArea: 0, requiresProductivity: true, requiresLand: 0 };
+  const b1 = new ctx.Building(config, 'A');
+  b1.active = 1;
+  b1.workerPriority = true;
+  const b2 = new ctx.Building(config, 'B');
+  b2.active = 1;
+  ctx.buildings = { A: b1, B: b2 };
+
+  pop.updateWorkerRequirements();
+  const ratio1 = b1.calculateBaseMinRatio(ctx.resources, 1000);
+  const ratio2 = b2.calculateBaseMinRatio(ctx.resources, 1000);
+  expect(ratio1).toBe(1);
+  expect(ratio2).toBeCloseTo(0.5);
+});

--- a/tests/workerPriorityUI.test.js
+++ b/tests/workerPriorityUI.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+test('adds prioritize checkbox next to worker cost', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><div id="c"></div>`, { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.document = dom.window.document;
+  ctx.resources = { colony: { workers: { value: 0 }, colonists: { value: 0 }, androids: { value: 0, cap: 0 } } };
+  ctx.populationModule = { updateWorkerRequirements: () => {}, workerResource: { cap: 0, value: 0, totalWorkersRequired: 0 } };
+  ctx.formatNumber = () => '';
+  ctx.capitalizeFirstLetter = s => s;
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code + '; this.updateStructureCostDisplay = updateStructureCostDisplay;', ctx);
+
+  const structure = {
+    name: 'test',
+    workerPriority: false,
+    getEffectiveCost: () => ({}),
+    getTotalWorkerNeed: () => 1,
+    getEffectiveWorkerMultiplier: () => 1
+  };
+
+  const el = ctx.document.getElementById('c');
+  ctx.updateStructureCostDisplay(el, structure);
+  const checkbox = el.querySelector('input[type="checkbox"]');
+  expect(checkbox).not.toBeNull();
+  checkbox.checked = true;
+  checkbox.dispatchEvent(new dom.window.Event('change'));
+  expect(structure.workerPriority).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add worker priority checkbox to building cost UI
- allocate workers to prioritized buildings before others
- test worker priority logic and UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a23bb941b8832787ec699f87ce5208