### PR TITLE
Exclude current orbital ring from terraformed count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,3 +307,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Evaporation and sublimation rate calculations use cached zonal coverage values.
 - fastForwardToEquilibrium now checks zonal biomass and buried hydrocarbons for stability, matching equilibrate.
 - Hydrology surface flow now uses durationSeconds instead of deltaTime to avoid floating point drift.
+- `getTerraformedPlanetCountExcludingCurrent` now deducts the current world's orbital ring, if present, when tallying previously terraformed worlds.

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -147,12 +147,14 @@ class SpaceManager extends EffectableEntity {
      * @returns {number}
      */
     getTerraformedPlanetCountExcludingCurrent() {
-        const count = this.getTerraformedPlanetCount();
-        const hasRing = this.currentWorldHasOrbitalRing();
+        let count = this.getTerraformedPlanetCount();
+        if (this.currentWorldHasOrbitalRing()) count--;
         if (this.currentRandomSeed !== null) {
-            return (this.isSeedTerraformed(String(this.currentRandomSeed)) || hasRing) ? Math.max(count - 1, 0) : count;
+            if (this.isSeedTerraformed(String(this.currentRandomSeed))) count--;
+            return Math.max(count, 0);
         }
-        return (this.isPlanetTerraformed(this.currentPlanetKey) || hasRing) ? Math.max(count - 1, 0) : count;
+        if (this.isPlanetTerraformed(this.currentPlanetKey)) count--;
+        return Math.max(count, 0);
     }
 
     getCurrentWorldName() {

--- a/tests/spaceManagerOrbitalRingCount.test.js
+++ b/tests/spaceManagerOrbitalRingCount.test.js
@@ -14,6 +14,17 @@ describe('SpaceManager orbital ring counting', () => {
     expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(2);
     delete global.projectManager;
   });
+
+  test('current world ring not counted in excluding method', () => {
+    const sm = new SpaceManager({ mars: {}, titan: {} });
+    sm.planetStatuses.mars.terraformed = true;
+    sm.planetStatuses.mars.orbitalRing = true;
+    sm.currentPlanetKey = 'mars';
+    global.projectManager = { projects: { orbitalRing: { ringCount: 1 } } };
+    expect(sm.getTerraformedPlanetCount()).toBe(2);
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(0);
+    delete global.projectManager;
+  });
 });
 
 delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- Prevent the current world's orbital ring from contributing to previous terraformed counts
- Test to ensure current orbital ring is excluded
- Note the counting change in AGENTS.md

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a85769e0ec8327ba0a52f335d14454