### PR TITLE
Disable story projects off-world

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,3 +308,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - fastForwardToEquilibrium now checks zonal biomass and buried hydrocarbons for stability, matching equilibrate.
 - Hydrology surface flow now uses durationSeconds instead of deltaTime to avoid floating point drift.
 - `getTerraformedPlanetCountExcludingCurrent` now deducts the current world's orbital ring, if present, when tallying previously terraformed worlds.
+- Story projects stop running and cannot be started on worlds other than their designated planet.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -126,6 +126,14 @@ class Project extends EffectableEntity {
       return this.hasSustainResources();
     }
 
+    if (
+      this.category === 'story' &&
+      this.attributes.planet &&
+      spaceManager.getCurrentPlanetKey() !== this.attributes.planet
+    ) {
+      return false;
+    }
+
     const cost = this.getScaledCost();
     const storageProj = this.attributes.canUseSpaceStorage && projectManager?.projects?.spaceStorage;
     for (const category in cost) {
@@ -253,6 +261,15 @@ class Project extends EffectableEntity {
 
   update(deltaTime) {
     if (!this.isActive || this.isCompleted || this.isPaused) return;
+
+    if (
+      this.category === 'story' &&
+      this.attributes.planet &&
+      spaceManager.getCurrentPlanetKey() !== this.attributes.planet
+    ) {
+      this.isActive = false;
+      return;
+    }
 
     if (!this.hasSustainResources(deltaTime)) {
       this.isActive = false;

--- a/tests/storyProjectPlanetRestriction.test.js
+++ b/tests/storyProjectPlanetRestriction.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function setup(currentPlanet) {
+  const ctx = { console, projectElements: {} };
+  ctx.EffectableEntity = require('../src/js/effectable-entity.js');
+  ctx.resources = { colony: {} };
+  ctx.spaceManager = { getCurrentPlanetKey() { return currentPlanet; } };
+  vm.createContext(ctx);
+  const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+  ctx.globalThis = ctx;
+  return ctx;
+}
+
+describe('story project planet restriction', () => {
+  test('cannot start on wrong planet', () => {
+    const ctx = setup('titan');
+    const config = {
+      name: 'test',
+      category: 'story',
+      cost: {},
+      duration: 1,
+      description: '',
+      unlocked: true,
+      attributes: { planet: 'mars' }
+    };
+    const project = new ctx.Project(config, 'test');
+    expect(project.canStart()).toBe(false);
+    expect(project.start(ctx.resources)).toBe(false);
+  });
+
+  test('active project stops after leaving planet', () => {
+    const ctx = setup('mars');
+    const config = {
+      name: 'test',
+      category: 'story',
+      cost: {},
+      duration: 1000,
+      description: '',
+      unlocked: true,
+      attributes: { planet: 'mars' }
+    };
+    const project = new ctx.Project(config, 'test');
+    expect(project.start(ctx.resources)).toBe(true);
+    ctx.spaceManager.getCurrentPlanetKey = () => 'titan';
+    project.update(1000);
+    expect(project.isActive).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent story projects from starting on worlds other than their designated planet
- stop running story projects when switching to a different world
- add tests for planet-restricted story projects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a873f73a408327ab81cf086ba389ad