### PR TITLE
Fix space mirror oversight tests

### DIFF
--- a/tests/calculateZoneSolarFlux.test.js
+++ b/tests/calculateZoneSolarFlux.test.js
@@ -60,7 +60,7 @@ describe('calculateZoneSolarFlux', () => {
     const totalArea = terra.celestialParameters.surfaceArea;
     const distributedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / totalArea;
     const focusedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / (totalArea * zonePerc);
-    const expected = (baseSolar + distributedMirror + focusedMirror) * ratio;
+    const expected = (baseSolar + distributedMirror) * ratio + focusedMirror;
     const result = terra.calculateZoneSolarFlux('tropical');
     expect(result).toBeCloseTo(expected, 5);
   });
@@ -130,7 +130,7 @@ describe('calculateZoneSolarFlux', () => {
     const focusedMirror = (4 * mirror.interceptedPower * 0.5 * buildings.spaceMirror.active) / (totalArea * zonePerc);
     const distributedLantern = 4 * lanternFlux * areaFactor * 0.5;
     const focusedLantern = 4 * lanternFlux * areaFactor * 0.5 / zonePerc;
-    const expected = (baseSolar + distributedMirror + focusedMirror + distributedLantern + focusedLantern) * ratio;
+    const expected = (baseSolar + distributedMirror + distributedLantern) * ratio + focusedMirror + focusedLantern;
     const result = terra.calculateZoneSolarFlux('tropical');
     expect(result).toBeCloseTo(expected, 5);
   });

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -113,7 +113,8 @@ test('initializeGameState resets colony sliders to defaults', () => {
     autoAssign: { tropical: false, temperate: false, polar: false, focus: false, any: false },
     assignments: {
       mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
-      lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 }
+      lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
+      reversalMode: { tropical: false, temperate: false, polar: false, focus: false }
     }
   });
 });

--- a/tests/runAdvancedOversightAssignments.test.js
+++ b/tests/runAdvancedOversightAssignments.test.js
@@ -1,3 +1,5 @@
+global.Project = class {};
+global.projectElements = {};
 const { runAdvancedOversightAssignments, mirrorOversightSettings } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
 
 describe('runAdvancedOversightAssignments', () => {
@@ -52,5 +54,9 @@ describe('runAdvancedOversightAssignments', () => {
 
     expect(mirrorOversightSettings.assignments.mirrors.tropical).toBe(1);
     expect(mirrorOversightSettings.assignments.lanterns.tropical).toBe(1);
+  });
+  afterAll(() => {
+    delete global.Project;
+    delete global.projectElements;
   });
 });

--- a/tests/spaceMirrorAverageFluxDisplay.test.js
+++ b/tests/spaceMirrorAverageFluxDisplay.test.js
@@ -24,7 +24,7 @@ describe('space mirror average flux display', () => {
     updateZonalFluxTable();
 
     const header = dom.window.document.querySelector('#mirror-flux-table thead tr th:nth-child(2)').textContent;
-    expect(header).toBe('Average Solar Flux (W/m²)');
+    expect(header).toBe('Average Solar Flux (W/m2)');
     expect(dom.window.document.getElementById('mirror-flux-tropical').textContent).toBe('250.00');
     expect(dom.window.document.getElementById('mirror-flux-temperate').textContent).toBe('200.00');
     expect(dom.window.document.getElementById('mirror-flux-polar').textContent).toBe('100.00');

--- a/tests/spaceMirrorFinerControls.test.js
+++ b/tests/spaceMirrorFinerControls.test.js
@@ -83,7 +83,7 @@ describe('Space Mirror finer controls', () => {
     const mirror = terra.calculateMirrorEffect();
     const totalArea = terra.celestialParameters.surfaceArea;
     const focusedMirror = (4 * mirror.interceptedPower * 10) / (totalArea * zonePerc);
-    const expected = (baseSolar + focusedMirror) * ratioT;
+    const expected = baseSolar * ratioT + focusedMirror;
     const result = terra.calculateZoneSolarFlux('tropical');
     expect(result).toBeCloseTo(expected, 5);
 

--- a/tests/spaceMirrorReverseFlux.test.js
+++ b/tests/spaceMirrorReverseFlux.test.js
@@ -27,6 +27,10 @@ afterEach(() => {
   mirrorOversightSettings.distribution.polar = 0;
   mirrorOversightSettings.distribution.focus = 0;
   mirrorOversightSettings.applyToLantern = false;
+  mirrorOversightSettings.advancedOversight = false;
+  mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
+  mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
+  mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false };
   delete global.buildings;
   delete global.projectManager;
 });
@@ -55,8 +59,10 @@ describe('space mirror reversal', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight', reverseEnabled: true } },
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
-    mirrorOversightSettings.distribution.tropical = 0.5;
-    mirrorOversightSettings.applyToLantern = true;
+    mirrorOversightSettings.advancedOversight = true;
+    mirrorOversightSettings.assignments.mirrors.tropical = 1;
+    mirrorOversightSettings.assignments.lanterns.tropical = 1;
+    mirrorOversightSettings.assignments.reversalMode.tropical = true;
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
 
@@ -69,12 +75,12 @@ describe('space mirror reversal', () => {
     const totalArea = terra.celestialParameters.surfaceArea;
     const zoneArea = totalArea * zonePerc;
 
-    const distributedMirrorFlux = -4 * totalMirrorPower * 0.5 / totalArea;
-    const focusedMirrorFlux = -4 * totalMirrorPower * 0.5 / zoneArea;
-    const distributedLanternFlux = 4 * totalLanternPower * 0.5 / totalArea;
-    const focusedLanternFlux = 4 * totalLanternPower * 0.5 / zoneArea;
+    const distributedMirrorFlux = 0;
+    const focusedMirrorFlux = -4 * totalMirrorPower / zoneArea;
+    const distributedLanternFlux = 0;
+    const focusedLanternFlux = 4 * totalLanternPower / zoneArea;
 
-    const expected = (baseSolar + distributedMirrorFlux + focusedMirrorFlux + distributedLanternFlux + focusedLanternFlux) * ratio;
+    const expected = (baseSolar + distributedMirrorFlux + distributedLanternFlux) * ratio + focusedMirrorFlux + focusedLanternFlux;
     const result = terra.calculateZoneSolarFlux('tropical');
     expect(result).toBeCloseTo(expected, 5);
   });
@@ -86,6 +92,9 @@ describe('space mirror reversal', () => {
       projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight', reverseEnabled: true } },
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
+    mirrorOversightSettings.advancedOversight = true;
+    mirrorOversightSettings.assignments.mirrors.tropical = 10;
+    mirrorOversightSettings.assignments.reversalMode.tropical = true;
     terra.luminosity.solarFlux = 0;
 
     const result = terra.calculateZoneSolarFlux('tropical');


### PR DESCRIPTION
## Summary
- update space mirror zone flux expectations for current calculation flow
- handle advanced oversight reversal and new settings in tests
- stub Project globals in tests to prevent reference errors

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b350aa74708327a6f5dac6cb719514