### PR TITLE
Clamp space mirror sliders each tick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,3 +335,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space mirror oversight sliders now clamp values so none go negative and their total always sums to 100.
 - Space disposal projects can auto-disable gas exports when atmospheric pressure falls below a configurable kPa threshold.
 - The Any Zone slider in the space mirror facility can be increased, taking percentage from the largest other sliders so the total remains 100%.
+- Space mirror facility now verifies slider percentages each tick, clamping out-of-range values and ensuring they total 100%.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -158,6 +158,57 @@ function toggleFinerControls(enabled) {
   updateMirrorOversightUI();
 }
 
+function sanitizeMirrorDistribution() {
+  const dist = mirrorOversightSettings.distribution;
+  const zones = ['tropical', 'temperate', 'polar', 'focus'];
+  let total = 0;
+  let changed = false;
+
+  zones.forEach(zone => {
+    let v = dist[zone];
+    if (v < 0) {
+      v = 0;
+      changed = true;
+    } else if (v > 1) {
+      v = 1;
+      changed = true;
+    }
+    dist[zone] = v;
+    total += v;
+  });
+
+  if (total !== 1) {
+    changed = true;
+    if (total > 1) {
+      let excess = total - 1;
+      zones
+        .slice()
+        .sort((a, b) => dist[b] - dist[a])
+        .forEach(zone => {
+          if (excess <= 0) return;
+          const reduce = Math.min(dist[zone], excess);
+          dist[zone] -= reduce;
+          excess -= reduce;
+        });
+    } else {
+      let deficit = 1 - total;
+      zones
+        .slice()
+        .sort((a, b) => dist[b] - dist[a])
+        .forEach(zone => {
+          if (deficit <= 0) return;
+          const add = Math.min(1 - dist[zone], deficit);
+          dist[zone] += add;
+          deficit -= add;
+        });
+    }
+  }
+
+  if (changed && typeof updateMirrorOversightUI === 'function') {
+    updateMirrorOversightUI();
+  }
+}
+
 function updateAssignmentDisplays() {
   const types = ['mirrors', 'lanterns'];
   const zones = ['tropical', 'temperate', 'polar', 'focus', 'any'];
@@ -653,6 +704,11 @@ function calculateZoneSolarFluxWithFacility(terraforming, zone, angleAdjusted = 
 }
 
 class SpaceMirrorFacilityProject extends Project {
+  update(deltaTime) {
+    sanitizeMirrorDistribution();
+    super.update(deltaTime);
+  }
+
   renderUI(container) {
     const mirrorDetails = document.createElement('div');
     mirrorDetails.classList.add('info-card', 'mirror-details-card');

--- a/tests/spaceMirrorDistributionSafeguard.test.js
+++ b/tests/spaceMirrorDistributionSafeguard.test.js
@@ -1,0 +1,30 @@
+const numbers = require('../src/js/numbers.js');
+
+global.Project = class { update() {} };
+global.formatNumber = numbers.formatNumber;
+global.toDisplayTemperature = numbers.toDisplayTemperature;
+global.getTemperatureUnit = numbers.getTemperatureUnit;
+
+const { SpaceMirrorFacilityProject, mirrorOversightSettings } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+
+afterAll(() => {
+  delete global.Project;
+  delete global.formatNumber;
+  delete global.toDisplayTemperature;
+  delete global.getTemperatureUnit;
+});
+
+describe('Space mirror distribution safeguard', () => {
+  test('clamps invalid slider values each tick', () => {
+    const project = new SpaceMirrorFacilityProject({ name: 'Space Mirror Facility', cost: {}, duration: 0 }, 'spaceMirrorFacility');
+    mirrorOversightSettings.distribution = { tropical: 1.2, temperate: -0.1, polar: 0.3, focus: 0.3 };
+    project.update(1000);
+    const dist = mirrorOversightSettings.distribution;
+    const total = dist.tropical + dist.temperate + dist.polar + dist.focus;
+    Object.values(dist).forEach(v => {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    });
+    expect(total).toBeCloseTo(1, 10);
+  });
+});


### PR DESCRIPTION
## Summary
- Sanitize space mirror oversight distribution every tick, clamping sliders to 0-100% and forcing totals to 100%
- Document slider validation in AGENTS instructions
- Test that invalid slider values are corrected each tick

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aafa288b308327920d8d116dbbde65