### PR TITLE
Add reflect mode toggle for space mirror facility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - The Any Zone slider in the space mirror facility can be increased, taking percentage from the largest other sliders so the total remains 100%.
 - Land usage recalculates on save load, and inactive structure construction checks land without reserving it.
 - Space mirror facility now verifies slider percentages each tick, clamping out-of-range values and ensuring they total 100%.
+- Space mirror facility now supports a reversible reflect mode with Toward World/Away From World selection.
 - Metal exportation project shows assigned ship count as current/maximum so players know remaining capacity.
 - Space export project's max export capacity line includes a tooltip explaining Earth's metal purchase limit.
 - Max export capacity tooltip is generated once and no longer updates each tick, making it readable.

--- a/tests/spaceMirrorReflectMode.test.js
+++ b/tests/spaceMirrorReflectMode.test.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('space mirror reflect mode', () => {
+  test('enableReversal shows reflect mode and saves selection', () => {
+    const originalDocument = global.document;
+    const originalProject = global.Project;
+    const originalFormat = global.formatNumber;
+    const originalTerraforming = global.terraforming;
+    const originalBuildings = global.buildings;
+    const originalProjectElements = global.projectElements;
+
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    global.Project = class {
+      saveState() { return {}; }
+      loadState() {}
+    };
+    global.formatNumber = v => v;
+    global.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      celestialParameters: { crossSectionArea: 1, surfaceArea: 1 },
+    };
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { unlocked: false } };
+    global.projectElements = {};
+
+    const { SpaceMirrorFacilityProject } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+    const config = { name: 'Space Mirror Facility', cost: {}, duration: 0 };
+    const project = new SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    project.enableReversal();
+
+    const container = document.getElementById('root');
+    project.renderUI(container);
+    project.updateUI();
+
+    const modeContainer = dom.window.document.querySelector('.mirror-details-card .mode-selection');
+    expect(modeContainer).not.toBeNull();
+    const buttons = modeContainer.querySelectorAll('button');
+    expect(buttons[0].textContent).toBe('Toward World');
+    expect(buttons[1].textContent).toBe('Away From World');
+
+    buttons[1].click();
+    expect(project.reverseEnabled).toBe(true);
+    const saved = project.saveState();
+    const loaded = new SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    loaded.loadState(saved);
+    expect(loaded.reverseEnabled).toBe(true);
+
+    global.document = originalDocument;
+    global.Project = originalProject;
+    global.formatNumber = originalFormat;
+    global.terraforming = originalTerraforming;
+    global.buildings = originalBuildings;
+    global.projectElements = originalProjectElements || {};
+    delete global.mirrorOversightSettings;
+    delete global.setMirrorDistribution;
+    delete global.resetMirrorOversightSettings;
+    delete global.initializeMirrorOversightUI;
+    delete global.updateMirrorOversightUI;
+    delete global.updateZonalFluxTable;
+    delete global.applyFocusedMelt;
+    delete global.calculateZoneSolarFluxWithFacility;
+    delete global.toggleFinerControls;
+    delete global.updateAssignmentDisplays;
+  });
+});


### PR DESCRIPTION
## Summary
- allow SpaceMirrorFacilityProject to toggle reflect direction and persist choice
- show Toward World/Away From World buttons in mirror status when reversal is enabled
- document new mirror reflect mode feature

## Testing
- `npm ci`
- `CI=true npm test` (fails: loadGamePlanet.test.js, playTimeSave.test.js, wgcSaveLoad.test.js, skillPointsSave.test.js)


------
https://chatgpt.com/codex/tasks/task_b_68b0cff023dc8327b7b67c1e0ed45ad5