### PR TITLE
Format WGC artifact logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,3 +294,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added Next-Generation Fusion research doubling Superalloy Fusion Reactor energy production.
 - Temperature penalty for colonies now affects Ecumenopolis Districts.
 - Colony energy penalty from temperature is continuous, scaling with distance below 15 °C or above 20 °C.
+- WGC logs now format artifact gains with two decimal places.

--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -226,7 +226,7 @@ class WarpGateCommand extends EffectableEntity {
     const rollsStr = rollResult.rolls.join(',');
     const outcome = success ? (critical ? 'Critical Success' : 'Success') : 'Fail';
     const rollerName = roller ? ` (${roller.firstName})` : '';
-    const artText = artifact ? ` +${artifactReward} Artifact${artifactReward === 1 ? '' : 's'}` : '';
+    const artText = artifact ? ` +${formatNumber(artifactReward, false, 2)} Artifact${artifactReward === 1 ? '' : 's'}` : '';
     let skillDetail = formatNumber(skillTotal, false, 2);
     if (event.type === 'individual' || event.type === 'science') {
       skillDetail = `${formatNumber(baseSkill, false, 2)}`;
@@ -411,7 +411,7 @@ class WarpGateCommand extends EffectableEntity {
         }
       });
     }
-    const summary = `Operation ${op.number} Complete: ${successes} success(es), ${art} artifact(s)`;
+    const summary = `Operation ${op.number} Complete: ${successes} success(es), ${formatNumber(art, false, 2)} artifact(s)`;
     op.summary = summary;
     this.addLog(teamIndex, `Team ${teamIndex + 1} - ${summary}`);
 
@@ -425,7 +425,7 @@ class WarpGateCommand extends EffectableEntity {
         resources.special.alienArtifact.increase(bonus);
       }
       this.totalArtifacts += bonus;
-      this.addLog(teamIndex, `Team ${teamIndex + 1} - Highest difficulty ${op.difficulty} reached +${bonus} Artifact${bonus === 1 ? '' : 's'}`);
+      this.addLog(teamIndex, `Team ${teamIndex + 1} - Highest difficulty ${op.difficulty} reached +${formatNumber(bonus, false, 2)} Artifact${bonus === 1 ? '' : 's'}`);
     }
 
     this.teamOperationCounts[teamIndex] += 1;

--- a/tests/wgcArtifactLogFormat.test.js
+++ b/tests/wgcArtifactLogFormat.test.js
@@ -1,0 +1,29 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC artifact log formatting', () => {
+  test('artifact gains use formatNumber with two decimals', () => {
+    const wgc = new WarpGateCommand();
+    for (let i = 0; i < 4; i++) {
+      wgc.recruitMember(0, i, WGCTeamMember.create('A' + i, '', 'Soldier', {}));
+    }
+    wgc.startOperation(0, 1); // difficulty 1 for decimal artifact reward
+    wgc.roll = () => ({ sum: 20, rolls: [20] }); // critical success guarantees artifact
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const event = { name: 'Test', type: 'individual', skill: 'athletics' };
+    wgc.resolveEvent(0, event);
+
+    const eventLog = wgc.logs[0][wgc.logs[0].length - 1];
+    expect(eventLog).toMatch(/\+1\.10 Artifact/);
+
+    wgc.finishOperation(0);
+    const summaryLog = wgc.logs[0].find(l => l.includes('Operation 1 Complete'));
+    expect(summaryLog).toMatch(/1\.10 artifact\(s\)/);
+    const bonusLog = wgc.logs[0].find(l => l.includes('Highest difficulty'));
+    expect(bonusLog).toMatch(/\+2\.00 Artifact/);
+    Math.random.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- format artifact rewards in WGC logs using formatNumber with two decimals
- add test to verify artifact log formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a67afb8958832782c04d01195791df