### PR TITLE
Make cargo rocket trading continuous

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,8 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Self Replicating Ships research now costs 8M advanced research points.
 - Dyson Swarm project displays when collectors exist even without receiver tech, hiding receiver energy output while allowing manual and automatic collector deployment.
 - Cargo Rocket project applies rates only once by honoring the `applyRates` flag in `estimateProjectCostAndGain`.
- - Cargo Rocket project becomes continuous after Ship trading research, immediately granting any pending gains and purchasing resources with funding over time.
+- Cargo Rocket project becomes continuous after Ship trading research, immediately granting any pending gains and purchasing resources with funding over time.
+- Cargo Rocket continuous mode displays a "Continuous" progress bar and a "Run" auto-start label.
 - Milestone festival color changed to a warm green.
 - Save-to-file default filenames include the current world name and timestamp.
 - Carbon asteroid mining can auto-disable when O2 pressure exceeds a threshold (default 15 kPa), and space mining pressure controls now label gases like CO2 and N2.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Self Replicating Ships research now costs 8M advanced research points.
 - Dyson Swarm project displays when collectors exist even without receiver tech, hiding receiver energy output while allowing manual and automatic collector deployment.
 - Cargo Rocket project applies rates only once by honoring the `applyRates` flag in `estimateProjectCostAndGain`.
