### PR TITLE
feat: add higher number units

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - WGC logs now format artifact gains with two decimal places.
 - Methane melting and freezing now respect methane ice coverage.
 - Freezing processes scale with liquid surface area and accept liquid coverage functions.
+- Added decillion, undecillion, and duodecillion number units.

--- a/src/js/numbers.js
+++ b/src/js/numbers.js
@@ -2,7 +2,13 @@ function formatNumber(value, integer = false, precision = 1, allowSmall = false)
     const absValue = Math.abs(value);
     let formatted;
 
-    if (absValue >= 1e30 - 1e27) {
+    if (absValue >= 1e39 - 1e36) {
+      formatted = integer && absValue % 1e39 === 0 ? (absValue / 1e39) + 'Dd' : (absValue / 1e39).toFixed(precision) + 'Dd';
+    } else if (absValue >= 1e36 - 1e33) {
+      formatted = integer && absValue % 1e36 === 0 ? (absValue / 1e36) + 'Ud' : (absValue / 1e36).toFixed(precision) + 'Ud';
+    } else if (absValue >= 1e33 - 1e30) {
+      formatted = integer && absValue % 1e33 === 0 ? (absValue / 1e33) + 'De' : (absValue / 1e33).toFixed(precision) + 'De';
+    } else if (absValue >= 1e30 - 1e27) {
       formatted = integer && absValue % 1e30 === 0 ? (absValue / 1e30) + 'No' : (absValue / 1e30).toFixed(precision) + 'No';
     } else if (absValue >= 1e27 - 1e24) {
       formatted = integer && absValue % 1e27 === 0 ? (absValue / 1e27) + 'Oc' : (absValue / 1e27).toFixed(precision) + 'Oc';

--- a/tests/formatNumberLargeUnits.test.js
+++ b/tests/formatNumberLargeUnits.test.js
@@ -1,0 +1,15 @@
+const { formatNumber } = require('../src/js/numbers.js');
+
+describe('formatNumber large units', () => {
+  test('formats decillion', () => {
+    expect(formatNumber(1e33, true)).toBe('1De');
+  });
+
+  test('formats undecillion', () => {
+    expect(formatNumber(1e36, true)).toBe('1Ud');
+  });
+
+  test('formats duodecillion', () => {
+    expect(formatNumber(1e39, true)).toBe('1Dd');
+  });
+});


### PR DESCRIPTION
## Summary
- extend large number formatting with decillion, undecillion, and duodecillion units
- cover new units with tests
- document new units in AGENTS instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a68d4bb7808327b3b5c83d1c4e6a87