### PR TITLE
feat: add auto max option to satellites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,3 +331,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Storage capacity display now scales with the selected build count.
 - Added an Any Zone option to space mirror finer controls for global distribution based on slider percentages.
 - Any Zone row now supports manual 0/±/Max assignment buttons for mirrors and lanterns.
+- Satellites project now features an Auto Max option that raises build count to the current colonist cap.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -5,6 +5,7 @@ class ScannerProject extends Project {
     this.buildCount = 1;
     this.step = 1;
     this.activeBuildCount = 1;
+    this.autoMax = true;
     this.el = {};
   }
 
@@ -57,6 +58,7 @@ class ScannerProject extends Project {
       buildCount: this.buildCount,
       activeBuildCount: this.activeBuildCount,
       step: this.step,
+      autoMax: this.autoMax,
       scanData: savedState
     };
   }
@@ -80,6 +82,9 @@ class ScannerProject extends Project {
     }
     if (state.step !== undefined) {
       this.step = state.step;
+    }
+    if (state.autoMax !== undefined) {
+      this.autoMax = state.autoMax;
     }
   }
 
@@ -158,6 +163,15 @@ class ScannerProject extends Project {
 
   update(deltaTime) {
     super.update(deltaTime);
+    if (this.autoMax) {
+      const limit = this.getColonistLimit();
+      if (this.buildCount < limit) {
+        this.buildCount = limit;
+        if (typeof updateProjectUI === 'function') {
+          updateProjectUI(this.name);
+        }
+      }
+    }
     if (this.scanData) {
       if (
         this.attributes.scanner &&
@@ -357,8 +371,22 @@ class ScannerProject extends Project {
     bMul.textContent = 'x10';
     mult.append(bDiv, bMul);
 
+    const autoContainer = document.createElement('div');
+    autoContainer.className = 'checkbox-container';
+    const autoMaxCheckbox = document.createElement('input');
+    autoMaxCheckbox.type = 'checkbox';
+    autoMaxCheckbox.id = `${this.name}-auto-max`;
+    autoMaxCheckbox.checked = this.autoMax;
+    autoMaxCheckbox.addEventListener('change', (e) => {
+      this.autoMax = e.target.checked;
+    });
+    const autoLabel = document.createElement('label');
+    autoLabel.htmlFor = autoMaxCheckbox.id;
+    autoLabel.textContent = 'Auto Max';
+    autoContainer.append(autoMaxCheckbox, autoLabel);
+
     controls.append(main, mult);
-    amountSection.append(amountTitle, amountDisplay, controls);
+    amountSection.append(amountTitle, amountDisplay, controls, autoContainer);
     topSection.appendChild(amountSection);
 
     // Deposits Section
@@ -388,7 +416,7 @@ class ScannerProject extends Project {
 
     container.appendChild(topSection);
 
-    this.el = { val, max, bPlus, bMinus, bMul, bDiv, b0, bMax, costSection, amountSection };
+    this.el = { val, max, bPlus, bMinus, bMul, bDiv, b0, bMax, costSection, amountSection, autoMaxCheckbox };
     if (dVal && dMax) {
       this.el.dVal = dVal;
       this.el.dMax = dMax;
@@ -419,6 +447,9 @@ class ScannerProject extends Project {
     }
     if (this.el.bMinus) {
       this.el.bMinus.textContent = `-${formatNumber(this.step, true)}`;
+    }
+    if (this.el.autoMaxCheckbox) {
+      this.el.autoMaxCheckbox.checked = this.autoMax;
     }
     if (this.el.dVal && this.el.dMax) {
       const depositType = this.attributes?.scanner?.depositType;

--- a/tests/scannerProjectAutoMax.test.js
+++ b/tests/scannerProjectAutoMax.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('ScannerProject auto max', () => {
+  const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
+
+  function createContext() {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = {
+      colony: {
+        metal: { value: 0, decrease(){}, updateStorageCap(){} },
+        electronics: { value: 0, decrease(){}, updateStorageCap(){} },
+        energy: { value: 0, decrease(){}, updateStorageCap(){} },
+        colonists: { value: 10000 }
+      }
+    };
+    vm.createContext(ctx);
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
+    global.resources = ctx.resources;
+    return ctx;
+  }
+
+  test('build count follows colonist cap when auto max enabled', () => {
+    const ctx = createContext();
+    const config = {
+      name: 'scan',
+      category: 'infra',
+      cost: {},
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: 1000,
+      unlocked: true,
+      attributes: { scanner: {} }
+    };
+    const project = new ctx.ScannerProject(config, 'scan');
+    project.update(0);
+    expect(project.buildCount).toBe(1);
+    ctx.resources.colony.colonists.value = 20000;
+    project.update(0);
+    expect(project.buildCount).toBe(2);
+    project.autoMax = false;
+    ctx.resources.colony.colonists.value = 30000;
+    project.update(0);
+    expect(project.buildCount).toBe(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Auto Max checkbox to satellite projects to automatically raise build count
- persist Auto Max setting in saves
- test auto max behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa517cbdec8327a27f6e9c957c4198