### PR TITLE
Add nanotech manager and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,3 +264,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Life designer day/night temperature rows display survival and growth status icons, and the separate survival temperature row has been removed.
 - Production, consumption, and maintenance displays scale with selected build count.
 - Life UI requirement icons display tooltips explaining failure when hovered.
+- Added nanotechManager and Nanocolony UI with growth and Stage I sliders.
+- Nanocolony growth consumes excess power and caps swarm size to land area m² × 10e18.

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
     <script src="src/js/colonyUI.js"></script>
     <script src="src/js/colonySliders.js"></script>
     <script src="src/js/colonySlidersUI.js"></script>
+    <script src="src/js/nanotech.js"></script>
     <script src="src/js/projects.js"></script>
     <script src="src/js/projects/SpaceshipProject.js"></script>
     <script src="src/js/projects/TerraformingDurationProject.js"></script>

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -61,6 +61,9 @@ function create() {
   colonies = initializeColonies(colonyParameters);
   createColonyButtons(colonies);
   initializeColonySlidersUI();
+  if (typeof nanotechManager !== 'undefined') {
+    nanotechManager.updateUI();
+  }
 
   // Combine buildings and colonies into the structures object
   structures = { ...buildings, ...colonies };
@@ -292,6 +295,10 @@ function initializeGameState(options = {}) {
   }
   if (preserveManagers && warpGateCommand && typeof warpGateCommand.reapplyEffects === 'function') {
     warpGateCommand.reapplyEffects();
+  }
+  if (typeof nanotechManager !== 'undefined' && typeof nanotechManager.reapplyEffects === 'function') {
+    nanotechManager.reapplyEffects();
+    nanotechManager.updateUI();
   }
 }
 

