### PR TITLE
Add tooltip for space export max capacity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,3 +341,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Land usage recalculates on save load, and inactive structure construction checks land without reserving it.
 - Space mirror facility now verifies slider percentages each tick, clamping out-of-range values and ensuring they total 100%.
 - Metal exportation project shows assigned ship count as current/maximum so players know remaining capacity.
+- Space export project's max export capacity line includes a tooltip explaining Earth's metal purchase limit.

--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -27,6 +27,11 @@ class SpaceExportProject extends SpaceExportBaseProject {
 
   updateUI() {
     super.updateUI();
+    const elements = projectElements[this.name];
+    if (elements && elements.maxDisposalElement) {
+      const capText = `Max Export Capacity: ${formatNumber(this.getExportCap(), true)} /s`;
+      elements.maxDisposalElement.innerHTML = `${capText} <span class="info-tooltip-icon" title="Earth is not interested in purchasing more metal than about 2 order of magnitude its 2025 yearly metal production.  This value may change as you progress further into the game.">&#9432;</span>`;
+    }
   }
 }
 

--- a/tests/spaceExportCapacityTooltip.test.js
+++ b/tests/spaceExportCapacityTooltip.test.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Space export max capacity tooltip', () => {
+  function setupContext() {
+    const dom = new JSDOM(
+      `<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`,
+      { runScripts: 'outside-only' }
+    );
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = n => n.toString();
+    ctx.formatBigInteger = n => n.toString();
+    ctx.toDisplayTemperature = x => x;
+    ctx.getTemperatureUnit = () => 'K';
+    ctx.gameSettings = { useCelsius: false };
+    ctx.projectElements = {};
+    ctx.shipEfficiency = 1;
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(
+      uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;',
+      ctx
+    );
+
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const exportCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceExportProject.js'), 'utf8');
+    vm.runInContext(exportCode + '; this.SpaceExportProject = SpaceExportProject;', ctx);
+    return ctx;
+  }
+
+  test('Max export capacity line includes tooltip', () => {
+    const ctx = setupContext();
+    ctx.resources = {
+      colony: { metal: { displayName: 'Metal', value: 0, increase() {}, decrease() {} } },
+      special: { spaceships: { value: 0 } },
+    };
+
+    const config = {
+      name: 'export',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        disposalAmount: 1000,
+        disposable: { colony: ['metal'] },
+        defaultDisposal: { category: 'colony', resource: 'metal' },
+      },
+    };
+
+    const project = new ctx.SpaceExportProject(config, 'export');
+    ctx.projectManager = {
+      projects: { export: project },
+      isBooleanFlagSet: () => false,
+      getProjectStatuses: () => Object.values({ export: project }),
+    };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    ctx.updateProjectUI('export');
+    const element = ctx.projectElements.export.maxDisposalElement;
+    const tooltip = element.querySelector('.info-tooltip-icon');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.getAttribute('title')).toBe(
+      'Earth is not interested in purchasing more metal than about 2 order of magnitude its 2025 yearly metal production.  This value may change as you progress further into the game.'
+    );
+    expect(element.innerHTML).toContain(' /s <span');
+  });
+});


### PR DESCRIPTION
## Summary
- Show an info tooltip on the Space Export project's max export capacity explaining Earth's metal demand limit
- Add unit test for the new tooltip
- Document feature in AGENTS guidelines

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab757d3c78832785c074f838dd431d