### PR TITLE
Add info icon to space export tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,3 +343,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Metal exportation project shows assigned ship count as current/maximum so players know remaining capacity.
 - Space export project's max export capacity line includes a tooltip explaining Earth's metal purchase limit.
 - Max export capacity tooltip is generated once and no longer updates each tick, making it readable.
+- Max export capacity tooltip now displays an info icon so the explanation is visible.

--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -33,6 +33,7 @@ class SpaceExportProject extends SpaceExportBaseProject {
       tooltip.classList.add('info-tooltip-icon');
       tooltip.title =
         'Earth is not interested in purchasing more metal than about 2 order of magnitude its 2025 yearly metal production.  This value may change as you progress further into the game.';
+      tooltip.innerHTML = '&#9432;';
       elements.maxDisposalElement.appendChild(document.createTextNode(' '));
       elements.maxDisposalElement.appendChild(tooltip);
     }

--- a/tests/spaceExportCapacityTooltip.test.js
+++ b/tests/spaceExportCapacityTooltip.test.js
@@ -82,6 +82,7 @@ describe('Space export max capacity tooltip', () => {
     const element = ctx.projectElements.export.maxDisposalElement;
     const tooltip = element.querySelector('.info-tooltip-icon');
     expect(tooltip).not.toBeNull();
+    expect(tooltip.textContent).toBe('\u24D8');
     expect(tooltip.getAttribute('title')).toBe(
       'Earth is not interested in purchasing more metal than about 2 order of magnitude its 2025 yearly metal production.  This value may change as you progress further into the game.'
     );


### PR DESCRIPTION
## Summary
- show an info icon for the space export metal cap tooltip
- test for the icon to ensure visibility
- document tooltip visibility in AGENTS instructions

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab791342e88327881803894f11bfa9