### PR TITLE
Show surface overflow sections and space autobuild tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,3 +312,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource tooltips display total production and total consumption at the top of their tables.
 - Atmospheric oxygen and methane above 1 Pa combust into water and carbon dioxide at a rate proportional to the world's surface area and the excess pressure product.
 - Water overflow in resource tooltips now appears in its own section beneath Consumption and Maintenance.
+- Surface ice and liquid water tooltips display overflow in a dedicated section.
+- Added spacing before the Autobuild Cost section in resource tooltips.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -178,6 +178,7 @@ function createTooltipElement(resourceName) {
   const autobuildDiv = document.createElement('div');
   autobuildDiv.id = `${resourceName}-tooltip-autobuild`;
   autobuildDiv.style.display = 'none';
+  autobuildDiv.appendChild(document.createElement('br'));
   const autoHeader = document.createElement('strong');
   autoHeader.textContent = 'Autobuild Cost (avg 10s):';
   autobuildDiv.appendChild(autoHeader);
@@ -760,7 +761,8 @@ function updateResourceRateDisplay(resource){
   }
 
   if (productionDiv) {
-    const productionEntries = Object.entries(resource.productionRateBySource).filter(([source, rate]) => rate !== 0);
+    const productionEntries = Object.entries(resource.productionRateBySource)
+      .filter(([source, rate]) => rate !== 0 && source !== 'Overflow' && source !== 'Overflow (not summed)');
     updateRateTable(productionDiv, productionEntries, r => `${formatNumber(r, false, 2)}/s`);
     productionDiv.style.display = productionEntries.length > 0 ? 'block' : 'none';
   }
@@ -773,7 +775,10 @@ function updateResourceRateDisplay(resource){
   }
 
   if (overflowDiv) {
-    const overflowEntries = Object.entries(resource.consumptionRateByType?.overflow || {})
+    const overflowEntries = [
+      ...Object.entries(resource.consumptionRateByType?.overflow || {}),
+      ...Object.entries(resource.productionRateByType?.overflow || {})
+    ]
       .filter(([, rate]) => rate !== 0)
       .map(([src, rate]) => [src.replace(' (not summed)', ''), rate]);
     updateRateTable(overflowDiv, overflowEntries, r => `${formatNumber(r, false, 2)}/s`);

--- a/tests/waterOverflowTooltip.test.js
+++ b/tests/waterOverflowTooltip.test.js
@@ -44,13 +44,14 @@ describe('overflow rate appears in tooltip', () => {
     ctx.updateResourceRateDisplay(liquid);
     const cwCons = dom.window.document.getElementById('water-tooltip-consumption').textContent;
     const cwOver = dom.window.document.getElementById('water-tooltip-overflow').textContent;
-    const lw = dom.window.document.getElementById('liquidWater-tooltip').innerHTML;
+    const lwProd = dom.window.document.getElementById('liquidWater-tooltip-production');
+    const lwOver = dom.window.document.getElementById('liquidWater-tooltip-overflow').textContent;
     expect(cwCons).not.toContain('Overflow');
     expect(cwOver).toContain('Overflow');
     expect(cwOver).toContain(numbers.formatNumber(5, false, 2));
-    expect(lw).toContain('Production');
-    expect(lw).toContain('Overflow');
-    expect(lw).toContain(numbers.formatNumber(5, false, 2));
+    expect(lwProd.style.display).toBe('none');
+    expect(lwOver).toContain('Overflow');
+    expect(lwOver).toContain(numbers.formatNumber(5, false, 2));
   });
 
   test('shows on colony water and ice', () => {
@@ -80,13 +81,14 @@ describe('overflow rate appears in tooltip', () => {
     ctx.updateResourceRateDisplay(ice);
     const cwCons = dom.window.document.getElementById('water-tooltip-consumption').textContent;
     const cwOver = dom.window.document.getElementById('water-tooltip-overflow').textContent;
-    const iw = dom.window.document.getElementById('ice-tooltip').innerHTML;
+    const iwProd = dom.window.document.getElementById('ice-tooltip-production');
+    const iwOver = dom.window.document.getElementById('ice-tooltip-overflow').textContent;
     expect(cwCons).not.toContain('Overflow');
     expect(cwOver).toContain('Overflow');
     expect(cwOver).toContain(numbers.formatNumber(2, false, 2));
-    expect(iw).toContain('Production');
-    expect(iw).toContain('Overflow');
-    expect(iw).toContain(numbers.formatNumber(2, false, 2));
+    expect(iwProd.style.display).toBe('none');
+    expect(iwOver).toContain('Overflow');
+    expect(iwOver).toContain(numbers.formatNumber(2, false, 2));
   });
 
   test('hides overflow section when none', () => {


### PR DESCRIPTION
## Summary
- display overflow for surface liquid water and ice in dedicated tooltip sections
- add spacing before Autobuild Cost section in resource tooltips
- test water overflow visibility for surface resources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8cd6ade6c8327988a142bba9a036c