### PR TITLE
feat: use MW units for nanotech energy limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,4 +281,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Nanobot silicon growth boost scales with actual silicon consumption rather than energy availability.
 - Nanotech UI shows both optimal and actual energy and silicon consumption rates, highlighting shortfalls in orange.
 - Nanotech swarm energy usage can be limited to a player-defined percentage of total energy production (default 10%).
-- Nanotech energy limit input now supports percentage of power or absolute watt modes via a dropdown with an explanatory tooltip.
+- Nanotech energy limit input now supports percentage of power or absolute (MW) modes via a dropdown with an explanatory tooltip, multiplying absolute entries by one million.

--- a/src/js/nanotech.js
+++ b/src/js/nanotech.js
@@ -190,12 +190,12 @@ class NanotechManager extends EffectableEntity {
             </div>
           </div>
           <div class="control-group">
-            <label for="nanotech-energy-limit">Energy Use Limit <span class="info-tooltip-icon" title="Percentage of power: Maximum percentage of total energy production the swarm may consume per second. Absolute: Fixed energy limit in watts the swarm may consume per second.">&#9432;</span></label>
+            <label for="nanotech-energy-limit">Energy Use Limit <span class="info-tooltip-icon" title="Percentage of power: Maximum percentage of total energy production the swarm may consume per second. Absolute (MW): Fixed energy limit in megawatts the swarm may consume per second.">&#9432;</span></label>
             <div style="display: flex; gap: 4px;">
               <input type="number" id="nanotech-energy-limit" min="0" max="100" step="any" value="${this.maxEnergyPercent}" style="flex:1;">
               <select id="nanotech-energy-limit-mode" style="flex:1;">
                 <option value="percent" selected>percentage of power</option>
-                <option value="absolute">absolute</option>
+                <option value="absolute">absolute (MW)</option>
               </select>
             </div>
             <span id="nanotech-growth-impact" class="slider-value">+0.00%</span>
@@ -258,7 +258,7 @@ class NanotechManager extends EffectableEntity {
         .addEventListener('input', (e) => {
           const val = parseFloat(e.target.value) || 0;
           if (this.energyLimitMode === 'absolute') {
-            this.maxEnergyAbsolute = val;
+            this.maxEnergyAbsolute = val * 1e6;
           } else {
             this.maxEnergyPercent = val;
           }
@@ -305,7 +305,7 @@ class NanotechManager extends EffectableEntity {
     if (eMode) eMode.value = this.energyLimitMode;
     if (eLimit && document.activeElement !== eLimit) {
       if (this.energyLimitMode === 'absolute') {
-        eLimit.value = this.maxEnergyAbsolute;
+        eLimit.value = this.maxEnergyAbsolute / 1e6;
         eLimit.removeAttribute('max');
       } else {
         eLimit.value = this.maxEnergyPercent;

--- a/tests/nanotechEnergyLimit.test.js
+++ b/tests/nanotechEnergyLimit.test.js
@@ -42,4 +42,33 @@ describe('nanotech energy usage limit', () => {
     expect(acc.colony.energy).toBeCloseTo(-200);
     expect(energy.consumptionRate).toBeCloseTo(200);
   });
+
+  test('absolute energy limit input uses MW', () => {
+    const { JSDOM } = require('jsdom');
+    const dom = new JSDOM('<!DOCTYPE html><div id="colony-buildings-buttons"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.Event = dom.window.Event;
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 0 });
+    global.resources = { colony: { energy }, surface: { land: new Resource({ name: 'land', category: 'surface', initialValue: 1, hasCap: true, baseCap: 1 }) } };
+    global.structures = {};
+    global.colonies = {};
+    global.buildings = {};
+    global.addEffect = jest.fn();
+    global.removeEffect = jest.fn();
+    global.formatNumber = (n) => n;
+    const nm = new NanotechManager();
+    nm.enable();
+    nm.energyLimitMode = 'absolute';
+    nm.updateUI();
+    const modeSelect = document.getElementById('nanotech-energy-limit-mode');
+    const absOption = modeSelect.querySelector('option[value="absolute"]');
+    expect(absOption.textContent).toBe('absolute (MW)');
+    const input = document.getElementById('nanotech-energy-limit');
+    input.value = '5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(nm.maxEnergyAbsolute).toBeCloseTo(5e6);
+    nm.updateUI();
+    expect(input.value).toBe('5');
+  });
 });


### PR DESCRIPTION
## Summary
- display nanotech energy limit absolute mode in MW
- scale absolute energy limit input by one million
- test absolute mode energy limit input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a3e89b28c083278aa5a9fdb911506f