### PR TITLE
Cache WGC team card UI references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Temperature penalty for colonies now affects Ecumenopolis Districts.
 - Colony energy penalty from temperature is continuous, scaling with distance below 15 °C or above 20 °C.
 - WGC logs now format artifact gains with two decimal places.
+- WGC team cards cache DOM nodes for buttons, inputs, selects, progress bars, logs and HP bars, rebuilding these caches when cards redraw or team counts change for faster updates.
 - Methane melting and freezing now respect methane ice coverage.
 - Planetary thrusters operate as a continuous project, drawing power from ongoing energy production instead of only stored energy.
 - Planetary thrusters appear in the Energy resource rate tooltip, listing their consumption.

--- a/tests/wgcUICacheInvalidation.test.js
+++ b/tests/wgcUICacheInvalidation.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+describe('WGC UI cache invalidation', () => {
+  test('hp bar updates after cache invalidation', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="wgc-hope"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.WGCTeamMember = require('../src/js/team-member.js').WGCTeamMember;
+    ctx.WarpGateCommand = require('../src/js/wgc.js').WarpGateCommand;
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'wgcUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    ctx.warpGateCommand = new ctx.WarpGateCommand();
+    ctx.initializeWGCUI();
+    ctx.warpGateCommand.enable();
+    const member = new ctx.WGCTeamMember({ firstName: 'A', classType: 'Soldier', health: 100, maxHealth: 100 });
+    ctx.warpGateCommand.recruitMember(0, 0, member);
+    ctx.redrawWGCTeamCards();
+    ctx.updateWGCUI();
+
+    member.health = 50;
+    ctx.updateWGCUI();
+    let fill = dom.window.document.querySelector('.team-hp-bar-fill');
+    expect(fill.style.height).toBe('50%');
+
+    ctx.invalidateWGCTeamCache();
+    member.health = 25;
+    ctx.updateWGCUI();
+    fill = dom.window.document.querySelector('.team-hp-bar-fill');
+    expect(fill.style.height).toBe('25%');
+  });
+});


### PR DESCRIPTION
## Summary
- Cache WGC team card controls and HP bars to avoid repeated DOM queries
- Refresh cached elements when team cards redraw or team count changes
- Add test ensuring WGC UI cache invalidation updates HP bars

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af90333b6c832799d7297bc717bb1b