### PR TITLE
Handle methane ice coverage in melt-freeze rates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,3 +295,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Temperature penalty for colonies now affects Ecumenopolis Districts.
 - Colony energy penalty from temperature is continuous, scaling with distance below 15 °C or above 20 °C.
 - WGC logs now format artifact gains with two decimal places.
+- Methane melting and freezing now respect methane ice coverage.

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -684,7 +684,8 @@ class Terraforming extends EffectableEntity{
                 availableHydrocarbonIce,
                 availableLiquidMethane,
                 availableBuriedHydrocarbonIce,
-                zoneArea
+                zoneArea,
+                () => this.zonalCoverageCache[zone]?.hydrocarbonIce ?? 0
             );
             const availableForMethaneMelt = availableHydrocarbonIce + availableBuriedHydrocarbonIce + (zonalChanges[zone].hydrocarbonIce || 0);
             const methaneMeltAmount = Math.min(methaneMeltFreezeRates.meltingRate * durationSeconds, availableForMethaneMelt);


### PR DESCRIPTION
## Summary
- Ensure methane melting and freezing calculations respect zonal methane ice coverage
- Validate methane coverage function is passed to melting/freezing rate helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a6817623a08327b6f3f5d6a1b37344