### PR TITLE
Persist space export capacity tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,3 +342,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space mirror facility now verifies slider percentages each tick, clamping out-of-range values and ensuring they total 100%.
 - Metal exportation project shows assigned ship count as current/maximum so players know remaining capacity.
 - Space export project's max export capacity line includes a tooltip explaining Earth's metal purchase limit.
+- Max export capacity tooltip is generated once and no longer updates each tick, making it readable.

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -88,6 +88,8 @@ class SpaceExportBaseProject extends SpaceshipProject {
     totalDisposal.id = `${this.name}-total-disposal`;
     const maxDisposal = document.createElement('div');
     maxDisposal.id = `${this.name}-max-disposal`;
+    const maxDisposalText = document.createElement('span');
+    maxDisposal.appendChild(maxDisposalText);
     const gainPerResource = document.createElement('div');
     gainPerResource.id = `${this.name}-gain-per-ship`;
     detailsGrid.append(selectContainer, disposalPerShip, totalDisposal, maxDisposal, gainPerResource);
@@ -101,6 +103,7 @@ class SpaceExportBaseProject extends SpaceshipProject {
       disposalPerShipElement: disposalPerShip,
       totalDisposalElement: totalDisposal,
       maxDisposalElement: maxDisposal,
+      maxDisposalText,
       gainPerResourceElement: gainPerResource,
     };
 
@@ -277,8 +280,8 @@ class SpaceExportBaseProject extends SpaceshipProject {
       }
     }
 
-    if (elements.maxDisposalElement && typeof this.getExportCap === 'function') {
-      elements.maxDisposalElement.textContent = `Max Export Capacity: ${formatNumber(this.getExportCap(), true)} /s`;
+    if (elements.maxDisposalText && typeof this.getExportCap === 'function') {
+      elements.maxDisposalText.textContent = `Max Export Capacity: ${formatNumber(this.getExportCap(), true)} /s`;
     }
     
     if (elements.gainPerResourceElement && this.attributes.fundingGainAmount) {

--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -25,13 +25,18 @@ class SpaceExportProject extends SpaceExportBaseProject {
     super.assignSpaceships(adjusted);
   }
 
-  updateUI() {
-    super.updateUI();
+  createResourceDisposalUI() {
+    const sectionContainer = super.createResourceDisposalUI();
     const elements = projectElements[this.name];
     if (elements && elements.maxDisposalElement) {
-      const capText = `Max Export Capacity: ${formatNumber(this.getExportCap(), true)} /s`;
-      elements.maxDisposalElement.innerHTML = `${capText} <span class="info-tooltip-icon" title="Earth is not interested in purchasing more metal than about 2 order of magnitude its 2025 yearly metal production.  This value may change as you progress further into the game.">&#9432;</span>`;
+      const tooltip = document.createElement('span');
+      tooltip.classList.add('info-tooltip-icon');
+      tooltip.title =
+        'Earth is not interested in purchasing more metal than about 2 order of magnitude its 2025 yearly metal production.  This value may change as you progress further into the game.';
+      elements.maxDisposalElement.appendChild(document.createTextNode(' '));
+      elements.maxDisposalElement.appendChild(tooltip);
     }
+    return sectionContainer;
   }
 }
 

--- a/tests/spaceExportCapacityTooltip.test.js
+++ b/tests/spaceExportCapacityTooltip.test.js
@@ -85,6 +85,9 @@ describe('Space export max capacity tooltip', () => {
     expect(tooltip.getAttribute('title')).toBe(
       'Earth is not interested in purchasing more metal than about 2 order of magnitude its 2025 yearly metal production.  This value may change as you progress further into the game.'
     );
-    expect(element.innerHTML).toContain(' /s <span');
+    const textSpan = element.querySelector('span:not(.info-tooltip-icon)');
+    expect(textSpan).not.toBeNull();
+    expect(textSpan.textContent).toBe('Max Export Capacity: 1000000000 /s');
+    expect(element.children[1]).toBe(tooltip);
   });
 });


### PR DESCRIPTION
## Summary
- Avoid rewriting max export capacity line so tooltip persists
- Render tooltip for space exports once during UI creation
- Update tests for stable max export capacity tooltip

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab76e8a0fc8327808fa734c124a77f