### PR TITLE
Handle ground albedo tooltip like other terraforming UI tooltips

### DIFF
--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -800,7 +800,7 @@ function updateLifeBox() {
         </thead>
         <tbody>
           <tr>
-            <td>Ground Albedo <span id="ground-albedo-tooltip" class="info-tooltip-icon" title="Base albedo blended with black dust (0.05 albedo) upgrades.">&#9432;</span></td>
+            <td>Ground Albedo <span id="ground-albedo-info" class="info-tooltip-icon">&#9432;<span id="ground-albedo-tooltip" class="resource-tooltip"></span></span></td>
             <td><span id="ground-albedo">${(terraforming.luminosity.groundAlbedo ?? 0).toFixed(2)}</span></td>
             <td><span id="ground-albedo-delta"></span></td>
           </tr>
@@ -878,7 +878,12 @@ function updateLifeBox() {
       const area = terraforming.celestialParameters.surfaceArea || 1;
       const coverage = area > 0 ? Math.min(upgrades / area, 1) : 0;
       const dustAlbedo = 0.05;
-      els.groundAlbedoTooltip.title = `Base: ${base.toFixed(2)}\nBlack dust albedo: ${dustAlbedo.toFixed(2)}\nBlack dust coverage: ${(coverage*100).toFixed(1)}%`;
+      const lines = [
+        `Base: ${base.toFixed(2)}`,
+        `Black dust albedo: ${dustAlbedo.toFixed(2)}`,
+        `Black dust coverage: ${(coverage * 100).toFixed(1)}%`
+      ];
+      els.groundAlbedoTooltip.innerHTML = lines.join('<br>');
     }
 
     if (els.surfaceAlbedo) {

--- a/tests/groundAlbedoTooltip.test.js
+++ b/tests/groundAlbedoTooltip.test.js
@@ -32,7 +32,7 @@ describe('ground albedo tooltip', () => {
     ctx.createLuminosityBox(row);
     ctx.updateLuminosityBox();
 
-    const tooltip = dom.window.document.getElementById('ground-albedo-tooltip').getAttribute('title');
+    const tooltip = dom.window.document.getElementById('ground-albedo-tooltip').textContent;
     expect(tooltip).toContain('Black dust albedo: 0.05');
     expect(tooltip).toContain('Black dust coverage: 30.0%');
   });


### PR DESCRIPTION
## Summary
- Render ground albedo tooltip with the info icon and resource-tooltip so it matches other terraforming UI tooltips
- Show base albedo, black dust albedo, and coverage in the tooltip
- Adjust ground albedo tooltip test for new structure

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b1a3f0bd8c8327b7034ea2a6c50643