### PR TITLE
Fix DOM stubs to prevent hanging tests

### DIFF
--- a/tests/advancedResearchCompletionTravel.test.js
+++ b/tests/advancedResearchCompletionTravel.test.js
@@ -15,11 +15,17 @@ describe('Completed advanced research persists across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/advancedResearchTravelPersistence.test.js
+++ b/tests/advancedResearchTravelPersistence.test.js
@@ -15,11 +15,17 @@ describe('Advanced research persists across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/alienArtifactTravelPersistence.test.js
+++ b/tests/alienArtifactTravelPersistence.test.js
@@ -15,11 +15,17 @@ describe('Alien artifacts persist across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/dayNightCycleDuration.test.js
+++ b/tests/dayNightCycleDuration.test.js
@@ -17,11 +17,17 @@ describe('day-night cycle duration', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/dysonSwarmTravelPersistence.test.js
+++ b/tests/dysonSwarmTravelPersistence.test.js
@@ -15,11 +15,17 @@ describe('Dyson Swarm collectors persist across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/gameUpdateTick.test.js
+++ b/tests/gameUpdateTick.test.js
@@ -15,11 +15,17 @@ describe('game update tick', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -75,6 +81,7 @@ describe('game update tick', () => {
       initializeLifeUI=()=>{};
       createMilestonesUI=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       updateDayNightDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};

--- a/tests/indexRuntime.test.js
+++ b/tests/indexRuntime.test.js
@@ -18,11 +18,17 @@ describe('index.html runtime', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -13,12 +13,18 @@ test('initializeGameState resets colony sliders to defaults', () => {
   });
 
   function createNullElement() {
-    return new Proxy(function () {}, {
-      get: () => createNullElement(),
-      apply: () => createNullElement(),
-      set: () => true,
-    });
-  }
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
+        set: () => true,
+      };
+      return new Proxy(function () {}, handler);
+    }
   const nullElement = createNullElement();
   const doc = dom.window.document;
   doc.createElement = () => nullElement;
@@ -73,6 +79,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
     initializeLifeUI=()=>{};
     createMilestonesUI=()=>{};
     initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
     updateDayNightDisplay=()=>{};
     addEffect=()=>{};
     removeEffect=()=>{};

--- a/tests/journalPersistOnTravel.test.js
+++ b/tests/journalPersistOnTravel.test.js
@@ -15,11 +15,17 @@ describe('journal persists when traveling', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/loadGamePlanet.test.js
+++ b/tests/loadGamePlanet.test.js
@@ -15,11 +15,17 @@ describe('load game planet initialization', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -76,6 +82,7 @@ describe('load game planet initialization', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};
       TabManager = class { activateTab(){} };

--- a/tests/nanotechNewGameReset.test.js
+++ b/tests/nanotechNewGameReset.test.js
@@ -15,11 +15,17 @@ describe('Nanotech new game reset', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/nanotechTravel.test.js
+++ b/tests/nanotechTravel.test.js
@@ -15,11 +15,17 @@ describe('Nanotech travel preservation', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/newGameResetsJournal.test.js
+++ b/tests/newGameResetsJournal.test.js
@@ -15,11 +15,17 @@ describe('new game resets journal history', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -74,6 +80,7 @@ describe('new game resets journal history', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};
       createPopup=()=>{};

--- a/tests/newGameResetsPlanet.test.js
+++ b/tests/newGameResetsPlanet.test.js
@@ -15,11 +15,17 @@ describe('new game resets to Mars', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -76,6 +82,7 @@ describe('new game resets to Mars', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};
       TabManager = class { activateTab(){} };

--- a/tests/planetSelection.test.js
+++ b/tests/planetSelection.test.js
@@ -15,11 +15,17 @@ describe('planet selection', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/planetSelectionBlocked.test.js
+++ b/tests/planetSelectionBlocked.test.js
@@ -15,11 +15,17 @@ describe('planet selection blocked when not terraformed', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/playTimeSave.test.js
+++ b/tests/playTimeSave.test.js
@@ -15,11 +15,17 @@ describe('play time persistence', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -71,6 +77,7 @@ describe('play time persistence', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};
       TabManager = class { activateTab(){} };

--- a/tests/regularResearchTravelReset.test.js
+++ b/tests/regularResearchTravelReset.test.js
@@ -15,11 +15,17 @@ describe('Regular research resets across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/skillPointsSave.test.js
+++ b/tests/skillPointsSave.test.js
@@ -15,11 +15,17 @@ describe('skillPoints save/load', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -71,6 +77,7 @@ describe('skillPoints save/load', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};
       TabManager = class { activateTab(){} };

--- a/tests/solisTravelPersistence.test.js
+++ b/tests/solisTravelPersistence.test.js
@@ -15,11 +15,17 @@ describe('Solis state persists across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/spaceStorageTravelPersistence.test.js
+++ b/tests/spaceStorageTravelPersistence.test.js
@@ -15,11 +15,17 @@ describe('Space Storage travel persistence', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/temperatureSettingTravel.test.js
+++ b/tests/temperatureSettingTravel.test.js
@@ -15,11 +15,17 @@ describe('temperature setting persists across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/totalPlayTimeTravel.test.js
+++ b/tests/totalPlayTimeTravel.test.js
@@ -15,11 +15,17 @@ describe('total play time travel persistence', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -72,6 +78,7 @@ describe('total play time travel persistence', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};
       TabManager = class { activateTab(){} };

--- a/tests/travelSkillPoint.test.js
+++ b/tests/travelSkillPoint.test.js
@@ -15,11 +15,17 @@ describe('skill point gained on first planet visit', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;

--- a/tests/wgcSaveLoad.test.js
+++ b/tests/wgcSaveLoad.test.js
@@ -15,11 +15,17 @@ describe('warpGateCommand save/load', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;
@@ -71,6 +77,7 @@ describe('warpGateCommand save/load', () => {
       createMilestonesUI=()=>{};
       updateDayNightDisplay=()=>{};
       initializeSpaceUI=()=>{};
+      updateResourceDisplay=()=>{};
       addEffect=()=>{};
       removeEffect=()=>{};
       TabManager = class { activateTab(){} };

--- a/tests/wgcTravelPersistence.test.js
+++ b/tests/wgcTravelPersistence.test.js
@@ -15,11 +15,17 @@ describe('WGC state persists across planet travel', () => {
     });
 
     function createNullElement() {
-      return new Proxy(function () {}, {
-        get: () => createNullElement(),
-        apply: () => createNullElement(),
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
         set: () => true,
-      });
+      };
+      return new Proxy(function () {}, handler);
     }
     const nullElement = createNullElement();
     const doc = dom.window.document;


### PR DESCRIPTION
## Summary
- make test DOM stubs safe by returning null for firstChild/children and adding classList mocks
- stub `updateResourceDisplay` in tests that initialize game state

## Testing
- `npm test -- tests/loadGamePlanet.test.js tests/dayNightCycleDuration.test.js tests/planetSelection.test.js tests/skills.test.js tests/resourceTooltipUnits.test.js tests/infraredVisionResearch.test.js tests/nanotechEnergyLimit.test.js tests/wgcSaveLoad.test.js tests/initializeGameStateSliders.test.js tests/lifeStatusTooltip.test.js tests/solisTravelPersistence.test.js tests/wgcTravelPersistence.test.js tests/spaceStorageTravelPersistence.test.js tests/gameUpdateTick.test.js tests/dysonSwarmTravelPersistence.test.js tests/skillPointsSave.test.js tests/planetSelectionBlocked.test.js tests/playTimeSave.test.js tests/indexRuntime.test.js tests/travelSkillPoint.test.js tests/advancedResearchCompletionTravel.test.js tests/newGameResetsJournal.test.js tests/regularResearchTravelReset.test.js tests/nanotechTravel.test.js tests/nanotechNewGameReset.test.js tests/alienArtifactTravelPersistence.test.js tests/journalPersistOnTravel.test.js tests/totalPlayTimeTravel.test.js tests/advancedResearchTravelPersistence.test.js tests/newGameResetsPlanet.test.js tests/temperatureSettingTravel.test.js --runInBand --verbose --color=0`

------
https://chatgpt.com/codex/tasks/task_b_68ab34bc20408327bf61201aec835d5a