### PR TITLE
Scale building effect displays by build count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Dyson Swarm project displays when collectors exist even without receiver tech, hiding receiver energy output while allowing manual and automatic collector deployment.
 - Cargo Rocket project applies rates only once by honoring the `applyRates` flag in `estimateProjectCostAndGain`.
 - Carbon asteroid mining can auto-disable when O2 pressure exceeds a threshold (default 15 kPa), and space mining pressure controls now label gases like CO2 and N2.
+- Production, consumption, and maintenance displays scale with selected build count.

--- a/tests/buildCountProdConsDisplay.test.js
+++ b/tests/buildCountProdConsDisplay.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+// load getProdConsSections from structuresUI.js within a jsdom context
+const { getProdConsSections } = (() => {
+  const dom = new JSDOM('<!DOCTYPE html><div></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.formatNumber = n => n;
+  ctx.formatStorageDetails = () => '';
+  ctx.resources = { colony: { water: { displayName: 'Water' }, metal: { displayName: 'Metal' } } };
+  ctx.terraforming = { celestialParameters: {} };
+  ctx.Colony = class {};
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+  return ctx;
+})();
+
+describe('build count scaling for production and consumption display', () => {
+  test('production, consumption, and maintenance scale with build count', () => {
+    const structure = {
+      name: 'testStruct',
+      getModifiedStorage: () => ({}),
+      powerPerBuilding: null,
+      requiresMaintenance: true,
+      maintenanceCost: { metal: 1 },
+      getModifiedProduction: () => ({ colony: { water: 2 } }),
+      getModifiedConsumption: () => ({ colony: { metal: 3 } }),
+    };
+
+    const sections = getProdConsSections(structure, 5);
+    const production = sections.find(sec => sec.key === 'production').data;
+    const consumption = sections.find(sec => sec.key === 'consumption').data;
+    const maintenance = sections.find(sec => sec.key === 'maintenance').data;
+
+    expect(production.colony.water).toBe(10);
+    expect(consumption.colony.metal).toBe(15);
+    expect(maintenance.metal).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- scale production, consumption and maintenance displays by selected build count
- test that build count affects production, consumption and maintenance values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a39e0edf4483279b736f66b4f84d16