### PR TITLE
Refactor travel prep for story and random worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,3 +282,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Nanotech UI shows both optimal and actual energy and silicon consumption rates, highlighting shortfalls in orange.
 - Nanotech swarm energy usage can be limited to a player-defined percentage of total energy production (default 10%).
 - Nanotech energy limit input now supports percentage of power or absolute (MW) modes via a dropdown with an explanatory tooltip, multiplying absolute entries by one million.
+- Story and random world travel now share preparation logic, saving Space Storage state and capping nanobots before initializing the new planet.

--- a/src/js/nanotech.js
+++ b/src/js/nanotech.js
@@ -113,7 +113,7 @@ class NanotechManager extends EffectableEntity {
       this.nanobots += this.nanobots * effectiveRate * (deltaTime / 1000);
     }
     const max = this.getMaxNanobots();
-    this.nanobots = Math.max(1, Math.min(this.nanobots, max));
+    this.nanobots = Math.max(0, Math.min(this.nanobots, max));
     this.applyMaintenanceEffects();
     this.updateUI();
   }
@@ -380,7 +380,7 @@ class NanotechManager extends EffectableEntity {
     this.maxEnergyAbsolute = state.maxEnergyAbsolute || 0;
     this.energyLimitMode = state.energyLimitMode || 'percent';
     const max = this.getMaxNanobots();
-    this.nanobots = Math.max(1, Math.min(this.nanobots, max));
+    this.nanobots = Math.max(0, Math.min(this.nanobots, max));
     this.reapplyEffects();
     this.updateUI();
   }

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -357,6 +357,20 @@ class SpaceManager extends EffectableEntity {
         return !!this.planetStatuses[key]?.visited;
     }
 
+    prepareForTravel() {
+        if (typeof saveGameToSlot === 'function') {
+            try { saveGameToSlot('pretravel'); } catch (_) {}
+        }
+        const storageState = projectManager?.projects?.spaceStorage?.saveTravelState
+            ? projectManager.projects.spaceStorage.saveTravelState()
+            : null;
+        if (typeof nanotechManager !== 'undefined'
+            && typeof nanotechManager.prepareForTravel === 'function') {
+            nanotechManager.prepareForTravel();
+        }
+        return storageState;
+    }
+
     recordCurrentWorldPopulation(pop) {
         if (this.currentRandomSeed !== null) {
             const seed = String(this.currentRandomSeed);
@@ -387,9 +401,6 @@ class SpaceManager extends EffectableEntity {
 
         const pop = globalThis?.resources?.colony?.colonists?.value || 0;
         this.recordCurrentWorldPopulation(pop);
-        if (typeof saveGameToSlot === 'function') {
-            try { saveGameToSlot('pretravel'); } catch (_) {}
-        }
 
         const departingTerraformed = this.currentRandomSeed !== null
             ? this.isSeedTerraformed(String(this.currentRandomSeed))
@@ -398,6 +409,8 @@ class SpaceManager extends EffectableEntity {
         const existing = this.randomWorldStatuses[s];
         const firstVisit = !existing?.visited;
         const destinationTerraformed = existing?.terraformed || false;
+
+        const storageState = this.prepareForTravel();
 
         this.currentRandomSeed = s;
         this.currentPlanetKey = s;
@@ -419,8 +432,6 @@ class SpaceManager extends EffectableEntity {
         if (firstVisit && departingTerraformed && !destinationTerraformed && typeof skillManager !== 'undefined' && skillManager) {
             skillManager.skillPoints += 1;
         }
-        const storageState = projectManager?.projects?.spaceStorage?.saveTravelState
-            ? projectManager.projects.spaceStorage.saveTravelState() : null;
         globalThis.currentPlanetParameters = res?.merged;
         if (typeof initializeGameState === 'function') {
             initializeGameState({ preserveManagers: true, preserveJournal: true });

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -241,17 +241,7 @@ function selectPlanet(planetKey){
         console.warn('Target planet already terraformed.');
         return;
     }
-    if (typeof saveGameToSlot === 'function') {
-        saveGameToSlot('pretravel');
-    }
-
-    const storageState = projectManager?.projects?.spaceStorage?.saveTravelState
-        ? projectManager.projects.spaceStorage.saveTravelState()
-        : null;
-
-    if (typeof nanotechManager !== 'undefined' && typeof nanotechManager.prepareForTravel === 'function') {
-        nanotechManager.prepareForTravel();
-    }
+    const storageState = _spaceManagerInstance.prepareForTravel();
 
     if(!_spaceManagerInstance.changeCurrentPlanet(planetKey)) return;
 

--- a/tests/nanotechRandomWorldTravel.test.js
+++ b/tests/nanotechRandomWorldTravel.test.js
@@ -1,0 +1,28 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('Random world travel preparation', () => {
+  beforeEach(() => {
+    global.resources = { colony: { colonists: { value: 0 } } };
+    global.saveGameToSlot = jest.fn();
+    global.initializeGameState = jest.fn();
+    global.updateProjectUI = jest.fn();
+    global.updateSpaceUI = jest.fn();
+    global.projectManager = { projects: { spaceStorage: { saveTravelState: jest.fn(() => null), loadTravelState: jest.fn() } } };
+    global.nanotechManager = { prepareForTravel: jest.fn() };
+  });
+
+  afterEach(() => {
+    delete global.nanotechManager;
+  });
+
+  test('calls nanotech and project travel preparation', () => {
+    const sm = new SpaceManager({ mars: { name: 'Mars' } });
+    sm.travelToRandomWorld({ merged: { name: 'Alpha' } }, '1');
+    expect(global.nanotechManager.prepareForTravel).toHaveBeenCalled();
+    expect(global.projectManager.projects.spaceStorage.saveTravelState).toHaveBeenCalled();
+  });
+});
+
+delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- centralize travel preparation in `SpaceManager.prepareForTravel` so both story and random world travel save Space Storage state and ready nanotech
- allow nanobots to drop to zero when no land remains
- test random world travel invokes nanotech and project travel preparation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4737055fc8327a48b944be0562b69