### PR TITLE
Show max ship capacity on metal exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,3 +340,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - The Any Zone slider in the space mirror facility can be increased, taking percentage from the largest other sliders so the total remains 100%.
 - Land usage recalculates on save load, and inactive structure construction checks land without reserving it.
 - Space mirror facility now verifies slider percentages each tick, clamping out-of-range values and ensuring they total 100%.
+- Metal exportation project shows assigned ship count as current/maximum so players know remaining capacity.

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -309,7 +309,14 @@ class SpaceshipProject extends Project {
       elements.autoAssignCheckbox.checked = this.autoAssignSpaceships || false;
     }
     if (elements.assignedSpaceshipsDisplay) {
-        elements.assignedSpaceshipsDisplay.textContent = formatBigInteger(this.assignedSpaceships);
+        const maxShips = typeof this.getMaxAssignableShips === 'function'
+          ? this.getMaxAssignableShips()
+          : null;
+        const assignedText = formatBigInteger(this.assignedSpaceships);
+        elements.assignedSpaceshipsDisplay.textContent =
+          maxShips != null
+            ? `${assignedText}/${formatBigInteger(maxShips)}`
+            : assignedText;
     }
     if (elements.availableSpaceshipsDisplay) {
         elements.availableSpaceshipsDisplay.textContent = formatBigInteger(Math.floor(resources.special.spaceships.value));

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -447,7 +447,14 @@ function updateProjectUI(projectName) {
 
   // Update Spaceships Assigned display if applicable
   if (elements?.assignedSpaceshipsDisplay && project.assignedSpaceships != null) {
-    elements.assignedSpaceshipsDisplay.textContent = `Spaceships Assigned: ${formatBigInteger(project.assignedSpaceships)}`;
+    const maxShips = typeof project.getMaxAssignableShips === 'function'
+      ? project.getMaxAssignableShips()
+      : null;
+    const assignedText = formatBigInteger(project.assignedSpaceships);
+    elements.assignedSpaceshipsDisplay.textContent =
+      maxShips != null
+        ? `Spaceships Assigned: ${assignedText}/${formatBigInteger(maxShips)}`
+        : `Spaceships Assigned: ${assignedText}`;
   }
 
   // Update Available Spaceships display if applicable

--- a/tests/spaceExportMaxShipDisplay.test.js
+++ b/tests/spaceExportMaxShipDisplay.test.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Space export assigned ships display', () => {
+  function setupContext() {
+    const dom = new JSDOM(
+      `<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`,
+      { runScripts: 'outside-only' }
+    );
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = n => n.toString();
+    ctx.formatBigInteger = n => n.toString();
+    ctx.toDisplayTemperature = x => x;
+    ctx.getTemperatureUnit = () => 'K';
+    ctx.gameSettings = { useCelsius: false };
+    ctx.projectElements = {};
+    ctx.shipEfficiency = 1;
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(
+      uiCode +
+        '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;',
+      ctx
+    );
+
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const exportCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceExportProject.js'), 'utf8');
+    vm.runInContext(exportCode + '; this.SpaceExportProject = SpaceExportProject;', ctx);
+    return ctx;
+  }
+
+  test('Assigned display shows current and max ships', () => {
+    const ctx = setupContext();
+    ctx.resources = {
+      colony: { metal: { displayName: 'Metal', value: 0, increase() {}, decrease() {} } },
+      special: { spaceships: { value: 1000 } },
+    };
+
+    const config = {
+      name: 'export',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        disposalAmount: 1000,
+        disposable: { colony: ['metal'] },
+        defaultDisposal: { category: 'colony', resource: 'metal' },
+      },
+    };
+
+    const project = new ctx.SpaceExportProject(config, 'export');
+    ctx.projectManager = {
+      projects: { export: project },
+      isBooleanFlagSet: () => false,
+      getProjectStatuses: () => Object.values({ export: project }),
+    };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.assignSpaceships(150);
+    ctx.updateProjectUI('export');
+
+    const assignedText = ctx.projectElements.export.assignedSpaceshipsDisplay.textContent;
+    const maxShips = project.getMaxAssignableShips();
+    expect(assignedText).toBe(`${150}/${maxShips}`);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Display assigned/maximum ships for SpaceExportProject so players see remaining capacity
- Expose same info in generic project UI
- Document feature in AGENTS and add test coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab57e707348327996f0000f9e77b09