### PR TITLE
Scale nanobot silicon growth by actual usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,3 +278,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Life UI requirement icons display tooltips explaining failure when hovered.
 - Nanotechnology system tracks a nanobot swarm with growth and Stage I sliders, consuming excess power, silicon, and producing glass while limiting maintenance. Silicon consumption draws from accumulated changes plus stored value, swarm size scales with land area, and only 1e15 bots survive travel.
 - Nanobot growth rate displays turn orange when power limits prevent reaching the optimal rate.
+- Nanobot silicon growth boost scales with actual silicon consumption rather than energy availability.

--- a/src/js/nanotech.js
+++ b/src/js/nanotech.js
@@ -12,17 +12,10 @@ class NanotechManager extends EffectableEntity {
     this.currentMaintenanceReduction = 0;
     this.enabled = false;
     this.powerFraction = 1;
+    this.siliconFraction = 1;
     this.effectiveGrowthRate = 0;
   }
 
-  getGrowthRate() {
-    return (
-      (this.growthSlider / 10) * 0.0025 +
-      (this.siliconSlider / 10) * 0.0015 -
-      (this.maintenanceSlider / 10) * 0.0015 -
-      (this.glassSlider / 10) * 0.0015
-    );
-  }
 
   getMaxNanobots() {
     if (typeof resources !== 'undefined' && resources.surface?.land) {
@@ -33,30 +26,13 @@ class NanotechManager extends EffectableEntity {
 
   produceResources(deltaTime, accumulatedChanges) {
     if (!this.enabled) return;
-    const rate = this.getGrowthRate();
-    let effectiveRate = rate;
+    const baseRate = (this.growthSlider / 10) * 0.0025;
     let powerFraction = 1;
+    let siliconFraction = 1;
     this.currentEnergyConsumption = 0;
     this.currentSiliconConsumption = 0;
     this.currentGlassProduction = 0;
     if (typeof resources !== 'undefined') {
-      const energyRes = resources.colony?.energy;
-      if (rate > 0 && energyRes && accumulatedChanges?.colony) {
-        const projected = energyRes.value + (accumulatedChanges.colony.energy || 0);
-        const overflowEnergy = Math.max(0, projected - energyRes.cap);
-        const availablePower = overflowEnergy;
-        const requiredPower = this.nanobots * 1e-12 * deltaTime / 1000;
-        const actualPower = Math.min(requiredPower, availablePower);
-        powerFraction = requiredPower > 0 ? actualPower / requiredPower : 0;
-        effectiveRate = rate * powerFraction;
-        this.currentEnergyConsumption = actualPower * 1000 / deltaTime;
-        const energyUsed = actualPower;
-        accumulatedChanges.colony.energy -= energyUsed;
-      } else if (rate > 0) {
-        effectiveRate = 0;
-        powerFraction = 0;
-      }
-
       const siliconRes = resources.colony?.silicon;
       if (siliconRes && accumulatedChanges?.colony) {
         const siliconRate = this.nanobots * 1e-18 * (this.siliconSlider / 10);
@@ -66,7 +42,14 @@ class NanotechManager extends EffectableEntity {
         this.currentSiliconConsumption = used / (deltaTime / 1000);
         accumulatedChanges.colony.silicon =
           (accumulatedChanges.colony.silicon || 0) - used;
-        siliconRes.modifyRate(-this.currentSiliconConsumption, 'Nanotech Silicon', 'nanotech');
+        siliconRes.modifyRate(
+          -this.currentSiliconConsumption,
+          'Nanotech Silicon',
+          'nanotech'
+        );
+        siliconFraction = needed > 0 ? used / needed : 1;
+      } else if (this.siliconSlider > 0) {
+        siliconFraction = 0;
       }
 
       const glassRes = resources.colony?.glass;
@@ -77,8 +60,31 @@ class NanotechManager extends EffectableEntity {
           (accumulatedChanges.colony.glass || 0) + glassRate * (deltaTime / 1000);
         glassRes.modifyRate(glassRate, 'Nanotech Glass', 'nanotech');
       }
+
+      const energyRes = resources.colony?.energy;
+      if (baseRate > 0 && energyRes && accumulatedChanges?.colony) {
+        const projected = energyRes.value + (accumulatedChanges.colony.energy || 0);
+        const overflowEnergy = Math.max(0, projected - energyRes.cap);
+        const availablePower = overflowEnergy;
+        const requiredPower = (this.nanobots * 1e-12 * deltaTime) / 1000;
+        const actualPower = Math.min(requiredPower, availablePower);
+        powerFraction = requiredPower > 0 ? actualPower / requiredPower : 0;
+        this.currentEnergyConsumption = (actualPower * 1000) / deltaTime;
+        accumulatedChanges.colony.energy -= actualPower;
+      } else if (baseRate > 0) {
+        powerFraction = 0;
+      }
+    } else if (this.siliconSlider > 0) {
+      siliconFraction = 0;
     }
     this.powerFraction = powerFraction;
+    this.siliconFraction = siliconFraction;
+    const siliconRate =
+      (this.siliconSlider / 10) * 0.0015 * this.siliconFraction;
+    const penalty =
+      (this.maintenanceSlider / 10) * 0.0015 +
+      (this.glassSlider / 10) * 0.0015;
+    const effectiveRate = baseRate * this.powerFraction + siliconRate - penalty;
     this.effectiveGrowthRate = effectiveRate;
     if (effectiveRate !== 0) {
       this.nanobots += this.nanobots * effectiveRate * (deltaTime / 1000);
@@ -237,13 +243,16 @@ class NanotechManager extends EffectableEntity {
     if (capEl) capEl.textContent = formatNumber(max);
     const growthEl = document.getElementById('nanobot-growth-rate');
     if (growthEl) {
-      const positiveOpt =
-        (this.growthSlider / 10) * 0.0025 + (this.siliconSlider / 10) * 0.0015;
-      const negativeOpt =
-        -(this.maintenanceSlider / 10) * 0.0015 -
+      const baseOpt = (this.growthSlider / 10) * 0.0025;
+      const siliconOpt = (this.siliconSlider / 10) * 0.0015;
+      const penalty =
+        (this.maintenanceSlider / 10) * 0.0015 +
         (this.glassSlider / 10) * 0.0015;
-      const optimalRate = positiveOpt + negativeOpt;
-      const effectiveRate = positiveOpt * this.powerFraction + negativeOpt;
+      const optimalRate = baseOpt + siliconOpt - penalty;
+      const effectiveRate =
+        baseOpt * this.powerFraction +
+        siliconOpt * this.siliconFraction -
+        penalty;
       growthEl.textContent = `${(effectiveRate * 100).toFixed(2)}%`;
       growthEl.style.color = effectiveRate < optimalRate ? 'orange' : '';
       this.effectiveGrowthRate = effectiveRate;
@@ -267,7 +276,7 @@ class NanotechManager extends EffectableEntity {
     const siliconImpactEl = document.getElementById('nanotech-silicon-impact');
     if (siliconImpactEl) {
       const optimal = (this.siliconSlider / 10) * 0.15;
-      const effective = optimal * this.powerFraction;
+      const effective = optimal * this.siliconFraction;
       siliconImpactEl.textContent = `+${effective.toFixed(2)}%`;
       siliconImpactEl.style.color = effective < optimal ? 'orange' : '';
     }

--- a/tests/nanotechGrowth.test.js
+++ b/tests/nanotechGrowth.test.js
@@ -40,6 +40,31 @@ describe('nanotech growth', () => {
     expect(manager.nanobots).toBeCloseTo(1 * (1 + 0.0015 * 0.5));
   });
 
+  test('silicon growth scales with silicon consumption', () => {
+    const manager = new NanotechManager();
+    manager.enable();
+    manager.siliconSlider = 10; // 0.15% per second
+    const dt = 1000;
+    const requiredEnergy = manager.nanobots * 1e-11 * (dt / 1000);
+    const neededSilicon = manager.nanobots * 1e-18 * (dt / 1000);
+    global.resources.colony.silicon.value = neededSilicon / 2;
+    const accumulated = { colony: { energy: requiredEnergy } };
+    manager.produceResources(dt, accumulated);
+    expect(manager.nanobots).toBeCloseTo(1 * (1 + 0.0015 * 0.5));
+  });
+
+  test('silicon growth unaffected by energy shortage', () => {
+    const manager = new NanotechManager();
+    manager.enable();
+    manager.siliconSlider = 10;
+    const dt = 1000;
+    const neededSilicon = manager.nanobots * 1e-18 * (dt / 1000);
+    global.resources.colony.silicon.value = neededSilicon;
+    const accumulated = { colony: { energy: 0 } };
+    manager.produceResources(dt, accumulated);
+    expect(manager.nanobots).toBeCloseTo(1 * (1 + 0.0015));
+  });
+
   test('swarm capped by land area', () => {
     const manager = new NanotechManager();
     manager.enable();

--- a/tests/nanotechGrowthColor.test.js
+++ b/tests/nanotechGrowthColor.test.js
@@ -17,7 +17,7 @@ describe('nanotech growth rate color', () => {
     ctx.resources = {
       colony: {
         energy: new Resource({ name: 'energy', category: 'colony', initialValue: 0, hasCap: true, baseCap: 0 }),
-        silicon: new Resource({ name: 'silicon', category: 'colony', initialValue: 1, hasCap: true, baseCap: 1 }),
+        silicon: new Resource({ name: 'silicon', category: 'colony', initialValue: 0, hasCap: true, baseCap: 1 }),
         glass: new Resource({ name: 'glass', category: 'colony', initialValue: 0, hasCap: true, baseCap: 1 })
       },
       surface: { land: new Resource({ name: 'land', category: 'surface', initialValue: 1e9, hasCap: true, baseCap: 1e9 }) }


### PR DESCRIPTION
## Summary
- Scale nanobot silicon growth bonus by consumed silicon instead of energy
- Show silicon consumption limits in nanotech UI and tests
- Add tests for silicon-driven growth and energy independence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a3d63d3b148327bfacda88f5fe0b11