### PR TITLE
Adjust self-replicating ships research cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,3 +250,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Autobuilder respects a strategic reserve percentage, preventing builds that would dip resources below the configured reserve.
 - Life UI checkmark table lists day and night temperatures for each zone.
 - Buildings requiring workers can be prioritized via a checkbox, allocating workers to them before others.
+- Self Replicating Ships research now costs 8M advanced research points.

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -510,7 +510,7 @@ const researchParameters = {
       id: 'self_replicating_ships',
       name: 'Self Replicating Ships',
       description: 'Unused spaceships duplicate themselves over time.',
-      cost: { research: 10000000000 },
+      cost: { advancedResearch: 8000000 },
       prerequisites: [],
       requiredFlags: ['selfReplicatingShipsUnlocked'],
       effects: [

--- a/tests/selfReplicatingShipsResearch.test.js
+++ b/tests/selfReplicatingShipsResearch.test.js
@@ -24,7 +24,7 @@ describe('Self Replicating Ships research', () => {
     const industry = ctx.researchParameters.industry;
     const research = industry.find(r => r.id === 'self_replicating_ships');
     expect(research).toBeDefined();
-    expect(research.cost.research).toBe(10000000000);
+    expect(research.cost.advancedResearch).toBe(8000000);
     expect(research.requiredFlags).toEqual(['selfReplicatingShipsUnlocked']);
     const flag = research.effects.find(e => e.type === 'booleanFlag' && e.flagId === 'selfReplicatingShips' && e.target === 'global' && e.value === true);
     expect(flag).toBeDefined();


### PR DESCRIPTION
## Summary
- require 8M advanced research points for self-replicating ships
- document new cost in AGENTS log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a27222d78c8327b933a4fb873bda4c