### PR TITLE
Cache life UI DOM nodes and add invalidation hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,3 +354,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Research UI caches DOM nodes for faster updates and rebuilds caches when research order changes.
 - Space Storage project caches ship and expansion auto-start labels and rebuilds them when the automation UI is recreated.
 - Project automation settings cache their child elements for faster visibility checks and refresh the cache when options change.
+- Life UI caches modify buttons, temperature units, and status table cells, refreshing caches when designs change or the table rebuilds.


### PR DESCRIPTION
## Summary
- Cache life designer modify buttons, temperature units, and per-zone status table cells during initialization.
- Rewrite `updateLifeUI` and `updateLifeStatusTable` to use cached elements for faster DOM updates.
- Invalidate caches via custom events when tentative designs change or the status table is rebuilt.

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68af8d7fe4788327ac901ae9f4e33b02