### PR TITLE
Cache automation settings children

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,3 +353,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo Rocket auto-start now saves selected cargo and clears selections when auto-start is off on load.
 - Research UI caches DOM nodes for faster updates and rebuilds caches when research order changes.
 - Space Storage project caches ship and expansion auto-start labels and rebuilds them when the automation UI is recreated.
+- Project automation settings cache their child elements for faster visibility checks and refresh the cache when options change.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -76,6 +76,7 @@ if (typeof SpaceStorageProject !== 'undefined') {
       const prioritize = this.createPrioritizeMegaCheckbox();
       container.append(ship, prioritize);
     }
+    invalidateAutomationSettingsCache(this.name);
   };
 }
 

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -1,5 +1,12 @@
 let projectElements = {};
 
+function invalidateAutomationSettingsCache(projectName) {
+  const els = projectElements[projectName];
+  if (els && els.automationSettingsContainer) {
+    els.cachedAutomationItems = Array.from(els.automationSettingsContainer.children);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // Subtab functionality to show/hide project categories
   document.querySelectorAll('.projects-subtabs .projects-subtab').forEach(tab => {
@@ -259,6 +266,7 @@ function createProjectItem(project) {
   };
   if (typeof project.renderAutomationUI === 'function') {
     project.renderAutomationUI(automationSettingsContainer);
+    invalidateAutomationSettingsCache(project.name);
   }
 
   const categoryContainer = getOrCreateCategoryContainer(project.category || 'general');
@@ -633,7 +641,8 @@ function updateProjectUI(projectName) {
     let hasVisibleAutomationItems = false;
 
     if (automationSettingsContainer) {
-      for (const child of automationSettingsContainer.children) {
+      const items = elements.cachedAutomationItems || [];
+      for (const child of items) {
         if (child && (child.nodeType === 1 || child instanceof Element) &&
             typeof getComputedStyle === 'function' &&
             getComputedStyle(child).display !== 'none') {

--- a/tests/automationSettingsCache.test.js
+++ b/tests/automationSettingsCache.test.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('automation settings cache', () => {
+  test('cache updates when automation items change', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="projects-subtab-content-wrapper"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.projectElements = {};
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = () => '';
+    ctx.SpaceMiningProject = function () {};
+    ctx.SpaceExportBaseProject = function () {};
+    ctx.SpaceStorageProject = function () {};
+
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    const storageUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'spaceStorageUI.js'), 'utf8');
+    vm.runInContext(
+      uiCode + '\n' + storageUICode +
+      '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.invalidateAutomationSettingsCache = invalidateAutomationSettingsCache; this.projectElements = projectElements;',
+      ctx
+    );
+
+    const project = Object.assign(new ctx.SpaceStorageProject(), {
+      name: 'spaceStorage',
+      displayName: 'Space Storage',
+      description: '',
+      category: 'mega',
+      autoStart: false,
+      shipOperationAutoStart: false,
+      prioritizeMegaProjects: false,
+      renderUI: () => {},
+      updateUI: () => {},
+      getEffectiveDuration: () => 1000,
+      getShipOperationDuration: () => 1000,
+      canStart: () => true,
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {},
+      assignedSpaceships: 0,
+      isShipOperationContinuous() { return false; }
+    });
+
+    ctx.projectManager = {
+      projects: { spaceStorage: project },
+      isBooleanFlagSet: () => true,
+      getProjectStatuses: () => [project]
+    };
+
+    ctx.createProjectItem(project);
+    ctx.updateProjectUI('spaceStorage');
+    const els = ctx.projectElements[project.name];
+
+    expect(els.cachedAutomationItems.length).toBe(3);
+
+    while (els.automationSettingsContainer.firstChild) {
+      els.automationSettingsContainer.firstChild.remove();
+    }
+    ctx.updateProjectUI('spaceStorage');
+    expect(els.cachedAutomationItems.length).toBe(3);
+    expect(els.automationSettingsContainer.style.display).toBe('flex');
+
+    ctx.invalidateAutomationSettingsCache(project.name);
+    ctx.updateProjectUI('spaceStorage');
+    expect(els.cachedAutomationItems.length).toBe(0);
+    expect(els.automationSettingsContainer.style.display).toBe('none');
+
+    const extra = dom.window.document.createElement('div');
+    extra.classList.add('checkbox-container');
+    els.automationSettingsContainer.appendChild(extra);
+    ctx.invalidateAutomationSettingsCache(project.name);
+    ctx.updateProjectUI('spaceStorage');
+    expect(els.cachedAutomationItems.length).toBe(1);
+    expect(els.automationSettingsContainer.style.display).toBe('flex');
+  });
+});


### PR DESCRIPTION
## Summary
- Cache automation settings container children and refresh cache after automation UI changes
- Iterate over cached automation items in project display updates
- Add test ensuring automation settings cache updates on DOM changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68af7736eebc83278e5d785abe7f2d0e