### PR TITLE
Cache space storage auto-start labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,3 +352,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Nanobot growth rate now shows three decimal places, and the nanobot count and cap turn green when maxed.
 - Cargo Rocket auto-start now saves selected cargo and clears selections when auto-start is off on load.
 - Research UI caches DOM nodes for faster updates and rebuilds caches when research order changes.
+- Space Storage project caches ship and expansion auto-start labels and rebuilds them when the automation UI is recreated.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -14,9 +14,8 @@ const storageResourceOptions = [
 if (typeof SpaceStorageProject !== 'undefined') {
   SpaceStorageProject.prototype.createShipAutoStartCheckbox = function () {
     const els = projectElements[this.name] || {};
-    if (els.autoStartCheckboxContainer) {
-      const autoLabel = els.autoStartCheckboxContainer.querySelector('label');
-      if (autoLabel) autoLabel.textContent = 'Auto Start Expansion';
+    if (els.autoStartLabel) {
+      els.autoStartLabel.textContent = 'Auto Start Expansion';
     }
     const container = document.createElement('div');
     container.classList.add('checkbox-container');
@@ -33,6 +32,7 @@ if (typeof SpaceStorageProject !== 'undefined') {
     projectElements[this.name] = {
       ...projectElements[this.name],
       shipAutoStartCheckbox: checkbox,
+      shipAutoStartLabel: label,
       shipAutoStartContainer: container,
     };
     return container;
@@ -61,6 +61,16 @@ if (typeof SpaceStorageProject !== 'undefined') {
 
   SpaceStorageProject.prototype.renderAutomationUI = function (container) {
     const els = projectElements[this.name] || {};
+    if (
+      els.shipAutoStartContainer &&
+      els.shipAutoStartContainer.parentElement !== container
+    ) {
+      delete els.shipAutoStartCheckbox;
+      delete els.shipAutoStartLabel;
+      delete els.shipAutoStartContainer;
+      delete els.prioritizeMegaCheckbox;
+      delete els.prioritizeMegaContainer;
+    }
     if (!els.shipAutoStartContainer) {
       const ship = this.createShipAutoStartCheckbox();
       const prioritize = this.createPrioritizeMegaCheckbox();
@@ -276,9 +286,8 @@ function renderSpaceStorageUI(project, container) {
 function updateSpaceStorageUI(project) {
   const els = projectElements[project.name];
   if (!els) return;
-  if (els.autoStartCheckboxContainer) {
-    const autoLabel = els.autoStartCheckboxContainer.querySelector('label');
-    if (autoLabel) autoLabel.textContent = 'Auto Start Expansion';
+  if (els.autoStartLabel) {
+    els.autoStartLabel.textContent = 'Auto Start Expansion';
   }
   if (els.shipAutoStartContainer && els.prioritizeMegaContainer) {
     const display = projectManager && typeof projectManager.isBooleanFlagSet === 'function' &&
@@ -286,13 +295,10 @@ function updateSpaceStorageUI(project) {
     els.shipAutoStartContainer.style.display = display;
     els.prioritizeMegaContainer.style.display = display;
   }
-  if (els.shipAutoStartContainer) {
-    const label = els.shipAutoStartContainer.querySelector('label');
-    if (label) {
-      label.textContent = project.isShipOperationContinuous()
-        ? 'Run'
-        : 'Auto Start Ships';
-    }
+  if (els.shipAutoStartLabel) {
+    els.shipAutoStartLabel.textContent = project.isShipOperationContinuous()
+      ? 'Run'
+      : 'Auto Start Ships';
   }
   if (els.usedDisplay) {
     els.usedDisplay.textContent = formatNumber(project.usedStorage, false, 2);

--- a/tests/spaceStorageAutomationRebuild.test.js
+++ b/tests/spaceStorageAutomationRebuild.test.js
@@ -4,8 +4,8 @@ const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules',
 const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 
-describe('Space Storage ship auto-start label', () => {
-  test('renames to Run in continuous mode and reverts otherwise', () => {
+describe('Space Storage automation UI recreation', () => {
+  test('recreates ship auto-start controls when automation section is rebuilt', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
       <div class="projects-subtab-content-wrapper"></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
@@ -16,6 +16,7 @@ describe('Space Storage ship auto-start label', () => {
     ctx.SpaceMiningProject = function () {};
     ctx.SpaceExportBaseProject = function () {};
     ctx.SpaceStorageProject = function () {};
+
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
     const storageUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
     vm.runInContext(
@@ -41,7 +42,7 @@ describe('Space Storage ship auto-start label', () => {
       maxRepeatCount: Infinity,
       unlocked: true,
       attributes: {},
-      assignedSpaceships: 50,
+      assignedSpaceships: 0,
       isShipOperationContinuous() { return this.assignedSpaceships > 100; }
     });
 
@@ -53,17 +54,38 @@ describe('Space Storage ship auto-start label', () => {
 
     ctx.createProjectItem(project);
     ctx.updateProjectUI('spaceStorage');
-    let label = ctx.projectElements[project.name].shipAutoStartLabel;
-    expect(label.textContent).toBe('Auto Start Ships');
 
-    project.assignedSpaceships = 150;
-    ctx.updateProjectUI('spaceStorage');
-    label = ctx.projectElements[project.name].shipAutoStartLabel;
-    expect(label.textContent).toBe('Run');
+    const els = ctx.projectElements[project.name];
+    const oldShipContainer = els.shipAutoStartContainer;
+    const oldShipLabel = els.shipAutoStartLabel;
 
-    project.assignedSpaceships = 50;
-    ctx.updateProjectUI('spaceStorage');
-    label = ctx.projectElements[project.name].shipAutoStartLabel;
-    expect(label.textContent).toBe('Auto Start Ships');
+    const newContainer = dom.window.document.createElement('div');
+    newContainer.classList.add('automation-settings-container');
+    els.cardFooter.replaceChild(newContainer, els.automationSettingsContainer);
+    els.automationSettingsContainer = newContainer;
+
+    const autoStartContainer = dom.window.document.createElement('div');
+    autoStartContainer.classList.add('checkbox-container');
+    const autoStartCheckbox = dom.window.document.createElement('input');
+    autoStartCheckbox.type = 'checkbox';
+    autoStartCheckbox.id = `${project.name}-auto-start`;
+    const autoStartLabel = dom.window.document.createElement('label');
+    autoStartLabel.htmlFor = autoStartCheckbox.id;
+    autoStartLabel.textContent = 'Auto start';
+    autoStartContainer.append(autoStartCheckbox, autoStartLabel);
+    newContainer.appendChild(autoStartContainer);
+    els.autoStartCheckbox = autoStartCheckbox;
+    els.autoStartCheckboxContainer = autoStartContainer;
+    els.autoStartLabel = autoStartLabel;
+
+    project.renderAutomationUI(newContainer);
+
+    const newShipContainer = ctx.projectElements[project.name].shipAutoStartContainer;
+    const newShipLabel = ctx.projectElements[project.name].shipAutoStartLabel;
+    expect(newShipContainer.parentElement).toBe(newContainer);
+    expect(newShipContainer).not.toBe(oldShipContainer);
+    expect(newShipLabel).not.toBe(oldShipLabel);
+    expect(newShipLabel.textContent).toBe('Auto Start Ships');
   });
 });
+

--- a/tests/spaceshipProjectAutoStartLabel.test.js
+++ b/tests/spaceshipProjectAutoStartLabel.test.js
@@ -62,12 +62,12 @@ describe('SpaceshipProject auto-start label', () => {
 
     project.continuous = true;
     ctx.updateProjectUI('test');
-    let label = ctx.projectElements.test.autoStartCheckboxContainer.querySelector('label');
+    let label = ctx.projectElements.test.autoStartLabel;
     expect(label.textContent).toBe('Run');
 
     project.continuous = false;
     ctx.updateProjectUI('test');
-    label = ctx.projectElements.test.autoStartCheckboxContainer.querySelector('label');
+    label = ctx.projectElements.test.autoStartLabel;
     expect(label.textContent).toBe('Auto start');
   });
 });


### PR DESCRIPTION
## Summary
- Cache expansion and ship auto-start labels when rendering Space Storage automation controls
- Reference cached labels in `updateSpaceStorageUI` to avoid repeated DOM queries
- Recreate cached automation elements when the automation section is rebuilt

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af684ec0a48327892b7277a6a6020c