### PR TITLE
Hide space mirror reversal column until unlocked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,3 +383,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage total cost display now shows cost per second in continuous mode.
 - Random World Generator re-renders after travel to respect new travel locks.
 - Space mirror facility advanced oversight now allocates mirrors and lanterns via bisection on zone temperature using `updateSurfaceTemperature`.
+- Space mirror reversal column hides until reversal is unlocked, removing its checkboxes when unavailable.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -685,6 +685,8 @@ function rebuildMirrorOversightCache() {
     lanternHeader: document.querySelector('#assignment-grid .grid-header:nth-child(3)') || null,
     lanternCells: Array.from(document.querySelectorAll('#assignment-grid .assign-cell[data-type="lanterns"]')),
     availableLanternCells: Array.from(document.querySelectorAll('.available-lantern-cell')),
+    reversalHeader: document.querySelector('#assignment-grid .grid-header:nth-child(4)') || null,
+    reversalCells: Array.from(document.querySelectorAll('#assignment-grid .grid-reversal-cell')),
     autoAssignBoxes: Array.from(document.querySelectorAll('#assignment-table .auto-assign')),
     assignmentControls: Array.from(document.querySelectorAll('#mirror-finer-content button, #mirror-finer-content input[type="checkbox"]:not(#mirror-use-finer)')),
     focusZoneCells: Array.from(document.querySelectorAll('#assignment-grid > div[data-zone="focus"]')),
@@ -761,6 +763,11 @@ function updateMirrorOversightUI() {
       lanternDiv.style.flexWrap = 'wrap';
     }
   }
+
+  const smfProject = (typeof projectManager !== 'undefined' && projectManager.projects)
+    ? projectManager.projects.spaceMirrorFacility
+    : null;
+  const reversalAvailable = !!(smfProject && smfProject.reversalAvailable);
   // Advanced oversight unlock check (boolean flag name: advancedOversight)
   let advancedUnlocked = false;
   if (typeof projectManager !== 'undefined') {
@@ -795,10 +802,20 @@ function updateMirrorOversightUI() {
   if (C.lanternHeader) C.lanternHeader.style.display = lanternUnlocked ? '' : 'none';
   if (C.lanternCells) C.lanternCells.forEach(cell => { cell.style.display = lanternUnlocked ? 'flex' : 'none'; });
   if (C.availableLanternCells) C.availableLanternCells.forEach(cell => { cell.style.display = lanternUnlocked ? 'flex' : 'none'; });
+  if (C.reversalHeader) C.reversalHeader.style.display = reversalAvailable ? '' : 'none';
+  if (C.reversalCells) C.reversalCells.forEach(cell => { cell.style.display = reversalAvailable ? 'flex' : 'none'; });
 
   const assignmentGrid = document.getElementById('assignment-grid');
   if (assignmentGrid) {
-    assignmentGrid.style.gridTemplateColumns = lanternUnlocked ? '100px 1fr 1fr 80px 50px' : '100px 1fr 80px 50px';
+    if (lanternUnlocked && reversalAvailable) {
+      assignmentGrid.style.gridTemplateColumns = '100px 1fr 1fr 80px 50px';
+    } else if (lanternUnlocked) {
+      assignmentGrid.style.gridTemplateColumns = '100px 1fr 1fr 50px';
+    } else if (reversalAvailable) {
+      assignmentGrid.style.gridTemplateColumns = '100px 1fr 80px 50px';
+    } else {
+      assignmentGrid.style.gridTemplateColumns = '100px 1fr 50px';
+    }
   }
 
   const useFiner = mirrorOversightSettings.useFinerControls;
@@ -1154,6 +1171,9 @@ class SpaceMirrorFacilityProject extends Project {
     if (elements && elements.reflectMode) {
       elements.reflectMode.container.style.display = '';
       elements.reflectMode.update();
+    }
+    if (typeof updateMirrorOversightUI === 'function') {
+      updateMirrorOversightUI();
     }
   }
 

--- a/tests/spaceMirrorReversalColumn.test.js
+++ b/tests/spaceMirrorReversalColumn.test.js
@@ -1,0 +1,76 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('space mirror reversal column', () => {
+  test('reversal column hidden until reversal enabled', () => {
+    const originalDocument = global.document;
+    const originalProject = global.Project;
+    const originalFormat = global.formatNumber;
+    const originalTerraforming = global.terraforming;
+    const originalBuildings = global.buildings;
+    const originalProjectElements = global.projectElements;
+    const originalProjectManager = global.projectManager;
+
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    global.Project = class {
+      saveState() { return {}; }
+      loadState() {}
+    };
+    global.formatNumber = v => v;
+    global.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      celestialParameters: { crossSectionArea: 1, surfaceArea: 1 },
+    };
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { unlocked: false } };
+    global.projectElements = {};
+
+    const { SpaceMirrorFacilityProject } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+    const config = { name: 'Space Mirror Facility', cost: {}, duration: 0 };
+    const project = new SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    global.projectManager = {
+      projects: { spaceMirrorFacility: project },
+      isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight',
+    };
+
+    const container = document.getElementById('root');
+    project.renderUI(container);
+    project.updateUI();
+
+    const header = document.querySelector('#assignment-grid .grid-header:nth-child(4)');
+    const cells = Array.from(document.querySelectorAll('#assignment-grid .grid-reversal-cell'));
+    expect(header.style.display).toBe('none');
+    cells.forEach(cell => {
+      expect(cell.style.display).toBe('none');
+    });
+
+    project.enableReversal();
+    project.updateUI();
+
+    expect(header.style.display).not.toBe('none');
+    cells.forEach(cell => {
+      if (cell.dataset.zone === 'focus') return;
+      expect(cell.style.display).not.toBe('none');
+    });
+
+    global.document = originalDocument;
+    global.Project = originalProject;
+    global.formatNumber = originalFormat;
+    global.terraforming = originalTerraforming;
+    global.buildings = originalBuildings;
+    global.projectElements = originalProjectElements || {};
+    global.projectManager = originalProjectManager;
+    delete global.mirrorOversightSettings;
+    delete global.setMirrorDistribution;
+    delete global.resetMirrorOversightSettings;
+    delete global.initializeMirrorOversightUI;
+    delete global.updateMirrorOversightUI;
+    delete global.updateZonalFluxTable;
+    delete global.applyFocusedMelt;
+    delete global.calculateZoneSolarFluxWithFacility;
+    delete global.toggleFinerControls;
+    delete global.updateAssignmentDisplays;
+  });
+});
+


### PR DESCRIPTION
## Summary
- Hide reversal column in space mirror finer controls when reversal isn't available, updating grid layout accordingly
- Refresh mirror oversight UI immediately when reversal unlocks
- Test reversal column visibility toggles with unlock state

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b35280183c832780ef0aff776402d2