### PR TITLE
Cache day-night progress container

### DIFF
--- a/src/js/day-night-cycle.js
+++ b/src/js/day-night-cycle.js
@@ -50,10 +50,17 @@ function rotationPeriodToDuration(rotationHours) {
   return (rotationHours / 24) * 30000;
 }
 
+let dayNightContainer = null;
 
+function resetDayNightContainerCache() {
+  dayNightContainer = null;
+}
 
 function updateDayNightDisplay() {
-  const container = document.querySelector('.day-night-progress-bar-container');
+  if (!dayNightContainer) {
+    dayNightContainer = document.querySelector('.day-night-progress-bar-container');
+  }
+  const container = dayNightContainer;
   if (typeof gameSettings !== 'undefined' && gameSettings.disableDayNightCycle) {
     if (container) container.style.display = 'none';
     return;
@@ -83,5 +90,5 @@ function updateDayNightDisplay() {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { DayNightCycle, rotationPeriodToDuration, updateDayNightDisplay };
+  module.exports = { DayNightCycle, rotationPeriodToDuration, updateDayNightDisplay, resetDayNightContainerCache };
 }

--- a/tests/dayNightDisplayCache.test.js
+++ b/tests/dayNightDisplayCache.test.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const { updateDayNightDisplay, resetDayNightContainerCache } = require('../src/js/day-night-cycle.js');
+
+describe('day-night display container caching', () => {
+  test('uses cached container until reset', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div class="day-night-progress-bar-container"><span id="progress-text"></span><div id="day-night-progress-bar"></div></div>', { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    global.dayNightCycle = { isDay: () => true, getDayProgress: () => 0 };
+    global.gameSettings = {};
+
+    updateDayNightDisplay();
+    const first = dom.window.document.querySelector('.day-night-progress-bar-container');
+    first.remove();
+    dom.window.document.body.innerHTML += '<div class="day-night-progress-bar-container" style="display:none"><span id="progress-text"></span><div id="day-night-progress-bar"></div></div>';
+    const second = dom.window.document.querySelector('.day-night-progress-bar-container');
+
+    updateDayNightDisplay();
+    expect(second.style.display).toBe('none');
+
+    resetDayNightContainerCache();
+    updateDayNightDisplay();
+    expect(second.style.display).toBe('block');
+
+    delete global.document;
+    delete global.dayNightCycle;
+    delete global.gameSettings;
+  });
+});
+

--- a/tests/physics.test.js
+++ b/tests/physics.test.js
@@ -23,7 +23,7 @@ describe('physics helpers', () => {
   });
 
   test('calculateActualAlbedoPhysics includes clouds and haze', () => {
-    const res = calculateActualAlbedoPhysics(0.3, 1, { h2o: 0.02 }, 9.81);
+    const res = calculateActualAlbedoPhysics(0.3, 1, { h2o: 0.02, ch4: 0.01 }, 9.81);
     expect(res.albedo).toBeGreaterThan(0.3);
     expect(res.cfCloud).toBeGreaterThan(0);
     expect(res.cfHaze).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- cache the day-night progress bar container element
- allow resetting the cached reference when DOM changes
- add tests covering container caching and fix physics haze test composition

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af5c3385b88327a79f2c7e1507aa03