### PR TITLE
Apply temperature penalty to Ecumenopolis Districts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,3 +289,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Starting a new game now fully resets the nanotech swarm and its sliders.
 - Projects can be reordered based on visibility rather than unlocked status, using a new `isVisible` method; Dyson Swarm has a custom implementation.
 - Random world equilibration now weights final day and night temperatures by each zone's surface area percentage.
+- Temperature penalty for colonies now affects Ecumenopolis Districts.

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -1385,7 +1385,7 @@ class Terraforming extends EffectableEntity{
 
       const colonyEnergyPenalty = this.calculateColonyEnergyPenalty()
       
-      for (let i = 1; i <= 6; i++) {
+      for (let i = 1; i <= 7; i++) {
         const temperaturePenaltyEffect = {
             effectId: 'temperaturePenalty',
             target: 'colony',

--- a/tests/ecumenopolisTemperaturePenalty.test.js
+++ b/tests/ecumenopolisTemperaturePenalty.test.js
@@ -1,0 +1,47 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+// Provide minimal globals expected by terraforming module
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = {};
+
+const Terraforming = require('../src/js/terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+Terraforming.prototype.updateSurfaceRadiation = function(){};
+
+describe('Ecumenopolis temperature penalty', () => {
+  test('temperature penalty applies to ecumenopolis districts', () => {
+    global.resources = {
+      surface: { land: { value: 1000000 } },
+      atmospheric: {},
+      special: { albedoUpgrades: { value: 0 } }
+    };
+    global.buildings = {};
+    global.colonies = {};
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, { distanceFromSun: 1, radius: 1, gravity: 1, albedo: 0 });
+
+    const originalAddEffect = global.addEffect;
+    const mockAddEffect = jest.fn();
+    global.addEffect = mockAddEffect;
+
+    tf.calculateSolarPanelMultiplier = () => 1;
+    tf.calculateWindTurbineMultiplier = () => 1;
+    tf.calculateColonyEnergyPenalty = () => 1.5;
+
+    tf.applyTerraformingEffects();
+
+    const calls = mockAddEffect.mock.calls.map(call => call[0]);
+    expect(calls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ target: 'colony', targetId: 't7_colony', effectId: 'temperaturePenalty', value: 1.5 })
+    ]));
+
+    global.addEffect = originalAddEffect;
+  });
+});


### PR DESCRIPTION
## Summary
- Extend colony temperature penalty effects to include Ecumenopolis Districts
- Document Ecumenopolis District temperature penalty in AGENTS notes
- Add unit test to ensure Ecumenopolis Districts receive the temperature penalty

## Testing
- `npm ci`
- `npm test` *(fails: oxygenFactoryPressureDisable.test.js, ghgFactoryTempDisable.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68a670ffb0f8832792e4e9d59cddb447