### PR TITLE
Clamp space mirror facility sliders to valid ranges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,3 +332,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added an Any Zone option to space mirror finer controls for global distribution based on slider percentages.
 - Any Zone row now supports manual 0/±/Max assignment buttons for mirrors and lanterns.
 - Satellites project now features an Auto Max option that raises build count to the current colonist cap.
+- Space mirror oversight sliders now clamp values so none go negative and their total always sums to 100.

--- a/tests/spaceMirrorSliderClamp.test.js
+++ b/tests/spaceMirrorSliderClamp.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('space mirror slider safeguards', () => {
+  test('sliders stay non-negative and sum to 100', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.projectElements = {};
+    ctx.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: false } };
+    ctx.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      calculateZoneSolarFlux: () => 0,
+      celestialParameters: { crossSectionArea: 100, surfaceArea: 100 },
+      temperature: { zones: { tropical: { value: 0 }, temperate: { value: 0 }, polar: { value: 0 } } }
+    };
+    ctx.projectManager = { isBooleanFlagSet: () => true };
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const mirrorCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMirrorFacilityProject.js'), 'utf8');
+    vm.runInContext(mirrorCode + '; this.SpaceMirrorFacilityProject = SpaceMirrorFacilityProject; this.setMirrorDistribution = setMirrorDistribution;', ctx);
+
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.spaceMirrorFacility;
+    const project = new ctx.SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    project.updateUI();
+
+    ctx.setMirrorDistribution('tropical', 70);
+    ctx.setMirrorDistribution('temperate', 40);
+    ctx.setMirrorDistribution('tropical', -10);
+    ctx.setMirrorDistribution('temperate', 200);
+
+    const zones = ['tropical', 'temperate', 'polar', 'focus', 'any'];
+    const values = zones.map(z => Number(dom.window.document.getElementById(`mirror-oversight-${z}`).value));
+    const total = values.reduce((a, b) => a + b, 0);
+    values.forEach(v => expect(v).toBeGreaterThanOrEqual(0));
+    expect(total).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Guard mirror oversight distribution from going negative and normalize totals to 100%
- Clamp automatic assignment math for mirrors and lanterns
- Add regression test ensuring sliders never drop below 0 and always sum to 100

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aa67cf2b388327addec33a4b40df14