### PR TITLE
Replace WGC team leader placeholder

### DIFF
--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -9,6 +9,22 @@ function joinLines(text) {
     return Array.isArray(text) ? text.join('\n') : text;
 }
 
+function getWGCTeamLeaderName(index) {
+    try {
+        const leader = warpGateCommand.teams[index][0];
+        const first = leader.firstName;
+        const last = leader.lastName ? ` ${leader.lastName}` : '';
+        const name = first ? first + last : '';
+        return name || `Team Leader ${index + 1}`;
+    } catch {
+        return `Team Leader ${index + 1}`;
+    }
+}
+
+function resolveStoryPlaceholders(text) {
+    return text.replace(/\$WGC_TEAM1_LEADER\$/g, getWGCTeamLeaderName(0));
+}
+
 function compareValues(current, target, comparison = 'gte') {
     switch (comparison) {
         case 'gt':
@@ -746,7 +762,8 @@ class StoryEvent {
                      break;
                  }
 
-                 const text = joinLines(this.narrative);
+                 const raw = joinLines(this.narrative);
+                 const text = resolveStoryPlaceholders(raw);
                  if (this.title) {
                     addJournalEntry([`${this.title}`, text], this.id, { type: 'chapter', id: this.id });
                  } else {

--- a/tests/wgcTeamLeaderPlaceholder.test.js
+++ b/tests/wgcTeamLeaderPlaceholder.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('WGC team leader placeholder', () => {
+  function createContext(wgc) {
+    const ctx = {
+      addJournalEntry: jest.fn(),
+      clearJournal: () => {},
+      document: { addEventListener: () => {}, removeEventListener: () => {} },
+      window: {}
+    };
+    if (wgc !== undefined) ctx.warpGateCommand = wgc;
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'progress.js'), 'utf8');
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.StoryManager = StoryManager;', ctx);
+    return ctx;
+  }
+
+  test('replaces placeholder with leader name', () => {
+    const ctx = createContext({ teams: [[{ firstName: 'Alice', lastName: 'Smith' }]] });
+    const progressData = { chapters: [{ id: 'c', type: 'journal', narrative: 'Leader: $WGC_TEAM1_LEADER$.' }] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.window.storyManager = manager;
+    const event = manager.findEventById('c');
+    event.trigger();
+    expect(ctx.addJournalEntry).toHaveBeenCalledWith('Leader: Alice Smith.', 'c', { type: 'chapter', id: 'c' });
+  });
+
+  test('defaults when leader missing', () => {
+    const ctx = createContext({ teams: [[]] });
+    const progressData = { chapters: [{ id: 'd', type: 'journal', narrative: '$WGC_TEAM1_LEADER$' }] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.window.storyManager = manager;
+    const event = manager.findEventById('d');
+    event.trigger();
+    expect(ctx.addJournalEntry).toHaveBeenCalledWith('Team Leader 1', 'd', { type: 'chapter', id: 'd' });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `$WGC_TEAM1_LEADER$` in story text with the first WGC team leader's name or a fallback
- Exercise placeholder replacement with dedicated tests

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b2ee5b71e48327a6091f7842862557