### PR TITLE
Clarify ground albedo tooltip with black dust value

### DIFF
--- a/src/js/terraformingUI.js
+++ b/src/js/terraformingUI.js
@@ -765,7 +765,7 @@ function updateLifeBox() {
         </thead>
         <tbody>
           <tr>
-            <td>Ground Albedo <span id="ground-albedo-tooltip" class="info-tooltip-icon" title="Base albedo blended with black dust upgrades.">&#9432;</span></td>
+            <td>Ground Albedo <span id="ground-albedo-tooltip" class="info-tooltip-icon" title="Base albedo blended with black dust (0.05 albedo) upgrades.">&#9432;</span></td>
             <td><span id="ground-albedo">${(terraforming.luminosity.groundAlbedo ?? 0).toFixed(2)}</span></td>
             <td><span id="ground-albedo-delta"></span></td>
           </tr>
@@ -826,7 +826,8 @@ function updateLifeBox() {
         ? resources.special.albedoUpgrades.value : 0;
       const area = terraforming.celestialParameters.surfaceArea || 1;
       const coverage = area > 0 ? Math.min(upgrades / area, 1) : 0;
-      groundTooltip.title = `Base: ${base.toFixed(2)}\nBlack dust coverage: ${(coverage*100).toFixed(1)}%`;
+      const dustAlbedo = 0.05;
+      groundTooltip.title = `Base: ${base.toFixed(2)}\nBlack dust albedo: ${dustAlbedo.toFixed(2)}\nBlack dust coverage: ${(coverage*100).toFixed(1)}%`;
     }
 
     const surfAlbEl = document.getElementById('surface-albedo');

--- a/tests/groundAlbedoTooltip.test.js
+++ b/tests/groundAlbedoTooltip.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('ground albedo tooltip', () => {
+  test('includes black dust albedo value and coverage', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div class="row"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.calculateAverageCoverage = () => 0;
+    ctx.calculateSurfaceFractions = () => ({ ocean: 0, ice: 0, biomass: 0 });
+    ctx.calculateZonalSurfaceFractions = () => ({ ocean: 0, ice: 0, biomass: 0 });
+    ctx.ZONES = ['tropical','temperate','polar'];
+    ctx.DEFAULT_SURFACE_ALBEDO = require('../src/js/physics.js').DEFAULT_SURFACE_ALBEDO;
+
+    ctx.resources = { special: { albedoUpgrades: { value: 30 } } };
+    ctx.terraforming = {
+      luminosity: { name: 'Luminosity', groundAlbedo: 0.3, surfaceAlbedo: 0.3, actualAlbedo: 0.3, albedo: 0.3, solarFlux: 1000, modifiedSolarFlux: 1000 },
+      celestialParameters: { albedo: 0.25, surfaceArea: 100 },
+      getLuminosityStatus: () => true,
+      calculateSolarPanelMultiplier: () => 1
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const row = dom.window.document.querySelector('.row');
+    ctx.createLuminosityBox(row);
+    ctx.updateLuminosityBox();
+
+    const tooltip = dom.window.document.getElementById('ground-albedo-tooltip').getAttribute('title');
+    expect(tooltip).toContain('Black dust albedo: 0.05');
+    expect(tooltip).toContain('Black dust coverage: 30.0%');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Explain in ground albedo tooltip that black dust uses an albedo of 0.05 and show its coverage
- Add test ensuring ground albedo tooltip displays dust value and coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a39edfb6a883279a767d5084e7c11f