### PR TITLE
Fix land usage handling on load and inactive builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,3 +335,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space mirror oversight sliders now clamp values so none go negative and their total always sums to 100.
 - Space disposal projects can auto-disable gas exports when atmospheric pressure falls below a configurable kPa threshold.
 - The Any Zone slider in the space mirror facility can be increased, taking percentage from the largest other sliders so the total remains 100%.
+- Land usage recalculates on save load, and inactive structure construction checks land without reserving it.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -365,7 +365,7 @@ class Building extends EffectableEntity {
           resources['underground'][deposit].reserve(this.requiresDeposit.underground[deposit]*buildCount);
         }
       }
-      if(this.requiresLand){
+      if(this.requiresLand && activate){
         resources.surface.land.reserve(this.requiresLand*buildCount);
       }
       const oldActive = this.active;

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -1,5 +1,27 @@
 globalGameIsLoadingFromSave = false;
 
+function recalculateLandUsage() {
+  if (!resources || !resources.surface || !resources.surface.land) return;
+  let reserved = 0;
+  if (typeof buildings !== 'undefined') {
+    for (const name in buildings) {
+      const b = buildings[name];
+      if (b.requiresLand && b.active > 0) {
+        reserved += b.active * b.requiresLand;
+      }
+    }
+  }
+  if (typeof colonies !== 'undefined') {
+    for (const name in colonies) {
+      const c = colonies[name];
+      if (c.requiresLand && c.active > 0) {
+        reserved += c.active * c.requiresLand;
+      }
+    }
+  }
+  resources.surface.land.reserved = reserved;
+}
+
 function getGameState() {
   return {
     dayNightCycle: (typeof dayNightCycle !== 'undefined' && typeof dayNightCycle.saveState === 'function') ? dayNightCycle.saveState() : undefined,
@@ -175,6 +197,10 @@ function loadGame(slotOrCustomString) {
           }
         }
       createColonyButtons(colonies);
+      recalculateLandUsage();
+      if (typeof updateResourceDisplay === 'function') {
+        updateResourceDisplay(resources);
+      }
 
       if (gameState.selectedBuildCounts) {
         for (const key in gameState.selectedBuildCounts) {
@@ -599,3 +625,7 @@ function updateStatisticsDisplay() {
 
 // Call the function to add event listeners when the page loads
 document.addEventListener('DOMContentLoaded', addSaveSlotListeners);
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getGameState, loadGame, recalculateLandUsage };
+}

--- a/tests/buildInactiveLand.test.js
+++ b/tests/buildInactiveLand.test.js
@@ -1,0 +1,41 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+
+describe('inactive build land handling', () => {
+  beforeEach(() => {
+    global.resources = {
+      colony: {},
+      surface: {
+        land: {
+          value: 5,
+          reserved: 0,
+          isAvailable(amount) { return this.value - this.reserved >= amount; },
+          reserve(amount) { if (this.isAvailable(amount)) { this.reserved += amount; return true; } return false; },
+          release(amount) { this.reserved = Math.max(this.reserved - amount, 0); }
+        }
+      }
+    };
+  });
+
+  test('does not reserve land when built inactive', () => {
+    const config = { name:'test', category:'resource', cost:{}, consumption:{}, production:{}, storage:{}, dayNightActivity:false, canBeToggled:false, requiresMaintenance:false, requiresDeposit:false, requiresWorker:0, maintenanceFactor:1, unlocked:true, requiresLand:2 };
+    const building = new Building(config, 'test');
+    const result = building.build(1, false);
+    expect(result).toBe(true);
+    expect(resources.surface.land.reserved).toBe(0);
+    expect(building.count).toBe(1);
+    expect(building.active).toBe(0);
+  });
+
+  test('fails to build inactive without enough land', () => {
+    resources.surface.land.value = 0;
+    const config = { name:'test', category:'resource', cost:{}, consumption:{}, production:{}, storage:{}, dayNightActivity:false, canBeToggled:false, requiresMaintenance:false, requiresDeposit:false, requiresWorker:0, maintenanceFactor:1, unlocked:true, requiresLand:1 };
+    const building = new Building(config, 'test');
+    const result = building.build(1, false);
+    expect(result).toBe(false);
+    expect(resources.surface.land.reserved).toBe(0);
+    expect(building.count).toBe(0);
+  });
+});

--- a/tests/loadGameRecalcLand.test.js
+++ b/tests/loadGameRecalcLand.test.js
@@ -1,0 +1,33 @@
+global.document = { addEventListener: () => {}, getElementById: () => ({ textContent: '' }) };
+const { loadGame } = require('../src/js/save.js');
+
+describe('loadGame recalculates land usage', () => {
+  beforeEach(() => {
+    global.createBuildingButtons = () => {};
+    global.initializeBuildingAlerts = () => {};
+    global.createColonyButtons = () => {};
+    global.tabManager = { activateTab: () => {} };
+    global.updateDayNightDisplay = () => {};
+    global.updateBuildingDisplay = () => {};
+    global.updateResourceDisplay = () => {};
+    global.applyDayNightSettingEffects = () => {};
+    global.currentPlanetParameters = { resources: { surface: { land: {} } } };
+  });
+
+  test('reserved land derives from active structures', () => {
+    global.resources = { surface: { land: { value: 100, reserved: 0, initializeFromConfig: () => {} } } };
+    global.buildings = { hut: { requiresLand: 3, active: 0, initializeFromConfig: () => {}, activeEffects: [], booleanFlags: [] } };
+    global.colonies = { base: { requiresLand: 5, active: 0, initializeFromConfig: () => {}, activeEffects: [], booleanFlags: [] } };
+    global.buildingsParameters = { hut: { requiresLand: 3 } };
+    global.colonyParameters = { base: { requiresLand: 5 } };
+
+    const saved = JSON.stringify({
+      resources: { surface: { land: { value: 100, reserved: 0 } } },
+      buildings: { hut: { active: 2 } },
+      colonies: { base: { active: 1 } }
+    });
+
+    loadGame(saved);
+    expect(resources.surface.land.reserved).toBe(2 * 3 + 1 * 5);
+  });
+});


### PR DESCRIPTION
## Summary
- Recalculate surface land reservations when loading save files
- Avoid reserving land when structures are built inactive while still validating land availability
- Test inactive build land handling and save-load land recalculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aaf7b023308327955584e3dcbd5db6