### PR TITLE
Display optimal and actual nanotech consumption rates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,3 +278,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Life UI requirement icons display tooltips explaining failure when hovered.
 - Nanotechnology system tracks a nanobot swarm with growth and Stage I sliders, consuming excess power, silicon, and producing glass while limiting maintenance. Silicon consumption draws from accumulated changes plus stored value, swarm size scales with land area, and only 1e15 bots survive travel.
 - Nanobot growth rate displays turn orange when power limits prevent reaching the optimal rate.
+- Nanotech UI shows both optimal and actual energy and silicon consumption rates, highlighting shortfalls in orange.

--- a/tests/nanotechConsumptionRate.test.js
+++ b/tests/nanotechConsumptionRate.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Resource } = require('../src/js/resource.js');
+
+describe('nanotech consumption display', () => {
+  test('shows actual and optimal rates', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="colony-buildings-buttons"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.resources = {
+      colony: {
+        energy: new Resource({ name: 'energy', category: 'colony', initialValue: 0, hasCap: true, baseCap: 0 }),
+        silicon: new Resource({ name: 'silicon', category: 'colony', initialValue: 0, hasCap: true, baseCap: 1 }),
+        glass: new Resource({ name: 'glass', category: 'colony', initialValue: 0, hasCap: true, baseCap: 1 })
+      },
+      surface: { land: new Resource({ name: 'land', category: 'surface', initialValue: 1e9, hasCap: true, baseCap: 1e9 }) }
+    };
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+    ctx.structures = {};
+    ctx.buildings = {};
+    ctx.colonies = {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'nanotech.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    const manager = ctx.nanotechManager;
+    manager.enable();
+    manager.growthSlider = 10;
+    manager.siliconSlider = 10;
+    const dt = 1000;
+    const requiredEnergy = manager.nanobots * 1e-12 * (dt / 1000);
+    const requiredSilicon = manager.nanobots * 1e-18 * (manager.siliconSlider / 10) * (dt / 1000);
+    const accumulated = { colony: { energy: requiredEnergy / 2, silicon: requiredSilicon / 2, glass: 0 } };
+    manager.produceResources(dt, accumulated);
+    const expectedEnergy = `${numbers.formatNumber(manager.currentEnergyConsumption, false, 2, true)} / ${numbers.formatNumber(manager.optimalEnergyConsumption, false, 2, true)} W`;
+    const expectedSilicon = `${numbers.formatNumber(manager.currentSiliconConsumption, false, 2, true)} / ${numbers.formatNumber(manager.optimalSiliconConsumption, false, 2, true)} ton/s`;
+    const doc = dom.window.document;
+    expect(doc.getElementById('nanotech-growth-energy').textContent).toBe(expectedEnergy);
+    expect(doc.getElementById('nanotech-growth-energy').style.color).toBe('orange');
+    expect(doc.getElementById('nanotech-silicon-rate').textContent).toBe(expectedSilicon);
+    expect(doc.getElementById('nanotech-silicon-rate').style.color).toBe('orange');
+  });
+});


### PR DESCRIPTION
## Summary
- Track optimal energy and silicon usage for nanobot growth
- Show both actual and optimal nanotech consumption rates in the UI, highlighting shortages
- Test nanotech UI displays and color when rates fall below optimal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a3d5ec4d7083279f7b8ca76318d053