### PR TITLE
Limit nanotech energy use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Nanobot growth rate displays turn orange when power limits prevent reaching the optimal rate.
 - Nanobot silicon growth boost scales with actual silicon consumption rather than energy availability.
 - Nanotech UI shows both optimal and actual energy and silicon consumption rates, highlighting shortfalls in orange.
+- Nanotech swarm energy usage can be limited to a player-defined percentage of total energy production (default 10%).

--- a/tests/nanotechEnergyLimit.test.js
+++ b/tests/nanotechEnergyLimit.test.js
@@ -1,0 +1,25 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Resource } = require('../src/js/resource.js');
+const { NanotechManager } = require('../src/js/nanotech.js');
+
+describe('nanotech energy usage limit', () => {
+  test('swarm consumption capped by energy percent', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 1000, hasCap: true, baseCap: 1e9 });
+    const silicon = new Resource({ name: 'silicon', category: 'colony', initialValue: 0 });
+    const glass = new Resource({ name: 'glass', category: 'colony', initialValue: 0 });
+    energy.modifyRate(1000, 'Generator', 'building');
+    global.resources = { colony: { energy, silicon, glass } };
+    global.structures = {};
+    const nm = new NanotechManager();
+    nm.enabled = true;
+    nm.nanobots = 1e15; // requires 1000 W
+    nm.maxEnergyPercent = 10; // 10%
+    nm.growthSlider = 10;
+    const acc = { colony: { energy: 0, silicon: 0, glass: 0 } };
+    nm.produceResources(1000, acc);
+    expect(nm.currentEnergyConsumption).toBeCloseTo(100, 5);
+    expect(acc.colony.energy).toBeCloseTo(-100);
+    expect(energy.consumptionRate).toBeCloseTo(100);
+  });
+});


### PR DESCRIPTION
## Summary
- add percentage cap for nanobot energy usage
- expose energy usage limit input in nanocolony UI
- persist energy usage limit and test consumption cap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a3dba7f0c88327807fe58fd9cefc2c