### PR TITLE
Display available counts in space mirror finer controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,3 +344,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space export project's max export capacity line includes a tooltip explaining Earth's metal purchase limit.
 - Max export capacity tooltip is generated once and no longer updates each tick, making it readable.
 - Max export capacity tooltip now displays an info icon so the explanation is visible.
+- Space mirror finer controls show counts of unassigned mirrors and lanterns available for manual assignment.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -735,7 +735,6 @@
     justify-content: center;
     gap: 4px;
 }
-
 #assignment-grid .assign-cell span {
     font-weight: bold;
     min-width: 40px;

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -347,15 +347,28 @@ function initializeMirrorOversightUI(container) {
         <button id="assignment-mul10">x10</button>
       </div>
     </div>
-    <div class="available-counts">
-      <div>Mirrors available: <span id="available-mirrors">0</span></div>
-      <div>Lanterns available: <span id="available-lanterns">0</span></div>
-    </div>
     <div id="assignment-grid">
       <div class="grid-header">Zone</div>
       <div class="grid-header">Mirrors</div>
       <div class="grid-header">Lanterns</div>
       <div class="grid-header">Auto</div>
+
+      <div class="grid-zone-label">Available</div>
+      <div class="assign-cell">
+        <button class="assign-zero" style="visibility: hidden;">0</button>
+        <button class="assign-minus" style="visibility: hidden;">-1</button>
+        <span id="available-mirrors">0</span>
+        <button class="assign-plus" style="visibility: hidden;">+1</button>
+        <button class="assign-max" style="visibility: hidden;">Max</button>
+      </div>
+      <div class="assign-cell available-lantern-cell" data-type="lanterns">
+        <button class="assign-zero" style="visibility: hidden;">0</button>
+        <button class="assign-minus" style="visibility: hidden;">-1</button>
+        <span id="available-lanterns">0</span>
+        <button class="assign-plus" style="visibility: hidden;">+1</button>
+        <button class="assign-max" style="visibility: hidden;">Max</button>
+      </div>
+      <div class="grid-auto-cell"></div>
 
       ${['tropical', 'temperate', 'polar', 'any'].map(zone => `
         <div class="grid-zone-label" data-zone="${zone}">${zone === 'any' ? 'Any Zone' : zone.charAt(0).toUpperCase() + zone.slice(1)}</div>
@@ -526,6 +539,15 @@ function updateMirrorOversightUI() {
   document.querySelectorAll('#assignment-grid .assign-cell[data-type="lanterns"]').forEach(cell => {
     cell.style.display = lanternUnlocked ? 'flex' : 'none';
   });
+
+  document.querySelectorAll('.available-lantern-cell').forEach(cell => {
+    cell.style.display = lanternUnlocked ? 'flex' : 'none';
+  });
+
+  const assignmentGrid = document.getElementById('assignment-grid');
+  if (assignmentGrid) {
+    assignmentGrid.style.gridTemplateColumns = lanternUnlocked ? '100px 1fr 1fr 50px' : '100px 1fr 50px';
+  }
 
   const useFiner = mirrorOversightSettings.useFinerControls;
   ['tropical','temperate','polar','focus','any'].forEach(zone => {

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -219,6 +219,15 @@ function updateAssignmentDisplays() {
         el.textContent = formatBuildingCount(mirrorOversightSettings.assignments[type][zone] || 0);
       }
     });
+
+    const availableEl = document.getElementById(`available-${type}`);
+    if (availableEl) {
+      const total = type === 'mirrors'
+        ? (buildings?.spaceMirror?.active || 0)
+        : (buildings?.hyperionLantern?.active || 0);
+      const assigned = zones.reduce((s, z) => s + (mirrorOversightSettings.assignments[type][z] || 0), 0);
+      availableEl.textContent = formatBuildingCount(Math.max(0, total - assigned));
+    }
   });
   const stepEl = document.getElementById('assignment-step-display');
   if (stepEl) stepEl.textContent = `x${formatNumber(mirrorOversightSettings.assignmentStep, true)}`;
@@ -337,6 +346,10 @@ function initializeMirrorOversightUI(container) {
         <span id="assignment-step-display">x1</span>
         <button id="assignment-mul10">x10</button>
       </div>
+    </div>
+    <div class="available-counts">
+      <div>Mirrors available: <span id="available-mirrors">0</span></div>
+      <div>Lanterns available: <span id="available-lanterns">0</span></div>
     </div>
     <div id="assignment-grid">
       <div class="grid-header">Zone</div>
@@ -856,6 +869,7 @@ if (typeof globalThis !== 'undefined') {
   globalThis.applyFocusedMelt = applyFocusedMelt;
   globalThis.calculateZoneSolarFluxWithFacility = calculateZoneSolarFluxWithFacility;
   globalThis.toggleFinerControls = toggleFinerControls;
+  globalThis.updateAssignmentDisplays = updateAssignmentDisplays;
 }
 
 if (typeof module !== 'undefined' && module.exports) {
@@ -872,5 +886,6 @@ if (typeof module !== 'undefined' && module.exports) {
     distributeAssignmentsFromSliders,
     distributeAutoAssignments,
     toggleFinerControls,
+    updateAssignmentDisplays,
   };
 }

--- a/tests/spaceMirrorAvailableCount.test.js
+++ b/tests/spaceMirrorAvailableCount.test.js
@@ -1,0 +1,32 @@
+const numbers = require('../src/js/numbers.js');
+const { JSDOM } = require('jsdom');
+global.Project = class {};
+global.projectElements = {};
+const {
+  initializeMirrorOversightUI,
+  mirrorOversightSettings,
+  resetMirrorOversightSettings,
+  updateAssignmentDisplays
+} = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+
+global.formatNumber = numbers.formatNumber;
+global.formatBuildingCount = numbers.formatBuildingCount;
+
+describe('space mirror available counts', () => {
+  test('shows unassigned mirrors and lanterns', () => {
+    resetMirrorOversightSettings();
+    const dom = new JSDOM('<div id="container"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const container = document.getElementById('container');
+    global.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 5 } };
+    initializeMirrorOversightUI(container);
+    mirrorOversightSettings.assignments.mirrors = { tropical: 3, temperate: 0, polar: 0, focus: 0, any: 0 };
+    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 2, focus: 0, any: 0 };
+    updateAssignmentDisplays();
+    expect(document.getElementById('available-mirrors').textContent).toBe('7');
+    expect(document.getElementById('available-lanterns').textContent).toBe('3');
+    delete global.window;
+    delete global.document;
+  });
+});


### PR DESCRIPTION
## Summary
- Show remaining unassigned mirrors and lanterns at the top of space mirror finer controls
- Track available assignments dynamically when counts or allocations change
- Test available mirror and lantern counts in finer controls

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab8170e3008327919f613c215dd0fd