### PR TITLE
Show total resource production and consumption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,3 +309,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Hydrology surface flow now uses durationSeconds instead of deltaTime to avoid floating point drift.
 - `getTerraformedPlanetCountExcludingCurrent` now deducts the current world's orbital ring, if present, when tallying previously terraformed worlds.
 - Story projects stop running and cannot be started on worlds other than their designated planet.
+- Resource tooltips display total production and total consumption at the top of their tables.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -91,7 +91,24 @@ function createTooltipElement(resourceName) {
   prodTable.style.display = 'table';
   prodTable.style.width = '100%';
   productionDiv.appendChild(prodTable);
-  productionDiv._info = { table: prodTable, rows: new Map() };
+  const prodTotalRow = document.createElement('div');
+  prodTotalRow.style.display = 'table-row';
+  const prodTotalLeft = document.createElement('div');
+  prodTotalLeft.style.display = 'table-cell';
+  prodTotalLeft.style.textAlign = 'left';
+  prodTotalLeft.style.paddingRight = '10px';
+  const prodTotalLeftStrong = document.createElement('strong');
+  prodTotalLeftStrong.textContent = 'Total :';
+  prodTotalLeft.appendChild(prodTotalLeftStrong);
+  const prodTotalRight = document.createElement('div');
+  prodTotalRight.style.display = 'table-cell';
+  prodTotalRight.style.textAlign = 'right';
+  const prodTotalRightStrong = document.createElement('strong');
+  prodTotalRight.appendChild(prodTotalRightStrong);
+  prodTotalRow.appendChild(prodTotalLeft);
+  prodTotalRow.appendChild(prodTotalRight);
+  prodTable.appendChild(prodTotalRow);
+  productionDiv._info = { table: prodTable, rows: new Map(), totalRow: prodTotalRow, totalRight: prodTotalRightStrong };
   tooltip.appendChild(productionDiv);
 
   const consumptionDiv = document.createElement('div');
@@ -106,7 +123,24 @@ function createTooltipElement(resourceName) {
   consTable.style.display = 'table';
   consTable.style.width = '100%';
   consumptionDiv.appendChild(consTable);
-  consumptionDiv._info = { table: consTable, rows: new Map() };
+  const consTotalRow = document.createElement('div');
+  consTotalRow.style.display = 'table-row';
+  const consTotalLeft = document.createElement('div');
+  consTotalLeft.style.display = 'table-cell';
+  consTotalLeft.style.textAlign = 'left';
+  consTotalLeft.style.paddingRight = '10px';
+  const consTotalLeftStrong = document.createElement('strong');
+  consTotalLeftStrong.textContent = 'Total :';
+  consTotalLeft.appendChild(consTotalLeftStrong);
+  const consTotalRight = document.createElement('div');
+  consTotalRight.style.display = 'table-cell';
+  consTotalRight.style.textAlign = 'right';
+  const consTotalRightStrong = document.createElement('strong');
+  consTotalRight.appendChild(consTotalRightStrong);
+  consTotalRow.appendChild(consTotalLeft);
+  consTotalRow.appendChild(consTotalRight);
+  consTable.appendChild(consTotalRow);
+  consumptionDiv._info = { table: consTable, rows: new Map(), totalRow: consTotalRow, totalRight: consTotalRightStrong };
   tooltip.appendChild(consumptionDiv);
 
   const autobuildDiv = document.createElement('div');
@@ -138,6 +172,11 @@ function updateRateTable(container, entries, formatter) {
   if (!container) return;
   const info = container._info;
   const used = new Set();
+  const total = entries.reduce((sum, [, val]) => sum + val, 0);
+  if (info.totalRight) {
+    info.totalRight.textContent = formatter(total);
+    info.totalRow.style.display = 'table-row';
+  }
   entries.sort((a, b) => b[1] - a[1]).forEach(([name, val]) => {
     let rowInfo = info.rows.get(name);
     if (!rowInfo) {

--- a/tests/resourceTooltipTotals.test.js
+++ b/tests/resourceTooltipTotals.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('resource tooltip totals', () => {
+  test('shows total production and consumption', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.oreScanner = { scanData: {} };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const resource = {
+      name: 'metal',
+      displayName: 'Metal',
+      category: 'colony',
+      value: 100,
+      cap: 1000,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 5,
+      consumptionRate: 1.5,
+      productionRateBySource: { Mine: 3, Factory: 2 },
+      consumptionRateBySource: { Smelter: 1, Upkeep: 0.5 },
+      unit: 'ton'
+    };
+
+    ctx.createResourceDisplay({ colony: { metal: resource } });
+    ctx.updateResourceRateDisplay(resource);
+
+    const doc = dom.window.document;
+    const prodTable = doc.querySelector('#metal-tooltip-production div[style*="display: table"]');
+    const prodTotalRow = prodTable.firstElementChild;
+    expect(prodTotalRow.firstElementChild.textContent).toBe('Total :');
+    expect(prodTotalRow.lastElementChild.textContent).toBe('5.00/s');
+
+    const consTable = doc.querySelector('#metal-tooltip-consumption div[style*="display: table"]');
+    const consTotalRow = consTable.firstElementChild;
+    expect(consTotalRow.firstElementChild.textContent).toBe('Total :');
+    expect(consTotalRow.lastElementChild.textContent).toBe('1.50/s');
+  });
+});


### PR DESCRIPTION
## Summary
- display bold total production and consumption in each resource tooltip table
- test resource tooltips show correct totals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a87c052070832781a59eee3d04c682