### PR TITLE
Disable atmospheric monitoring limits by default

### DIFF
--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -8,12 +8,10 @@ class SpaceMiningProject extends SpaceshipProject {
     this.hasOxygenPressureControl = false;
     const maxPressure = config.attributes?.maxPressure;
     if (typeof maxPressure === 'number') {
-      this.disableAbovePressure = true;
       this.disablePressureThreshold = maxPressure;
     }
     const maxOxygenPressure = config.attributes?.maxOxygenPressure;
     if (typeof maxOxygenPressure === 'number') {
-      this.disableAboveOxygenPressure = true;
       this.disableOxygenPressureThreshold = maxOxygenPressure;
       this.hasOxygenPressureControl = true;
     }

--- a/tests/spaceMiningDefaultPressure.test.js
+++ b/tests/spaceMiningDefaultPressure.test.js
@@ -4,7 +4,7 @@ const vm = require('vm');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('SpaceMiningProject default pressure threshold', () => {
-  test('constructor initializes pressure limit from attributes', () => {
+  test('constructor initializes pressure thresholds without enabling them', () => {
     const ctx = { console, EffectableEntity, shipEfficiency: 1 };
     vm.createContext(ctx);
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
@@ -27,12 +27,14 @@ describe('SpaceMiningProject default pressure threshold', () => {
         repeatable: true,
         maxRepeatCount: Infinity,
         unlocked: true,
-        attributes: { spaceMining: true, maxPressure: 0.1 }
+        attributes: { spaceMining: true, maxPressure: 0.1, maxOxygenPressure: 10 }
       }
     };
     ctx.projectManager.initializeProjects(params);
     const project = ctx.projectManager.projects.mine;
-    expect(project.disableAbovePressure).toBe(true);
+    expect(project.disableAbovePressure).toBe(false);
     expect(project.disablePressureThreshold).toBe(0.1);
+    expect(project.disableAboveOxygenPressure).toBe(false);
+    expect(project.disableOxygenPressureThreshold).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary
- Keep atmospheric monitoring pressure limits disabled until player opts in
- Record default pressure thresholds without activating them
- Test that thresholds are set but checkboxes start unchecked

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa27f80a088327aa13f8e64eff886f