### PR TITLE
Use shared ship capacity across space projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,3 +285,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Nanotech energy limit input now supports percentage of power or absolute (MW) modes via a dropdown with an explanatory tooltip, multiplying absolute entries by one million.
 - Story and random world travel now share preparation logic, saving Space Storage state and capping nanobots before initializing the new planet.
 - Resource disposal and space export in continuous mode display total export as per-second rates.
+- Space export and disposal projects use a shared `getShipCapacity` method so ship capacity effects scale assignment limits and per-ship amounts.

--- a/src/js/projects/SpaceDisposalProject.js
+++ b/src/js/projects/SpaceDisposalProject.js
@@ -42,11 +42,9 @@ class SpaceDisposalProject extends SpaceExportBaseProject {
 
     let removed = 0;
     if (this.isContinuous()) {
-      const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
       removed =
-        (this.attributes.disposalAmount || 0) *
+        this.getShipCapacity() *
         this.assignedSpaceships *
-        efficiency *
         (1000 / this.getEffectiveDuration());
     } else {
       const totalDisposal = this.calculateSpaceshipTotalDisposal();

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -189,8 +189,7 @@ class SpaceExportBaseProject extends SpaceshipProject {
     }
 
     if (elements.disposalPerShipElement) {
-      const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
-      const perShip = this.attributes.disposalAmount * efficiency;
+      const perShip = this.getShipCapacity();
       elements.disposalPerShipElement.textContent = `Max Export/Ship: ${formatNumber(perShip, true)}`;
     }
 

--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -11,8 +11,8 @@ class SpaceExportProject extends SpaceExportBaseProject {
   }
 
   getMaxAssignableShips() {
-    const capacity = this.attributes.disposalAmount || 1;
-    return Math.floor((this.getEffectiveDuration()/1000)*this.getExportCap() / (capacity));
+    const capacity = this.getShipCapacity() || 1;
+    return Math.floor((this.getEffectiveDuration()/1000)*this.getExportCap() / capacity);
   }
 
   assignSpaceships(count) {

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -230,11 +230,11 @@ class SpaceMiningProject extends SpaceshipProject {
 
   calculateSpaceshipGainPerShip() {
     if (this.attributes.dynamicWaterImport && this.attributes.resourceGainPerShip?.surface?.ice) {
-      const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
       const zones = ['tropical', 'temperate', 'polar'];
       const allBelow = zones.every(z => (terraforming?.temperature?.zones?.[z]?.value || 0) <= 273.15);
       const resource = allBelow ? 'ice' : 'liquidWater';
-      return { surface: { [resource]: this.attributes.resourceGainPerShip.surface.ice * efficiency } };
+      const capacity = this.getShipCapacity(this.attributes.resourceGainPerShip.surface.ice);
+      return { surface: { [resource]: capacity } };
     }
     return super.calculateSpaceshipGainPerShip();
   }

--- a/tests/spaceExportProject.test.js
+++ b/tests/spaceExportProject.test.js
@@ -60,6 +60,33 @@ describe('SpaceExportProject', () => {
     expect(project.assignedSpaceships).toBe(Math.min(100, maxShips));
   });
 
+  test('max assignable ships scales with ship capacity', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 2 };
+    ctx.resources = { special: { spaceships: { value: 100 } }, colony: { metal: {} } };
+    ctx.spaceManager = { getTerraformedPlanetCountExcludingCurrent: () => 1 };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const exportSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportProject.js'), 'utf8');
+    vm.runInContext(exportSubclass + '; this.SpaceExportProject = SpaceExportProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    global.resources = ctx.resources;
+    global.spaceManager = ctx.spaceManager;
+
+    const config = ctx.projectParameters.exportResources;
+    const project = new ctx.SpaceExportProject(config, 'exportResources');
+    const duration = project.getEffectiveDuration();
+    const expected = Math.floor((duration / 1000) * project.getExportCap() / (config.attributes.disposalAmount * ctx.shipEfficiency));
+    expect(project.getMaxAssignableShips()).toBe(expected);
+  });
+
   test('getExportCap excludes current terraformed world', () => {
     const ctx = { console, EffectableEntity, shipEfficiency: 1 };
     ctx.resources = { special: { spaceships: { value: 100 } }, colony: { metal: {} } };
@@ -116,7 +143,7 @@ describe('SpaceExportProject', () => {
     const duration = project.getEffectiveDuration();
     const gain = project.calculateSpaceshipTotalResourceGain(true);
     const expected =
-      config.attributes.disposalAmount * ctx.shipEfficiency * project.assignedSpaceships * (1000 / duration) * config.attributes.fundingGainAmount;
+      project.getShipCapacity() * project.assignedSpaceships * (1000 / duration) * config.attributes.fundingGainAmount;
     expect(gain.colony.funding).toBeCloseTo(expected);
   });
 });


### PR DESCRIPTION
## Summary
- Add `getShipCapacity` to `SpaceshipProject` and replace manual ship efficiency calculations
- Scale space export assignment limit with ship capacity effects
- Update export and disposal UI and logic to use the shared ship capacity helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4a545cc1083279d71d466d5fcac51