--- a/src/js/nanotech.js
+++ b/src/js/nanotech.js
@@ -1,0 +1,190 @@
+class NanotechManager extends EffectableEntity {
+  constructor() {
+    super({ description: 'Manages the nanobot swarm' });
+    this.nanobots = 1; // starting nanobot count
+    this.growthSlider = 0; // 0-10
+    this.siliconSlider = 0; // 0-10
+    this.maintenanceSlider = 0; // 0-10
+    this.glassSlider = 0; // 0-10
+  }
+
+  getGrowthRate() {
+    return (
+      (this.growthSlider / 10) * 0.0015 +
+      (this.siliconSlider / 10) * 0.0015 -
+      (this.maintenanceSlider / 10) * 0.0015 -
+      (this.glassSlider / 10) * 0.0015
+    );
+  }
+
+  getMaxNanobots() {
+    if (typeof resources !== 'undefined' && resources.surface?.land) {
+      return resources.surface.land.value * 10000 * 1e19;
+    }
+    return Infinity;
+  }
+
+  produceResources(deltaTime, accumulatedChanges) {
+    const rate = this.getGrowthRate();
+    let effectiveRate = rate;
+    if (rate > 0 && typeof resources !== 'undefined') {
+      const energyRes = resources.colony?.energy;
+      if (energyRes && accumulatedChanges?.colony) {
+        const projected = energyRes.value + (accumulatedChanges.colony.energy || 0);
+        const overflowEnergy = Math.max(0, projected - energyRes.cap);
+        const availablePower = overflowEnergy / (deltaTime / 1000);
+        const requiredPower = this.nanobots * 1e-11;
+        const powerFraction = requiredPower > 0 ? Math.min(availablePower / requiredPower, 1) : 0;
+        effectiveRate = rate * powerFraction;
+        const energyUsed = Math.min(requiredPower, availablePower) * (deltaTime / 1000);
+        accumulatedChanges.colony.energy -= energyUsed;
+      } else {
+        effectiveRate = 0;
+      }
+    }
+    if (effectiveRate !== 0) {
+      this.nanobots += this.nanobots * effectiveRate * (deltaTime / 1000);
+    }
+    const max = this.getMaxNanobots();
+    this.nanobots = Math.min(this.nanobots, max);
+    this.applyMaintenanceEffects();
+    this.updateUI();
+  }
+
+  applyMaintenanceEffects() {
+    if (typeof buildings === 'undefined' || !buildings) return;
+    const sizeFactor = Math.min(1, this.nanobots / 1000);
+    const mult = 1 - (this.maintenanceSlider / 10) * 0.5 * sizeFactor;
+    for (const name in buildings) {
+      ['metal', 'glass', 'water'].forEach((res) => {
+        addEffect({
+          target: 'building',
+          targetId: name,
+          type: 'maintenanceCostMultiplier',
+          resourceCategory: 'colony',
+          resourceId: res,
+          value: mult,
+          effectId: `nanotechMaint_${res}`,
+          sourceId: 'nanotechMaintenance',
+        });
+      });
+    }
+  }
+
+  updateUI() {
+    if (typeof document === 'undefined') return;
+    const buildingList = document.getElementById('colony-buildings-buttons');
+    let container = document.getElementById('nanocolony-container');
+    if (!container && buildingList) {
+      container = document.createElement('div');
+      container.id = 'nanocolony-container';
+      container.classList.add('project-card');
+      buildingList.insertAdjacentElement('afterend', container);
+      container.innerHTML = `
+        <div class="card-header"><span class="card-title">Nanocolony</span></div>
+        <div class="card-body">
+          <div class="nanobot-stats">
+            <div class="nanobot-count">Nanobots: <span id="nanobot-count">1</span></div>
+            <div class="nanobot-growth">Growth rate: <span id="nanobot-growth-rate">0%</span></div>
+          </div>
+          <div class="slider-row">
+            <label for="nanotech-growth-slider">Growth</label>
+            <input type="range" id="nanotech-growth-slider" min="0" max="10" step="1">
+            <div class="slider-description"><small>The swarm will consume power over storage (not stored energy) to grow. Each nanobot needs 10e-12W.</small></div>
+          </div>
+          <div class="nanotech-stage">
+            <h4>Stage I</h4>
+            <div class="slider-row">
+              <label for="nanotech-silicon-slider">Silicon Consumption</label>
+              <input type="range" id="nanotech-silicon-slider" min="0" max="10" step="1">
+              <div class="slider-description"><small>Consumes silicon to boost growth.</small></div>
+            </div>
+            <div class="slider-row">
+              <label for="nanotech-maintenance-slider">Maintenance I<span class="info-tooltip-icon" title="Reduces metal, glass, and water maintenance by up to 50%, if the swarm is large enough">&#9432;</span></label>
+              <input type="range" id="nanotech-maintenance-slider" min="0" max="10" step="1">
+              <div class="slider-description"><small>Reduces metal, glass, and water maintenance by up to 50%.</small></div>
+            </div>
+            <div class="slider-row">
+              <label for="nanotech-glass-slider">Glass Production</label>
+              <input type="range" id="nanotech-glass-slider" min="0" max="10" step="1">
+              <div class="slider-description"><small>Diverts growth to fabricate glass.</small></div>
+            </div>
+          </div>
+        </div>`;
+      document
+        .getElementById('nanotech-growth-slider')
+        .addEventListener('input', (e) => {
+          this.growthSlider = parseInt(e.target.value);
+          this.updateUI();
+        });
+      document
+        .getElementById('nanotech-silicon-slider')
+        .addEventListener('input', (e) => {
+          this.siliconSlider = parseInt(e.target.value);
+          this.updateUI();
+        });
+      document
+        .getElementById('nanotech-maintenance-slider')
+        .addEventListener('input', (e) => {
+          this.maintenanceSlider = parseInt(e.target.value);
+          this.updateUI();
+        });
+      document
+        .getElementById('nanotech-glass-slider')
+        .addEventListener('input', (e) => {
+          this.glassSlider = parseInt(e.target.value);
+          this.updateUI();
+        });
+    }
+    if (!container) return;
+    const countEl = document.getElementById('nanobot-count');
+    if (countEl) countEl.textContent = Math.floor(this.nanobots).toString();
+    const growthEl = document.getElementById('nanobot-growth-rate');
+    if (growthEl)
+      growthEl.textContent = `${(this.getGrowthRate() * 100).toFixed(2)}%`;
+    const gSlider = document.getElementById('nanotech-growth-slider');
+    if (gSlider) gSlider.value = this.growthSlider;
+    const sSlider = document.getElementById('nanotech-silicon-slider');
+    if (sSlider) sSlider.value = this.siliconSlider;
+    const mSlider = document.getElementById('nanotech-maintenance-slider');
+    if (mSlider) mSlider.value = this.maintenanceSlider;
+    const glSlider = document.getElementById('nanotech-glass-slider');
+    if (glSlider) glSlider.value = this.glassSlider;
+  }
+
+  saveState() {
+    return {
+      nanobots: this.nanobots,
+      growthSlider: this.growthSlider,
+      siliconSlider: this.siliconSlider,
+      maintenanceSlider: this.maintenanceSlider,
+      glassSlider: this.glassSlider,
+    };
+  }
+
+  loadState(state) {
+    if (!state) return;
+    this.nanobots = state.nanobots || 1;
+    this.growthSlider = state.growthSlider || 0;
+    this.siliconSlider = state.siliconSlider || 0;
+    this.maintenanceSlider = state.maintenanceSlider || 0;
+    this.glassSlider = state.glassSlider || 0;
+    const max = this.getMaxNanobots();
+    this.nanobots = Math.min(this.nanobots, max);
+    this.reapplyEffects();
+    this.updateUI();
+  }
+
+  reapplyEffects() {
+    this.applyMaintenanceEffects();
+  }
+}
+
+const nanotechManager = new NanotechManager();
+if (typeof globalThis !== 'undefined') {
+  globalThis.nanotechManager = nanotechManager;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { NanotechManager };
+}

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -401,6 +401,10 @@ function produceResources(deltaTime, buildings) {
     updateAndroidResearch(deltaTime, resources, globalEffects, accumulatedChanges);
   }
 
