### PR TITLE
Expand resource tooltip width

### DIFF
--- a/src/css/resource.css
+++ b/src/css/resource.css
@@ -58,7 +58,7 @@
     border-radius: 5px;
     font-size: 12px;
     z-index: 1;
-    width: 200px;
+    width: 220px;
     top: 100%;
     left: 50%;
     transform: translateX(-50%);

--- a/tests/resourceTooltipWidth.test.js
+++ b/tests/resourceTooltipWidth.test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('resource tooltip width', () => {
+  test('resource tooltip width is 220px', () => {
+    const css = fs.readFileSync(path.join(__dirname, '..', 'src/css', 'resource.css'), 'utf8');
+    const dom = new JSDOM(`<!DOCTYPE html><style>${css}</style><div class="resource-item"><span id="tip" class="resource-tooltip"></span></div>`);
+    const tooltip = dom.window.document.getElementById('tip');
+    tooltip.style.display = 'block';
+    const style = dom.window.getComputedStyle(tooltip);
+    expect(style.width).toBe('220px');
+  });
+});


### PR DESCRIPTION
## Summary
- widen resource tooltips for improved readability
- add test ensuring new tooltip width

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b1a57ac69c83278398544fe872f79e