### PR TITLE
Show Dyson Swarm collectors without receiver tech

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,3 +255,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Geothermal power generation research only appears on worlds with geothermal deposits.
 - Storage Depot maintenance cost reduced to 10% of its previous value.
 - Self Replicating Ships research now costs 8M advanced research points.
+- Dyson Swarm project displays when collectors exist even without receiver tech, hiding receiver energy output while allowing manual and automatic collector deployment.

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -28,7 +28,6 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
   }
 
   canStartCollector() {
-    if (!this.isCompleted) return false;
     if (this.collectorProgress > 0) return false;
     const storageProj = this.attributes.canUseSpaceStorage && projectManager?.projects?.spaceStorage;
     for (const cat in this.collectorCost) {
@@ -102,17 +101,15 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
 
   update(delta) {
     super.update(delta);
-    if (this.isCompleted) {
-      if (this.collectorProgress > 0) {
-        this.collectorProgress -= delta;
-        if (this.collectorProgress <= 0) {
-          this.collectorProgress = 0;
-          this.collectors += 1;
-          if (this.autoDeployCollectors) this.startCollector();
-        }
-      } else if (this.autoDeployCollectors) {
-        this.startCollector();
+    if (this.collectorProgress > 0) {
+      this.collectorProgress -= delta;
+      if (this.collectorProgress <= 0) {
+        this.collectorProgress = 0;
+        this.collectors += 1;
+        if (this.autoDeployCollectors && (this.isCompleted || this.collectors > 0)) this.startCollector();
       }
+    } else if (this.autoDeployCollectors && (this.isCompleted || this.collectors > 0)) {
+      this.startCollector();
     }
   }
 

--- a/src/js/projects/dysonswarmUI.js
+++ b/src/js/projects/dysonswarmUI.js
@@ -35,9 +35,12 @@ function renderDysonSwarmUI(project, container) {
 function updateDysonSwarmUI(project) {
   const els = projectElements[project.name];
   if (!els) return;
+  const showCard = project.isCompleted || project.collectors > 0;
   if (els.swarmCard) {
-    els.swarmCard.style.display = project.isCompleted ? 'block' : 'none';
+    els.swarmCard.style.display = showCard ? 'block' : 'none';
   }
+  if (!showCard) return;
+
   els.collectorsDisplay.textContent = formatNumber(project.collectors, false, 2);
   els.powerPerDisplay.textContent = formatNumber(project.energyPerCollector, false, 2);
   const total = project.energyPerCollector * project.collectors;
@@ -54,15 +57,16 @@ function updateDysonSwarmUI(project) {
     }
     els.costDisplay.textContent = parts.join(', ');
   }
-  if (!project.isCompleted) {
-    els.startButton.textContent = 'Receiver Incomplete';
-    els.startButton.style.background = '#999';
-    els.startButton.disabled = true;
-    els.autoCheckbox.disabled = true;
-    return;
-  } else {
-    els.startButton.disabled = false;
-    els.autoCheckbox.disabled = false;
+  if (els.startButton) {
+    els.startButton.parentElement.style.display = '';
+  }
+  if (els.autoCheckbox) {
+    const canAuto = project.unlocked || project.collectors > 0;
+    els.autoCheckbox.parentElement.style.display = canAuto ? '' : 'none';
+    els.autoCheckbox.disabled = !canAuto;
+  }
+  if (els.totalPowerDisplay) {
+    els.totalPowerDisplay.parentElement.style.display = (project.unlocked && project.isCompleted) ? '' : 'none';
   }
   if (project.collectorProgress > 0) {
     const pct = ((project.collectorDuration - project.collectorProgress) / project.collectorDuration) * 100;
@@ -74,6 +78,7 @@ function updateDysonSwarmUI(project) {
     const dur = Math.round(project.collectorDuration / 1000);
     els.startButton.textContent = `Deploy Collector (${dur}s)`;
     els.startButton.style.background = can ? '#4caf50' : '#f44336';
+    els.startButton.disabled = !can;
   }
   els.autoCheckbox.checked = project.autoDeployCollectors;
 }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -423,7 +423,8 @@ function updateProjectUI(projectName) {
     const planetOk = !project.attributes.planet ||
       (typeof spaceManager !== 'undefined' && spaceManager.getCurrentPlanetKey &&
        spaceManager.getCurrentPlanetKey() === project.attributes.planet);
-    if (project.unlocked && planetOk) {
+    const showDueToCollectors = project.name === 'dysonSwarmReceiver' && project.collectors > 0;
+    if ((project.unlocked || showDueToCollectors) && planetOk) {
       projectItem.style.display = 'block';
     } else {
       projectItem.style.display = 'none';
@@ -650,6 +651,12 @@ function updateProjectUI(projectName) {
   if (elements.downButton) {
     elements.downButton.classList.toggle('disabled', currentIndex === -1 || currentIndex === categoryProjects.length - 1);
   }
+
+  if (!project.unlocked && project.name === 'dysonSwarmReceiver' && project.collectors > 0) {
+    if (elements.progressButton) elements.progressButton.style.display = 'none';
+    if (elements.autoStartCheckboxContainer) elements.autoStartCheckboxContainer.style.display = 'none';
+    if (elements.cardFooter) elements.cardFooter.style.display = 'none';
+  }
 }
 
 
@@ -761,7 +768,8 @@ function updateMegaProjectsVisibility() {
       const planetOk = !p.attributes.planet ||
         (typeof spaceManager !== 'undefined' && spaceManager.getCurrentPlanetKey &&
          spaceManager.getCurrentPlanetKey() === p.attributes.planet);
-      return p.category === 'mega' && p.unlocked && planetOk;
+      const dysonCollectors = p.name === 'dysonSwarmReceiver' && p.collectors > 0;
+      return p.category === 'mega' && planetOk && (p.unlocked || dysonCollectors);
     });
   }
 

--- a/tests/dysonSwarmCardVisibility.test.js
+++ b/tests/dysonSwarmCardVisibility.test.js
@@ -5,7 +5,7 @@ const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 
 describe('Dyson Swarm card visibility', () => {
-  test('card hidden until project complete', () => {
+  test('shows when collectors exist even without receiver', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.document = dom.window.document;
@@ -24,6 +24,7 @@ describe('Dyson Swarm card visibility', () => {
       collectorProgress: 0,
       autoDeployCollectors: false,
       isCompleted: false,
+      unlocked: false,
       canStartCollector: () => true,
       startCollector: () => {}
     };
@@ -35,8 +36,18 @@ describe('Dyson Swarm card visibility', () => {
     const card = ctx.projectElements[project.name].swarmCard;
     expect(card.style.display).toBe('none');
 
-    project.isCompleted = true;
+    project.collectors = 5;
     ctx.updateDysonSwarmUI(project);
     expect(card.style.display).toBe('block');
+    const els = ctx.projectElements[project.name];
+    expect(els.startButton.parentElement.style.display).toBe('');
+    expect(els.autoCheckbox.parentElement.style.display).toBe('');
+    expect(els.autoCheckbox.disabled).toBe(false);
+    expect(els.totalPowerDisplay.parentElement.style.display).toBe('none');
+
+    project.unlocked = true;
+    project.isCompleted = true;
+    ctx.updateDysonSwarmUI(project);
+    expect(els.startButton.parentElement.style.display).toBe('');
   });
 });

--- a/tests/dysonSwarmCollector.test.js
+++ b/tests/dysonSwarmCollector.test.js
@@ -44,7 +44,7 @@ describe('Dyson Swarm collector behaviour', () => {
     expect(project.collectorProgress).toBe(project.collectorDuration - 1000);
   });
 
-  test('collector cannot start before receiver completion', () => {
+  test('collector can start before receiver completion', () => {
     const ctx = {
       console,
       EffectableEntity,
@@ -63,7 +63,7 @@ describe('Dyson Swarm collector behaviour', () => {
     };
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
-    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
     const baseCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'TerraformingDurationProject.js'), 'utf8');
     vm.runInContext(baseCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
     const dysonCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'dysonswarm.js'), 'utf8');
@@ -71,8 +71,59 @@ describe('Dyson Swarm collector behaviour', () => {
 
     const params = { name: 'dyson', category: 'mega', cost: {}, duration: 0, description: '', repeatable: false, unlocked: true, attributes: {} };
     const project = new ctx.DysonSwarmReceiverProject(params, 'dyson');
+    project.collectorCost = { colony: { glass: 1, electronics: 1, components: 1 } };
 
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.projects.dyson = project;
+
+    project.isCompleted = false;
     const started = project.startCollector();
-    expect(started).toBe(false);
+    expect(started).toBe(true);
+    expect(project.collectorProgress).toBe(project.collectorDuration);
+    ctx.projectManager.updateProjects(1000);
+    expect(project.collectorProgress).toBe(project.collectorDuration - 1000);
+  });
+
+  test('auto deploy starts collectors without receiver completion', () => {
+    const ctx = {
+      console,
+      EffectableEntity,
+      resources: {
+        colony: {
+          glass: { value: 10, decrease: () => {}, updateStorageCap: () => {} },
+          electronics: { value: 10, decrease: () => {}, updateStorageCap: () => {} },
+          components: { value: 10, decrease: () => {}, updateStorageCap: () => {} }
+        }
+      },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+    const baseCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'TerraformingDurationProject.js'), 'utf8');
+    vm.runInContext(baseCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
+    const dysonCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'dysonswarm.js'), 'utf8');
+    vm.runInContext(dysonCode + '; this.DysonSwarmReceiverProject = DysonSwarmReceiverProject;', ctx);
+
+    const params = { name: 'dyson', category: 'mega', cost: {}, duration: 0, description: '', repeatable: false, unlocked: true, attributes: {} };
+    const project = new ctx.DysonSwarmReceiverProject(params, 'dyson');
+    project.collectorCost = { colony: { glass: 1, electronics: 1, components: 1 } };
+    project.isCompleted = false;
+    project.collectors = 1;
+    project.autoDeployCollectors = true;
+
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.projects.dyson = project;
+
+    project.update(0);
+    expect(project.collectorProgress).toBe(project.collectorDuration);
+
+    project.update(project.collectorDuration);
+    expect(project.collectors).toBe(2);
+    expect(project.collectorProgress).toBe(project.collectorDuration);
   });
 });

--- a/tests/dysonSwarmCollectorDuration.test.js
+++ b/tests/dysonSwarmCollectorDuration.test.js
@@ -42,6 +42,7 @@ describe('Dyson Swarm collector duration UI', () => {
       collectorProgress: 0,
       autoDeployCollectors: false,
       isCompleted: true,
+      unlocked: true,
       canStartCollector: () => true,
       startCollector: () => {},
       renderUI(container) { ctx.renderDysonSwarmUI(this, container); },

--- a/tests/dysonSwarmLockedProjectUI.test.js
+++ b/tests/dysonSwarmLockedProjectUI.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+
+describe('Dyson Swarm project visibility without tech', () => {
+  test('project shows but cannot start receiver', () => {
+    const html = `<!DOCTYPE html>
+      <div class="projects-subtab" data-subtab="mega-projects"></div>
+      <div id="mega-projects"></div>
+      <div class="projects-subtab-content-wrapper"></div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.window = dom.window;
+    ctx.projectElements = {};
+    ctx.formatNumber = n => n;
+    ctx.formatBigInteger = n => n;
+    ctx.resources = { special: { spaceships: { value: 0 } } };
+    ctx.spaceManager = { getCurrentPlanetKey: () => 'mars' };
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.updateMegaProjectsVisibility = updateMegaProjectsVisibility; this.projectElements = projectElements;', ctx);
+
+    const project = {
+      name: 'dysonSwarmReceiver',
+      displayName: 'Dyson Swarm Receiver',
+      description: '',
+      cost: {},
+      attributes: {},
+      category: 'mega',
+      unlocked: false,
+      collectors: 2,
+      isCompleted: false,
+      repeatable: false,
+      repeatCount: 0,
+      maxRepeatCount: 1,
+      autoStart: false,
+      isActive: false,
+      getEffectiveCost: () => ({}),
+      getScaledCost: () => ({}),
+      getEffectiveDuration: () => 1000,
+      getProgress: () => 0,
+      canStart: () => false,
+      renderUI: () => {},
+      updateUI: () => {}
+    };
+
+    ctx.projectManager = {
+      projects: { dysonSwarmReceiver: project },
+      projectOrder: ['dysonSwarmReceiver'],
+      getProjectStatuses() { return this.projectOrder.map(name => this.projects[name]); },
+      reorderProject: () => {},
+      isBooleanFlagSet: () => false,
+      startProject: () => {}
+    };
+
+    ctx.createProjectItem(project);
+    ctx.updateProjectUI(project.name);
+    ctx.updateMegaProjectsVisibility();
+
+    const els = ctx.projectElements[project.name];
+    expect(els.projectItem.style.display).toBe('block');
+    expect(els.progressButton.style.display).toBe('none');
+    const megaSubtab = dom.window.document.querySelector('.projects-subtab[data-subtab="mega-projects"]');
+    expect(megaSubtab.classList.contains('hidden')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow auto-deploying Dyson Swarm collectors when at least one exists even if the receiver is unbuilt
- Display collector auto-start control whenever collectors are present while keeping receiver power hidden until unlocked
- Test collector auto-deployment and project card visibility without receiver tech

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a27653043c8327b03d4ba65aff3a0d