### PR TITLE
Make colony temperature penalty continuous

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,3 +292,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Planetary thrusters clamp spin and motion changes to their targets, preventing overshoot.
 - Added Next-Generation Fusion research doubling Superalloy Fusion Reactor energy production.
 - Temperature penalty for colonies now affects Ecumenopolis Districts.
+- Colony energy penalty from temperature is continuous, scaling with distance below 15 °C or above 20 °C.

--- a/tests/colonyEnergyPenalty.test.js
+++ b/tests/colonyEnergyPenalty.test.js
@@ -1,0 +1,45 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+// Minimal globals expected by terraforming module
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = {};
+
+const Terraforming = require('../src/js/terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+Terraforming.prototype.updateSurfaceRadiation = function(){};
+
+describe('calculateColonyEnergyPenalty', () => {
+  test('returns 1 within 15°C to 20°C range', () => {
+    const tf = { temperature: { zones: {
+      tropical: { value: 290 },
+      temperate: { value: 291 },
+      polar: { value: 292 }
+    } } };
+    const penalty = Terraforming.prototype.calculateColonyEnergyPenalty.call(tf);
+    expect(penalty).toBe(1);
+  });
+
+  test('scales with temperature above 20°C', () => {
+    const temp = 300; // Kelvin
+    const expected = 1 + (temp - 293.15) / 10;
+    const tf = { temperature: { zones: {
+      tropical: { value: temp },
+      temperate: { value: temp },
+      polar: { value: temp }
+    } } };
+    const penalty = Terraforming.prototype.calculateColonyEnergyPenalty.call(tf);
+    expect(penalty).toBeCloseTo(expected);
+  });
+
+  test('scales with temperature below 15°C', () => {
+    const temp = 280; // Kelvin
+    const expected = 1 + (288.15 - temp) / 10;
+    const tf = { temperature: { zones: {
+      tropical: { value: temp },
+      temperate: { value: temp },
+      polar: { value: temp }
+    } } };
+    const penalty = Terraforming.prototype.calculateColonyEnergyPenalty.call(tf);
+    expect(penalty).toBeCloseTo(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- Smooth colony temperature energy penalty with neutral range at 15–20 °C
- Document new continuous penalty behavior
- Test energy penalty calculations above and below comfort range

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a677a7028883278c201ed9aa26ae1f