### PR TITLE
Add story world random travel lock

### DIFF
--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -445,7 +445,10 @@ function renderWorldDetail(res, seedUsed, forcedType) {
   const alreadyTerraformed = seedUsed && typeof globalThis.spaceManager?.isSeedTerraformed === 'function'
     ? globalThis.spaceManager.isSeedTerraformed(seedUsed)
     : false;
-  const travelDisabled = !eqDone || alreadyTerraformed;
+  const lockedByStory = typeof globalThis.spaceManager?.isRandomTravelLocked === 'function'
+    ? globalThis.spaceManager.isRandomTravelLocked()
+    : false;
+  const travelDisabled = lockedByStory || !eqDone || alreadyTerraformed;
   const showTemps = !seedUsed || eqDone;
   const meanTVal = (showTemps && temps)
     ? `${fmt(Math.round(toDisplayTemp(temps.mean)))} ${tempUnit}`
@@ -456,9 +459,11 @@ function renderWorldDetail(res, seedUsed, forcedType) {
   const nightTVal = (showTemps && temps)
     ? `${fmt(Math.round(toDisplayTemp(temps.night)))} ${tempUnit}`
     : '—';
-  const warningMsg = !eqDone
-    ? 'Press Equilibrate at least once before traveling.'
-    : (alreadyTerraformed ? 'This world has already been terraformed.' : '');
+  const warningMsg = lockedByStory
+    ? 'You must complete the story for the current world first'
+    : (!eqDone
+      ? 'Press Equilibrate at least once before traveling.'
+      : (alreadyTerraformed ? 'This world has already been terraformed.' : ''));
   const gWarn = c.gravity > 10
     ? '<span class="info-tooltip-icon" title="Humans and their bodies are very sensitive to high gravity.  Every value of gravity above 10 reduces happiness by 5% of its value, for a maximum of a 100% reduction">⚠</span>'
     : '';

--- a/src/js/story/callisto.js
+++ b/src/js/story/callisto.js
@@ -1,4 +1,4 @@
-var progressCallisto = { chapters: [], storyProjects: {} };
+var progressCallisto = { rwgLock: false, chapters: [], storyProjects: {} };
 /* -------------------------------------------------
  *  CALLISTO STORY‑ARC  (Chapters 7 – 11)
  *  – Arrival on Callisto → Operation Sidestep →

--- a/src/js/story/ganymede.js
+++ b/src/js/story/ganymede.js
@@ -1,4 +1,4 @@
-var progressGanymede = { chapters: [], storyProjects: {} };
+var progressGanymede = { rwgLock: false, chapters: [], storyProjects: {} };
 
 /* -------------------------------------------------
  *  GANYMEDE STORY‑ARC  (Chapters 10 - 13)
@@ -455,6 +455,7 @@ progressGanymede.chapters.push(
             { type: 'terraforming', terraformingParameter: 'complete' }
         ],
         reward: [
+            { target: 'spaceManager', type: 'setRwgLock', targetId: 'ganymede', value: true },
             { target: 'spaceManager', type: 'enable', targetId: 'space-random' },
             // Ensure the main Space tab is brought to the front when unlocking Random
             { target: 'tab', targetId: 'space', type: 'activateTab', onLoad: false },

--- a/src/js/story/mars.js
+++ b/src/js/story/mars.js
@@ -1,4 +1,5 @@
 var progressMars = {
+    rwgLock: false,
     "chapters": [
       {
         id: "chapter0.1",

--- a/src/js/story/titan.js
+++ b/src/js/story/titan.js
@@ -1,4 +1,4 @@
-var progressTitan = { chapters: [], storyProjects: {} };
+var progressTitan = { rwgLock: false, chapters: [], storyProjects: {} };
 
 progressTitan.storyProjects.earthProbe = {
   type: 'Project',

--- a/tests/nanotechRandomWorldTravel.test.js
+++ b/tests/nanotechRandomWorldTravel.test.js
@@ -19,6 +19,7 @@ describe('Random world travel preparation', () => {
 
   test('calls nanotech and project travel preparation', () => {
     const sm = new SpaceManager({ mars: { name: 'Mars' } });
+    sm.setRwgLock('mars', true);
     sm.travelToRandomWorld({ merged: { name: 'Alpha' } }, '1');
     expect(global.nanotechManager.prepareForTravel).toHaveBeenCalled();
     expect(global.projectManager.projects.spaceStorage.saveTravelState).toHaveBeenCalled();

--- a/tests/preTravelWorldState.test.js
+++ b/tests/preTravelWorldState.test.js
@@ -6,6 +6,7 @@ describe('pre-travel save preserves current world', () => {
   test('traveling to a random world saves the original world', () => {
     global.resources = { colony: { colonists: { value: 5 } } };
     const sm = new SpaceManager({ mars: { name: 'Mars' } });
+    sm.setRwgLock('mars', true);
 
     let saved = null;
     global.saveGameToSlot = (slot) => {

--- a/tests/randomTravelSkillPoint.test.js
+++ b/tests/randomTravelSkillPoint.test.js
@@ -25,6 +25,7 @@ describe('random world travel skill points', () => {
 
   test('awards a skill point when leaving a terraformed world for a random world', () => {
     const sm = new SpaceManager({ mars: { name: 'Mars' } });
+    sm.setRwgLock('mars', true);
     sm.updateCurrentPlanetTerraformedStatus(true);
 
     sm.travelToRandomWorld({ merged: { name: 'Alpha' } }, '1');

--- a/tests/randomWorldKey.test.js
+++ b/tests/randomWorldKey.test.js
@@ -35,6 +35,7 @@ describe('SpaceManager random world key', () => {
 
   test('current planet key tracks story and random worlds', () => {
     const sm = new SpaceManager({ mars: { name: 'Mars' }, titan: { name: 'Titan' } });
+    sm.setRwgLock('mars', true);
     expect(sm.getCurrentPlanetKey()).toBe('mars');
     const result = { merged: { name: 'Randomia' } };
     const seed = 42;

--- a/tests/rwgLuminositySave.test.js
+++ b/tests/rwgLuminositySave.test.js
@@ -59,6 +59,7 @@ describe('RWG solar luminosity persistence', () => {
 
     const sm = new sandbox.SpaceManager({ mars: { name: 'Mars' } });
     sandbox.spaceManager = sm;
+    sm.setRwgLock('mars', true);
     sm.travelToRandomWorld({ merged: { name: 'Alpha', celestialParameters: { starLuminosity: 2 } }, star: { luminositySolar: 2 } }, '42');
     expect(sandbox.getStarLuminosity()).toBe(2);
 

--- a/tests/rwgTravelLock.test.js
+++ b/tests/rwgTravelLock.test.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Random World Generator travel lock', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<div id="rwg-result"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.formatNumber = n => n;
+    global.calculateAtmosphericPressure = () => 0;
+    global.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+    global.getGameSpeed = () => 1;
+    global.setGameSpeed = () => {};
+    global.runEquilibration = jest.fn(async (override) => ({ override }));
+    global.deepMerge = (a, b) => ({ ...a, ...b });
+    global.defaultPlanetParameters = {};
+    global.initializeGameState = jest.fn();
+    global.spaceManager = {
+      isSeedTerraformed: () => false,
+      isRandomTravelLocked: () => true,
+      travelToRandomWorld: jest.fn()
+    };
+  });
+
+  test('disables travel and shows warning when locked', async () => {
+    const { renderWorldDetail, attachEquilibrateHandler, attachTravelHandler } = require('../src/js/rwgUI.js');
+    const res = {
+      star: { name: 'Sun', spectralType: 'G', luminositySolar: 1, massSolar: 1, temperatureK: 5800, habitableZone: { inner: 0.5, outer: 1.5 } },
+      merged: {
+        celestialParameters: { distanceFromSun: 1, radius: 6000, gravity: 9.8, albedo: 0.3, rotationPeriod: 24 },
+        resources: {
+          atmospheric: {
+            carbonDioxide: { initialValue: 1 },
+            inertGas: { initialValue: 1 },
+            oxygen: { initialValue: 0 },
+            atmosphericWater: { initialValue: 0 },
+            atmosphericMethane: { initialValue: 0 }
+          },
+          surface: {}
+        },
+        classification: { archetype: 'mars-like' }
+      },
+      override: { resources: { atmospheric: {} } }
+    };
+    const box = document.getElementById('rwg-result');
+    box.innerHTML = renderWorldDetail(res, 'seed', 'mars-like');
+    attachEquilibrateHandler(res, 'seed', 'mars-like', box);
+    attachTravelHandler(res, 'seed');
+
+    let travelBtn = document.getElementById('rwg-travel-btn');
+    let warning = document.getElementById('rwg-travel-warning');
+    expect(travelBtn.disabled).toBe(true);
+    expect(warning.textContent).toContain('You must complete the story for the current world first');
+
+    global.spaceManager.isRandomTravelLocked = () => false;
+    document.getElementById('rwg-equilibrate-btn').click();
+    await new Promise(setImmediate);
+    await new Promise(setImmediate);
+
+    travelBtn = document.getElementById('rwg-travel-btn');
+    warning = document.getElementById('rwg-travel-warning');
+    expect(travelBtn.disabled).toBe(false);
+    expect(warning).toBeNull();
+  });
+});

--- a/tests/rwgTravelTerraformedSeed.test.js
+++ b/tests/rwgTravelTerraformedSeed.test.js
@@ -20,6 +20,7 @@ describe('RWG prevents travel to terraformed seeds', () => {
     global.deepMerge = (a,b) => ({ ...a, ...b });
     global.defaultPlanetParameters = {};
     global.spaceManager = new SpaceManager({ mars: {} });
+    global.spaceManager.setRwgLock('mars', true);
   });
 
   test('travel button disabled when seed already terraformed', async () => {

--- a/tests/spaceManagerRandomTravel.test.js
+++ b/tests/spaceManagerRandomTravel.test.js
@@ -21,6 +21,7 @@ describe('SpaceManager random world travel population tracking', () => {
 
   test('records departure time and ecumenopolis coverage', () => {
     const sm = new SpaceManager({ mars: { name: 'Mars' } });
+    sm.setRwgLock('mars', true);
     resources.colony.colonists.value = 100;
     colonies.t7_colony.active = 5;
     jest.spyOn(Date, 'now').mockReturnValue(1000);

--- a/tests/spaceUIRandomWorldNoWarning.test.js
+++ b/tests/spaceUIRandomWorldNoWarning.test.js
@@ -33,7 +33,7 @@ describe('space UI warning on random world', () => {
 
     ctx.spaceManager = new ctx.SpaceManager(planetParameters);
     ctx.initializeSpaceUI(ctx.spaceManager);
-
+    ctx.spaceManager.setRwgLock('mars', true);
     ctx.spaceManager.travelToRandomWorld({ merged: { name: 'Alpha' } }, '1');
     ctx.updateSpaceUI();
 


### PR DESCRIPTION
## Summary
- gate random world travel on story completion with new rwgLock flags
- reward Ganymede chapter 13.6 with random world access
- block random world travel via UI and SpaceManager when lock is active

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2ef11192c8327a036c001a9f665cc