### PR TITLE
Show net resource change including autobuild

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,3 +369,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Calcite aerosol decays with a 240 second half-life and its consumption appears in resource rates.
 - Surface, actual albedo, and solar flux tooltips now refresh in real time with breakdowns.
 - Ground albedo tooltip shows white dust albedo and coverage, hiding coverage lines when a dust type has 0%.
+- Resource tooltips show a Net Change (including autobuild) line before production, subtracting the last 10 seconds of autobuild cost from the net rate.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -80,6 +80,10 @@ function createTooltipElement(resourceName) {
   });
   tooltip.appendChild(zonesDiv);
 
+  const netDiv = document.createElement('div');
+  netDiv.id = `${resourceName}-tooltip-net`;
+  tooltip.appendChild(netDiv);
+
   const productionDiv = document.createElement('div');
   productionDiv.id = `${resourceName}-tooltip-production`;
   productionDiv.style.display = 'none';
@@ -705,6 +709,7 @@ function updateResourceRateDisplay(resource){
   const timeDiv = entry?.tooltip?.timeDiv || document.getElementById(`${resource.name}-tooltip-time`);
   const assignmentsDiv = entry?.tooltip?.assignmentsDiv || document.getElementById(`${resource.name}-tooltip-assignments`);
   const zonesDiv = entry?.tooltip?.zonesDiv || document.getElementById(`${resource.name}-tooltip-zones`);
+  const netDiv = entry?.tooltip?.netDiv || document.getElementById(`${resource.name}-tooltip-net`);
   const productionDiv = entry?.tooltip?.productionDiv || document.getElementById(`${resource.name}-tooltip-production`);
   const consumptionDiv = entry?.tooltip?.consumptionDiv || document.getElementById(`${resource.name}-tooltip-consumption`);
   const overflowDiv = entry?.tooltip?.overflowDiv || document.getElementById(`${resource.name}-tooltip-overflow`);
@@ -826,6 +831,14 @@ function updateResourceRateDisplay(resource){
   } else if (zonesDiv) {
     zonesDiv.style.display = 'none';
   }
+  const autobuildAvg = typeof autobuildCostTracker !== 'undefined'
+    ? autobuildCostTracker.getAverageCost(resource.category, resource.name)
+    : 0;
+  if (netDiv) {
+    const netIncAuto = netRate - autobuildAvg;
+    const text = `Net Change (including autobuild): ${formatNumber(netIncAuto, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s`;
+    if (netDiv.textContent !== text) netDiv.textContent = text;
+  }
 
   if (productionDiv) {
     const productionEntries = Object.entries(resource.productionRateBySource)
@@ -854,7 +867,7 @@ function updateResourceRateDisplay(resource){
 
   if (autobuildDiv) {
     if (typeof autobuildCostTracker !== 'undefined') {
-      const avgCost = autobuildCostTracker.getAverageCost(resource.category, resource.name);
+      const avgCost = autobuildAvg;
       if (avgCost > 0) {
         autobuildDiv.style.display = 'block';
         autobuildDiv._info.value.textContent = `${formatNumber(avgCost, false, 2)}${resource.unit ? ' ' + resource.unit : ''}/s`;
@@ -918,6 +931,7 @@ function cacheSingleResource(category, resourceName) {
       timeDiv: document.getElementById(`${resourceName}-tooltip-time`),
       assignmentsDiv: document.getElementById(`${resourceName}-tooltip-assignments`),
       zonesDiv: document.getElementById(`${resourceName}-tooltip-zones`),
+      netDiv: document.getElementById(`${resourceName}-tooltip-net`),
       productionDiv: document.getElementById(`${resourceName}-tooltip-production`),
       consumptionDiv: document.getElementById(`${resourceName}-tooltip-consumption`),
       overflowDiv: document.getElementById(`${resourceName}-tooltip-overflow`),

--- a/tests/resourceTooltipNetChangeAutobuild.test.js
+++ b/tests/resourceTooltipNetChangeAutobuild.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('resource tooltip net change including autobuild', () => {
+  test('shows net change minus autobuild average cost', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.oreScanner = { scanData: {} };
+
+    let code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'autobuild.js'), 'utf8');
+    vm.runInContext(code, ctx);
+    code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const resource = {
+      name: 'metal',
+      displayName: 'Metal',
+      category: 'colony',
+      value: 100,
+      cap: 1000,
+      hasCap: true,
+      reserved: 0,
+      unlocked: true,
+      productionRate: 10,
+      consumptionRate: 2,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      unit: 'ton'
+    };
+
+    ctx.createResourceDisplay({ colony: { metal: resource } });
+    ctx.autobuildCostTracker.recordCost('Habitat', { colony: { metal: 3 } });
+    ctx.autobuildCostTracker.update(1000);
+
+    ctx.updateResourceRateDisplay(resource);
+
+    const netEl = dom.window.document.getElementById('metal-tooltip-net');
+    const expected = `Net Change (including autobuild): ${numbers.formatNumber(5, false, 2)} ton/s`;
+    expect(netEl.textContent).toBe(expected);
+  });
+});

--- a/tests/resourceTooltipUnits.test.js
+++ b/tests/resourceTooltipUnits.test.js
@@ -105,6 +105,11 @@ describe('resource tooltip units', () => {
     const tooltip = dom.window.document.getElementById('metal-tooltip').innerHTML;
     expect(tooltip).toContain('Value');
     expect(tooltip).toContain('ton');
-    expect(tooltip).not.toContain(' ton/s');
+    const netText = dom.window.document.getElementById('metal-tooltip-net').textContent;
+    expect(netText).toContain(' ton/s');
+    const prodHtml = dom.window.document.getElementById('metal-tooltip-production').innerHTML;
+    expect(prodHtml).not.toContain(' ton/s');
+    const consHtml = dom.window.document.getElementById('metal-tooltip-consumption').innerHTML;
+    expect(consHtml).not.toContain(' ton/s');
   });
 });


### PR DESCRIPTION
## Summary
- display a Net Change (including autobuild) row in resource tooltips
- document tooltip net change feature
- cover net change logic with unit tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b1ed4738748327bd27e7f1ee0009c3