### PR TITLE
Add tooltip for Construction Office strategic reserve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resources with `hideRate` enabled no longer display a per-second rate in the resource list.
 - Construction Office UI card unlocks with research and sits to the right of colony sliders.
 - Construction Office card manages autobuilder status and strategic reserve, persisting settings through saves and travel.
+- Strategic reserve input includes an info tooltip explaining its effect.
 - Construction Office visibility updates dynamically based on research unlocks.
 - Autobuilder respects a strategic reserve percentage, preventing builds that would dip resources below the configured reserve.
 - Life UI checkmark table lists day and night temperatures for each zone.

--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -161,7 +161,13 @@ function initializeConstructionOfficeUI() {
 
     const reserveDiv = document.createElement('div');
     const reserveLabel = document.createElement('label');
-    reserveLabel.textContent = 'Strategic reserve: ';
+    reserveLabel.textContent = 'Strategic reserve ';
+    const reserveInfo = document.createElement('span');
+    reserveInfo.classList.add('info-tooltip-icon');
+    reserveInfo.innerHTML = '&#9432;';
+    reserveInfo.title = 'Prevents the Construction Office from using resources from storage if spending them would drop any resource below the specified percentage of its capacity.';
+    reserveLabel.appendChild(reserveInfo);
+    reserveLabel.appendChild(document.createTextNode(': '));
     const reserveInput = document.createElement('input');
     reserveInput.type = 'number';
     reserveInput.min = '0';

--- a/tests/constructionOfficeUI.test.js
+++ b/tests/constructionOfficeUI.test.js
@@ -18,11 +18,15 @@ describe('Construction Office UI', () => {
     const status = document.getElementById('autobuilder-status');
     const pauseBtn = document.getElementById('autobuilder-pause-btn');
     const reserveInput = document.getElementById('strategic-reserve-input');
+    const reserveLabel = reserveInput.previousSibling;
+    const reserveIcon = reserveLabel.querySelector('.info-tooltip-icon');
 
     expect(status.textContent).toBe('active');
     expect(pauseBtn.textContent).toBe('Pause');
     expect(reserveInput.value).toBe('0');
     expect(reserveInput.nextSibling.textContent).toBe('%');
+    expect(reserveIcon).toBeTruthy();
+    expect(reserveIcon.getAttribute('title')).toBe('Prevents the Construction Office from using resources from storage if spending them would drop any resource below the specified percentage of its capacity.');
 
     pauseBtn.click();
     expect(status.textContent).toBe('disabled');


### PR DESCRIPTION
## Summary
- Add info tooltip to Construction Office strategic reserve input describing its storage threshold behavior
- Document tooltip addition in AGENTS instructions
- Test for tooltip presence and title in Construction Office UI tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a273fac5b48327bd1f7139405e0009