### PR TITLE
Ensure projects are unlocked in rate tests

### DIFF
--- a/tests/importColonistsRate.test.js
+++ b/tests/importColonistsRate.test.js
@@ -21,6 +21,7 @@ describe('Import colonists auto-start rate', () => {
 
     const config = ctx.projectParameters.import_colonists_1;
     const project = new ctx.Project(config, 'import');
+    project.unlocked = true;
     project.start(ctx.resources);
     project.autoStart = true;
 

--- a/tests/scannerProjectRate.test.js
+++ b/tests/scannerProjectRate.test.js
@@ -26,6 +26,7 @@ describe('ScannerProject auto-start cost rate', () => {
 
     const config = ctx.projectParameters.satellite;
     const project = new ctx.ScannerProject(config, 'sat');
+    project.unlocked = true;
     project.buildCount = 5;
     project.start(ctx.resources);
     project.autoStart = true;


### PR DESCRIPTION
## Summary
- Unlock scanner project before starting to validate cost rate scaling
- Unlock colonist import project prior to start to test resource gain rate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab3805a588832792ed08449a1db629