### PR TITLE
Show colonist worker count in tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,3 +372,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource tooltips show a Net Change (including autobuild) line before production, subtracting the last 10 seconds of autobuild cost from the net rate.
 - Space storage tooltips separate transfer and expansion costs, and resource tooltips ignore consumption when costs are paid from space storage.
 - Resource tooltips split into three columns when too tall to fit above or below the viewport, prioritizing below placement.
+- Workers tooltip lists how many workers come from colonists above the android count.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -425,6 +425,22 @@ function updateWorkerAssignments(assignmentsDiv) {
   if (ratioDiv.textContent !== ratioText) ratioDiv.textContent = ratioText;
 
   if (typeof resources !== 'undefined') {
+    let colonistDiv = assignmentsDiv._colonistDiv;
+    if (!colonistDiv) {
+      colonistDiv = document.createElement('div');
+      const existingAndroidDiv = assignmentsDiv._androidDiv;
+      if (existingAndroidDiv && existingAndroidDiv.parentNode === assignmentsDiv) {
+        assignmentsDiv.insertBefore(colonistDiv, existingAndroidDiv);
+      } else {
+        assignmentsDiv.appendChild(colonistDiv);
+      }
+      assignmentsDiv._colonistDiv = colonistDiv;
+    }
+    const colonists = resources.colony?.colonists?.value || 0;
+    const colonistWorkers = Math.floor(populationModule.getEffectiveWorkerRatio() * colonists);
+    const colonistText = `${formatNumber(colonistWorkers, true)} from colonists`;
+    if (colonistDiv.textContent !== colonistText) colonistDiv.textContent = colonistText;
+
     let androidDiv = assignmentsDiv._androidDiv;
     if (!androidDiv) {
       androidDiv = document.createElement('div');

--- a/tests/workerTooltip.test.js
+++ b/tests/workerTooltip.test.js
@@ -13,7 +13,7 @@ describe('worker resource tooltip', () => {
     ctx.formatDuration = numbers.formatDuration;
     ctx.oreScanner = { scanData: {} };
     ctx.populationModule = { getEffectiveWorkerRatio: () => 0.6 };
-    ctx.resources = { colony: { androids: { value: 5 } } };
+    ctx.resources = { colony: { androids: { value: 5 }, colonists: { value: 100 } } };
     ctx.buildings = {
       mine: { displayName: 'Mine', active: 2, getTotalWorkerNeed: () => 5, getEffectiveWorkerMultiplier: () => 1 },
       factory: { displayName: 'Factory', active: 1, getTotalWorkerNeed: () => 20, getEffectiveWorkerMultiplier: () => 1 }
@@ -44,6 +44,7 @@ describe('worker resource tooltip', () => {
     ctx.updateResourceRateDisplay(workers);
     const html = dom.window.document.getElementById('workers-tooltip').innerHTML;
     expect(html).toContain('60%');
+    expect(html).toContain('60 from colonists');
     expect(html).toContain('5 from androids');
   });
 
@@ -70,6 +71,7 @@ describe('worker resource tooltip', () => {
     ctx.createResourceDisplay({ colony: { workers } });
     ctx.updateResourceRateDisplay(workers);
     const html = dom.window.document.getElementById('workers-tooltip').innerHTML;
+    expect(html).toContain('60 from colonists');
     expect(html).toContain('3 from androids');
     expect(html).not.toContain('Deeper Mining');
   });
@@ -98,6 +100,7 @@ describe('worker resource tooltip', () => {
     ctx.createResourceDisplay({ colony: { workers } });
     ctx.updateResourceRateDisplay(workers);
     const html = dom.window.document.getElementById('workers-tooltip').innerHTML;
+    expect(html).toContain('60 from colonists');
     expect(html).toContain('1 from androids');
     expect(html).not.toContain('5 from androids');
     expect(html).not.toContain('Deeper Mining');


### PR DESCRIPTION
## Summary
- list workers provided by colonists above android contributions in the workers tooltip
- test worker tooltip breakdown
- document workers tooltip update

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b201972e008327a0aaac15a39c8a1b