### PR TITLE
Refresh RWG after travel to respect travel lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,3 +379,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - GHG and oxygen factory settings now export from src/js/ghg-automation.js.
 - Random World Generator history lists visited worlds with names, types, seeds, states and departure times.
 - Random world departures now log timestamp and Ecumenopolis land coverage.
+- Random World Generator re-renders after travel to respect new travel locks.

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -208,7 +208,16 @@ function attachTravelHandler(res, sStr) {
     if (!equilibratedWorlds.has(sStr) && !equilibratedWorlds.has(canonical)) return;
     if (spaceManager?.isSeedTerraformed && (spaceManager.isSeedTerraformed(canonical) || spaceManager.isSeedTerraformed(sStr))) return;
     if (spaceManager?.travelToRandomWorld) {
-      spaceManager.travelToRandomWorld(res, sStr);
+      const travelled = spaceManager.travelToRandomWorld(res, sStr);
+      if (travelled) {
+        const box = document.getElementById('rwg-result');
+        if (box) {
+          box.innerHTML = renderWorldDetail(res, sStr);
+          attachEquilibrateHandler(res, sStr, undefined, box);
+          attachTravelHandler(res, sStr);
+        }
+        updateRandomWorldUI();
+      }
     }
   };
 }
@@ -441,9 +450,10 @@ function renderWorldDetail(res, seedUsed, forcedType) {
       </div>
     </div>` : '';
 
+  const sm = typeof spaceManager !== 'undefined' ? spaceManager : globalThis.spaceManager;
   const eqDone = seedUsed && equilibratedWorlds.has(seedUsed);
-  const alreadyTerraformed = seedUsed && spaceManager.isSeedTerraformed(seedUsed);
-  const lockedByStory = spaceManager.isRandomTravelLocked();
+  const alreadyTerraformed = seedUsed && sm?.isSeedTerraformed ? sm.isSeedTerraformed(seedUsed) : false;
+  const lockedByStory = sm?.isRandomTravelLocked ? sm.isRandomTravelLocked() : false;
   const travelDisabled = lockedByStory || !eqDone || alreadyTerraformed;
   const showTemps = !seedUsed || eqDone;
   const meanTVal = (showTemps && temps)


### PR DESCRIPTION
## Summary
- Re-render Random World Generator results after traveling so the new travel lock is immediately reflected
- Guard `renderWorldDetail` with a safe SpaceManager reference
- Test RWG UI refresh after travel

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2f2a6ee98832792f34a450b7002ec