### PR TITLE
Track random world departure metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,3 +376,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource tooltips split into three columns when too tall to fit above or below the viewport, prioritizing below placement.
 - Workers tooltip lists how many workers come from colonists above the android count.
 - Resource tooltips only update while hovered, reducing unnecessary DOM work.
+- Random world departures now log timestamp and Ecumenopolis land coverage.

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -10,6 +10,11 @@ const SOL_STAR = {
     habitableZone: { inner: 0.95, outer: 1.37 }
 };
 
+var getEcumenopolisLandFraction = globalThis.getEcumenopolisLandFraction || function () { return 0; };
+if (typeof module !== 'undefined' && module.exports) {
+    ({ getEcumenopolisLandFraction } = require('./advanced-research/ecumenopolis.js'));
+}
+
 class SpaceManager extends EffectableEntity {
     constructor(planetsData) { // Keep planetsData for validation
         super({ description: 'Manages planetary travel' });
@@ -44,6 +49,8 @@ class SpaceManager extends EffectableEntity {
                 enabled: false, // visible/selectable in UI
                 colonists: 0,
                 orbitalRing: false,
+                departedAt: null,
+                ecumenopolisPercent: 0,
                 // Add other statuses later if needed
             };
         });
@@ -374,6 +381,8 @@ class SpaceManager extends EffectableEntity {
     }
 
     recordCurrentWorldPopulation(pop) {
+        const departedAt = Date.now();
+        const ecoPercent = getEcumenopolisLandFraction(globalThis.terraforming) * 100;
         if (this.currentRandomSeed !== null) {
             const seed = String(this.currentRandomSeed);
             if (!this.randomWorldStatuses[seed]) {
@@ -383,14 +392,20 @@ class SpaceManager extends EffectableEntity {
                     colonists: 0,
                     original: this.getCurrentWorldOriginal(),
                     visited: true,
-                    orbitalRing: false
+                    orbitalRing: false,
+                    departedAt: null,
+                    ecumenopolisPercent: 0
                 };
             } else {
                 this.randomWorldStatuses[seed].visited = true;
             }
             this.randomWorldStatuses[seed].colonists = pop;
+            this.randomWorldStatuses[seed].departedAt = departedAt;
+            this.randomWorldStatuses[seed].ecumenopolisPercent = ecoPercent;
         } else if (this.planetStatuses[this.currentPlanetKey]) {
             this.planetStatuses[this.currentPlanetKey].colonists = pop;
+            this.planetStatuses[this.currentPlanetKey].departedAt = departedAt;
+            this.planetStatuses[this.currentPlanetKey].ecumenopolisPercent = ecoPercent;
         }
     }
 
@@ -424,7 +439,9 @@ class SpaceManager extends EffectableEntity {
                 colonists: 0,
                 original: res,
                 visited: true,
-                orbitalRing: false
+                orbitalRing: false,
+                departedAt: null,
+                ecumenopolisPercent: 0
             };
         } else {
             existing.original = existing.original || res;
@@ -517,6 +534,12 @@ class SpaceManager extends EffectableEntity {
                     }
                     if (typeof saved.orbitalRing === 'boolean') {
                         this.planetStatuses[planetKey].orbitalRing = saved.orbitalRing;
+                    }
+                    if (typeof saved.departedAt === 'number') {
+                        this.planetStatuses[planetKey].departedAt = saved.departedAt;
+                    }
+                    if (typeof saved.ecumenopolisPercent === 'number') {
+                        this.planetStatuses[planetKey].ecumenopolisPercent = saved.ecumenopolisPercent;
                     }
                 }
             });

--- a/tests/spaceManagerRandomTravel.test.js
+++ b/tests/spaceManagerRandomTravel.test.js
@@ -5,6 +5,8 @@ const SpaceManager = require('../src/js/space.js');
 describe('SpaceManager random world travel population tracking', () => {
   beforeEach(() => {
     global.resources = { colony: { colonists: { value: 0 } } };
+    global.terraforming = { initialLand: 100 };
+    global.colonies = { t7_colony: { active: 0, requiresLand: 1 } };
     global.saveGameToSlot = jest.fn();
     global.initializeGameState = jest.fn();
     global.projectManager = { projects: { spaceStorage: { saveTravelState: jest.fn(() => null), loadTravelState: jest.fn() } } };
@@ -12,15 +14,29 @@ describe('SpaceManager random world travel population tracking', () => {
     global.updateSpaceUI = jest.fn();
   });
 
-  test('records colonists when leaving worlds', () => {
+  afterEach(() => {
+    delete global.terraforming;
+    delete global.colonies;
+  });
+
+  test('records departure time and ecumenopolis coverage', () => {
     const sm = new SpaceManager({ mars: { name: 'Mars' } });
     resources.colony.colonists.value = 100;
+    colonies.t7_colony.active = 5;
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
     sm.travelToRandomWorld({ merged: { name: 'Alpha' } }, '1');
     expect(sm.planetStatuses.mars.colonists).toBe(100);
+    expect(sm.planetStatuses.mars.departedAt).toBe(1000);
+    expect(sm.planetStatuses.mars.ecumenopolisPercent).toBeCloseTo(5);
     resources.colony.colonists.value = 50;
+    colonies.t7_colony.active = 10;
+    Date.now.mockReturnValue(2000);
     sm.travelToRandomWorld({ merged: { name: 'Beta' } }, '2');
     expect(sm.randomWorldStatuses['1'].colonists).toBe(50);
+    expect(sm.randomWorldStatuses['1'].departedAt).toBe(2000);
+    expect(sm.randomWorldStatuses['1'].ecumenopolisPercent).toBeCloseTo(10);
     expect(sm.getCurrentWorldName()).toBe('Beta');
+    Date.now.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- record departure timestamp and ecumenopolis land coverage when leaving a world
- persist new departure metadata across saves
- test departure logging for colonists, time, and ecumenopolis percentage

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b25dec44d48327874e7a45a8ddb526