### PR TITLE
Enforce minimum gap for GHG automation thresholds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Terraforming Bureau automation for GHG and oxygen factories now only operates once the Terraforming Bureau research is completed, preventing the checkboxes from functioning prematurely. Atmospheric Monitoring oversight for carbon and nitrogen space mining projects likewise requires its research before automation activates.
 - GHG factory automation now produces only the greenhouse gas required to reach the target temperature using Newton's method.
 - GHG factory automation supports automatic reversal: when reverse is enabled, it disables between two thresholds and removes greenhouse gases or calcite above the upper limit.
+- GHG automation temperature thresholds maintain at least a 1 °C gap, adjusting the other threshold when one changes.
 - Oxygen factory automation now produces only the oxygen required to reach the target pressure using Newton's method.
 - Life designer day/night temperature rows display survival and growth status icons, and the separate survival temperature row has been removed.
 - Production, consumption, and maintenance displays scale with selected build count.

--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
     <script src="src/js/wgc.js"></script>
     <script src="src/js/wgcUI.js"></script>
     <script src="src/js/globals.js"></script>
+    <script src="src/js/ghg-automation.js"></script>
     <script src="src/js/game-speed.js"></script>
     <script src="src/js/autobuild.js"></script>
     <script src="src/js/gold-asteroid.js"></script>

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -535,7 +535,11 @@ class Building extends EffectableEntity {
         terraforming && terraforming.temperature
       ) {
         const A = ghgFactorySettings.disableTempThreshold;
-        const B = ghgFactorySettings.reverseTempThreshold ?? A + 5;
+        let B = ghgFactorySettings.reverseTempThreshold ?? A + 5;
+        if (B - A < 1) {
+          B = A + 1;
+          ghgFactorySettings.reverseTempThreshold = B;
+        }
         const currentTemp = terraforming.temperature.value;
         let recipeKey = this.currentRecipeKey || 'ghg';
         let resourceName = recipeKey === 'calcite' ? 'calciteAerosol' : 'greenhouseGas';

--- a/src/js/ghg-automation.js
+++ b/src/js/ghg-automation.js
@@ -1,0 +1,18 @@
+function enforceGhgFactoryTempGap(changed){
+  const minGap = 1;
+  const A = ghgFactorySettings.disableTempThreshold;
+  let B = ghgFactorySettings.reverseTempThreshold;
+  if (B === undefined || isNaN(B)) {
+    B = A + minGap;
+  }
+  if (B - A < minGap) {
+    if (changed === 'B') {
+      ghgFactorySettings.disableTempThreshold = B - minGap;
+    } else {
+      B = A + minGap;
+    }
+  }
+  ghgFactorySettings.reverseTempThreshold = B;
+}
+
+globalThis.enforceGhgFactoryTempGap = enforceGhgFactoryTempGap;

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -55,6 +55,7 @@ let ghgFactorySettings = {
   disableTempThreshold: 283.15, // Kelvin
   reverseTempThreshold: 283.15
 };
+globalThis.ghgFactorySettings = ghgFactorySettings;
 
 let oxygenFactorySettings = {
   autoDisableAbovePressure: false,

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -372,6 +372,7 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.ghgFactorySettings){
       Object.assign(ghgFactorySettings, gameState.ghgFactorySettings);
+      enforceGhgFactoryTempGap();
     }
 
     if(gameState.oxygenFactorySettings){

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -516,6 +516,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     if(ghgFactorySettings.reverseTempThreshold === undefined){
       ghgFactorySettings.reverseTempThreshold = ghgFactorySettings.disableTempThreshold;
     }
+    enforceGhgFactoryTempGap();
 
     updateGhgTempControl = () => {
       tempLabel.textContent = 'Disable if avg T > ';
@@ -533,16 +534,19 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     tempInput.addEventListener('input', () => {
       const val = parseFloat(tempInput.value);
       ghgFactorySettings.disableTempThreshold = gameSettings.useCelsius ? val + 273.15 : val;
-      // Keep B synced to A when reversal is not available
       if(!structure.reversalAvailable){
         ghgFactorySettings.reverseTempThreshold = ghgFactorySettings.disableTempThreshold;
-        updateGhgTempControl();
+      } else {
+        enforceGhgFactoryTempGap('A');
       }
+      updateGhgTempControl();
     });
 
     tempInputB.addEventListener('input', () => {
       const val = parseFloat(tempInputB.value);
       ghgFactorySettings.reverseTempThreshold = gameSettings.useCelsius ? val + 273.15 : val;
+      enforceGhgFactoryTempGap('B');
+      updateGhgTempControl();
     });
 
     autoBuildContainer.appendChild(tempControl);

--- a/tests/ghgFactoryTempGap.test.js
+++ b/tests/ghgFactoryTempGap.test.js
@@ -1,0 +1,33 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+global.planetParameters = { mars: { buildingParameters: { maintenanceFraction: 0 } } };
+require('../src/js/globals.js');
+require('../src/js/ghg-automation.js');
+
+describe('GHG automation threshold gap enforcement', () => {
+  beforeEach(() => {
+    ghgFactorySettings.disableTempThreshold = 280;
+    ghgFactorySettings.reverseTempThreshold = 281;
+  });
+
+  test('raises upper threshold when lower increases too close', () => {
+    ghgFactorySettings.disableTempThreshold = 285;
+    enforceGhgFactoryTempGap('A');
+    expect(ghgFactorySettings.reverseTempThreshold).toBeCloseTo(286, 5);
+  });
+
+  test('lowers lower threshold when upper decreases too close', () => {
+    ghgFactorySettings.reverseTempThreshold = 280;
+    enforceGhgFactoryTempGap('B');
+    expect(ghgFactorySettings.disableTempThreshold).toBeCloseTo(279, 5);
+  });
+
+  test('ensures minimum gap when called without parameter', () => {
+    ghgFactorySettings.disableTempThreshold = 283;
+    ghgFactorySettings.reverseTempThreshold = 283.2;
+    enforceGhgFactoryTempGap();
+    expect(
+      ghgFactorySettings.reverseTempThreshold - ghgFactorySettings.disableTempThreshold
+    ).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Move GHG factory temperature gap enforcement into its own helper script
- Include helper in HTML so UI and save routines adjust paired thresholds automatically

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b251836b608327b4caec0c46ea8250