### PR TITLE
Move auto-active checkbox before label in set-active button

### DIFF
--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -357,7 +357,6 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
   const setActiveLabel = document.createElement('span');
   setActiveLabel.textContent = 'Set active to target';
-  setActiveButton.appendChild(setActiveLabel);
 
   const autoActiveCheckbox = document.createElement('input');
   autoActiveCheckbox.type = 'checkbox';
@@ -368,7 +367,9 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     structure.autoActiveEnabled = autoActiveCheckbox.checked;
   });
   autoActiveCheckbox.addEventListener('click', e => e.stopPropagation());
+
   setActiveButton.appendChild(autoActiveCheckbox);
+  setActiveButton.appendChild(setActiveLabel);
 
   setActiveButton.addEventListener('click', () => {
     const pop = resources.colony.colonists.value;

--- a/tests/setActiveToTargetButton.test.js
+++ b/tests/setActiveToTargetButton.test.js
@@ -5,7 +5,7 @@ const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 
 describe('Set active to target button', () => {
-  test('clicking sets active count to auto build target', () => {
+  function setup() {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
 
@@ -69,9 +69,20 @@ describe('Set active to target button', () => {
 
     ctx.updateStructureDisplay({ [structure.name]: structure });
 
+    return { dom, ctx, structure };
+  }
+
+  test('clicking sets active count to auto build target', () => {
+    const { dom, structure } = setup();
     const btn = dom.window.document.getElementById(`${structure.name}-set-active-button`);
     btn.click();
-
     expect(structure.active).toBe(3);
+  });
+
+  test('checkbox appears before label inside button', () => {
+    const { dom, structure } = setup();
+    const btn = dom.window.document.getElementById(`${structure.name}-set-active-button`);
+    const checkbox = btn.querySelector('input.auto-active-checkbox');
+    expect(btn.firstChild).toBe(checkbox);
   });
 });


### PR DESCRIPTION
## Summary
- Move auto-active checkbox to left of text inside "Set active to target" button
- Test that auto-active checkbox renders before the label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a90ee23b048327a0ded7d8a652d4e0