### PR TITLE
Persist cargo rocket auto-start selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,3 +350,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Colony and nanocolony sliders now share styling, differing only in width.
 - Production and consumption displays update existing DOM nodes without rebuilding, preventing orphaned elements.
 - Nanobot growth rate now shows three decimal places, and the nanobot count and cap turn green when maxed.
+- Cargo Rocket auto-start now saves selected cargo and clears selections when auto-start is off on load.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -3,6 +3,7 @@ class CargoRocketProject extends Project {
     super(config, name);
     this.spaceshipPriceIncrease = 0;
     this.convertedToContinuous = false;
+    this.selectedResources = [];
   }
 
   isContinuous() {
@@ -51,7 +52,10 @@ class CargoRocketProject extends Project {
         const quantityInput = document.createElement('input');
         quantityInput.type = 'number';
         quantityInput.min = 0;
-        quantityInput.value = 0;
+        const selected = this.selectedResources.find(
+          (sr) => sr.category === category && sr.resource === resourceId
+        );
+        quantityInput.value = selected ? selected.quantity : 0;
         quantityInput.classList.add('resource-selection-input', `resource-selection-${this.name}`);
         quantityInput.dataset.category = category;
         quantityInput.dataset.resource = resourceId;
@@ -414,6 +418,21 @@ class CargoRocketProject extends Project {
       }
     }
     return totals;
+  }
+
+  saveState() {
+    const state = super.saveState();
+    if (this.autoStart) {
+      state.selectedResources = this.selectedResources;
+    }
+    return state;
+  }
+
+  loadState(state) {
+    super.loadState(state);
+    this.selectedResources = this.autoStart && state.selectedResources
+      ? state.selectedResources
+      : [];
   }
 
   applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {

--- a/tests/cargoRocketSelectionPersistence.test.js
+++ b/tests/cargoRocketSelectionPersistence.test.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+function setup() {
+  const dom = new JSDOM(`<!DOCTYPE html>
+    <div class="projects-subtab-content-wrapper">
+      <div id="resources-projects-list" class="projects-list"></div>
+    </div>`, { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.document = dom.window.document;
+  ctx.console = console;
+  ctx.formatNumber = numbers.formatNumber;
+  ctx.formatBigInteger = numbers.formatBigInteger;
+  ctx.projectElements = {};
+  ctx.resources = {
+    colony: {
+      funding: { value: 0, displayName: 'Funding', unlocked: true },
+      metal: { value: 0, displayName: 'Metal', unlocked: true },
+      glass: { value: 0, displayName: 'Glass', unlocked: true },
+      water: { value: 0, displayName: 'Water', unlocked: true },
+      food: { value: 0, displayName: 'Food', unlocked: true },
+      components: { value: 0, displayName: 'Components', unlocked: true },
+      electronics: { value: 0, displayName: 'Electronics', unlocked: true },
+      androids: { value: 0, displayName: 'Androids', unlocked: true }
+    },
+    special: { spaceships: { value: 0, displayName: 'Spaceships', unlocked: true } }
+  };
+  ctx.buildings = {};
+  ctx.terraforming = {};
+
+  const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+  vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+  const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager;', ctx);
+  const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'CargoRocketProject.js'), 'utf8');
+  vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+  const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+  vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+  const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+  vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+  ctx.projectManager = new ctx.ProjectManager();
+  ctx.projectManager.initializeProjects({ cargo_rocket: ctx.projectParameters.cargo_rocket });
+  ctx.projectManager.isBooleanFlagSet = () => false;
+
+  ctx.initializeProjectsUI();
+  ctx.projectElements = vm.runInContext('projectElements', ctx);
+  return { dom, ctx };
+}
+
+describe('CargoRocketProject selection persistence', () => {
+  test('restores selection when autoStart enabled', () => {
+    const { ctx: ctx1 } = setup();
+    const project1 = ctx1.projectManager.projects.cargo_rocket;
+    project1.autoStart = true;
+    project1.selectedResources = [{ category: 'colony', resource: 'metal', quantity: 5 }];
+    const saved = project1.saveState();
+
+    const { ctx: ctx2 } = setup();
+    const project2 = ctx2.projectManager.projects.cargo_rocket;
+    project2.loadState(saved);
+    ctx2.createProjectItem(project2);
+    ctx2.projectElements = vm.runInContext('projectElements', ctx2);
+    const input = ctx2.projectElements.cargo_rocket.resourceSelectionContainer
+      .querySelector('.resource-selection-cargo_rocket[data-resource="metal"]');
+    expect(project2.selectedResources).toEqual([{ category: 'colony', resource: 'metal', quantity: 5 }]);
+    expect(input.value).toBe('5');
+  });
+
+  test('clears selection when autoStart disabled', () => {
+    const { ctx: ctx1 } = setup();
+    const project1 = ctx1.projectManager.projects.cargo_rocket;
+    project1.autoStart = false;
+    project1.selectedResources = [{ category: 'colony', resource: 'metal', quantity: 5 }];
+    const state = project1.saveState();
+    state.selectedResources = [{ category: 'colony', resource: 'metal', quantity: 5 }];
+
+    const { ctx: ctx2 } = setup();
+    const project2 = ctx2.projectManager.projects.cargo_rocket;
+    project2.loadState(state);
+    ctx2.createProjectItem(project2);
+    ctx2.projectElements = vm.runInContext('projectElements', ctx2);
+    const input = ctx2.projectElements.cargo_rocket.resourceSelectionContainer
+      .querySelector('.resource-selection-cargo_rocket[data-resource="metal"]');
+    expect(project2.selectedResources).toEqual([]);
+    expect(input.value).toBe('0');
+  });
+});


### PR DESCRIPTION
## Summary
- Remember cargo selections for Cargo Rocket when auto-start is enabled
- Clear cargo selections on load if auto-start is disabled
- Document feature and add tests for save/load behavior

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log` *(fails: initial average temperature for mars exceeds tolerance)*

------
https://chatgpt.com/codex/tasks/task_b_68adb56bcc0883278679744ef8c9e036