### PR TITLE
refactor: move factory automation settings to module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,3 +376,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource tooltips split into three columns when too tall to fit above or below the viewport, prioritizing below placement.
 - Workers tooltip lists how many workers come from colonists above the android count.
 - Resource tooltips only update while hovered, reducing unnecessary DOM work.
+- GHG and oxygen factory settings now export from src/js/ghg-automation.js.

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
     <script src="src/js/effectable-entity.js"></script>
     <script src="src/js/tab.js"></script>
     <script src="src/js/ui-utils.js"></script>
+    <script src="src/js/ghg-automation.js"></script>
     <script src="src/js/save.js"></script>
     <script src="src/js/structuresUI.js"></script>
     <script src="src/js/day-night-cycle.js"></script>
@@ -126,7 +127,6 @@
     <script src="src/js/wgc.js"></script>
     <script src="src/js/wgcUI.js"></script>
     <script src="src/js/globals.js"></script>
-    <script src="src/js/ghg-automation.js"></script>
     <script src="src/js/game-speed.js"></script>
     <script src="src/js/autobuild.js"></script>
     <script src="src/js/gold-asteroid.js"></script>

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -1,3 +1,12 @@
+var ghgFactorySettingsRef = ghgFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('./ghg-automation.js').ghgFactorySettings
+    : globalThis.ghgFactorySettings);
+var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('./ghg-automation.js').oxygenFactorySettings
+    : globalThis.oxygenFactorySettings);
+
 // Building Class (Core Game Logic)
 class Building extends EffectableEntity {
   constructor(config, buildingName) {
@@ -531,14 +540,14 @@ class Building extends EffectableEntity {
       if (
         this.name === 'ghgFactory' &&
         hasAtmosphericOversight &&
-        ghgFactorySettings.autoDisableAboveTemp &&
+        ghgFactorySettingsRef.autoDisableAboveTemp &&
         terraforming && terraforming.temperature
       ) {
-        const A = ghgFactorySettings.disableTempThreshold;
-        let B = ghgFactorySettings.reverseTempThreshold ?? A + 5;
+        const A = ghgFactorySettingsRef.disableTempThreshold;
+        let B = ghgFactorySettingsRef.reverseTempThreshold ?? A + 5;
         if (B - A < 1) {
           B = A + 1;
-          ghgFactorySettings.reverseTempThreshold = B;
+          ghgFactorySettingsRef.reverseTempThreshold = B;
         }
         const currentTemp = terraforming.temperature.value;
         let recipeKey = this.currentRecipeKey || 'ghg';
@@ -628,12 +637,12 @@ class Building extends EffectableEntity {
       if (
         this.name === 'oxygenFactory' &&
         hasAtmosphericOversight &&
-        oxygenFactorySettings.autoDisableAbovePressure &&
+        oxygenFactorySettingsRef.autoDisableAbovePressure &&
         terraforming && resources.atmospheric?.oxygen &&
         typeof calculateAtmosphericPressure === 'function'
       ) {
         const oxygen = resources.atmospheric.oxygen;
-        const targetPa = oxygenFactorySettings.disablePressureThreshold * 1000;
+        const targetPa = oxygenFactorySettingsRef.disablePressureThreshold * 1000;
         const currentPa = calculateAtmosphericPressure(
           oxygen.value,
           terraforming.celestialParameters.gravity,

--- a/src/js/ghg-automation.js
+++ b/src/js/ghg-automation.js
@@ -1,4 +1,15 @@
-function enforceGhgFactoryTempGap(changed){
+const ghgFactorySettings = {
+  autoDisableAboveTemp: false,
+  disableTempThreshold: 283.15, // Kelvin
+  reverseTempThreshold: 283.15,
+};
+
+const oxygenFactorySettings = {
+  autoDisableAbovePressure: false,
+  disablePressureThreshold: 15, // kPa
+};
+
+function enforceGhgFactoryTempGap(changed) {
   const minGap = 1;
   const A = ghgFactorySettings.disableTempThreshold;
   let B = ghgFactorySettings.reverseTempThreshold;
@@ -15,4 +26,14 @@ function enforceGhgFactoryTempGap(changed){
   ghgFactorySettings.reverseTempThreshold = B;
 }
 
-globalThis.enforceGhgFactoryTempGap = enforceGhgFactoryTempGap;
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    ghgFactorySettings,
+    oxygenFactorySettings,
+    enforceGhgFactoryTempGap,
+  };
+} else {
+  globalThis.ghgFactorySettings = ghgFactorySettings;
+  globalThis.oxygenFactorySettings = oxygenFactorySettings;
+  globalThis.enforceGhgFactoryTempGap = enforceGhgFactoryTempGap;
+}

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -50,18 +50,6 @@ let colonySliderSettings = {
   oreMineWorkers: 0
 };
 
-let ghgFactorySettings = {
-  autoDisableAboveTemp: false,
-  disableTempThreshold: 283.15, // Kelvin
-  reverseTempThreshold: 283.15
-};
-globalThis.ghgFactorySettings = ghgFactorySettings;
-
-let oxygenFactorySettings = {
-  autoDisableAbovePressure: false,
-  disablePressureThreshold: 15 // kPa
-};
-
 
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
 let skillManager;

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -1,3 +1,12 @@
+var ghgFactorySettingsRef = ghgFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('./ghg-automation.js').ghgFactorySettings
+    : globalThis.ghgFactorySettings);
+var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('./ghg-automation.js').oxygenFactorySettings
+    : globalThis.oxygenFactorySettings);
+
 globalGameIsLoadingFromSave = false;
 
 function recalculateLandUsage() {
@@ -46,8 +55,8 @@ function getGameState() {
     selectedBuildCounts: typeof selectedBuildCounts !== 'undefined' ? selectedBuildCounts : undefined,
     settings: typeof gameSettings !== 'undefined' ? gameSettings : undefined,
     colonySliderSettings: typeof colonySliderSettings !== 'undefined' ? colonySliderSettings : undefined,
-    ghgFactorySettings: typeof ghgFactorySettings !== 'undefined' ? ghgFactorySettings : undefined,
-    oxygenFactorySettings: typeof oxygenFactorySettings !== 'undefined' ? oxygenFactorySettings : undefined,
+    ghgFactorySettings: typeof ghgFactorySettingsRef !== 'undefined' ? ghgFactorySettingsRef : undefined,
+    oxygenFactorySettings: typeof oxygenFactorySettingsRef !== 'undefined' ? oxygenFactorySettingsRef : undefined,
     mirrorOversightSettings: typeof globalThis.mirrorOversightSettings !== 'undefined' ? globalThis.mirrorOversightSettings : undefined,
     constructionOffice: typeof saveConstructionOfficeState === 'function' ? saveConstructionOfficeState() : undefined,
     playTimeSeconds: typeof playTimeSeconds !== 'undefined' ? playTimeSeconds : undefined,
@@ -371,12 +380,12 @@ function loadGame(slotOrCustomString) {
     }
 
     if(gameState.ghgFactorySettings){
-      Object.assign(ghgFactorySettings, gameState.ghgFactorySettings);
+      Object.assign(ghgFactorySettingsRef, gameState.ghgFactorySettings);
       enforceGhgFactoryTempGap();
     }
 
     if(gameState.oxygenFactorySettings){
-      Object.assign(oxygenFactorySettings, gameState.oxygenFactorySettings);
+      Object.assign(oxygenFactorySettingsRef, gameState.oxygenFactorySettings);
     }
 
     if(gameState.mirrorOversightSettings){

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -1,3 +1,12 @@
+var ghgFactorySettingsRef = ghgFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('./ghg-automation.js').ghgFactorySettings
+    : globalThis.ghgFactorySettings);
+var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('./ghg-automation.js').oxygenFactorySettings
+    : globalThis.oxygenFactorySettings);
+
 // structures-ui.js
 
 // Create an object to store the selected build count for each structure
@@ -484,9 +493,9 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     const tempCheckbox = document.createElement('input');
     tempCheckbox.type = 'checkbox';
     tempCheckbox.classList.add('ghg-temp-checkbox');
-    tempCheckbox.checked = ghgFactorySettings.autoDisableAboveTemp;
+    tempCheckbox.checked = ghgFactorySettingsRef.autoDisableAboveTemp;
     tempCheckbox.addEventListener('change', () => {
-      ghgFactorySettings.autoDisableAboveTemp = tempCheckbox.checked;
+      ghgFactorySettingsRef.autoDisableAboveTemp = tempCheckbox.checked;
     });
     tempControl.appendChild(tempCheckbox);
 
@@ -513,8 +522,8 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     unitSpan.classList.add('ghg-temp-unit');
     tempControl.appendChild(unitSpan);
 
-    if(ghgFactorySettings.reverseTempThreshold === undefined){
-      ghgFactorySettings.reverseTempThreshold = ghgFactorySettings.disableTempThreshold;
+    if(ghgFactorySettingsRef.reverseTempThreshold === undefined){
+      ghgFactorySettingsRef.reverseTempThreshold = ghgFactorySettingsRef.disableTempThreshold;
     }
     enforceGhgFactoryTempGap();
 
@@ -522,8 +531,8 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
       tempLabel.textContent = 'Disable if avg T > ';
       unitSpan.textContent = getTemperatureUnit();
       // Update both inputs (A and B)
-      tempInput.value = toDisplayTemperature(ghgFactorySettings.disableTempThreshold);
-      tempInputB.value = toDisplayTemperature(ghgFactorySettings.reverseTempThreshold);
+      tempInput.value = toDisplayTemperature(ghgFactorySettingsRef.disableTempThreshold);
+      tempInputB.value = toDisplayTemperature(ghgFactorySettingsRef.reverseTempThreshold);
       // Show the B side whenever reversal is available
       const showReverse = !!structure.reversalAvailable;
       betweenLabel.style.display = showReverse ? 'inline' : 'none';
@@ -533,9 +542,9 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
     tempInput.addEventListener('input', () => {
       const val = parseFloat(tempInput.value);
-      ghgFactorySettings.disableTempThreshold = gameSettings.useCelsius ? val + 273.15 : val;
+      ghgFactorySettingsRef.disableTempThreshold = gameSettings.useCelsius ? val + 273.15 : val;
       if(!structure.reversalAvailable){
-        ghgFactorySettings.reverseTempThreshold = ghgFactorySettings.disableTempThreshold;
+        ghgFactorySettingsRef.reverseTempThreshold = ghgFactorySettingsRef.disableTempThreshold;
       } else {
         enforceGhgFactoryTempGap('A');
       }
@@ -544,7 +553,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
     tempInputB.addEventListener('input', () => {
       const val = parseFloat(tempInputB.value);
-      ghgFactorySettings.reverseTempThreshold = gameSettings.useCelsius ? val + 273.15 : val;
+      ghgFactorySettingsRef.reverseTempThreshold = gameSettings.useCelsius ? val + 273.15 : val;
       enforceGhgFactoryTempGap('B');
       updateGhgTempControl();
     });
@@ -571,9 +580,9 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     const pressureCheckbox = document.createElement('input');
     pressureCheckbox.type = 'checkbox';
     pressureCheckbox.classList.add('o2-pressure-checkbox');
-    pressureCheckbox.checked = oxygenFactorySettings.autoDisableAbovePressure;
+    pressureCheckbox.checked = oxygenFactorySettingsRef.autoDisableAbovePressure;
     pressureCheckbox.addEventListener('change', () => {
-      oxygenFactorySettings.autoDisableAbovePressure = pressureCheckbox.checked;
+      oxygenFactorySettingsRef.autoDisableAbovePressure = pressureCheckbox.checked;
     });
     pressureControl.appendChild(pressureCheckbox);
 
@@ -585,10 +594,10 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     pressureInput.type = 'number';
     pressureInput.step = 1;
     pressureInput.classList.add('o2-pressure-input');
-    pressureInput.value = oxygenFactorySettings.disablePressureThreshold;
+    pressureInput.value = oxygenFactorySettingsRef.disablePressureThreshold;
     pressureInput.addEventListener('input', () => {
       const val = parseFloat(pressureInput.value);
-      oxygenFactorySettings.disablePressureThreshold = val;
+      oxygenFactorySettingsRef.disablePressureThreshold = val;
     });
     pressureControl.appendChild(pressureInput);
 
@@ -1022,9 +1031,9 @@ function updateDecreaseButtonText(button, buildCount) {
         if (ghgEls && ghgEls.container) {
           const enabled = structure.isBooleanFlagSet('terraformingBureauFeature');
           ghgEls.container.style.display = enabled ? 'flex' : 'none';
-          if (ghgEls.checkbox) ghgEls.checkbox.checked = ghgFactorySettings.autoDisableAboveTemp;
-          if (ghgEls.inputA) ghgEls.inputA.value = toDisplayTemperature(ghgFactorySettings.disableTempThreshold);
-          if (ghgEls.inputB) ghgEls.inputB.value = toDisplayTemperature(ghgFactorySettings.reverseTempThreshold);
+          if (ghgEls.checkbox) ghgEls.checkbox.checked = ghgFactorySettingsRef.autoDisableAboveTemp;
+          if (ghgEls.inputA) ghgEls.inputA.value = toDisplayTemperature(ghgFactorySettingsRef.disableTempThreshold);
+          if (ghgEls.inputB) ghgEls.inputB.value = toDisplayTemperature(ghgFactorySettingsRef.reverseTempThreshold);
           const showReverse = !!structure.reversalAvailable;
           if (ghgEls.betweenLabel) ghgEls.betweenLabel.style.display = showReverse ? 'inline' : 'none';
           if (ghgEls.inputB) ghgEls.inputB.style.display = showReverse ? 'inline' : 'none';
@@ -1035,8 +1044,8 @@ function updateDecreaseButtonText(button, buildCount) {
         if (o2Els && o2Els.container) {
           const enabled = structure.isBooleanFlagSet('terraformingBureauFeature');
           o2Els.container.style.display = enabled ? 'flex' : 'none';
-          if (o2Els.checkbox) o2Els.checkbox.checked = oxygenFactorySettings.autoDisableAbovePressure;
-          if (o2Els.input) o2Els.input.value = oxygenFactorySettings.disablePressureThreshold;
+          if (o2Els.checkbox) o2Els.checkbox.checked = oxygenFactorySettingsRef.autoDisableAbovePressure;
+          if (o2Els.input) o2Els.input.value = oxygenFactorySettingsRef.disablePressureThreshold;
         }
       }
   

--- a/tests/advancedResearchSubtabReset.test.js
+++ b/tests/advancedResearchSubtabReset.test.js
@@ -47,7 +47,8 @@ describe('research subtab visibility reset on load', () => {
     ctx.selectedBuildCounts = {};
     ctx.gameSettings = {};
     ctx.colonySliderSettings = {};
-    ctx.ghgFactorySettings = {};
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
     ctx.mirrorOversightSettings = {};
     ctx.playTimeSeconds = 0;
     ctx.planetParameters = { mars: { resources: {} } };

--- a/tests/autobuildSetActiveSetting.test.js
+++ b/tests/autobuildSetActiveSetting.test.js
@@ -26,7 +26,10 @@ function setup(settingEnabled){
   ctx.formatResourceDetails = () => '';
   ctx.formatStorageDetails = () => '';
   ctx.updateColonyDetailsDisplay = () => {};
-  ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0 };
+  const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+  vm.runInContext(factorySettings, ctx);
+  ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+  ctx.ghgFactorySettings.disableTempThreshold = 0;
   ctx.Colony = class {};
   ctx.updateEmptyBuildingMessages = () => {};
   ctx.updateBuildingDisplay = () => {};

--- a/tests/buildingCategoryUnhideButton.test.js
+++ b/tests/buildingCategoryUnhideButton.test.js
@@ -20,7 +20,12 @@ describe('category unhide button', () => {
     ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
     ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0 } } };
     ctx.globalEffects = { isBooleanFlagSet: () => false };
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.ghgFactorySettings.restartCap = 1;
+    ctx.ghgFactorySettings.restartTimer = 0;
     ctx.dayNightCycle = { isNight: () => false };
     ctx.toDisplayTemperature = () => 0;
     ctx.getTemperatureUnit = () => 'K';

--- a/tests/colonyConsumptionCap.test.js
+++ b/tests/colonyConsumptionCap.test.js
@@ -17,7 +17,12 @@ describe('colony consumption cap', () => {
     ctx.updateColonyDetailsDisplay = () => {};
     ctx.createColonyDetails = () => dom.window.document.createElement('div');
     ctx.globalEffects = { isBooleanFlagSet: () => false };
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.ghgFactorySettings.restartCap = 1;
+    ctx.ghgFactorySettings.restartTimer = 0;
     ctx.dayNightCycle = { isNight: () => false };
     ctx.toDisplayTemperature = () => 0;
     ctx.getTemperatureUnit = () => 'K';

--- a/tests/colonyHideButtonState.test.js
+++ b/tests/colonyHideButtonState.test.js
@@ -17,7 +17,12 @@ describe('colony hide button state', () => {
     ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
     ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0 } } };
     ctx.globalEffects = { isBooleanFlagSet: () => false };
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.ghgFactorySettings.restartCap = 1;
+    ctx.ghgFactorySettings.restartTimer = 0;
     ctx.dayNightCycle = { isNight: () => false };
     ctx.toDisplayTemperature = () => 0;
     ctx.getTemperatureUnit = () => 'K';

--- a/tests/colonyUpgrade.test.js
+++ b/tests/colonyUpgrade.test.js
@@ -18,7 +18,12 @@ describe('colony upgrade', () => {
     ctx.updateColonyDetailsDisplay = () => {};
     ctx.createColonyDetails = () => dom.window.document.createElement('div');
     ctx.globalEffects = { isBooleanFlagSet: () => false };
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.ghgFactorySettings.restartCap = 1;
+    ctx.ghgFactorySettings.restartTimer = 0;
     ctx.dayNightCycle = { isNight: () => false };
     ctx.toDisplayTemperature = () => 0;
     ctx.getTemperatureUnit = () => 'K';

--- a/tests/dayNightIconDisplay.test.js
+++ b/tests/dayNightIconDisplay.test.js
@@ -16,7 +16,12 @@ describe('day night icon display', () => {
     ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
     ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0 } } };
     ctx.globalEffects = { isBooleanFlagSet: () => false };
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.ghgFactorySettings.restartCap = 1;
+    ctx.ghgFactorySettings.restartTimer = 0;
     ctx.dayNightCycle = { isNight: () => false, isDay: () => true };
     ctx.toDisplayTemperature = () => 0;
     ctx.getTemperatureUnit = () => 'K';

--- a/tests/ecumenopolisUpgrade.test.js
+++ b/tests/ecumenopolisUpgrade.test.js
@@ -18,7 +18,12 @@ describe('Ecumenopolis upgrade', () => {
     ctx.updateColonyDetailsDisplay = () => {};
     ctx.createColonyDetails = () => dom.window.document.createElement('div');
     ctx.globalEffects = { isBooleanFlagSet: () => false };
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.ghgFactorySettings.restartCap = 1;
+    ctx.ghgFactorySettings.restartTimer = 0;
     ctx.dayNightCycle = { isNight: () => false };
     ctx.toDisplayTemperature = () => 0;
     ctx.getTemperatureUnit = () => 'K';

--- a/tests/ghgFactoryReverseAutomation.test.js
+++ b/tests/ghgFactoryReverseAutomation.test.js
@@ -1,8 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { ghgFactorySettings } = require('../src/js/ghg-automation.js');
 const { Building } = require('../src/js/building.js');
-
-global.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, reverseTempThreshold: 0 };
 
 function createFactory(){
   const config = {

--- a/tests/ghgFactoryTempDisable.test.js
+++ b/tests/ghgFactoryTempDisable.test.js
@@ -1,8 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { ghgFactorySettings } = require('../src/js/ghg-automation.js');
 const { Building } = require('../src/js/building.js');
-
-global.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 283.15 };
 
 const researchedManagerStub = {
   getResearchById: () => ({ isResearched: true })

--- a/tests/ghgFactoryTempGap.test.js
+++ b/tests/ghgFactoryTempGap.test.js
@@ -1,8 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
-global.planetParameters = { mars: { buildingParameters: { maintenanceFraction: 0 } } };
-require('../src/js/globals.js');
-require('../src/js/ghg-automation.js');
+const { ghgFactorySettings } = require('../src/js/ghg-automation.js');
+const { enforceGhgFactoryTempGap } = require('../src/js/ghg-automation.js');
 
 describe('GHG automation threshold gap enforcement', () => {
   beforeEach(() => {

--- a/tests/oxygenFactoryPressureDisable.test.js
+++ b/tests/oxygenFactoryPressureDisable.test.js
@@ -1,8 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { oxygenFactorySettings } = require('../src/js/ghg-automation.js');
 const { Building } = require('../src/js/building.js');
-
-global.oxygenFactorySettings = { autoDisableAbovePressure: false, disablePressureThreshold: 15 };
 global.calculateAtmosphericPressure = (amount) => amount * 1000; // 1 unit => 1 kPa
 
 const researchedManagerStub = {

--- a/tests/researchAlertPersistence.test.js
+++ b/tests/researchAlertPersistence.test.js
@@ -44,7 +44,8 @@ describe('research alerts persist after loading', () => {
     ctx.spaceManager = { saveState: () => ({}), loadState: () => {}, getCurrentPlanetKey: () => 'mars' };
     ctx.selectedBuildCounts = {};
     ctx.colonySliderSettings = {};
-    ctx.ghgFactorySettings = {};
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
     ctx.mirrorOversightSettings = {};
     ctx.playTimeSeconds = 0;
     ctx.planetParameters = { mars: { resources: {} } };

--- a/tests/setActiveToTargetButton.test.js
+++ b/tests/setActiveToTargetButton.test.js
@@ -22,7 +22,10 @@ describe('Set active to target button', () => {
     ctx.formatResourceDetails = () => '';
     ctx.formatStorageDetails = () => '';
     ctx.updateColonyDetailsDisplay = () => {};
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
     ctx.Colony = class {};
     ctx.updateEmptyBuildingMessages = () => {};
     ctx.updateBuildingDisplay = () => {};

--- a/tests/spaceRandomTabReset.test.js
+++ b/tests/spaceRandomTabReset.test.js
@@ -58,7 +58,8 @@ describe('space random tab visibility reset on load', () => {
     ctx.selectedBuildCounts = {};
     ctx.gameSettings = {};
     ctx.colonySliderSettings = {};
-    ctx.ghgFactorySettings = {};
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
     ctx.mirrorOversightSettings = {};
     ctx.playTimeSeconds = 0;
 

--- a/tests/structureButtonNameNode.test.js
+++ b/tests/structureButtonNameNode.test.js
@@ -22,7 +22,10 @@ describe('structure button name node', () => {
     ctx.formatResourceDetails = () => '';
     ctx.formatStorageDetails = () => '';
     ctx.updateColonyDetailsDisplay = () => {};
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
     ctx.Colony = class {};
     ctx.updateEmptyBuildingMessages = () => {};
     ctx.updateBuildingDisplay = () => {};

--- a/tests/tabVisibilityReset.test.js
+++ b/tests/tabVisibilityReset.test.js
@@ -45,7 +45,8 @@ describe('tab visibility reset on load', () => {
     ctx.selectedBuildCounts = {};
     ctx.gameSettings = {};
     ctx.colonySliderSettings = {};
-    ctx.ghgFactorySettings = {};
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
     ctx.mirrorOversightSettings = {};
     ctx.playTimeSeconds = 0;
     ctx.planetParameters = { mars: { resources:{} } };

--- a/tests/toggleButtonLoad.test.js
+++ b/tests/toggleButtonLoad.test.js
@@ -17,7 +17,12 @@ describe('toggle button count after load', () => {
     ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
     ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0 } } };
     ctx.globalEffects = { isBooleanFlagSet: () => false };
-    ctx.ghgFactorySettings = { autoDisableAboveTemp: false, disableTempThreshold: 0, restartCap: 1, restartTimer: 0 };
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.ghgFactorySettings.restartCap = 1;
+    ctx.ghgFactorySettings.restartTimer = 0;
     ctx.dayNightCycle = { isNight: () => false };
     ctx.toDisplayTemperature = () => 0;
     ctx.getTemperatureUnit = () => 'K';


### PR DESCRIPTION
## Summary
- merge factory settings into ghg-automation module and export settings with gap enforcement
- load unified module in browser and update imports across game logic and tests
- document relocation in AGENTS instructions

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b25fcc17d88327b3ad55ee91660ca1