### PR TITLE
Reset WGC recruit points when changing class

### DIFF
--- a/src/js/wgcUI.js
+++ b/src/js/wgcUI.js
@@ -372,11 +372,15 @@ function openRecruitDialog(teamIndex, slotIndex, member) {
     statValues.power = newBaseStats.power;
     statValues.athletics = newBaseStats.athletics;
     statValues.wit = newBaseStats.wit;
+    alloc.power = 0;
+    alloc.athletics = 0;
+    alloc.wit = 0;
     const statContainers = statsDiv.querySelectorAll('.wgc-stat-container');
     statContainers.forEach((container, index) => {
       const statName = ['power', 'athletics', 'wit'][index];
       container.querySelector('span:nth-child(2)').textContent = statValues[statName];
     });
+    remainingSpan.textContent = `Points left: ${pointsToSpend}`;
     classDescDiv.textContent = classDescriptions[classSelect.value] || '';
   });
   win.appendChild(statsDiv);

--- a/tests/constructionOfficeUI.test.js
+++ b/tests/constructionOfficeUI.test.js
@@ -18,7 +18,7 @@ describe('Construction Office UI', () => {
     const status = document.getElementById('autobuilder-status');
     const pauseBtn = document.getElementById('autobuilder-pause-btn');
     const reserveInput = document.getElementById('strategic-reserve-input');
-    const reserveLabel = reserveInput.previousSibling;
+    const reserveLabel = reserveInput.parentElement.previousSibling;
     const reserveIcon = reserveLabel.querySelector('.info-tooltip-icon');
 
     expect(status.textContent).toBe('active');

--- a/tests/wgcClassChangeResetPoints.test.js
+++ b/tests/wgcClassChangeResetPoints.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WGCTeamMember } = require('../src/js/team-member.js');
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC recruit class change resets points', () => {
+  test('changing class after allocating points resets allocation', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WGCTeamMember = WGCTeamMember;
+    ctx.WarpGateCommand = WarpGateCommand;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.warpGateCommand.enable();
+    ctx.updateWGCUI();
+
+    ctx.openRecruitDialog(0, 1, null);
+
+    const overlay = dom.window.document.querySelector('.wgc-popup-overlay');
+    const plusButton = overlay.querySelector('.wgc-stat-container button');
+    plusButton.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+    const classSelect = overlay.querySelector('select');
+    classSelect.value = 'Social Scientist';
+    classSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    const remainingDiv = Array.from(overlay.querySelectorAll('div')).find(d => d.textContent.startsWith('Points left'));
+    expect(remainingDiv.textContent).toBe('Points left: 5');
+
+    const firstName = overlay.querySelector('input[placeholder="First Name (required)"]');
+    firstName.value = 'Test';
+    const confirmButton = Array.from(overlay.querySelectorAll('button')).find(b => b.textContent === 'Confirm');
+    confirmButton.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+    const member = ctx.warpGateCommand.teams[0][1];
+    expect(member.classType).toBe('Social Scientist');
+    expect(member.power).toBe(0);
+    expect(member.athletics).toBe(0);
+    expect(member.wit).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- reset allocation and remaining points when switching class in WGC recruit dialog
- cover class-change reset behavior with new unit test
- update Construction Office UI test to align with current markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8950bcd1c8327aa5b4c183ce66826