### PR TITLE
Fix rate unit wrapping in resource tooltip

### DIFF
--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -103,6 +103,8 @@ function createTooltipElement(resourceName) {
   const prodTotalRight = document.createElement('div');
   prodTotalRight.style.display = 'table-cell';
   prodTotalRight.style.textAlign = 'right';
+  prodTotalRight.style.minWidth = '90px';
+  prodTotalRight.style.whiteSpace = 'nowrap';
   const prodTotalRightStrong = document.createElement('strong');
   prodTotalRight.appendChild(prodTotalRightStrong);
   prodTotalRow.appendChild(prodTotalLeft);
@@ -135,6 +137,8 @@ function createTooltipElement(resourceName) {
   const consTotalRight = document.createElement('div');
   consTotalRight.style.display = 'table-cell';
   consTotalRight.style.textAlign = 'right';
+  consTotalRight.style.minWidth = '90px';
+  consTotalRight.style.whiteSpace = 'nowrap';
   const consTotalRightStrong = document.createElement('strong');
   consTotalRight.appendChild(consTotalRightStrong);
   consTotalRow.appendChild(consTotalLeft);
@@ -167,6 +171,8 @@ function createTooltipElement(resourceName) {
   const overflowTotalRight = document.createElement('div');
   overflowTotalRight.style.display = 'table-cell';
   overflowTotalRight.style.textAlign = 'right';
+  overflowTotalRight.style.minWidth = '90px';
+  overflowTotalRight.style.whiteSpace = 'nowrap';
   const overflowTotalRightStrong = document.createElement('strong');
   overflowTotalRight.appendChild(overflowTotalRightStrong);
   overflowTotalRow.appendChild(overflowTotalLeft);
@@ -227,6 +233,8 @@ function updateRateTable(container, entries, formatter) {
       const right = document.createElement('div');
       right.style.display = 'table-cell';
       right.style.textAlign = 'right';
+      right.style.minWidth = '90px';
+      right.style.whiteSpace = 'nowrap';
       row.appendChild(left);
       row.appendChild(right);
       info.table.appendChild(row);

--- a/tests/resourceTooltipRateValueWidth.test.js
+++ b/tests/resourceTooltipRateValueWidth.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('resource tooltip rate value width', () => {
+  test('rate value cell has min width and no wrap', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.oreScanner = { scanData: {} };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const resource = {
+      name: 'metal',
+      displayName: 'Metal',
+      category: 'colony',
+      value: 100,
+      cap: 1000,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 1,
+      consumptionRate: 0,
+      productionRateBySource: { 'A very long source name': 1 },
+      consumptionRateBySource: {},
+      unit: null
+    };
+
+    ctx.createResourceDisplay({ colony: { metal: resource } });
+    ctx.updateResourceRateDisplay(resource);
+
+    const rightCell = dom.window.document.querySelector('#metal-tooltip-production div[style*="table-row"] div:last-child');
+    expect(rightCell.style.minWidth).toBe('90px');
+    expect(rightCell.style.whiteSpace).toBe('nowrap');
+  });
+});


### PR DESCRIPTION
## Summary
- restore original resource row grid layout
- keep tooltip rate values on one line by giving value cells min width
- add test to ensure tooltip rate values have fixed width

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b1a6a14fe083278b18c9a7cc54d5a3