### PR TITLE
Respect strategic reserve for colony autobuilds

### DIFF
--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -139,10 +139,10 @@ class Colony extends Building {
     }
   }
   
-  // Override canAfford if colonies have unique costs or conditions
-  canAfford(resources) {
-    // Add unique colony-specific conditions
-    return super.canAfford(resources);
+  // Override canAfford to allow colony-specific checks while preserving strategic reserve support
+  canAfford(buildCount = 1, reservePercent = 0) {
+    // Add unique colony-specific conditions in future if needed
+    return super.canAfford(buildCount, reservePercent);
   }
 
   adjustNeedRatio(resource, ratio, deltaTime) {

--- a/tests/autobuildColonyStrategicReserve.test.js
+++ b/tests/autobuildColonyStrategicReserve.test.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('autobuild strategic reserve for colony buildings', () => {
+  test('avoids building below reserve', () => {
+    const ctx = {
+      console,
+      module: { exports: {} },
+      resources: {
+        colony: {
+          colonists: { value: 100, cap: 100 },
+          metal: { value: 80, cap: 100, decrease(v) { this.value -= v; } },
+        },
+        surface: {},
+        underground: {},
+      },
+      buildings: {},
+      maintenanceFraction: 0,
+    };
+    vm.createContext(ctx);
+
+    let code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(code + '\nthis.EffectableEntity = EffectableEntity;', ctx);
+    code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'building.js'), 'utf8');
+    vm.runInContext(code + '\nthis.Building = Building;', ctx);
+    code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colony.js'), 'utf8');
+    vm.runInContext(code + '\nthis.Colony = Colony;', ctx);
+    code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'autobuild.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const config = {
+      name: 'Base',
+      category: 'Colony',
+      cost: { colony: { metal: 50 } },
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: {},
+      canBeToggled: false,
+      maintenanceFactor: 1,
+      requiresMaintenance: false,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true,
+      surfaceArea: 0,
+      requiresProductivity: true,
+    };
+
+    const colony = new ctx.Colony(config, 'base');
+    colony.autoBuildEnabled = true;
+    colony.autoBuildPercent = 100;
+
+    ctx.module.exports.setStrategicReserve(50);
+    ctx.module.exports.autoBuild({ base: colony });
+    expect(colony.count).toBe(0);
+
+    ctx.resources.colony.metal.value = 150;
+    ctx.resources.colony.metal.cap = 200;
+    ctx.module.exports.autoBuild({ base: colony });
+    expect(colony.count).toBe(1);
+    expect(ctx.resources.colony.metal.value).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Pass the strategic reserve through Colony.canAfford so the autobuilder doesn't consume reserved resources
- Cover colony autobuild strategic reserve behavior with a new unit test

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b2544b414c83278b4b705337eeb8ab