### PR TITLE
Use temperature setting in life tooltip

### DIFF
--- a/src/js/life.js
+++ b/src/js/life.js
@@ -170,10 +170,17 @@ class LifeDesign {
       const zoneData = terraforming.temperature.zones[zoneName];
       let reason = null;
 
-      if (zoneData.day < temperatureRanges.min) reason = `Day too cold (${formatNumber(zoneData.day,false,1)}K < ${formatNumber(temperatureRanges.min,false,1)}K)`;
-      else if (zoneData.day > temperatureRanges.max) reason = `Day too hot (${formatNumber(zoneData.day,false,1)}K > ${formatNumber(temperatureRanges.max,false,1)}K)`;
-      else if (zoneData.night < temperatureRanges.min) reason = `Night too cold (${formatNumber(zoneData.night,false,1)}K < ${formatNumber(temperatureRanges.min,false,1)}K)`;
-      else if (zoneData.night > temperatureRanges.max) reason = `Night too hot (${formatNumber(zoneData.night,false,1)}K > ${formatNumber(temperatureRanges.max,false,1)}K)`;
+      const unit = typeof getTemperatureUnit === 'function' ? getTemperatureUnit() : 'K';
+      const fmt = v => formatNumber(
+        typeof toDisplayTemperature === 'function' ? toDisplayTemperature(v) : v,
+        false,
+        1
+      );
+
+      if (zoneData.day < temperatureRanges.min) reason = `Day too cold (${fmt(zoneData.day)}${unit} < ${fmt(temperatureRanges.min)}${unit})`;
+      else if (zoneData.day > temperatureRanges.max) reason = `Day too hot (${fmt(zoneData.day)}${unit} > ${fmt(temperatureRanges.max)}${unit})`;
+      else if (zoneData.night < temperatureRanges.min) reason = `Night too cold (${fmt(zoneData.night)}${unit} < ${fmt(temperatureRanges.min)}${unit})`;
+      else if (zoneData.night > temperatureRanges.max) reason = `Night too hot (${fmt(zoneData.night)}${unit} > ${fmt(temperatureRanges.max)}${unit})`;
 
       return { pass: reason === null, reason: reason };
   }
@@ -183,9 +190,16 @@ class LifeDesign {
       const temperatureRanges = this.getTemperatureRanges().survival;
       const zoneData = terraforming.temperature.zones[zoneName];
       let reason = null;
- 
-      if (zoneData.day < temperatureRanges.min) reason = `Day too cold (${formatNumber(zoneData.day,false,1)}K < ${formatNumber(temperatureRanges.min,false,1)}K)`;
-      else if (zoneData.day > temperatureRanges.max) reason = `Day too hot (${formatNumber(zoneData.day,false,1)}K > ${formatNumber(temperatureRanges.max,false,1)}K)`;
+
+      const unit = typeof getTemperatureUnit === 'function' ? getTemperatureUnit() : 'K';
+      const fmt = v => formatNumber(
+        typeof toDisplayTemperature === 'function' ? toDisplayTemperature(v) : v,
+        false,
+        1
+      );
+
+      if (zoneData.day < temperatureRanges.min) reason = `Day too cold (${fmt(zoneData.day)}${unit} < ${fmt(temperatureRanges.min)}${unit})`;
+      else if (zoneData.day > temperatureRanges.max) reason = `Day too hot (${fmt(zoneData.day)}${unit} > ${fmt(temperatureRanges.max)}${unit})`;
  
       return { pass: reason === null, reason: reason };
   }
@@ -195,9 +209,16 @@ class LifeDesign {
       const temperatureRanges = this.getTemperatureRanges().survival;
       const zoneData = terraforming.temperature.zones[zoneName];
       let reason = null;
- 
-      if (zoneData.night < temperatureRanges.min) reason = `Night too cold (${formatNumber(zoneData.night,false,1)}K < ${formatNumber(temperatureRanges.min,false,1)}K)`;
-      else if (zoneData.night > temperatureRanges.max) reason = `Night too hot (${formatNumber(zoneData.night,false,1)}K > ${formatNumber(temperatureRanges.max,false,1)}K)`;
+
+      const unit = typeof getTemperatureUnit === 'function' ? getTemperatureUnit() : 'K';
+      const fmt = v => formatNumber(
+        typeof toDisplayTemperature === 'function' ? toDisplayTemperature(v) : v,
+        false,
+        1
+      );
+
+      if (zoneData.night < temperatureRanges.min) reason = `Night too cold (${fmt(zoneData.night)}${unit} < ${fmt(temperatureRanges.min)}${unit})`;
+      else if (zoneData.night > temperatureRanges.max) reason = `Night too hot (${fmt(zoneData.night)}${unit} > ${fmt(temperatureRanges.max)}${unit})`;
  
       return { pass: reason === null, reason: reason };
   }

