### PR TITLE
Use zone percentages for RWG final temperatures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,3 +288,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space export and disposal projects use a shared `getShipCapacity` method so ship capacity effects scale assignment limits and per-ship amounts.
 - Starting a new game now fully resets the nanotech swarm and its sliders.
 - Projects can be reordered based on visibility rather than unlocked status, using a new `isVisible` method; Dyson Swarm has a custom implementation.
+- Random world equilibration now weights final day and night temperatures by each zone's surface area percentage.

--- a/src/js/rwgEquilibrate.js
+++ b/src/js/rwgEquilibrate.js
@@ -132,15 +132,15 @@
         out.classification.TeqK = Math.round(eqT);
       }
 
-      if (terra.temperature && terra.temperature.zones && typeof getZoneRatio === 'function') {
+      if (terra.temperature && terra.temperature.zones && typeof getZonePercentage === 'function') {
         const z = terra.temperature.zones;
-        const ratios = {
-          tropical: getZoneRatio('tropical'),
-          temperate: getZoneRatio('temperate'),
-          polar: getZoneRatio('polar')
+        const weights = {
+          tropical: getZonePercentage('tropical'),
+          temperate: getZonePercentage('temperate'),
+          polar: getZonePercentage('polar')
         };
-        const day = z.tropical.day * ratios.tropical + z.temperate.day * ratios.temperate + z.polar.day * ratios.polar;
-        const night = z.tropical.night * ratios.tropical + z.temperate.night * ratios.temperate + z.polar.night * ratios.polar;
+        const day = z.tropical.day * weights.tropical + z.temperate.day * weights.temperate + z.polar.day * weights.polar;
+        const night = z.tropical.night * weights.tropical + z.temperate.night * weights.temperate + z.polar.night * weights.polar;
         out.finalTemps = { mean: terra.temperature.value, day, night };
       }
     }
@@ -352,7 +352,7 @@
   }
 
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { runEquilibration, buildSandboxResourcesFromOverride };
+    module.exports = { runEquilibration, buildSandboxResourcesFromOverride, copyBackToOverrideFromSandbox };
   } else {
     globalThis.runEquilibration = runEquilibration;
   }

--- a/tests/rwgFinalTemps.test.js
+++ b/tests/rwgFinalTemps.test.js
@@ -1,0 +1,25 @@
+const { copyBackToOverrideFromSandbox } = require('../src/js/rwgEquilibrate.js');
+
+describe('copyBackToOverrideFromSandbox temperature weighting', () => {
+  test('weights day and night temps by zone surface area', () => {
+    global.getZonePercentage = zone => ({ tropical: 0.5, temperate: 0.3, polar: 0.2 }[zone] || 0);
+    const terra = {
+      temperature: {
+        value: 0,
+        zones: {
+          tropical: { day: 100, night: 80 },
+          temperate: { day: 200, night: 60 },
+          polar: { day: 300, night: 40 }
+        }
+      },
+      zonalWater: {},
+      zonalSurface: {},
+      zonalHydrocarbons: {}
+    };
+    const result = copyBackToOverrideFromSandbox({}, {}, terra);
+    const expectedDay = 100 * 0.5 + 200 * 0.3 + 300 * 0.2;
+    const expectedNight = 80 * 0.5 + 60 * 0.3 + 40 * 0.2;
+    expect(result.finalTemps.day).toBeCloseTo(expectedDay);
+    expect(result.finalTemps.night).toBeCloseTo(expectedNight);
+  });
+});


### PR DESCRIPTION
## Summary
- weight RWG final day/night temperatures by each zone's surface area percentage
- expose `copyBackToOverrideFromSandbox` for testing
- test temperature weighting

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a5c6070f7c8327b0684635a065fdfb