### PR TITLE
Fix advanced oversight target input resets

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -782,15 +782,19 @@ function updateMirrorOversightUI() {
   const toDisp = (typeof toDisplayTemperature === 'function') ? toDisplayTemperature : (v => v);
   ['tropical','temperate','polar'].forEach(k => {
     const input = document.getElementById(`adv-target-${k}`);
-    if (input && mirrorOversightSettings.targets) {
+    if (input && mirrorOversightSettings.targets && document.activeElement !== input) {
       const v = mirrorOversightSettings.targets[k] || 293.15;
       input.value = (toDisp(v)).toFixed(2);
     }
     const sel = document.getElementById(`adv-priority-${k}`);
-    if (sel) sel.value = String(mirrorOversightSettings.priority[k] || 1);
+    if (sel && document.activeElement !== sel) sel.value = String(mirrorOversightSettings.priority[k] || 1);
   });
   const waterRow = document.getElementById('adv-water-row');
   if (waterRow) waterRow.style.display = focusEnabled ? 'flex' : 'none';
+  const waterInput = document.getElementById('adv-target-water');
+  if (waterInput && mirrorOversightSettings.targets && document.activeElement !== waterInput) {
+    waterInput.value = Number(mirrorOversightSettings.targets.water || 0);
+  }
   const C = mirrorOversightCache || {};
   if (C.lanternHeader) C.lanternHeader.style.display = lanternUnlocked ? '' : 'none';
   if (C.lanternCells) C.lanternCells.forEach(cell => { cell.style.display = lanternUnlocked ? 'flex' : 'none'; });

--- a/tests/advancedOversightTargetInput.test.js
+++ b/tests/advancedOversightTargetInput.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('advanced oversight target inputs', () => {
+  test('values are not overwritten while focused', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div id="mirror-oversight-container">
+        <div id="mirror-advanced-oversight-div"></div>
+        <div id="advanced-oversight-controls">
+          <input id="adv-target-tropical" />
+          <select id="adv-priority-tropical"></select>
+          <div id="adv-water-row"></div>
+          <input id="adv-target-water" />
+        </div>
+      </div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectManager = { isBooleanFlagSet: () => true };
+    ctx.buildings = {};
+    ctx.projectElements = {};
+    ctx.Project = class {};
+    ctx.toDisplayTemperature = v => v;
+    ctx.getTemperatureUnit = () => 'K';
+    ctx.formatNumber = () => '';
+    ctx.terraforming = {
+      calculateZoneSolarFlux: () => 0,
+      temperature: { zones: { tropical: { value: 0 }, temperate: { value: 0 }, polar: { value: 0 } } },
+      celestialParameters: { crossSectionArea: 1, surfaceArea: 1 },
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 })
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects/SpaceMirrorFacilityProject.js'), 'utf8');
+    vm.runInContext(code + '; this.updateMirrorOversightUI = updateMirrorOversightUI; this.mirrorOversightSettings = mirrorOversightSettings;', ctx);
+
+    ctx.mirrorOversightSettings.advancedOversight = true;
+    ctx.mirrorOversightSettings.targets.tropical = 300;
+    ctx.updateMirrorOversightUI();
+
+    const input = dom.window.document.getElementById('adv-target-tropical');
+    expect(input.value).toBe('300.00');
+    input.focus();
+    input.value = '310.00';
+    ctx.updateMirrorOversightUI();
+    expect(input.value).toBe('310.00');
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent advanced oversight target and priority inputs from being overwritten while the player is editing
- Add regression test ensuring advanced oversight target values remain during focus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b35216d3188327b1852b20d3495149