### PR TITLE
docs: clarify test command to avoid watch reruns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,9 @@ To ensure this works properly, every feature in the game that has an UI should h
 
 # Testing
 - Run `npm ci` to install dependencies before running tests.
-- Save tests output to a file so you don't have to rerun it just to read the results.
+- Save test output to a file so you don't have to rerun it just to read the results.
+- Run tests **once** in non-watch mode with `CI=true npm test` and report how many passed or failed. Pipe the command to `tee` (e.g., `CI=true npm test 2>&1 | tee test.log`) so the results are both displayed and stored.
 - Write tests for any new feature.
-- Run tests with `npm test` and report how many passed or failed.
 - Avoid asserting on exact story text; check IDs or prerequisites instead.
 
 # Storytelling style


### PR DESCRIPTION
## Summary
- advise running tests once in non-watch mode with `CI=true npm test`
- document piping test output to `tee` to avoid reruns when reading results

## Testing
- `CI=true npm test 2>&1 | tee /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_b_68ab77f6b1548327ab1b190c51409469