### PR TITLE
feat: separate water overflow tooltip section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,3 +311,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Story projects stop running and cannot be started on worlds other than their designated planet.
 - Resource tooltips display total production and total consumption at the top of their tables.
 - Atmospheric oxygen and methane above 1 Pa combust into water and carbon dioxide at a rate proportional to the world's surface area and the excess pressure product.
+- Water overflow in resource tooltips now appears in its own section beneath Consumption and Maintenance.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -143,6 +143,38 @@ function createTooltipElement(resourceName) {
   consumptionDiv._info = { table: consTable, rows: new Map(), totalRow: consTotalRow, totalRight: consTotalRightStrong };
   tooltip.appendChild(consumptionDiv);
 
+  const overflowDiv = document.createElement('div');
+  overflowDiv.id = `${resourceName}-tooltip-overflow`;
+  overflowDiv.style.display = 'none';
+  overflowDiv.appendChild(document.createElement('br'));
+  const overflowHeader = document.createElement('strong');
+  overflowHeader.textContent = 'Overflow:';
+  overflowDiv.appendChild(overflowHeader);
+  overflowDiv.appendChild(document.createElement('br'));
+  const overflowTable = document.createElement('div');
+  overflowTable.style.display = 'table';
+  overflowTable.style.width = '100%';
+  overflowDiv.appendChild(overflowTable);
+  const overflowTotalRow = document.createElement('div');
+  overflowTotalRow.style.display = 'table-row';
+  const overflowTotalLeft = document.createElement('div');
+  overflowTotalLeft.style.display = 'table-cell';
+  overflowTotalLeft.style.textAlign = 'left';
+  overflowTotalLeft.style.paddingRight = '10px';
+  const overflowTotalLeftStrong = document.createElement('strong');
+  overflowTotalLeftStrong.textContent = 'Total :';
+  overflowTotalLeft.appendChild(overflowTotalLeftStrong);
+  const overflowTotalRight = document.createElement('div');
+  overflowTotalRight.style.display = 'table-cell';
+  overflowTotalRight.style.textAlign = 'right';
+  const overflowTotalRightStrong = document.createElement('strong');
+  overflowTotalRight.appendChild(overflowTotalRightStrong);
+  overflowTotalRow.appendChild(overflowTotalLeft);
+  overflowTotalRow.appendChild(overflowTotalRight);
+  overflowTable.appendChild(overflowTotalRow);
+  overflowDiv._info = { table: overflowTable, rows: new Map(), totalRow: overflowTotalRow, totalRight: overflowTotalRightStrong };
+  tooltip.appendChild(overflowDiv);
+
   const autobuildDiv = document.createElement('div');
   autobuildDiv.id = `${resourceName}-tooltip-autobuild`;
   autobuildDiv.style.display = 'none';
@@ -607,6 +639,7 @@ function updateResourceRateDisplay(resource){
   const zonesDiv = document.getElementById(`${resource.name}-tooltip-zones`);
   const productionDiv = document.getElementById(`${resource.name}-tooltip-production`);
   const consumptionDiv = document.getElementById(`${resource.name}-tooltip-consumption`);
+  const overflowDiv = document.getElementById(`${resource.name}-tooltip-overflow`);
   const autobuildDiv = document.getElementById(`${resource.name}-tooltip-autobuild`);
 
   const netRate = resource.productionRate - resource.consumptionRate;
@@ -733,9 +766,18 @@ function updateResourceRateDisplay(resource){
   }
 
   if (consumptionDiv) {
-    const consumptionEntries = Object.entries(resource.consumptionRateBySource).filter(([source, rate]) => rate !== 0);
+    const consumptionEntries = Object.entries(resource.consumptionRateBySource)
+      .filter(([source, rate]) => rate !== 0 && source !== 'Overflow (not summed)');
     updateRateTable(consumptionDiv, consumptionEntries, r => `${formatNumber(r, false, 2)}/s`);
     consumptionDiv.style.display = consumptionEntries.length > 0 ? 'block' : 'none';
+  }
+
+  if (overflowDiv) {
+    const overflowEntries = Object.entries(resource.consumptionRateByType?.overflow || {})
+      .filter(([, rate]) => rate !== 0)
+      .map(([src, rate]) => [src.replace(' (not summed)', ''), rate]);
+    updateRateTable(overflowDiv, overflowEntries, r => `${formatNumber(r, false, 2)}/s`);
+    overflowDiv.style.display = overflowEntries.length > 0 ? 'block' : 'none';
   }
 
   if (autobuildDiv) {

--- a/tests/waterOverflowTooltip.test.js
+++ b/tests/waterOverflowTooltip.test.js
@@ -24,7 +24,9 @@ describe('overflow rate appears in tooltip', () => {
       value: 100, cap: 100, hasCap: true, reserved: 0, unlocked: true,
       productionRate: 0, consumptionRate: 5,
       productionRateBySource: {},
-      consumptionRateBySource: { Overflow: 5 },
+      productionRateByType: {},
+      consumptionRateBySource: { 'Overflow (not summed)': 5 },
+      consumptionRateByType: { overflow: { 'Overflow (not summed)': 5 } },
       unit: 'ton'
     };
     const liquid = {
@@ -32,17 +34,20 @@ describe('overflow rate appears in tooltip', () => {
       value: 0, cap: 0, hasCap: false, reserved: 0, unlocked: true,
       productionRate: 5, consumptionRate: 0,
       productionRateBySource: { Overflow: 5 },
+      productionRateByType: { overflow: { Overflow: 5 } },
       consumptionRateBySource: {},
+      consumptionRateByType: {},
       unit: 'ton'
     };
     ctx.createResourceDisplay({ colony: { water: colonyWater }, surface: { liquidWater: liquid } });
     ctx.updateResourceRateDisplay(colonyWater);
     ctx.updateResourceRateDisplay(liquid);
-    const cw = dom.window.document.getElementById('water-tooltip').innerHTML;
+    const cwCons = dom.window.document.getElementById('water-tooltip-consumption').textContent;
+    const cwOver = dom.window.document.getElementById('water-tooltip-overflow').textContent;
     const lw = dom.window.document.getElementById('liquidWater-tooltip').innerHTML;
-    expect(cw).toContain('Consumption and Maintenance');
-    expect(cw).toContain('Overflow');
-    expect(cw).toContain(numbers.formatNumber(5, false, 2));
+    expect(cwCons).not.toContain('Overflow');
+    expect(cwOver).toContain('Overflow');
+    expect(cwOver).toContain(numbers.formatNumber(5, false, 2));
     expect(lw).toContain('Production');
     expect(lw).toContain('Overflow');
     expect(lw).toContain(numbers.formatNumber(5, false, 2));
@@ -55,7 +60,9 @@ describe('overflow rate appears in tooltip', () => {
       value: 100, cap: 100, hasCap: true, reserved: 0, unlocked: true,
       productionRate: 0, consumptionRate: 2,
       productionRateBySource: {},
-      consumptionRateBySource: { Overflow: 2 },
+      productionRateByType: {},
+      consumptionRateBySource: { 'Overflow (not summed)': 2 },
+      consumptionRateByType: { overflow: { 'Overflow (not summed)': 2 } },
       unit: 'ton'
     };
     const ice = {
@@ -63,19 +70,40 @@ describe('overflow rate appears in tooltip', () => {
       value: 0, cap: 0, hasCap: false, reserved: 0, unlocked: true,
       productionRate: 2, consumptionRate: 0,
       productionRateBySource: { Overflow: 2 },
+      productionRateByType: { overflow: { Overflow: 2 } },
       consumptionRateBySource: {},
+      consumptionRateByType: {},
       unit: 'ton'
     };
     ctx.createResourceDisplay({ colony: { water: colonyWater }, surface: { ice: ice } });
     ctx.updateResourceRateDisplay(colonyWater);
     ctx.updateResourceRateDisplay(ice);
-    const cw = dom.window.document.getElementById('water-tooltip').innerHTML;
+    const cwCons = dom.window.document.getElementById('water-tooltip-consumption').textContent;
+    const cwOver = dom.window.document.getElementById('water-tooltip-overflow').textContent;
     const iw = dom.window.document.getElementById('ice-tooltip').innerHTML;
-    expect(cw).toContain('Consumption and Maintenance');
-    expect(cw).toContain('Overflow');
-    expect(cw).toContain(numbers.formatNumber(2, false, 2));
+    expect(cwCons).not.toContain('Overflow');
+    expect(cwOver).toContain('Overflow');
+    expect(cwOver).toContain(numbers.formatNumber(2, false, 2));
     expect(iw).toContain('Production');
     expect(iw).toContain('Overflow');
     expect(iw).toContain(numbers.formatNumber(2, false, 2));
+  });
+
+  test('hides overflow section when none', () => {
+    const { dom, ctx } = setup();
+    const colonyWater = {
+      name: 'water', displayName: 'Water', category: 'colony',
+      value: 100, cap: 100, hasCap: true, reserved: 0, unlocked: true,
+      productionRate: 0, consumptionRate: 0,
+      productionRateBySource: {},
+      productionRateByType: {},
+      consumptionRateBySource: {},
+      consumptionRateByType: {},
+      unit: 'ton'
+    };
+    ctx.createResourceDisplay({ colony: { water: colonyWater } });
+    ctx.updateResourceRateDisplay(colonyWater);
+    const overflow = dom.window.document.getElementById('water-tooltip-overflow');
+    expect(overflow.style.display).toBe('none');
   });
 });


### PR DESCRIPTION
## Summary
- show water overflow in its own tooltip section beneath Consumption and Maintenance
- test for overflow section visibility and absence when no overflow
- note new behavior in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8caea67088327a03f870aab1f970e