### PR TITLE
Clarify advanced oversight priority tooltip

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -369,7 +369,7 @@ function initializeMirrorOversightUI(container) {
   advDiv.innerHTML = `
     <input type="checkbox" id="mirror-advanced-oversight">
     <label for="mirror-advanced-oversight">Advanced Oversight</label>
-    <span class="info-tooltip-icon" title="Unlocks target-based control: set temperature targets per zone and a water melt target. Mirrors and lanterns auto-assign by priority when enabled.">&#9432;</span>
+    <span class="info-tooltip-icon" title="Unlocks target-based control: set temperature targets per zone and a water melt target. Mirrors and lanterns auto-assign by priority when enabled; lower numbers are assigned first.">&#9432;</span>
   `;
   if (lanternDivInit) {
     lanternDivInit.style.display = 'flex';
@@ -385,7 +385,7 @@ function initializeMirrorOversightUI(container) {
   advancedControls.innerHTML = `
     <div class="control-group">
       <span class="control-label" style="font-weight:600;">Targets & Priority</span>
-      <span class="info-tooltip-icon" title="Set temperature targets for Tropical, Temperate, and Polar zones using the current unit, plus a water melt target when focusing. Priorities 1 to 5 decide assignment order.">&#9432;</span>
+      <span class="info-tooltip-icon" title="Set temperature targets for Tropical, Temperate, and Polar zones using the current unit, plus a water melt target when focusing. Priorities 1 to 5 decide assignment order; lower numbers are assigned first.">&#9432;</span>
     </div>
     <div class="stats-grid three-col" style="row-gap:8px;">
       <div class="stat-item" style="display:flex; gap:8px; align-items:center;">

--- a/tests/spaceMirrorAdvancedOversight.test.js
+++ b/tests/spaceMirrorAdvancedOversight.test.js
@@ -3,6 +3,9 @@ global.projectElements = {};
 global.terraforming = { calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }) };
 const originalFormatNumber = global.formatNumber;
 global.formatNumber = () => '';
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.document = dom.window.document;
 
 const {
   setMirrorDistribution,
@@ -10,6 +13,7 @@ const {
   mirrorOversightSettings,
   toggleAdvancedOversight,
   resetMirrorOversightSettings,
+  initializeMirrorOversightUI,
 } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
 
 // cleanup globals injected by module
@@ -46,5 +50,13 @@ describe('advanced mirror oversight', () => {
     toggleAdvancedOversight(true);
     distributeAssignmentsFromSliders('mirrors');
     expect(mirrorOversightSettings.assignments.mirrors.any).toBe(0);
+  });
+
+  test('advanced oversight tooltip clarifies priority order', () => {
+    const container = document.createElement('div');
+    initializeMirrorOversightUI(container);
+    const tooltip = container.querySelector('#mirror-advanced-oversight-div .info-tooltip-icon');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.getAttribute('title')).toMatch(/lower numbers are assigned first/i);
   });
 });


### PR DESCRIPTION
## Summary
- Clarify priority tooltip in advanced oversight so players know lower numbers allocate first
- Mention priority order in advanced controls tooltip and test its presence

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b3524fe9908327b62c0050277228cd