### PR TITLE
Scale storage display with build count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,3 +325,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Autobuild priority and auto-active settings persist through planet travel.
 - Settings page arranged in three columns with temperature and dark mode options first.
 - Colony tab split into separate structures and controls sections, placing the Nanocolony below colony controls.
+- Storage capacity display now scales with the selected build count.

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -985,7 +985,9 @@ function updateDecreaseButtonText(button, buildCount) {
     }
 
     const providesParts = [];
-    const storageText = formatStorageDetails(structure.getModifiedStorage());
+    const storageText = formatStorageDetails(
+      scaleResourceMap(structure.getModifiedStorage(), buildCount)
+    );
     if (storageText) {
       providesParts.push(storageText);
     }

--- a/tests/storageProvidesScaleWithBuildCount.test.js
+++ b/tests/storageProvidesScaleWithBuildCount.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+// load getProdConsSections from structuresUI.js within a jsdom context
+const { getProdConsSections } = (() => {
+  const dom = new JSDOM('<!DOCTYPE html><div></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.formatNumber = n => n;
+  ctx.formatStorageDetails = storage => `${storage.colony.water} Water`;
+  ctx.resources = { colony: { water: { displayName: 'Water' } } };
+  ctx.terraforming = { celestialParameters: {} };
+  ctx.Colony = class {};
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+  return ctx;
+})();
+
+describe('storage provides scaling with build count', () => {
+  test('storage values scale according to build count', () => {
+    const structure = {
+      name: 'testStruct',
+      getModifiedStorage: () => ({ colony: { water: 2 } }),
+      powerPerBuilding: null,
+      requiresMaintenance: false,
+      maintenanceCost: {},
+      getModifiedProduction: () => ({}),
+      getModifiedConsumption: () => ({})
+    };
+
+    const sections = getProdConsSections(structure, 5);
+    const provides = sections.find(sec => sec.key === 'provides').data;
+    expect(provides[0]).toBe('10 Water');
+  });
+});


### PR DESCRIPTION
## Summary
- scale storage display in building UI with selected build count
- test storage capacity scaling with build count
- document storage scaling feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9bcc3325883279d1d1f8e17c66f50