### PR TITLE
Cache project resource inputs for cost updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,3 +355,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space Storage project caches ship and expansion auto-start labels and rebuilds them when the automation UI is recreated.
 - Project automation settings cache their child elements for faster visibility checks and refresh the cache when options change.
 - Life UI caches modify buttons, temperature units, and status table cells, refreshing caches when designs change or the table rebuilds.
+- Project resource-selection grids cache their input elements for quicker cost calculations and rebuild those caches when grids are reset.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -254,8 +254,12 @@ class CargoRocketProject extends Project {
     this.remainingTime = 20000;
 
     // Update the visible entered amount in the resource selection UI
+    const elements = projectElements[this.name];
+    const inputs = elements?.selectionInputs || [];
     this.pendingResourceGains.forEach(({ resource, quantity }) => {
-      const inputElement = document.querySelector(`.resource-selection-${this.name}[data-resource="${resource}"]`);
+      const inputElement = inputs.find(
+        (input) => input.dataset.resource === resource
+      );
       if (inputElement) {
         inputElement.value = quantity;
       }

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -404,7 +404,22 @@ function updateTotalCostDisplay(project) {
   let totalCost = 0;
 
   const elements = projectElements[project.name] || {};
-  const quantityInputs = elements.selectionInputs || [];
+  let quantityInputs = elements.selectionInputs || [];
+
+  if (!quantityInputs.length || quantityInputs.some((i) => !i.isConnected)) {
+    if (typeof invalidateCargoSelectionCache === 'function') {
+      invalidateCargoSelectionCache(project);
+      quantityInputs = elements.selectionInputs || [];
+    } else if (elements.resourceSelectionContainer) {
+      quantityInputs = Array.from(
+        elements.resourceSelectionContainer.querySelectorAll(
+          `.resource-selection-${project.name}`
+        )
+      );
+      elements.selectionInputs = quantityInputs;
+    }
+  }
+
   quantityInputs.forEach((input) => {
     const category = input?.dataset?.category;
     const resource = input?.dataset?.resource;

--- a/tests/cargoRocketCostCacheRebuild.test.js
+++ b/tests/cargoRocketCostCacheRebuild.test.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+function setup() {
+  const dom = new JSDOM(`<!DOCTYPE html>
+    <div class="projects-subtab-content-wrapper">
+      <div id="resources-projects-list" class="projects-list"></div>
+    </div>`, { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.document = dom.window.document;
+  ctx.console = console;
+  ctx.formatNumber = numbers.formatNumber;
+  ctx.formatBigInteger = numbers.formatBigInteger;
+  ctx.projectElements = {};
+  ctx.resources = {
+    colony: {
+      funding: { value: 100, displayName: 'Funding', unlocked: true },
+      metal: { value: 0, displayName: 'Metal', unlocked: true },
+      glass: { value: 0, displayName: 'Glass', unlocked: true },
+      water: { value: 0, displayName: 'Water', unlocked: true },
+      food: { value: 0, displayName: 'Food', unlocked: true },
+      components: { value: 0, displayName: 'Components', unlocked: true },
+      electronics: { value: 0, displayName: 'Electronics', unlocked: true },
+      androids: { value: 0, displayName: 'Androids', unlocked: true }
+    },
+    special: { spaceships: { value: 0, displayName: 'Spaceships', unlocked: true } }
+  };
+  ctx.buildings = {};
+  ctx.terraforming = {};
+
+  const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+  vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+  const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager;', ctx);
+  const cargoCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'CargoRocketProject.js'), 'utf8');
+  vm.runInContext(cargoCode + '; this.CargoRocketProject = CargoRocketProject;', ctx);
+  const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+  vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+  const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+  vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+  ctx.projectManager = new ctx.ProjectManager();
+  ctx.projectManager.initializeProjects({ cargo_rocket: ctx.projectParameters.cargo_rocket });
+  ctx.projectManager.isBooleanFlagSet = () => false;
+
+  ctx.initializeProjectsUI();
+  ctx.projectElements = vm.runInContext('projectElements', ctx);
+  ctx.createProjectItem(ctx.projectManager.projects.cargo_rocket);
+  ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+  return { ctx };
+}
+
+describe('Cargo Rocket total cost cache rebuild', () => {
+  test('repopulates selectionInputs when empty before cost update', () => {
+    const { ctx } = setup();
+    const project = ctx.projectManager.projects.cargo_rocket;
+    const elements = ctx.projectElements.cargo_rocket;
+    const metalInput = elements.selectionInputs.find(i => i.dataset.resource === 'metal');
+    metalInput.value = 2;
+
+    elements.selectionInputs = [];
+    ctx.updateProjectUI('cargo_rocket');
+
+    expect(elements.totalCostValue.textContent).toBe(numbers.formatNumber(4, true));
+    expect(elements.selectionInputs.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Cache cargo rocket resource selection inputs in `projectElements`
- Refresh cached inputs on rebuild and use them for total cost calculations
- Document resource selection caching and add regression test

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68af90368d00832783129a406a912e56