### PR TITLE
Fix redundant prod/cons DOM building in structures UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,3 +348,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage water withdrawals can target colony water or surface via a withdraw-mode dropdown.
 - Manual building toggle buttons now uncheck the Set active to target option when clicked.
 - Colony and nanocolony sliders now share styling, differing only in width.
+- Production and consumption displays update existing DOM nodes without rebuilding, preventing orphaned elements.

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -944,7 +944,12 @@ function updateDecreaseButtonText(button, buildCount) {
 
     const sections = getProdConsSections(structure, buildCount);
     const keyString = sections
-      .map(sec => `${sec.key}:${(sec.keys || []).join('|')}`)
+      .map(sec => {
+        const keys = sec.key === 'provides'
+          ? sec.data.map((_, i) => String(i)).join('|')
+          : (sec.keys || []).join('|');
+        return `${sec.key}:${keys}`;
+      })
       .join(';');
 
     if (productionConsumptionElement.dataset.sectionKeys !== keyString) {

--- a/tests/prodConsElementReuse.test.js
+++ b/tests/prodConsElementReuse.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+const structuresUI = (() => {
+  const dom = new JSDOM('<!DOCTYPE html><div></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.resources = { colony: { water: { displayName: 'Water' }, metal: { displayName: 'Metal' } } };
+  ctx.formatNumber = n => n;
+  ctx.terraforming = { celestialParameters: {} };
+  ctx.Colony = class {};
+  ctx.buildings = {};
+  ctx.colonies = {};
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+  return ctx;
+})();
+
+describe('buildProdConsElement reuse', () => {
+  test('buildProdConsElement called only once and nodes remain attached', () => {
+    const structure = {
+      name: 'testStruct',
+      getModifiedStorage: () => ({}),
+      powerPerBuilding: null,
+      requiresMaintenance: true,
+      maintenanceCost: { metal: 1 },
+      getModifiedProduction: () => ({ colony: { water: 2 } }),
+      getModifiedConsumption: () => ({ colony: { metal: 3 } }),
+    };
+    const element = structuresUI.document.createElement('div');
+
+    let callCount = 0;
+    const originalBuild = structuresUI.buildProdConsElement;
+    structuresUI.buildProdConsElement = function(...args) {
+      callCount++;
+      return originalBuild.apply(this, args);
+    };
+
+    structuresUI.updateProductionConsumptionDetails(structure, element, 1);
+    const firstSpan = element.querySelector('span');
+
+    structuresUI.updateProductionConsumptionDetails(structure, element, 1);
+
+    expect(callCount).toBe(1);
+    expect(element.contains(firstSpan)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid rebuilding production/consumption UI nodes by tracking section keys
- Document prod/cons element reuse to prevent orphaned nodes
- Test that buildProdConsElement only runs once and updates in place

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aca0b48ef08327bdebdeb8892f7fa4