+ - Cargo Rocket project becomes continuous after Ship trading research, immediately granting any pending gains and purchasing resources with funding over time.
 - Milestone festival color changed to a warm green.
 - Save-to-file default filenames include the current world name and timestamp.
 - Carbon asteroid mining can auto-disable when O2 pressure exceeds a threshold (default 15 kPa), and space mining pressure controls now label gases like CO2 and N2.

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -470,14 +470,10 @@ function updateProjectUI(projectName) {
   if (elements.autoStartCheckbox) {
     elements.autoStartCheckbox.checked = project.autoStart || false;
   }
-  if (
-    elements.autoStartLabel &&
-    typeof SpaceshipProject !== 'undefined' &&
-    project instanceof SpaceshipProject
-  ) {
-    elements.autoStartLabel.textContent = project.isContinuous()
-      ? 'Run'
-      : 'Auto start';
+  if (elements.autoStartLabel) {
+    const continuous =
+      typeof project.isContinuous === 'function' && project.isContinuous();
+    elements.autoStartLabel.textContent = continuous ? 'Run' : 'Auto start';
   }
 
 
@@ -541,7 +537,12 @@ function updateProjectUI(projectName) {
 
       // Update the duration in the progress bar display
       if (elements.progressButton) {
-        if (typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject && project.isContinuous()) {
+        const isContinuousProject =
+          typeof project.isContinuous === 'function' &&
+          project.isContinuous() &&
+          ((typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject) ||
+            (typeof CargoRocketProject !== 'undefined' && project instanceof CargoRocketProject));
+        if (isContinuousProject) {
           if (project.autoStart && project.isActive && !project.isPaused) {
             elements.progressButton.textContent = 'Continuous';
             elements.progressButton.style.background = '#4caf50';

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -800,7 +800,7 @@ const researchParameters = {
       {
         id: 'trading',
         name: 'Ship trading',
-        description: 'Allows the export of metal via a new special project and purchase of ships via the cargo rocket special project.  Also significantly reduces the duration of cargo rockets.',
+        description: 'Allows the export of metal via a new special project and purchase of ships via the cargo rocket special project.  Cargo rockets become continuous, consuming funding and delivering purchases in real time.',
         cost: { research: 50000000 },
         prerequisites: [],
         effects: [
@@ -819,7 +819,7 @@ const researchParameters = {
               target : 'project',
               targetId : 'cargo_rocket',
               type: 'booleanFlag',
-              flagId : 'instantDuration',
+              flagId : 'continuousTrading',
               value : true
             }
         ],

--- a/tests/cargoRocketContinuousUI.test.js
+++ b/tests/cargoRocketContinuousUI.test.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('CargoRocketProject continuous progress UI', () => {
+  test('shows Continuous or Stopped and Run label', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="projects-subtab-content-wrapper">
+        <div id="resources-projects-list" class="projects-list"></div>
+      </div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = () => '';
+    ctx.formatBigInteger = () => '';
+    ctx.projectElements = {};
+    ctx.resources = {
+      colony: {
+        funding: { value: 0 },
+        metal: { value: 0, displayName: 'Metal', unlocked: true },
+      },
+      special: { spaceships: { value: 0, unlocked: true } },
+    };
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+
+    const config = {
+      name: 'cargo',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: { resourceChoiceGainCost: { colony: { metal: 1 } } }
+    };
+    const project = new ctx.CargoRocketProject(config, 'cargo');
+
+    ctx.projectManager = {
+      projects: { cargo: project },
+      isBooleanFlagSet: () => false,
+      getProjectStatuses: () => Object.values({ cargo: project })
+    };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.addEffect({ type: 'booleanFlag', flagId: 'continuousTrading', value: true });
+    project.autoStart = true;
+    project.isActive = true;
+    ctx.updateProjectUI('cargo');
+
+    const elements = ctx.projectElements.cargo;
+    expect(elements.autoStartLabel.textContent).toBe('Run');
+    expect(elements.progressButton.textContent).toBe('Continuous');
+    expect(elements.progressButton.style.background).toBe('rgb(76, 175, 80)');
+
+    project.autoStart = false;
+    ctx.updateProjectUI('cargo');
+    expect(elements.progressButton.textContent).toBe('Stopped');
+    expect(elements.progressButton.style.background).toBe('rgb(244, 67, 54)');
+  });
+});

--- a/tests/cargoRocketProject.test.js
+++ b/tests/cargoRocketProject.test.js
@@ -151,4 +151,55 @@ describe('Cargo Rocket project', () => {
     expect(ctx.resources.colony.funding.modifyRate).toHaveBeenCalledTimes(1);
     expect(ctx.resources.special.spaceships.modifyRate).toHaveBeenCalledTimes(1);
   });
+
+  test('trading research converts cargo rocket to continuous mode', () => {
+    const ctx = {
+      console,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      resources: {
+        colony: {
+          funding: { value: 100, decrease(amount){ this.value -= amount; }, increase(){}, modifyRate(){}, },
+          metal: { value: 0, increase(amount){ this.value += amount; }, modifyRate(){}, }
+        },
+        special: { spaceships: { value: 0, increase(){}, modifyRate(){}, } }
+      },
+      projectManager: { projects: {}, durationMultiplier: 1 },
+    };
+    vm.createContext(ctx);
+    global.resources = ctx.resources;
+    global.projectManager = ctx.projectManager;
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+
+    const config = {
+      name: 'Cargo Rocket',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { resourceChoiceGainCost: { colony: { metal: 2 } } }
+    };
+
+    const project = new ctx.CargoRocketProject(config, 'cargo_rocket');
+    project.selectedResources = [{ category: 'colony', resource: 'metal', quantity: 1 }];
+    project.start(ctx.resources);
+    expect(ctx.resources.colony.funding.value).toBe(98);
+
+    project.addEffect({ type: 'booleanFlag', flagId: 'continuousTrading', value: true });
+    project.update(0);
+    expect(ctx.resources.colony.metal.value).toBe(1);
+    expect(project.pendingResourceGains).toBeNull();
+    expect(project.isContinuous()).toBe(true);
+
+    project.selectedResources = [{ category: 'colony', resource: 'metal', quantity: 1 }];
+    project.applyCostAndGain(1000);
+    expect(ctx.resources.colony.funding.value).toBeCloseTo(96);
+    expect(ctx.resources.colony.metal.value).toBeCloseTo(2);
+  });
 });


### PR DESCRIPTION
## Summary
- Make Cargo Rocket project continuous once Ship trading research is completed
- Flush pending cargo rocket purchases and consume funding per second for new trades
- Document continuous trading change in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab07d3a4cc8327841994ebfadcb2a1