### PR TITLE
Use cached zonal coverage in terraforming utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,4 +302,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added decillion, undecillion, and duodecillion number units.
 - Melting and freezing rate calculations use cached coverage values.
 - Hydrology surface flow uses cached zonal coverage values.
+- Evaporation and sublimation rate calculations use cached zonal coverage values.
 - fastForwardToEquilibrium now checks zonal biomass and buried hydrocarbons for stability, matching equilibrate.

--- a/src/js/terraforming-utils.js
+++ b/src/js/terraforming-utils.js
@@ -121,9 +121,12 @@ function calculateZonalSurfaceFractions(terraforming, zone) {
 
 function calculateZonalEvaporationSublimationRates(terraforming, zone, dayTemp, nightTemp, waterVaporPressure, co2VaporPressure, avgAtmPressure, zonalSolarFlux) {
   const zoneArea = terraforming.celestialParameters.surfaceArea * zonePercentage(zone);
-  const liquidWaterCoverage = calculateZonalCoverage(terraforming, zone, 'liquidWater');
-  const iceCoverage = calculateZonalCoverage(terraforming, zone, 'ice');
-  const dryIceCoverage = calculateZonalCoverage(terraforming, zone, 'dryIce');
+  const liquidWaterCoverage = terraforming.zonalCoverageCache[zone]?.liquidWater ??
+    calculateZonalCoverage(terraforming, zone, 'liquidWater');
+  const iceCoverage = terraforming.zonalCoverageCache[zone]?.ice ??
+    calculateZonalCoverage(terraforming, zone, 'ice');
+  const dryIceCoverage = terraforming.zonalCoverageCache[zone]?.dryIce ??
+    calculateZonalCoverage(terraforming, zone, 'dryIce');
   return baseCalculateEvapSubl({
     zoneArea,
     liquidWaterCoverage,

--- a/tests/terraformingUtilsIntegration.test.js
+++ b/tests/terraformingUtilsIntegration.test.js
@@ -90,6 +90,8 @@ describe('terraforming-utils integration', () => {
       terra.zonalWater[z].liquid = 0;
     }
 
+    terra._updateZonalCoverageCache();
+
     const rates = calculateEvaporationSublimationRates(
       terra,
       'polar',


### PR DESCRIPTION
## Summary
- use zonal coverage cache when calculating evaporation and sublimation rates
- document cached coverage use in AGENTS instructions
- update integration test to refresh coverage cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a699d161f08327be4b39d4f110da39