### PR TITLE
Add hover jump effect to milestone buttons

### DIFF
--- a/src/css/milestones.css
+++ b/src/css/milestones.css
@@ -16,7 +16,8 @@
     border: 1px solid #ccc;
     border-radius: 5px;
     cursor: pointer;
-    transition: background-color 0.3s ease, color 0.3s ease;
+    transition: background-color 0.3s ease, color 0.3s ease,
+                transform 0.2s ease, box-shadow 0.2s ease;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -54,6 +55,12 @@
     background-color: #b0b0b0; /* Gray for locked */
     color: #333;
     cursor: not-allowed;
+}
+
+/* Hover effect matches world cards */
+.milestone-button:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 /* Total bonuses display */

--- a/tests/milestoneHoverEffect.test.js
+++ b/tests/milestoneHoverEffect.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('milestone hover effect', () => {
+  test('milestone button hover applies jump effect', () => {
+    const css = fs.readFileSync(path.join(__dirname, '..', 'src/css', 'milestones.css'), 'utf8');
+    const hoverSection = css.match(/\.milestone-button:hover\s*{[^}]*}/);
+    expect(hoverSection).not.toBeNull();
+    expect(hoverSection[0]).toMatch(/transform:\s*translateY\(-3px\)/);
+    expect(hoverSection[0]).toMatch(/box-shadow:\s*0 4px 12px rgba\(0, 0, 0, 0\.4\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add hover transition and box-shadow to milestone buttons for a subtle jump effect
- Test milestone button hover CSS for transform and shadow settings

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b1ed11035c8327a144b43ff470e53b