### PR TITLE
Allow travel from random worlds without terraforming

### DIFF
--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -174,11 +174,14 @@ function updateSpaceUI() {
     if (!allPlanetData) return;
 
     const currentKey = _spaceManagerInstance.getCurrentPlanetKey();
-    const canChangePlanet = _spaceManagerInstance.isPlanetTerraformed(currentKey);
+    const currentSeed = _spaceManagerInstance.getCurrentRandomSeed ? _spaceManagerInstance.getCurrentRandomSeed() : null;
+    const isTerraformed = _spaceManagerInstance.isPlanetTerraformed(currentKey);
+    const canChangePlanet = currentSeed !== null || isTerraformed;
 
     if (statusContainer) {
-        statusContainer.style.display = canChangePlanet ? 'none' : 'block';
-        statusContainer.textContent = canChangePlanet ? '' : 'Current planet must be fully terraformed before traveling.';
+        const showWarning = currentSeed === null && !isTerraformed;
+        statusContainer.style.display = showWarning ? 'block' : 'none';
+        statusContainer.textContent = showWarning ? 'Current planet must be fully terraformed before traveling.' : '';
     }
 
     Object.entries(allPlanetData).forEach(([key, data]) => {
@@ -229,7 +232,8 @@ function selectPlanet(planetKey){
         return;
     }
     const currentKey = _spaceManagerInstance.getCurrentPlanetKey();
-    if(!_spaceManagerInstance.isPlanetTerraformed(currentKey)) {
+    const currentSeed = _spaceManagerInstance.getCurrentRandomSeed ? _spaceManagerInstance.getCurrentRandomSeed() : null;
+    if(currentSeed === null && !_spaceManagerInstance.isPlanetTerraformed(currentKey)) {
         console.warn('Cannot travel until current planet is terraformed.');
         return;
     }

--- a/tests/spaceUIRandomWorldNoWarning.test.js
+++ b/tests/spaceUIRandomWorldNoWarning.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+
+function loadScript(file, ctx) {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', file), 'utf8');
+  vm.runInContext(code, ctx);
+}
+
+describe('space UI warning on random world', () => {
+  test('no warning or block when on random world', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="planet-selection-options"></div><div id="travel-status"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.console = console;
+    ctx.planetParameters = planetParameters;
+    ctx.saveGameToSlot = () => {};
+    ctx.projectManager = { projects: { spaceStorage: { saveTravelState: () => null, loadTravelState: () => {} } } };
+    ctx.nanotechManager = { prepareForTravel: () => {} };
+    ctx.initializeGameState = () => {};
+    ctx.updateProjectUI = () => {};
+    ctx.skillManager = { skillPoints: 0 };
+
+    vm.runInContext(`${effectCode}\n${spaceCode}; this.EffectableEntity = EffectableEntity; this.SpaceManager = SpaceManager;`, ctx);
+    loadScript('spaceUI.js', ctx);
+
+    ctx.spaceManager = new ctx.SpaceManager(planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+
+    ctx.spaceManager.travelToRandomWorld({ merged: { name: 'Alpha' } }, '1');
+    ctx.updateSpaceUI();
+
+    const status = dom.window.document.getElementById('travel-status');
+    expect(status.style.display).toBe('none');
+    expect(status.textContent).toBe('');
+    const titanButton = dom.window.document.querySelector('.select-planet-button[data-planet-key="titan"]');
+    expect(titanButton.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Hide the terraforming travel warning when exploring random worlds
- Permit switching to story planets from un-terraformmed random worlds
- Test random-world travel displays no warning and keeps selection buttons enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8779018308327a5d82a6c82d12b2e