### PR TITLE
Display per-second cost for continuous space storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,4 +379,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - GHG and oxygen factory settings now export from src/js/ghg-automation.js.
 - Random World Generator history lists visited worlds with names, types, seeds, states and departure times.
 - Random world departures now log timestamp and Ecumenopolis land coverage.
+- Space storage total cost display now shows cost per second in continuous mode.
 - Random World Generator re-renders after travel to respect new travel locks.

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -400,6 +400,10 @@ class SpaceStorageProject extends SpaceshipProject {
 
   updateCostAndGains(elements) {
     super.updateCostAndGains(elements);
+    if (elements.totalCostElement && this.isShipOperationContinuous()) {
+      const perSecondCost = this.calculateSpaceshipTotalCost(true);
+      elements.totalCostElement.innerHTML = formatTotalCostDisplay(perSecondCost, this, true);
+    }
     if (elements.transferRateElement) {
       const amount = this.calculateTransferAmount();
       const seconds = this.getShipOperationDuration() / 1000;

--- a/tests/spaceStorageContinuousCostDisplay.test.js
+++ b/tests/spaceStorageContinuousCostDisplay.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceStorageProject continuous total cost UI', () => {
+  test('shows per-second total cost', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="mega-projects-list" class="projects-list"></div></div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.formatNumber = n => n.toString();
+    ctx.formatBigInteger = n => n.toString();
+    ctx.projectElements = {};
+    ctx.resources = {
+      colony: { energy: { displayName: 'Energy', value: 0, decrease() {}, increase() {} } },
+      surface: {},
+      atmospheric: {},
+      special: { spaceships: { value: 101 } }
+    };
+    ctx.spaceManager = {
+      getTerraformedPlanetCount: () => 0,
+      getTerraformedPlanetCountIncludingCurrent: () => 1
+    };
+    ctx.EffectableEntity = EffectableEntity;
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(uiCode + '; this.createProjectItem = createProjectItem; this.updateProjectUI = updateProjectUI; this.initializeProjectsUI = initializeProjectsUI; this.projectElements = projectElements;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const storageCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceStorageProject.js'), 'utf8');
+    vm.runInContext(storageCode + '; this.SpaceStorageProject = SpaceStorageProject;', ctx);
+    const storageUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'spaceStorageUI.js'), 'utf8');
+    vm.runInContext(storageUICode + '; this.renderSpaceStorageUI = renderSpaceStorageUI; this.updateSpaceStorageUI = updateSpaceStorageUI;', ctx);
+
+    const attrs = { spaceStorage: true, costPerShip: { colony: { energy: 10 } }, transportPerShip: 1 };
+    const params = { name: 'spaceStorage', category: 'mega', cost: {}, duration: 1000, description: '', repeatable: true, maxRepeatCount: Infinity, unlocked: true, attributes: attrs };
+    const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
+    ctx.projectManager = { projects: { spaceStorage: project }, isBooleanFlagSet: () => false, getProjectStatuses: () => Object.values({ spaceStorage: project }) };
+
+    ctx.initializeProjectsUI();
+    ctx.createProjectItem(project);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+
+    project.assignSpaceships(101);
+    ctx.updateProjectUI('spaceStorage');
+
+    const text = ctx.projectElements.spaceStorage.totalCostElement.textContent;
+    expect(text).toBe('Total Cost: Energy: 1010/s');
+  });
+});


### PR DESCRIPTION
## Summary
- show space storage total cost as a per-second value when ship transfers run continuously
- test per-second cost formatting for continuous space storage
- document continuous space storage cost change

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b2f4ba28b483278c85bbde805f11b0