### PR TITLE
Cache random world tab elements for faster access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,3 +355,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space Storage project caches ship and expansion auto-start labels and rebuilds them when the automation UI is recreated.
 - Project automation settings cache their child elements for faster visibility checks and refresh the cache when options change.
 - Life UI caches modify buttons, temperature units, and status table cells, refreshing caches when designs change or the table rebuilds.
+- Space UI caches Random World tab elements and rebuilds the cache when the tabs regenerate.

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -8,28 +8,59 @@ const planetUIElements = {};
 let spaceUIInitialized = false;
 // Track visibility of the Random subtab
 let spaceRandomTabVisible = false;
+// Cached nodes for the Random world subtab button and content container
+let spaceRandomTabButton = null;
+let spaceRandomContentContainer = null;
 // Cache the last rendered world so we can skip redundant updates
 let lastWorldKey = null;
 let lastWorldSeed = null;
 
+function cacheSpaceRandomElements() {
+    spaceRandomTabButton = document.querySelector('.space-subtab[data-subtab="space-random"]');
+    spaceRandomContentContainer = document.getElementById('space-random');
+}
+
+function ensureSpaceRandomElements() {
+    if (!spaceRandomTabButton || !spaceRandomContentContainer) {
+        cacheSpaceRandomElements();
+        return;
+    }
+    const body = document.body;
+    if (!body) {
+        cacheSpaceRandomElements();
+        return;
+    }
+    try {
+        if (!body.contains(spaceRandomTabButton) || !body.contains(spaceRandomContentContainer)) {
+            cacheSpaceRandomElements();
+        }
+    } catch {
+        cacheSpaceRandomElements();
+    }
+}
+
+function invalidateSpaceRandomCache() {
+    spaceRandomTabButton = null;
+    spaceRandomContentContainer = null;
+}
+
 function showSpaceRandomTab() {
     spaceRandomTabVisible = true;
-    const tab = document.querySelector('.space-subtab[data-subtab="space-random"]');
-    const content = document.getElementById('space-random');
-    if (tab) tab.classList.remove('hidden');
-    if (content) content.classList.remove('hidden');
+    ensureSpaceRandomElements();
+    if (spaceRandomTabButton) spaceRandomTabButton.classList.remove('hidden');
+    if (spaceRandomContentContainer) spaceRandomContentContainer.classList.remove('hidden');
 }
 
 function hideSpaceRandomTab() {
     spaceRandomTabVisible = false;
-    const tab = document.querySelector('.space-subtab[data-subtab="space-random"]');
-    const content = document.getElementById('space-random');
-    if (tab) tab.classList.add('hidden');
-    if (content) content.classList.add('hidden');
+    ensureSpaceRandomElements();
+    if (spaceRandomTabButton) spaceRandomTabButton.classList.add('hidden');
+    if (spaceRandomContentContainer) spaceRandomContentContainer.classList.add('hidden');
 }
 
 function updateSpaceRandomVisibility() {
     if (!_spaceManagerInstance) return;
+    ensureSpaceRandomElements();
     if (_spaceManagerInstance.randomTabEnabled) {
         if (!spaceRandomTabVisible) {
             showSpaceRandomTab();
@@ -40,6 +71,7 @@ function updateSpaceRandomVisibility() {
 }
 
 function initializeSpaceTabs() {
+    invalidateSpaceRandomCache();
     document.querySelectorAll('.space-subtab').forEach(tab => {
         tab.addEventListener('click', () => {
             document.querySelectorAll('.space-subtab').forEach(t => t.classList.remove('active'));
@@ -49,6 +81,7 @@ function initializeSpaceTabs() {
             document.getElementById(id).classList.add('active');
         });
     });
+    cacheSpaceRandomElements();
 }
 
 function activateSpaceSubtab(subtabId) {


### PR DESCRIPTION
## Summary
- cache random-world subtab button and container on space tab init
- use cached nodes when toggling random-world tab visibility
- reset cache when space tabs rebuild

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af9031e9108327a68f8db344ce0015