### PR TITLE
Show white dust info in ground albedo tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,3 +368,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space UI caches Random World tab elements and rebuilds the cache when the tabs regenerate.
 - Calcite aerosol decays with a 240 second half-life and its consumption appears in resource rates.
 - Surface, actual albedo, and solar flux tooltips now refresh in real time with breakdowns.
+- Ground albedo tooltip shows white dust albedo and coverage, hiding coverage lines when a dust type has 0%.

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -873,16 +873,36 @@ function updateLifeBox() {
     }
     if (els.groundAlbedoTooltip) {
       const base = terraforming.celestialParameters.albedo;
-      const upgrades = (typeof resources !== 'undefined' && resources.special && resources.special.albedoUpgrades)
-        ? resources.special.albedoUpgrades.value : 0;
       const area = terraforming.celestialParameters.surfaceArea || 1;
-      const coverage = area > 0 ? Math.min(upgrades / area, 1) : 0;
-      const dustAlbedo = 0.05;
+      const special = (typeof resources !== 'undefined' && resources.special) ? resources.special : {};
+      const black = (special.albedoUpgrades && typeof special.albedoUpgrades.value === 'number')
+        ? special.albedoUpgrades.value : 0;
+      const white = (special.whiteDust && typeof special.whiteDust.value === 'number')
+        ? special.whiteDust.value : 0;
+
+      const bRatioRaw = area > 0 ? Math.max(0, black / area) : 0;
+      const wRatioRaw = area > 0 ? Math.max(0, white / area) : 0;
+      const totalApplied = Math.min(bRatioRaw + wRatioRaw, 1);
+      let shareBlack = 0, shareWhite = 0;
+      if (totalApplied > 0) {
+        const sumRaw = bRatioRaw + wRatioRaw;
+        shareWhite = (wRatioRaw / sumRaw) * totalApplied;
+        shareBlack = totalApplied - shareWhite;
+      }
+
+      const blackAlbedo = 0.05;
+      const whiteAlbedo = 0.8;
       const lines = [
         `Base: ${base.toFixed(2)}`,
-        `Black dust albedo: ${dustAlbedo.toFixed(2)}`,
-        `Black dust coverage: ${(coverage * 100).toFixed(1)}%`
+        `Black dust albedo: ${blackAlbedo.toFixed(2)}`,
       ];
+      if (shareBlack > 0) {
+        lines.push(`Black dust coverage: ${(shareBlack * 100).toFixed(1)}%`);
+      }
+      lines.push(`White dust albedo: ${whiteAlbedo.toFixed(2)}`);
+      if (shareWhite > 0) {
+        lines.push(`White dust coverage: ${(shareWhite * 100).toFixed(1)}%`);
+      }
       els.groundAlbedoTooltip.innerHTML = lines.join('<br>');
     }
 

--- a/tests/groundAlbedoTooltip.test.js
+++ b/tests/groundAlbedoTooltip.test.js
@@ -6,35 +6,58 @@ const vm = require('vm');
 const numbers = require('../src/js/numbers.js');
 
 describe('ground albedo tooltip', () => {
-  test('includes black dust albedo value and coverage', () => {
+  function setupDOM() {
     const dom = new JSDOM('<!DOCTYPE html><div class="row"></div>', { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
-
     ctx.formatNumber = numbers.formatNumber;
     ctx.calculateAverageCoverage = () => 0;
     ctx.calculateSurfaceFractions = () => ({ ocean: 0, ice: 0, biomass: 0 });
     ctx.calculateZonalSurfaceFractions = () => ({ ocean: 0, ice: 0, biomass: 0 });
-    ctx.ZONES = ['tropical','temperate','polar'];
+    ctx.ZONES = ['tropical', 'temperate', 'polar'];
     ctx.DEFAULT_SURFACE_ALBEDO = require('../src/js/physics.js').DEFAULT_SURFACE_ALBEDO;
-
-    ctx.resources = { special: { albedoUpgrades: { value: 30 } } };
     ctx.terraforming = {
       luminosity: { name: 'Luminosity', groundAlbedo: 0.3, surfaceAlbedo: 0.3, actualAlbedo: 0.3, albedo: 0.3, solarFlux: 1000, modifiedSolarFlux: 1000 },
       celestialParameters: { albedo: 0.25, surfaceArea: 100 },
       getLuminosityStatus: () => true,
       calculateSolarPanelMultiplier: () => 1
     };
-
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraforming', 'terraformingUI.js'), 'utf8');
     vm.runInContext(code, ctx);
+    return { dom, ctx };
+  }
 
+  test('includes black and white dust albedo values and coverage', () => {
+    const { dom, ctx } = setupDOM();
+    ctx.resources = { special: { albedoUpgrades: { value: 30 }, whiteDust: { value: 20 } } };
     const row = dom.window.document.querySelector('.row');
     ctx.createLuminosityBox(row);
     ctx.updateLuminosityBox();
-
     const tooltip = dom.window.document.getElementById('ground-albedo-tooltip').textContent;
     expect(tooltip).toContain('Black dust albedo: 0.05');
     expect(tooltip).toContain('Black dust coverage: 30.0%');
+    expect(tooltip).toContain('White dust albedo: 0.80');
+    expect(tooltip).toContain('White dust coverage: 20.0%');
+  });
+
+  test('omits white dust coverage when zero', () => {
+    const { dom, ctx } = setupDOM();
+    ctx.resources = { special: { albedoUpgrades: { value: 30 }, whiteDust: { value: 0 } } };
+    const row = dom.window.document.querySelector('.row');
+    ctx.createLuminosityBox(row);
+    ctx.updateLuminosityBox();
+    const tooltip = dom.window.document.getElementById('ground-albedo-tooltip').textContent;
+    expect(tooltip).toContain('Black dust coverage: 30.0%');
+    expect(tooltip).not.toContain('White dust coverage');
+  });
+
+  test('omits black dust coverage when zero', () => {
+    const { dom, ctx } = setupDOM();
+    ctx.resources = { special: { albedoUpgrades: { value: 0 }, whiteDust: { value: 20 } } };
+    const row = dom.window.document.querySelector('.row');
+    ctx.createLuminosityBox(row);
+    ctx.updateLuminosityBox();
+    const tooltip = dom.window.document.getElementById('ground-albedo-tooltip').textContent;
+    expect(tooltip).toContain('White dust coverage: 20.0%');
+    expect(tooltip).not.toContain('Black dust coverage');
   });
 });
-


### PR DESCRIPTION
## Summary
- Display white dust albedo in ground albedo tooltip alongside black dust
- Hide dust coverage lines when a dust type has 0% coverage
- Test tooltip behavior for black and white dust combinations

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b1a52922f08327b5c17e331ce0bf89