### PR TITLE
Enable adjustment of Any Zone slider for mirrors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,3 +333,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Any Zone row now supports manual 0/±/Max assignment buttons for mirrors and lanterns.
 - Satellites project now features an Auto Max option that raises build count to the current colonist cap.
 - Space mirror oversight sliders now clamp values so none go negative and their total always sums to 100.
+- The Any Zone slider in the space mirror facility can be increased, taking percentage from the largest other sliders so the total remains 100%.

--- a/tests/spaceMirrorAnySlider.test.js
+++ b/tests/spaceMirrorAnySlider.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('space mirror any zone slider', () => {
+  test('increasing any zone pulls from largest sliders first', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.projectElements = {};
+    ctx.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: false } };
+    ctx.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      calculateZoneSolarFlux: () => 0,
+      celestialParameters: { crossSectionArea: 100, surfaceArea: 100 },
+      temperature: { zones: { tropical: { value: 0 }, temperate: { value: 0 }, polar: { value: 0 } } }
+    };
+    ctx.projectManager = { isBooleanFlagSet: () => true };
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const mirrorCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMirrorFacilityProject.js'), 'utf8');
+    vm.runInContext(mirrorCode + '; this.SpaceMirrorFacilityProject = SpaceMirrorFacilityProject; this.setMirrorDistribution = setMirrorDistribution;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.spaceMirrorFacility;
+    const project = new ctx.SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    project.updateUI();
+
+    ctx.setMirrorDistribution('tropical', 60);
+    ctx.setMirrorDistribution('temperate', 25);
+    ctx.setMirrorDistribution('polar', 10);
+    ctx.setMirrorDistribution('any', 70);
+
+    const getVal = z => Number(dom.window.document.getElementById(`mirror-oversight-${z}`).value);
+    expect(getVal('any')).toBe(70);
+    expect(getVal('tropical')).toBe(0);
+    expect(getVal('temperate')).toBe(20);
+    expect(getVal('polar')).toBe(10);
+    const total = ['tropical', 'temperate', 'polar', 'focus', 'any'].reduce((s, z) => s + getVal(z), 0);
+    expect(total).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow the Any Zone slider in the Space Mirror Facility to be adjusted, redistributing percentage from the largest other zones so totals stay at 100%
- Wire up UI and logic for the Any Zone slider and cover behavior with tests
- Document Any Zone slider reallocation in AGENTS.md

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa71db6dbc8327813ce34677b63b05