### PR TITLE
Fix tooltip positioning when near bottom of viewport

### DIFF
--- a/src/css/resource.css
+++ b/src/css/resource.css
@@ -70,6 +70,12 @@
     display: block;
   }
 
+  .resource-tooltip.above {
+    bottom: 100%;
+    top: auto;
+    transform: translateX(-50%) translateY(-4px);
+  }
+
   .resource-festival {
     color: #6AA84F;
     font-weight: bold;

--- a/src/css/terraforming.css
+++ b/src/css/terraforming.css
@@ -77,3 +77,9 @@
   .info-tooltip-icon:hover .resource-tooltip {
     display: block;
   }
+
+  .resource-tooltip.above {
+    bottom: 100%;
+    top: auto;
+    transform: translateX(-50%) translateY(-4px);
+  }

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -424,7 +424,11 @@ function createResourceElement(category, resourceObj, resourceName) {
         ${resourceObj.hideRate ? '' : `<div class="resource-pps" id="${resourceName}-pps-resources-container">+0/s</div>`}
       </div>
     `;
-    resourceElement.appendChild(createTooltipElement(resourceName));
+    const tooltip = createTooltipElement(resourceName);
+    resourceElement.appendChild(tooltip);
+    if (typeof addTooltipHover === 'function') {
+      addTooltipHover(resourceElement, tooltip);
+    }
   } else if (category === 'underground' || resourceObj.name === 'land') {
     // Display for deposits
     resourceElement.innerHTML = `
@@ -439,7 +443,11 @@ function createResourceElement(category, resourceObj, resourceName) {
       </div>
     `;
     if (resourceObj.name === 'land') {
-      resourceElement.appendChild(createTooltipElement(resourceName));
+      const tooltip = createTooltipElement(resourceName);
+      resourceElement.appendChild(tooltip);
+      if (typeof addTooltipHover === 'function') {
+        addTooltipHover(resourceElement, tooltip);
+      }
     }
 
     // Add scanning progress below deposits
@@ -460,7 +468,11 @@ function createResourceElement(category, resourceObj, resourceName) {
         ${resourceObj.hideRate ? '' : `<div class="resource-pps" id="${resourceName}-pps-resources-container">+0/s</div>`}
       </div>
     `;
-    resourceElement.appendChild(createTooltipElement(resourceName));
+    const tooltip = createTooltipElement(resourceName);
+    resourceElement.appendChild(tooltip);
+    if (typeof addTooltipHover === 'function') {
+      addTooltipHover(resourceElement, tooltip);
+    }
   }
 
   return resourceElement;

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -334,6 +334,10 @@ function createTemperatureBox(row) {
       windMultiplier: atmosphereBox.querySelector('#wind-turbine-multiplier'),
       gases: gasElements
     };
+    const els = terraformingUICache.atmosphere;
+    if (typeof addTooltipHover === 'function') {
+      addTooltipHover(els.opticalDepthInfo, els.opticalDepthTooltip);
+    }
   }
 
   function updateAtmosphereBox() {
@@ -838,6 +842,7 @@ function updateLifeBox() {
       box: luminosityBox,
       groundAlbedo: luminosityBox.querySelector('#ground-albedo'),
       groundAlbedoDelta: luminosityBox.querySelector('#ground-albedo-delta'),
+      groundAlbedoInfo: luminosityBox.querySelector('#ground-albedo-info'),
       groundAlbedoTooltip: luminosityBox.querySelector('#ground-albedo-tooltip'),
       surfaceAlbedo: luminosityBox.querySelector('#surface-albedo'),
       surfaceAlbedoDelta: luminosityBox.querySelector('#surface-albedo-delta'),
@@ -855,6 +860,13 @@ function updateLifeBox() {
       solarPanelMultiplier: luminosityBox.querySelector('#solar-panel-multiplier'),
       target: luminosityBox.querySelector('.terraforming-target')
     };
+    const els = terraformingUICache.luminosity;
+    if (typeof addTooltipHover === 'function') {
+      addTooltipHover(els.groundAlbedoInfo, els.groundAlbedoTooltip);
+      addTooltipHover(els.surfaceAlbedoInfo, els.surfaceAlbedoTooltip);
+      addTooltipHover(els.actualAlbedoInfo, els.actualAlbedoTooltip);
+      addTooltipHover(els.solarFluxInfo, els.solarFluxTooltip);
+    }
   }
   
   function updateLuminosityBox() {

--- a/src/js/ui-utils.js
+++ b/src/js/ui-utils.js
@@ -15,6 +15,21 @@ function activateSubtab(subtabClass, contentClass, subtabId, unhide = false) {
   }
 }
 
+function addTooltipHover(anchor, tooltip) {
+  if (!anchor || !tooltip) return;
+  anchor.addEventListener('mouseenter', () => {
+    const bottom = tooltip.getBoundingClientRect().bottom;
+    if (bottom > window.innerHeight) {
+      tooltip.classList.add('above');
+    } else {
+      tooltip.classList.remove('above');
+    }
+  });
+  anchor.addEventListener('mouseleave', () => {
+    tooltip.classList.remove('above');
+  });
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { activateSubtab };
+  module.exports = { activateSubtab, addTooltipHover };
 }

--- a/tests/tooltipAbovePlacement.test.js
+++ b/tests/tooltipAbovePlacement.test.js
@@ -1,0 +1,40 @@
+const { JSDOM } = require('jsdom');
+const { addTooltipHover } = require('../src/js/ui-utils.js');
+
+describe('addTooltipHover', () => {
+  let dom;
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+  });
+
+  test('adds and removes above class when needed', () => {
+    const anchor = document.createElement('div');
+    const tooltip = document.createElement('div');
+    anchor.appendChild(tooltip);
+    addTooltipHover(anchor, tooltip);
+    Object.defineProperty(window, 'innerHeight', { value: 500, writable: true });
+    tooltip.getBoundingClientRect = () => ({ bottom: 600 });
+    anchor.dispatchEvent(new window.Event('mouseenter'));
+    expect(tooltip.classList.contains('above')).toBe(true);
+    anchor.dispatchEvent(new window.Event('mouseleave'));
+    expect(tooltip.classList.contains('above')).toBe(false);
+  });
+
+  test('does not add above when within viewport', () => {
+    const anchor = document.createElement('div');
+    const tooltip = document.createElement('div');
+    anchor.appendChild(tooltip);
+    addTooltipHover(anchor, tooltip);
+    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true });
+    tooltip.getBoundingClientRect = () => ({ bottom: 400 });
+    anchor.dispatchEvent(new window.Event('mouseenter'));
+    expect(tooltip.classList.contains('above')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `addTooltipHover` helper to flip tooltips above when they would overflow the window
- wire tooltip hover logic into resource and terraforming UIs and add corresponding CSS
- test tooltip orientation behavior

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b1a4d7616483279aa6af3b5bfa91ae