### PR TITLE
Add pressure threshold automation to space disposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,3 +333,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Any Zone row now supports manual 0/±/Max assignment buttons for mirrors and lanterns.
 - Satellites project now features an Auto Max option that raises build count to the current colonist cap.
 - Space mirror oversight sliders now clamp values so none go negative and their total always sums to 100.
+- Space disposal projects can auto-disable gas exports when atmospheric pressure falls below a configurable kPa threshold.


### PR DESCRIPTION
## Summary
- add "Disable if pressure below" automation for gas disposal projects
- support saving/loading pressure settings
- test that space disposal halts and resumes based on pressure limits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa735b69648327bec6d4dc5781bfdf