### PR TITLE
Make planetary thrusters continuous

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - WGC logs now format artifact gains with two decimal places.
 - Methane melting and freezing now respect methane ice coverage.
 - Planetary thrusters operate as a continuous project, drawing power from ongoing energy production instead of only stored energy.
+- Planetary thrusters appear in the Energy resource rate tooltip, listing their consumption.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,3 +296,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Colony energy penalty from temperature is continuous, scaling with distance below 15 °C or above 20 °C.
 - WGC logs now format artifact gains with two decimal places.
 - Methane melting and freezing now respect methane ice coverage.
+- Planetary thrusters operate as a continuous project, drawing power from ongoing energy production instead of only stored energy.

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -479,7 +479,10 @@ class PlanetaryThrustersProject extends Project{
     }
     const p = terraforming.celestialParameters;
     if(!p){ this.lastActiveTime = 0; return; }
-
+    const fraction = Math.min(1, activeTime / deltaTime);
+    if(this.autoStart === false && resources?.colony?.energy?.modifyRate){
+      resources.colony.energy.modifyRate(-this.power * fraction * productivity, 'Planetary Thrusters', 'project');
+    }
     const dt = activeTime / 1000;
     const energyUsed = this.power * dt * productivity;
     if(accumulatedChanges){

--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -97,6 +97,32 @@ describe('Planetary Thrusters project', () => {
     expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalledWith(-20, 'Planetary Thrusters', 'project');
   });
 
+  test('applyCostAndGain adds energy rate when autoStart disabled', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const subclassCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'PlanetaryThrustersProject.js'), 'utf8');
+    vm.runInContext(subclassCode + '; this.PlanetaryThrustersProject = PlanetaryThrustersProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.resources = { colony: { energy: { modifyRate: jest.fn(), value: 100, decrease(){}, updateStorageCap(){} } } };
+    global.resources = ctx.resources;
+    ctx.terraforming = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+
+    const config = ctx.projectParameters.planetaryThruster;
+    const project = new ctx.PlanetaryThrustersProject(config, 'pt');
+    project.isCompleted = true;
+    project.power = 20;
+    project.spinInvest = true;
+    project.prepareJob();
+    project.update(1000);
+    project.updateUI = () => {};
+    project.applyCostAndGain(1000, null, 1);
+    expect(ctx.resources.colony.energy.modifyRate).toHaveBeenCalledWith(-20, 'Planetary Thrusters', 'project');
+  });
+
   test('saveState and loadState preserve settings', () => {
     const ctx = { console, EffectableEntity };
     vm.createContext(ctx);

--- a/tests/planetaryThrustersDayNightCycle.test.js
+++ b/tests/planetaryThrustersDayNightCycle.test.js
@@ -47,6 +47,7 @@ describe('Planetary Thrusters day-night cycle', () => {
 
     const initialDuration = ctx.dayNightCycle.dayDuration;
     project.update(10000000);
+    project.applyCostAndGain(10000000, null, 1);
     const newPeriod = ctx.terraforming.celestialParameters.rotationPeriod;
 
     expect(newPeriod).not.toBe(20);

--- a/tests/planetaryThrustersEnergySpent.test.js
+++ b/tests/planetaryThrustersEnergySpent.test.js
@@ -38,6 +38,7 @@ describe('Planetary Thrusters energy tracking', () => {
     project.prepareJob(true, true);
     project.activeMode = 'spin';
     project.update(1000);
+    project.applyCostAndGain(1000, null, 1);
     const spinEnergy = project.energySpentSpin;
 
     // switch to motion without resetting spin energy
@@ -54,6 +55,7 @@ describe('Planetary Thrusters energy tracking', () => {
 
     // accumulate motion energy
     project.update(1000);
+    project.applyCostAndGain(1000, null, 1);
     const motionEnergy = project.energySpentMotion;
 
     // switch to spin without resetting motion energy

--- a/tests/planetaryThrustersNoOvershoot.test.js
+++ b/tests/planetaryThrustersNoOvershoot.test.js
@@ -44,6 +44,7 @@ describe('Planetary Thrusters target clamping', () => {
     const requiredPower = project.dVreq * p.mass / (project.getThrustPowerRatio() * 86400);
     project.power = requiredPower * 2; // overshoot in one tick
     project.update(1000);
+    project.applyCostAndGain(1000, null, 1);
     expect(p.rotationPeriod).toBeCloseTo(project.tgtDays * 24, 10);
     expect(project.spinInvest).toBe(false);
 
@@ -59,6 +60,7 @@ describe('Planetary Thrusters target clamping', () => {
     const requiredPowerM = project.dVreq * p.mass / (project.getThrustPowerRatio() * 86400);
     project.power = requiredPowerM * 2;
     project.update(1000);
+    project.applyCostAndGain(1000, null, 1);
     expect(p.distanceFromSun).toBeCloseTo(project.tgtAU, 10);
     expect(project.motionInvest).toBe(false);
   });

--- a/tests/planetaryThrustersOrientation.test.js
+++ b/tests/planetaryThrustersOrientation.test.js
@@ -42,6 +42,7 @@ describe('Planetary Thrusters orientation', () => {
     const requiredPower = project.dVreq * p.mass / (project.getThrustPowerRatio() * 86400);
     project.power = requiredPower / 10;
     project.update(1000);
+    project.applyCostAndGain(1000, null, 1);
     expect(p.rotationPeriod).toBeGreaterThan(6);
 
     // motion orientation
@@ -56,6 +57,7 @@ describe('Planetary Thrusters orientation', () => {
     const requiredPowerM = project.dVreq * p.mass / (project.getThrustPowerRatio() * 86400);
     project.power = requiredPowerM / 10;
     project.update(1000);
+    project.applyCostAndGain(1000, null, 1);
     expect(p.distanceFromSun).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
## Summary
- Rework planetary thrusters into a continuous project that draws power each tick using available production
- Track energy via accumulated changes so thrusters consume generated energy, not just stored reserves
- Expand and adjust tests for new continuous behavior and energy accounting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a6869a8a708327a8364822d961e0db