+  if (typeof nanotechManager !== 'undefined' && typeof nanotechManager.produceResources === 'function') {
+    nanotechManager.produceResources(deltaTime, accumulatedChanges);
+  }
+
   if (projectManager) {
     const names = projectManager.projectOrder || Object.keys(projectManager.projects || {});
     const projectData = {};

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -14,6 +14,7 @@ function getGameState() {
     journalEntrySources: typeof journalEntrySources !== 'undefined' ? journalEntrySources : undefined,
     journalHistorySources: typeof journalHistorySources !== 'undefined' ? journalHistorySources : undefined,
     goldenAsteroid: (typeof goldenAsteroid !== 'undefined' && typeof goldenAsteroid.saveState === 'function') ? goldenAsteroid.saveState() : undefined,
+    nanotechManager: (typeof nanotechManager !== 'undefined' && typeof nanotechManager.saveState === 'function') ? nanotechManager.saveState() : undefined,
     solisManager: (typeof solisManager !== 'undefined' && typeof solisManager.saveState === 'function') ? solisManager.saveState() : undefined,
     warpGateCommand: (typeof warpGateCommand !== 'undefined' && typeof warpGateCommand.saveState === 'function') ? warpGateCommand.saveState() : undefined,
     lifeDesigner: (typeof lifeDesigner !== 'undefined' && typeof lifeDesigner.saveState === 'function') ? lifeDesigner.saveState() : undefined,
@@ -231,6 +232,10 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.goldenAsteroid){
       goldenAsteroid.loadState(gameState.goldenAsteroid);
+    }
+
+    if(gameState.nanotechManager){
+      nanotechManager.loadState(gameState.nanotechManager);
     }
 
     if(gameState.solisManager){

--- a/tests/nanotechGrowth.test.js
+++ b/tests/nanotechGrowth.test.js
@@ -1,0 +1,46 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+global.addEffect = () => {};
+global.buildings = {};
+
+const { NanotechManager } = require('../src/js/nanotech.js');
+const { Resource } = require('../src/js/resource.js');
+
+describe('nanotech growth', () => {
+  beforeEach(() => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 0, hasCap: true, baseCap: 0 });
+    const land = new Resource({ name: 'land', category: 'surface', initialValue: 1e9, hasCap: true, baseCap: 1e9 });
+    global.resources = { colony: { energy }, surface: { land } };
+  });
+
+  test('grows at full rate when power available', () => {
+    const manager = new NanotechManager();
+    manager.growthSlider = 10; // 0.15% per second
+    const dt = 1000;
+    const requiredEnergy = manager.nanobots * 1e-11 * (dt / 1000);
+    const accumulated = { colony: { energy: requiredEnergy } };
+    manager.produceResources(dt, accumulated);
+    expect(manager.nanobots).toBeCloseTo(1 * (1 + 0.0015));
+  });
+
+  test('growth scales with limited power', () => {
+    const manager = new NanotechManager();
+    manager.growthSlider = 10;
+    const dt = 1000;
+    const requiredEnergy = manager.nanobots * 1e-11 * (dt / 1000);
+    const accumulated = { colony: { energy: requiredEnergy / 2 } };
+    manager.produceResources(dt, accumulated);
+    expect(manager.nanobots).toBeCloseTo(1 * (1 + 0.0015 * 0.5));
+  });
+
+  test('swarm capped by land area', () => {
+    const manager = new NanotechManager();
+    const land = global.resources.surface.land;
+    land.value = 0;
+    manager.nanobots = 5;
+    const dt = 1000;
+    const accumulated = { colony: { energy: 1 } };
+    manager.produceResources(dt, accumulated);
+    expect(manager.nanobots).toBe(0);
+  });
+});

--- a/tests/nanotechIntegration.test.js
+++ b/tests/nanotechIntegration.test.js
@@ -1,0 +1,25 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Resource, produceResources } = require('../src/js/resource.js');
+
+describe('nanotech produceResources integration', () => {
+  test('resource.js calls nanotechManager.produceResources with changes', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 0, hasCap: true, baseCap: 0 });
+    global.resources = { colony: { energy }, surface: { land: new Resource({ name: 'land', category: 'surface', initialValue: 1, hasCap: true, baseCap: 1 }) } };
+    global.structures = {};
+    global.buildings = {};
+    global.dayNightCycle = { isDay: () => true };
+    global.fundingModule = null;
+    global.terraforming = null;
+    global.lifeManager = null;
+    global.researchManager = null;
+    global.updateShipReplication = null;
+    global.updateAndroidResearch = null;
+    global.projectManager = null;
+    const spy = jest.fn();
+    global.nanotechManager = { produceResources: spy };
+    produceResources(1000);
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][1]).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- cap nanobot swarm to land area and spend excess energy for growth
- display slider descriptions for growth and Stage I controls
- test nanobot growth scaling, land cap, and integration with resource loop

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a3b8fa42008327995465da1f0b9baa