### PR TITLE
Show failure reasons on life status icons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,3 +263,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Terraforming Bureau oversight adds an auto-disable option for oxygen factories when O2 pressure exceeds a configurable threshold (default 15 kPa).
 - Life designer day/night temperature rows display survival and growth status icons, and the separate survival temperature row has been removed.
 - Production, consumption, and maintenance displays scale with selected build count.
+- Life UI requirement icons display tooltips explaining failure when hovered.

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -573,22 +573,23 @@ function updateLifeStatusTable() {
         if (!cell) return;
         
         if (typeof result !== 'object' || result === null || typeof result.pass === 'undefined') {
-             console.error(`Invalid result format for ${elementId}:`, result);
-             cell.innerHTML = '?';
-             cell.title = 'Error fetching status';
-             return;
+            console.error(`Invalid result format for ${elementId}:`, result);
+            cell.innerHTML = '<span title="Error fetching status">?</span>';
+            cell.title = 'Error fetching status';
+            return;
         }
 
         if (result.pass) {
             cell.innerHTML = '&#x2705;';
             cell.title = '';
         } else {
+            const reason = result.reason || 'Failed';
             // Add reduction % for global radiation cell if applicable
             const reductionText = (isGlobalRadiation && result.reduction > 0)
                                  ? ` (-${result.reduction.toFixed(0)}% Growth)`
                                  : '';
-            cell.innerHTML = `&#x274C;${reductionText}`; // Display X and reduction
-            cell.title = result.reason || 'Failed';
+            cell.innerHTML = `<span title="${reason}">&#x274C;</span>${reductionText}`; // Display X with tooltip and reduction
+            cell.title = reason;
         }
     };
 

--- a/tests/lifeStatusTooltip.test.js
+++ b/tests/lifeStatusTooltip.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const numbers = require('../src/js/numbers.js');
+const physics = require('../src/js/physics.js');
+const zones = require('../src/js/zones.js');
+
+describe('life requirement icon tooltips', () => {
+  test('failing icons show explanatory tooltips', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.getZonePercentage = zones.getZonePercentage;
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+
+    ctx.terraforming = {
+      temperature: {
+        zones: {
+          tropical: { day: 303.15, night: 303.15 },
+          temperate: { day: 303.15, night: 303.15 },
+          polar: { day: 303.15, night: 303.15 }
+        }
+      },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      radiationPenalty: 0,
+      calculateSolarPanelMultiplier: () => 1,
+      calculateZonalSolarPanelMultiplier: () => 1,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0, 0, 0, 0, 0, 0, 0, 0);
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    const moistureCell = dom.window.document.getElementById('moisture-tropical-status');
+    const moistureIcon = moistureCell.querySelector('span');
+    expect(moistureIcon.getAttribute('title')).toBe('Need liquid water');
+
+    const dayCell = dom.window.document.getElementById('day-temp-global');
+    const dayIcon = dayCell.querySelector('span');
+    expect(dayIcon.getAttribute('title')).toBe('Survives but cannot grow');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Add tooltips to failing life requirement icons
- Document life UI tooltip behavior in AGENTS.md
- Test that failing life requirements display explanatory tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a3a34c19d48327bf88859831e7e9f2