--- a/tests/lifeTooltipTempUnit.test.js
+++ b/tests/lifeTooltipTempUnit.test.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const physics = require('../src/js/physics.js');
+const zones = require('../src/js/zones.js');
+
+describe('life temperature tooltip units', () => {
+  test('uses display unit based on setting', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="life-terraforming"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.gameSettings = { useCelsius: true };
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+    ctx.getZonePercentage = zones.getZonePercentage;
+
+    const numbersCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'numbers.js'), 'utf8');
+    vm.runInContext(numbersCode + '; this.formatNumber = formatNumber; this.toDisplayTemperature = toDisplayTemperature; this.getTemperatureUnit = getTemperatureUnit;', ctx);
+
+    ctx.resources = {
+      surface: { biomass: { value: 0 }, liquidWater: {} },
+      atmospheric: {
+        carbonDioxide: { value: 0 },
+        oxygen: { value: 0 },
+        atmosphericWater: { value: 0 }
+      },
+      colony: { research: { value: 0 }, funding: { value: 0 }, androids: { value: 0 }, components: { value: 0 }, electronics: { value: 0 } }
+    };
+
+    ctx.terraforming = {
+      temperature: {
+        zones: {
+          tropical: { day: 400, night: 100 },
+          temperate: { day: 400, night: 100 },
+          polar: { day: 400, night: 100 }
+        }
+      },
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: { liquid: 0 }, temperate: { liquid: 0 }, polar: { liquid: 0 } },
+      getMagnetosphereStatus: () => true,
+      radiationPenalty: 0,
+      calculateSolarPanelMultiplier: () => 1,
+      calculateZonalSolarPanelMultiplier: () => 1,
+      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 }
+    };
+
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInContext(lifeCode + '; this.LifeDesigner = LifeDesigner;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'lifeUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.initializeLifeTerraformingDesignerUI = initializeLifeTerraformingDesignerUI; this.updateLifeUI = updateLifeUI;', ctx);
+
+    ctx.lifeDesigner = new ctx.LifeDesigner();
+    ctx.lifeDesigner.enable();
+    ctx.lifeDesigner.createNewDesign(0,0,0,0,0,0,0,0);
+
+    ctx.initializeLifeTerraformingDesignerUI();
+    ctx.updateLifeUI();
+
+    const tooltip = dom.window.document
+      .getElementById('day-temp-tropical')
+      .querySelector('.temp-status')
+      .getAttribute('title');
+
+    expect(tooltip).toContain('\u00B0C');
+    expect(tooltip).not.toContain('K');
+  });
+});
+

--- a/tests/spaceMirrorFinerControls.test.js
+++ b/tests/spaceMirrorFinerControls.test.js
@@ -1,10 +1,15 @@
 const { getZoneRatio, getZonePercentage } = require('../src/js/zones.js');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 const lifeParameters = require('../src/js/life-parameters.js');
+const numbers = require('../src/js/numbers.js');
 const { JSDOM } = require('jsdom');
 
 global.Project = class {};
 global.projectElements = {};
+global.formatNumber = numbers.formatNumber;
+global.formatBuildingCount = numbers.formatBuildingCount;
+global.toDisplayTemperature = numbers.toDisplayTemperature;
+global.getTemperatureUnit = numbers.getTemperatureUnit;
 const {
   mirrorOversightSettings,
   toggleFinerControls,
@@ -125,7 +130,7 @@ describe('Space Mirror finer controls', () => {
     };
     initializeMirrorOversightUI(container);
     updateMirrorOversightUI();
-    const cell = container.querySelector('#assignment-table td.assign-cell[data-type="lanterns"]');
+    const cell = container.querySelector('#assignment-grid .assign-cell[data-type="lanterns"]');
     expect(cell.style.display).toBe('none');
     delete global.window;
     delete global.document;
@@ -180,8 +185,8 @@ describe('Space Mirror finer controls', () => {
     global.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 0 } };
     initializeMirrorOversightUI(container);
     toggleFinerControls(true);
-    const minusBtn = container.querySelector('#assignment-any-row td.assign-cell[data-type="mirrors"] .assign-minus');
-    const plusBtn = container.querySelector('#assignment-any-row td.assign-cell[data-type="mirrors"] .assign-plus');
+    const minusBtn = container.querySelector('#assignment-grid .assign-cell[data-type="mirrors"][data-zone="any"] .assign-minus');
+    const plusBtn = container.querySelector('#assignment-grid .assign-cell[data-type="mirrors"][data-zone="any"] .assign-plus');
     expect(mirrorOversightSettings.assignments.mirrors.any).toBe(10);
     minusBtn.click();
     expect(mirrorOversightSettings.assignments.mirrors.any).toBe(9);


### PR DESCRIPTION
## Summary
- display day/night survival tooltips using the selected temperature unit
- cover new behavior with a life tooltip unit test
- stabilize Space Mirror finer controls test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa02b5158c83278c915e19d6a216cb