### PR TITLE
Cache research UI elements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,3 +351,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Production and consumption displays update existing DOM nodes without rebuilding, preventing orphaned elements.
 - Nanobot growth rate now shows three decimal places, and the nanobot count and cap turn green when maxed.
 - Cargo Rocket auto-start now saves selected cargo and clears selections when auto-start is off on load.
+- Research UI caches DOM nodes for faster updates and rebuilds caches when research order changes.

--- a/src/js/research.js
+++ b/src/js/research.js
@@ -165,6 +165,9 @@ class Research {
         );
       }
       this.orderDirty = true;
+      if (typeof invalidateResearchUICache === 'function') {
+        invalidateResearchUICache();
+      }
     }
   
     // Check if a research is available (i.e., prerequisites are met)

--- a/tests/researchToggleCompleted.test.js
+++ b/tests/researchToggleCompleted.test.js
@@ -6,26 +6,32 @@ const { JSDOM } = require(jsdomPath);
 
 describe('toggleCompletedResearch', () => {
   test('hides and shows completed research items', () => {
-    const dom = new JSDOM(`<!DOCTYPE html><div class="research-item"><button id="research-completed"></button></div><div class="research-item"><button id="research-unfinished"></button></div><button class="toggle-completed-button">Hide Completed</button>`, { runScripts: 'outside-only' });
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div id="energy-research-buttons"></div>
+      <button class="toggle-completed-button">Hide Completed</button>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     // stub global dependencies
     ctx.canAffordResearch = () => true;
     ctx.formatNumber = () => '';
-    ctx.researchManager = { researches: {
-      energy: [
-        { id: 'completed', name: 'Done', description: '', cost: { research: 0 }, isResearched: true },
-        { id: 'unfinished', name: 'Not Done', description: '', cost: { research: 0 }, isResearched: false }
-      ],
-      industry: [],
-      colonization: [],
-      terraforming: [],
-      advanced: []
-    } };
+    ctx.currentPlanetParameters = { resources: { surface: {}, atmospheric: {}, underground: {} } };
+    ctx.researchManager = {
+      researches: {
+        energy: [
+          { id: 'completed', name: 'Done', description: '', cost: { research: 0 }, isResearched: true },
+          { id: 'unfinished', name: 'Not Done', description: '', cost: { research: 0 }, isResearched: false }
+        ],
+        industry: [],
+        colonization: [],
+        terraforming: [],
+        advanced: []
+      },
+      getResearchesByCategory(category) { return this.researches[category] || []; }
+    };
 
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'researchUI.js'), 'utf8');
-    vm.runInContext(code + '; this.updateAllResearchButtons = updateAllResearchButtons; this.toggleCompletedResearch = toggleCompletedResearch;', ctx);
+    vm.runInContext(code + '; this.rebuildResearchCaches = rebuildResearchCaches; this.updateAllResearchButtons = updateAllResearchButtons; this.toggleCompletedResearch = toggleCompletedResearch;', ctx);
 
-    // initial render
+    ctx.rebuildResearchCaches();
     ctx.updateAllResearchButtons(ctx.researchManager.researches);
 
     const completedItem = dom.window.document.querySelector('#research-completed').closest('.research-item');


### PR DESCRIPTION
## Summary
- cache research button, cost, description, and toggle nodes for each research
- update research button and visibility functions to use cached elements
- rebuild caches automatically when research order changes

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af5e2e35088327a3f11c9cfcb9ab4c