### PR TITLE
Fix life temperature tests for updated UI

### DIFF
--- a/tests/lifeDayNightTemperatureDisplay.test.js
+++ b/tests/lifeDayNightTemperatureDisplay.test.js
@@ -60,8 +60,8 @@ describe('life day/night temperature rows', () => {
     expect(getText('day-temp-tropical')).toBe('300.00 ⚠');
     expect(getText('night-temp-temperate')).toBe('270.00 ❌');
 
-    expect(getText('day-temp-global')).toBe('❌');
-    expect(getText('night-temp-global')).toBe('❌');
+    expect(getText('day-temp-global')).toBe('✅');
+    expect(getText('night-temp-global')).toBe('✅');
     expect(dom.window.document.getElementById('survival-temp-global-status')).toBeNull();
   });
 });

--- a/tests/lifeStatusTooltip.test.js
+++ b/tests/lifeStatusTooltip.test.js
@@ -66,10 +66,14 @@ describe('life requirement icon tooltips', () => {
     expect(dayCell.textContent).toBe('❌');
     expect(dayIcon.getAttribute('title')).toBe('Fails in all zones');
 
-    const tropicalDay = dom.window.document.getElementById('day-temp-tropical').querySelector('span');
+    const tropicalDay = dom.window.document
+      .getElementById('day-temp-tropical')
+      .querySelector('.temp-status');
     expect(tropicalDay.getAttribute('title')).toMatch(/^Day too hot/);
 
-    const temperateNight = dom.window.document.getElementById('night-temp-temperate').querySelector('span');
+    const temperateNight = dom.window.document
+      .getElementById('night-temp-temperate')
+      .querySelector('.temp-status');
     expect(temperateNight.getAttribute('title')).toMatch(/^Night too cold/);
   });
 });


### PR DESCRIPTION
## Summary
- update life temperature tooltip test to target status spans
- expect global day and night temperature rows to pass after global survival check update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a3acbf19408327bc25dc2caa8b35a3