### PR TITLE
Add absolute energy limit mode for nanocolony

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,3 +281,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Nanobot silicon growth boost scales with actual silicon consumption rather than energy availability.
 - Nanotech UI shows both optimal and actual energy and silicon consumption rates, highlighting shortfalls in orange.
 - Nanotech swarm energy usage can be limited to a player-defined percentage of total energy production (default 10%).
+- Nanotech energy limit input now supports percentage of power or absolute watt modes via a dropdown with an explanatory tooltip.

--- a/tests/nanotechEnergyLimit.test.js
+++ b/tests/nanotechEnergyLimit.test.js
@@ -22,4 +22,24 @@ describe('nanotech energy usage limit', () => {
     expect(acc.colony.energy).toBeCloseTo(-100);
     expect(energy.consumptionRate).toBeCloseTo(100);
   });
+
+  test('swarm consumption capped by absolute limit', () => {
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 1000, hasCap: true, baseCap: 1e9 });
+    const silicon = new Resource({ name: 'silicon', category: 'colony', initialValue: 0 });
+    const glass = new Resource({ name: 'glass', category: 'colony', initialValue: 0 });
+    energy.modifyRate(1000, 'Generator', 'building');
+    global.resources = { colony: { energy, silicon, glass } };
+    global.structures = {};
+    const nm = new NanotechManager();
+    nm.enabled = true;
+    nm.nanobots = 1e15; // requires 1000 W
+    nm.energyLimitMode = 'absolute';
+    nm.maxEnergyAbsolute = 200; // 200 W cap
+    nm.growthSlider = 10;
+    const acc = { colony: { energy: 0, silicon: 0, glass: 0 } };
+    nm.produceResources(1000, acc);
+    expect(nm.currentEnergyConsumption).toBeCloseTo(200, 5);
+    expect(acc.colony.energy).toBeCloseTo(-200);
+    expect(energy.consumptionRate).toBeCloseTo(200);
+  });
 });


### PR DESCRIPTION
## Summary
- Allow nanobot swarm energy usage to be capped by a percentage of production or an absolute watt value
- Provide dropdown next to energy limit input to choose the mode with explanatory tooltip
- Cover absolute mode with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a3e68a25448327aea169c139c2354b