### PR TITLE
Ensure cargo rocket run toggle halts resource flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ Unassigned mirrors or lanterns no longer affect luminosity, and lantern controls
 The Random World Generator manager builds procedural planets and moons with lockable orbit and type options. Worlds must equilibrate before travel; a progress window tracks simulated time and allows canceling or ending early once the minimum fast-forward is reached. Seeds encode UI selections so players can revisit specific worlds, and the manager prevents travel to terraformed seeds while persisting star luminosity and other parameters through saves. Traveling from a fully terraformed world to a random world awards a skill point on the first visit, and planetary thrusters on these worlds use the host star's mass for orbital calculations.
 
 # Changelogs
+- Cargo rocket continuous mode only produces or consumes resources when the Run checkbox is enabled.
 - The collector progress bar continues updating after the receiver is finished and controls stay disabled until the receiver completes.
 - The solar collector UI remains hidden until the receiver is built.
 - The collector cost now appears on the Dyson Swarm card.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -565,8 +565,7 @@ class ProjectManager extends EffectableEntity {
       project.update(deltaTime);
 
       if (
-        typeof SpaceshipProject !== 'undefined' &&
-        project instanceof SpaceshipProject &&
+        typeof project.isContinuous === 'function' &&
         project.isContinuous() &&
         !project.autoStart &&
         project.isActive

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -339,6 +339,7 @@ class CargoRocketProject extends Project {
     const totals = { cost: {}, gain: {} };
     if (!this.isActive) return totals;
     if (this.isContinuous()) {
+      if (!this.autoStart) return totals;
       const seconds = deltaTime / 1000;
       if (this.selectedResources && this.selectedResources.length > 0) {
         let costPerSecond = 0;
@@ -416,7 +417,7 @@ class CargoRocketProject extends Project {
   }
 
   applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
-    if (!this.isActive || !this.isContinuous()) return;
+    if (!this.isActive || !this.isContinuous() || !this.autoStart) return;
     if (!this.selectedResources || this.selectedResources.length === 0) return;
     const seconds = deltaTime / 1000;
     const purchases = [];

--- a/tests/cargoRocketProject.test.js
+++ b/tests/cargoRocketProject.test.js
@@ -196,6 +196,7 @@ describe('Cargo Rocket project', () => {
     expect(ctx.resources.colony.metal.value).toBe(1);
     expect(project.pendingResourceGains).toBeNull();
     expect(project.isContinuous()).toBe(true);
+    project.autoStart = true;
 
     project.selectedResources = [{ category: 'colony', resource: 'metal', quantity: 1 }];
     project.applyCostAndGain(1000);

--- a/tests/cargoRocketRunToggle.test.js
+++ b/tests/cargoRocketRunToggle.test.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+function stubResource(value) {
+  return {
+    value,
+    decrease(amount) { this.value = Math.max(this.value - amount, 0); },
+    increase(amount) { this.value += amount; },
+    modifyRate: jest.fn(),
+    updateStorageCap: () => {}
+  };
+}
+
+function createChanges(resources) {
+  const changes = {};
+  for (const category in resources) {
+    changes[category] = {};
+    for (const resource in resources[category]) {
+      changes[category][resource] = 0;
+    }
+  }
+  return changes;
+}
+
+function applyChanges(resources, changes) {
+  for (const category in changes) {
+    for (const resource in changes[category]) {
+      if (resources[category]?.[resource]) {
+        resources[category][resource].value += changes[category][resource];
+      }
+    }
+  }
+}
+
+describe('cargo rocket continuous run toggle', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = { console, EffectableEntity };
+    ctx.resources = {
+      colony: {
+        funding: stubResource(100),
+        metal: stubResource(0)
+      }
+    };
+    vm.createContext(ctx);
+    const projCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projCode + '; this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
+    ctx.projectManager = new ctx.ProjectManager();
+    const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'CargoRocketProject.js'), 'utf8');
+    vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+    global.resources = ctx.resources;
+    global.projectManager = ctx.projectManager;
+  });
+
+  test('stops resource flow when run disabled', () => {
+    const config = {
+      name: 'Cargo Rocket',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      unlocked: true,
+      attributes: { resourceChoiceGainCost: { colony: { metal: 2 } } }
+    };
+    const project = new ctx.CargoRocketProject(config, 'cargo_rocket');
+    project.selectedResources = [{ category: 'colony', resource: 'metal', quantity: 1 }];
+    project.start(ctx.resources);
+    project.addEffect({ type: 'booleanFlag', flagId: 'continuousTrading', value: true });
+    project.update(0);
+    project.autoStart = true;
+    ctx.projectManager.projects.cargo_rocket = project;
+
+    let changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
+    const metalAfterRun = ctx.resources.colony.metal.value;
+    const fundingAfterRun = ctx.resources.colony.funding.value;
+    expect(metalAfterRun).toBeGreaterThan(0);
+    expect(fundingAfterRun).toBeLessThan(100);
+
+    project.autoStart = false;
+    ctx.projectManager.updateProjects(1000);
+    expect(project.isActive).toBe(false);
+    changes = createChanges(ctx.resources);
+    project.applyCostAndGain(1000, changes);
+    applyChanges(ctx.resources, changes);
+    expect(ctx.resources.colony.metal.value).toBe(metalAfterRun);
+    expect(ctx.resources.colony.funding.value).toBe(fundingAfterRun);
+  });
+});


### PR DESCRIPTION
## Summary
- Stop continuous projects when the Run checkbox is disabled
- Require Cargo Rocket continuous mode to run before producing or consuming resources
- Cover Cargo Rocket run toggle with a dedicated test

## Testing
- `npm test`
- `npx jest tests/cargoRocketRunToggle.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68ab1b2c6ac483278460a3640cd95969