### PR TITLE
Ensure thrusters burn toward targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,5 +290,6 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Projects can be reordered based on visibility rather than unlocked status, using a new `isVisible` method; Dyson Swarm has a custom implementation.
 - Random world equilibration now weights final day and night temperatures by each zone's surface area percentage.
 - Planetary thrusters clamp spin and motion changes to their targets, preventing overshoot.
+- Planetary thrusters now apply delta v toward the target, accelerating or decelerating depending on whether the goal is lower or higher.
 - Added Next-Generation Fusion research doubling Superalloy Fusion Reactor energy production.
 - Temperature penalty for colonies now affects Ecumenopolis Districts.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -470,7 +470,7 @@ class PlanetaryThrustersProject extends Project{
 
     /* ------ spin -------- */
     if(this.spinInvest){
-      const sign=this.tgtDays<this.spinStartDays?1:-1;
+      const sign = this.tgtDays < getRotHours(p) / 24 ? 1 : -1;
         const dΩ=sign*dvTick/(p.radius*1e3);
         const ω=2*Math.PI/(getRotHours(p)*3600)+dΩ;
         let newPeriod=2*Math.PI/ω/3600;
@@ -537,7 +537,8 @@ class PlanetaryThrustersProject extends Project{
         const mu=G*(p.starMass || SOLAR_MASS);
         let a_sma=p.distanceFromSun*AU_IN_METERS;
         const v=Math.sqrt(mu/a_sma);
-        let E=-mu/(2*a_sma)+v*a*dt*(this.tgtAU>this.startAU?+1:-1);
+        const orientation = this.tgtAU > p.distanceFromSun ? 1 : -1;
+        let E=-mu/(2*a_sma)+v*a*dt*orientation;
         a_sma=-mu/(2*E);
         p.distanceFromSun=a_sma/AU_IN_METERS;
         if((this.tgtAU>this.startAU&&p.distanceFromSun>=this.tgtAU)||

--- a/tests/planetaryThrustersOrientation.test.js
+++ b/tests/planetaryThrustersOrientation.test.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+const thrusterCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'PlanetaryThrustersProject.js'), 'utf8');
+const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+
+describe('Planetary Thrusters orientation', () => {
+  test('applies delta v toward the target', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.projectElements = {};
+    ctx.terraforming = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.resources = { colony: { energy: { value: 1e40, decrease(v){ this.value -= v; }, updateStorageCap(){} } } };
+
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(thrusterCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const project = new ctx.PlanetaryThrustersProject(ctx.projectParameters.planetaryThruster, 'thruster');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    project.complete();
+    const p = ctx.terraforming.celestialParameters;
+
+    // spin orientation
+    project.el.rotTarget.value = 0.5; // 12 hour day
+    project.calcSpinCost();
+    project.spinInvest = true;
+    project.prepareJob(true, true);
+    project.activeMode = 'spin';
+    p.rotationPeriod = 6; // overshoot to 6 hours before update
+    const requiredPower = project.dVreq * p.mass / (project.getThrustPowerRatio() * 86400);
+    project.power = requiredPower / 10;
+    project.update(1000);
+    expect(p.rotationPeriod).toBeGreaterThan(6);
+
+    // motion orientation
+    project.power = 0;
+    project.motionInvest = true;
+    project.spinInvest = false;
+    project.el.distTarget.value = 2; // target higher orbit
+    project.calcMotionCost();
+    project.prepareJob(true, true);
+    project.activeMode = 'motion';
+    project.startAU = 3; // flip orientation if using startAU
+    const requiredPowerM = project.dVreq * p.mass / (project.getThrustPowerRatio() * 86400);
+    project.power = requiredPowerM / 10;
+    project.update(1000);
+    expect(p.distanceFromSun).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- orient thruster burns based on current spin or orbital distance
- add regression test for thruster burn direction
- document new thruster behavior in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a6767a74e88327b95e765461b3a59b