### PR TITLE
feat: add water withdraw target for space storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,3 +345,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Max export capacity tooltip is generated once and no longer updates each tick, making it readable.
 - Max export capacity tooltip now displays an info icon so the explanation is visible.
 - Space mirror finer controls show counts of unassigned mirrors and lanterns available for manual assignment.
+- Space storage water withdrawals can target colony water or surface via a withdraw-mode dropdown.

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -15,6 +15,7 @@ class SpaceStorageProject extends SpaceshipProject {
     this.shipWithdrawMode = false;
     this.pendingTransfers = [];
     this.prioritizeMegaProjects = false;
+    this.waterWithdrawTarget = 'colony';
   }
 
   getDurationWithTerraformBonus(baseDuration) {
@@ -93,7 +94,9 @@ class SpaceStorageProject extends SpaceshipProject {
       const all = this.selectedResources.map(({ category, resource }) => {
         const stored = this.resourceUsage[resource] || 0;
         const target = resource === 'liquidWater'
-          ? { category: 'colony', resource: 'water' }
+          ? (this.waterWithdrawTarget === 'surface'
+            ? { category: 'surface', resource: 'liquidWater' }
+            : { category: 'colony', resource: 'water' })
           : { category, resource };
         const targetRes = resources[target.category][target.resource];
         const destFree = targetRes.cap - targetRes.value;
@@ -389,6 +392,7 @@ class SpaceStorageProject extends SpaceshipProject {
       resourceUsage: this.resourceUsage,
       pendingTransfers: this.pendingTransfers,
       prioritizeMegaProjects: this.prioritizeMegaProjects,
+      waterWithdrawTarget: this.waterWithdrawTarget,
       shipOperation: {
         remainingTime: this.shipOperationRemainingTime,
         startingDuration: this.shipOperationStartingDuration,
@@ -407,6 +411,7 @@ class SpaceStorageProject extends SpaceshipProject {
     this.resourceUsage = state.resourceUsage || {};
     this.pendingTransfers = state.pendingTransfers || [];
     this.prioritizeMegaProjects = state.prioritizeMegaProjects || false;
+    this.waterWithdrawTarget = state.waterWithdrawTarget || 'colony';
     const ship = state.shipOperation || {};
     this.shipOperationRemainingTime = ship.remainingTime || 0;
     this.shipOperationStartingDuration = ship.startingDuration || 0;


### PR DESCRIPTION
## Summary
- allow choosing colony or surface when withdrawing water from space storage
- add water destination dropdown in withdraw mode
- cover new behavior with unit tests

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ac8f27c6a48327a6531561de629a87