### PR TITLE
Align space storage water dropdown with label

### DIFF
--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -130,14 +130,15 @@ function renderSpaceStorageUI(project, container) {
 
     const label = document.createElement('label');
     label.htmlFor = checkbox.id;
-    label.textContent = opt.label;
+
+    const textSpan = document.createElement('span');
+    textSpan.textContent = opt.label;
 
     const fullIcon = document.createElement('span');
     fullIcon.classList.add('storage-full-icon');
     fullIcon.innerHTML = '&#9888;&#xFE0E;';
     fullIcon.title = 'Colony storage full';
     fullIcon.style.display = 'none';
-    label.appendChild(fullIcon);
 
     const usage = document.createElement('span');
     usage.id = `${project.name}-usage-${opt.resource}`;
@@ -160,10 +161,11 @@ function renderSpaceStorageUI(project, container) {
           updateSpaceStorageUI(project);
         }
       });
-      resourceItem.append(checkbox, label, waterSelect, usage);
-    } else {
-      resourceItem.append(checkbox, label, usage);
+      textSpan.append(' ', waterSelect);
     }
+
+    label.append(textSpan, fullIcon);
+    resourceItem.append(checkbox, label, usage);
     resourceGrid.appendChild(resourceItem);
 
     if (opt.requiresFlag) {

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -192,6 +192,11 @@ describe('Space Storage UI', () => {
     const select = dom.window.document.getElementById('spaceStorage-water-destination');
     expect(select.style.display).toBe('none');
 
+    const span = select.parentElement;
+    expect(span.tagName).toBe('SPAN');
+    expect(span.textContent.startsWith('Water')).toBe(true);
+    expect(span.parentElement.tagName).toBe('LABEL');
+
     project.shipWithdrawMode = true;
     ctx.updateSpaceStorageUI(project);
     expect(select.style.display).toBe('');


### PR DESCRIPTION
## Summary
- Embed the colony/surface water destination selector inside the water label span for space storage
- Add unit test to ensure the selector resides in the same span as the water text

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ac9327a1288327b6f3d582b27e1f51