### PR TITLE
Use durationSeconds for surface flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,3 +304,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Hydrology surface flow uses cached zonal coverage values.
 - Evaporation and sublimation rate calculations use cached zonal coverage values.
 - fastForwardToEquilibrium now checks zonal biomass and buried hydrocarbons for stability, matching equilibrate.
+- Hydrology surface flow now uses durationSeconds instead of deltaTime to avoid floating point drift.

--- a/src/js/hydrology.js
+++ b/src/js/hydrology.js
@@ -13,7 +13,7 @@ if (isNodeHydro) {
 }
 meltingFreezingRatesUtil = meltingFreezingRatesUtil || globalThis.meltingFreezingRates;
 
-function _simulateSurfaceFlow(zonalInput, deltaTime, zonalTemperatures, zoneElevationsInput, config) {
+function _simulateSurfaceFlow(zonalInput, durationSeconds, zonalTemperatures, zoneElevationsInput, config) {
     const { liquidProp, iceProp, buriedIceProp, meltingPoint, zonalDataKey, viscosity, iceCoverageType } = config;
     const zonalData = zonalInput[zonalDataKey] ? zonalInput[zonalDataKey] : zonalInput;
     const terraforming = zonalInput[zonalDataKey] ? zonalInput : null;
@@ -26,7 +26,7 @@ function _simulateSurfaceFlow(zonalInput, deltaTime, zonalTemperatures, zoneElev
 
     const baseFlowRate = 0.001;
     const flowRateCoefficient = (baseFlowRate * radiusScale) / (viscosity || 1.0);
-    const secondsMultiplier = deltaTime / 1000;
+    const secondsMultiplier = durationSeconds;
     let totalMelt = 0;
 
     const zones = (typeof ZONES !== 'undefined') ? ZONES : ['tropical', 'temperate', 'polar'];
@@ -177,8 +177,8 @@ function _simulateSurfaceFlow(zonalInput, deltaTime, zonalTemperatures, zoneElev
     return { changes, totalMelt };
 }
 
-function simulateSurfaceWaterFlow(zonalWaterInput, deltaTime, zonalTemperatures = {}, zoneElevationsInput) {
-    return _simulateSurfaceFlow(zonalWaterInput, deltaTime, zonalTemperatures, zoneElevationsInput, {
+function simulateSurfaceWaterFlow(zonalWaterInput, durationSeconds, zonalTemperatures = {}, zoneElevationsInput) {
+    return _simulateSurfaceFlow(zonalWaterInput, durationSeconds, zonalTemperatures, zoneElevationsInput, {
         liquidProp: 'liquid',
         iceProp: 'ice',
         buriedIceProp: 'buriedIce',
@@ -189,8 +189,8 @@ function simulateSurfaceWaterFlow(zonalWaterInput, deltaTime, zonalTemperatures 
     });
 }
 
-function simulateSurfaceHydrocarbonFlow(zonalHydrocarbonInput, deltaTime, zonalTemperatures = {}, zoneElevationsInput) {
-    return _simulateSurfaceFlow(zonalHydrocarbonInput, deltaTime, zonalTemperatures, zoneElevationsInput, {
+function simulateSurfaceHydrocarbonFlow(zonalHydrocarbonInput, durationSeconds, zonalTemperatures = {}, zoneElevationsInput) {
+    return _simulateSurfaceFlow(zonalHydrocarbonInput, durationSeconds, zonalTemperatures, zoneElevationsInput, {
         liquidProp: 'liquid',
         iceProp: 'ice',
         buriedIceProp: null,

--- a/src/js/terraforming.js
+++ b/src/js/terraforming.js
@@ -515,11 +515,11 @@ class Terraforming extends EffectableEntity{
         for (const z of zones) {
           tempMap[z] = this.temperature.zones[z].value;
         }
-        const waterFlowResult = simulateSurfaceWaterFlow(this, deltaTime, tempMap);
+        const waterFlowResult = simulateSurfaceWaterFlow(this, durationSeconds, tempMap);
         this.flowMeltAmount = waterFlowResult.totalMelt;
         this.flowMeltRate = this.flowMeltAmount / durationSeconds * 86400;
 
-        const hydrocarbonFlowResult = simulateSurfaceHydrocarbonFlow(this, deltaTime, tempMap);
+        const hydrocarbonFlowResult = simulateSurfaceHydrocarbonFlow(this, durationSeconds, tempMap);
         this.flowMethaneMeltAmount = hydrocarbonFlowResult.totalMelt;
         this.flowMethaneMeltRate = this.flowMethaneMeltAmount / durationSeconds * 86400;
 

--- a/tests/hydrology.test.js
+++ b/tests/hydrology.test.js
@@ -84,7 +84,7 @@ describe('hydrology melting with buried ice', () => {
     };
     const temps = { polar: 250, temperate: 274, tropical: 260 };
     const terra = makeTerraforming(zonalWater);
-    const { totalMelt: melt } = simulateSurfaceWaterFlow(terra, 1000, temps, zoneElevations);
+    const { totalMelt: melt } = simulateSurfaceWaterFlow(terra, 1, temps, zoneElevations);
     const slopeFactor = 1 + (zoneElevations.polar - zoneElevations.temperate);
     const zoneArea = getZonePercentage('polar');
     const coverage = terra.zonalCoverageCache.polar.ice;
@@ -106,7 +106,7 @@ describe('hydrology melting with buried ice', () => {
       tropical: { liquid: 20, ice: 0, buriedIce: 0 }
     };
     const temps = { polar: 260, temperate: 260, tropical: 260 };
-    const { totalMelt: moved } = simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1000, temps, zoneElevations);
+    const { totalMelt: moved } = simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1, temps, zoneElevations);
     expect(moved).toBeCloseTo(0); // no melting expected
     expect(zonalWater.polar.liquid).toBeCloseTo(5);
     expect(zonalWater.temperate.liquid).toBeCloseTo(50);
@@ -119,7 +119,7 @@ describe('hydrology melting with buried ice', () => {
       tropical: { liquid: 40, ice: 0, buriedIce: 0 }
     };
     const temps = { polar: 260, temperate: 260, tropical: 260 };
-    simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1000, temps, zoneElevations);
+    simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1, temps, zoneElevations);
     expect(zonalWater.temperate.liquid).toBeGreaterThanOrEqual(40);
     expect(zonalWater.polar.liquid).toBeLessThanOrEqual(10);
   });
@@ -131,7 +131,7 @@ describe('hydrology melting with buried ice', () => {
       tropical: { liquid: 10, ice: 0, buriedIce: 0 }
     };
     const temps = { polar: 260, temperate: 260, tropical: 260 };
-    simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1000, temps, zoneElevations);
+    simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1, temps, zoneElevations);
     expect(zonalWater.polar.liquid).toBeLessThanOrEqual(10);
     expect(zonalWater.temperate.liquid).toBeGreaterThanOrEqual(10);
   });
@@ -143,7 +143,7 @@ describe('hydrology melting with buried ice', () => {
       tropical: { liquid: 0, ice: 0, buriedIce: 0 }
     };
     const temps = { polar: 260, temperate: 260, tropical: 260 };
-    simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1000, temps, zoneElevations);
+    simulateSurfaceWaterFlow(makeTerraforming(zonalWater), 1, temps, zoneElevations);
     expect(zonalWater.tropical.liquid).toBeCloseTo(0, 5);
   });
 
@@ -157,14 +157,14 @@ describe('hydrology melting with buried ice', () => {
     const temps = { polar: 250, temperate: 274, tropical: 260 };
     const meltMars = simulateSurfaceWaterFlow(
       makeTerraformingWithRadius(JSON.parse(JSON.stringify(zonalWater)), marsRadius),
-      1000,
+      1,
       temps,
       zoneElevations
     ).totalMelt;
 
     const meltBig = simulateSurfaceWaterFlow(
       makeTerraformingWithRadius(JSON.parse(JSON.stringify(zonalWater)), marsRadius * 2),
-      1000,
+      1,
       temps,
       zoneElevations
     ).totalMelt;
@@ -182,7 +182,7 @@ describe('hydrocarbon flow', () => {
     };
     const temps = { polar: 85, temperate: 95, tropical: 85 };
     const terra = makeHydroTerraforming(zonalHydro);
-    const { totalMelt: melt } = simulateSurfaceHydrocarbonFlow(terra, 1000, temps, zoneElevations);
+    const { totalMelt: melt } = simulateSurfaceHydrocarbonFlow(terra, 1, temps, zoneElevations);
     const slopeFactor = 1 + (zoneElevations.polar - zoneElevations.temperate);
     const zoneArea = getZonePercentage('polar');
     const coverage = terra.zonalCoverageCache.polar.hydrocarbonIce;


### PR DESCRIPTION
## Summary
- Refactor hydrology surface flow to accept `durationSeconds` instead of millisecond `deltaTime`
- Pass new seconds-based duration from terraforming update loop
- Adjust hydrology tests for the updated API and document feature

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a6a039b1fc8327be9c932ed0af208d