### PR TITLE
Use cached coverage in melt/freezing rate calculations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - WGC logs now format artifact gains with two decimal places.
 - Methane melting and freezing now respect methane ice coverage.
 - Freezing processes scale with liquid surface area and accept liquid coverage functions.
+- Melting and freezing rate calculations use cached coverage values.

--- a/src/js/hydrology.js
+++ b/src/js/hydrology.js
@@ -195,7 +195,7 @@ function simulateSurfaceHydrocarbonFlow(zonalHydrocarbonInput, deltaTime, zonalT
 }
 
 // Compute melting and freezing rates for a surface zone based on temperature
-function calculateMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1, iceCoverageFn, liquidCoverageFn) {
+function calculateMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1, iceCoverage = 1, liquidCoverage = 1) {
     return meltingFreezingRatesUtil({
         temperature,
         freezingPoint: 273.15,
@@ -203,12 +203,12 @@ function calculateMeltingFreezingRates(temperature, availableIce, availableLiqui
         availableLiquid,
         availableBuriedIce,
         zoneArea,
-        iceCoverageFn,
-        liquidCoverageFn
+        iceCoverage,
+        liquidCoverage
     });
 }
 
-function calculateMethaneMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1, iceCoverageFn, liquidCoverageFn) {
+function calculateMethaneMeltingFreezingRates(temperature, availableIce, availableLiquid, availableBuriedIce = 0, zoneArea = 1, iceCoverage = 1, liquidCoverage = 1) {
     return meltingFreezingRatesUtil({
         temperature,
         freezingPoint: 90.7,
@@ -216,8 +216,8 @@ function calculateMethaneMeltingFreezingRates(temperature, availableIce, availab
         availableLiquid,
         availableBuriedIce,
         zoneArea,
-        iceCoverageFn,
-        liquidCoverageFn,
+        iceCoverage,
+        liquidCoverage,
     });
 }
 

--- a/src/js/phase-change-utils.js
+++ b/src/js/phase-change-utils.js
@@ -32,11 +32,11 @@
    freezingPoint,
    availableIce = 0,
    availableLiquid = 0,
-   availableBuriedIce = 0,
-   zoneArea = 1,
-   iceCoverageFn,
-   liquidCoverageFn
- }) {
+  availableBuriedIce = 0,
+  zoneArea = 1,
+  iceCoverage = 1,
+  liquidCoverage = 1
+}) {
    const meltingRateMultiplier = 0.000001; // per K per second
    const freezingRateMultiplier = 0.000001; // per K per second
  
@@ -46,11 +46,8 @@
    if (temperature > freezingPoint) {
      const diff = temperature - freezingPoint;
 
-     let surfaceIceCoverage = 1;
-     if (iceCoverageFn) {
-       surfaceIceCoverage = iceCoverageFn();
-     }
-     const surfaceMeltCap = surfaceIceCoverage > 1e-10 ? zoneArea * surfaceIceCoverage * 0.1 : zoneArea * Math.sqrt(surfaceIceCoverage) * 0.1 * 1e-5;
+    const surfaceIceCoverage = iceCoverage;
+    const surfaceMeltCap = surfaceIceCoverage > 1e-10 ? zoneArea * surfaceIceCoverage * 0.1 : zoneArea * Math.sqrt(surfaceIceCoverage) * 0.1 * 1e-5;
      const cappedSurfaceIce = Math.min(availableIce || 0, surfaceMeltCap);
      const surfaceMeltRate = cappedSurfaceIce * meltingRateMultiplier * diff;
  
@@ -68,12 +65,9 @@
    } else if (temperature < freezingPoint && availableLiquid > 0) {
      const diff = freezingPoint - temperature;
 
-     let surfaceLiquidCoverage = 1;
-     if (liquidCoverageFn) {
-       surfaceLiquidCoverage = liquidCoverageFn();
-     }
+    const surfaceLiquidCoverage = liquidCoverage;
 
-     freezingRate = availableLiquid * freezingRateMultiplier * diff * surfaceLiquidCoverage;
+    freezingRate = availableLiquid * freezingRateMultiplier * diff * surfaceLiquidCoverage;
   }
  
    return { meltingRate, freezingRate };

--- a/src/js/terraforming-utils.js
+++ b/src/js/terraforming-utils.js
@@ -155,9 +155,9 @@ const calculateZonalMeltingFreezingRates = (terraforming, zone, temperature) => 
   const availableBuriedIce = terraforming.zonalWater?.[zone]?.buriedIce || 0;
   const availableLiquid = terraforming.zonalWater?.[zone]?.liquid || 0;
   const zoneArea = terraforming.celestialParameters.surfaceArea * zonePercentage(zone);
-  const iceCoverageFn = () => terraforming.zonalCoverageCache[zone]?.ice ?? 0;
-  const liquidCoverageFn = () => terraforming.zonalCoverageCache[zone]?.liquidWater ?? 0;
-  return baseCalculateMeltFreeze(temperature, availableIce, availableLiquid, availableBuriedIce, zoneArea, iceCoverageFn, liquidCoverageFn);
+  const iceCoverage = terraforming.zonalCoverageCache[zone]?.ice ?? 0;
+  const liquidCoverage = terraforming.zonalCoverageCache[zone]?.liquidWater ?? 0;
+  return baseCalculateMeltFreeze(temperature, availableIce, availableLiquid, availableBuriedIce, zoneArea, iceCoverage, liquidCoverage);
 };
 
 if (!isNode) {

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -685,8 +685,8 @@ class Terraforming extends EffectableEntity{
                 availableLiquidMethane,
                 availableBuriedHydrocarbonIce,
                 zoneArea,
-                () => this.zonalCoverageCache[zone]?.hydrocarbonIce ?? 0,
-                () => this.zonalCoverageCache[zone]?.liquidMethane ?? 0
+                this.zonalCoverageCache[zone]?.hydrocarbonIce ?? 0,
+                this.zonalCoverageCache[zone]?.liquidMethane ?? 0
             );
             const availableForMethaneMelt = availableHydrocarbonIce + availableBuriedHydrocarbonIce + (zonalChanges[zone].hydrocarbonIce || 0);
             const methaneMeltAmount = Math.min(methaneMeltFreezeRates.meltingRate * durationSeconds, availableForMethaneMelt);

--- a/tests/hydrology.test.js
+++ b/tests/hydrology.test.js
@@ -35,7 +35,7 @@ function makeTerraformingWithRadius(zonalWater, radius) {
 describe('hydrology melting with buried ice', () => {
   test('calculateMeltingFreezingRates respects area cap', () => {
     const T = 280; // above freezing
-    const res = calculateMeltingFreezingRates(T, 0, 0, 10, 1, () => 0, () => 0);
+    const res = calculateMeltingFreezingRates(T, 0, 0, 10, 1, 0, 0);
     expect(res.meltingRate).toBeCloseTo(0);
     expect(res.freezingRate).toBe(0);
   });
@@ -45,7 +45,7 @@ describe('hydrology melting with buried ice', () => {
     const diff = 273.15 - T;
     const coverage = 0.2;
     const availableLiquid = 10;
-    const res = calculateMeltingFreezingRates(T, 0, availableLiquid, 0, 1, () => 0, () => coverage);
+    const res = calculateMeltingFreezingRates(T, 0, availableLiquid, 0, 1, 0, coverage);
     const expected = availableLiquid * 0.000001 * diff * coverage;
     expect(res.freezingRate).toBeCloseTo(expected);
   });

--- a/tests/methaneRates.test.js
+++ b/tests/methaneRates.test.js
@@ -9,10 +9,8 @@ const hydrocarbon = require('../src/js/hydrocarbon-cycle.js');
 jest.mock('../src/js/hydrology.js', () => {
   const original = jest.requireActual('../src/js/hydrology.js');
   const mockMethaneRates = jest.fn((...args) => {
-    const iceCoverageFn = args[5];
-    const liquidCoverageFn = args[6];
-    mockMethaneRates.coverageIceValue = iceCoverageFn ? iceCoverageFn() : undefined;
-    mockMethaneRates.coverageLiquidValue = liquidCoverageFn ? liquidCoverageFn() : undefined;
+    mockMethaneRates.coverageIceValue = args[5];
+    mockMethaneRates.coverageLiquidValue = args[6];
     return { meltingRate: 0, freezingRate: 0 };
   });
   return {
@@ -92,7 +90,7 @@ describe('methane atmospheric rate tracking', () => {
 });
 
 describe('methane melting/freezing coverage', () => {
-  test('passes methane ice coverage function', () => {
+  test('passes methane coverage values', () => {
     const params = getPlanetParameters('titan');
     global.currentPlanetParameters = params;
     const res = createResources();

--- a/tests/phaseChangeUtils.test.js
+++ b/tests/phaseChangeUtils.test.js
@@ -47,8 +47,8 @@ describe('meltingFreezingRates helper', () => {
       availableBuriedIce: 2,
       zoneArea: 1
     };
-    params.iceCoverageFn = () => params.availableIce / params.zoneArea;
-    params.liquidCoverageFn = () => params.availableLiquid / params.zoneArea;
+    params.iceCoverage = params.availableIce / params.zoneArea;
+    params.liquidCoverage = params.availableLiquid / params.zoneArea;
     const utilRes = utils.meltingFreezingRates(params);
     const hydro = require('../src/js/hydrology.js');
     const hydroRes = hydro.calculateMeltingFreezingRates(
@@ -57,8 +57,8 @@ describe('meltingFreezingRates helper', () => {
       params.availableLiquid,
       params.availableBuriedIce,
       params.zoneArea,
-      () => params.availableIce / params.zoneArea,
-      () => params.availableLiquid / params.zoneArea
+      params.iceCoverage,
+      params.liquidCoverage
     );
     expect(utilRes.meltingRate).toBeCloseTo(hydroRes.meltingRate);
     expect(utilRes.freezingRate).toBeCloseTo(hydroRes.freezingRate);


### PR DESCRIPTION
## Summary
- Refactor phase-change utilities and hydrology to accept coverage values directly, using cached zonal coverage for melt/freeze rates
- Update terraforming helpers and methane handling to pass cached coverage instead of recomputing
- Adjust tests for new melt/freeze API and document change in AGENTS

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a68c3cae008327a34e34fd8faaf691