### PR TITLE
Hide Solis upgrades until story flag

### DIFF
--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -167,14 +167,12 @@ function initializeSolisUI() {
     title.textContent = 'Solis Shop';
     shopContainer.insertBefore(title, container);
     
-    ['funding', 'metal', 'food', 'components', 'electronics', 'glass', 'water', 'androids', 'colonistRocket', 'research', 'advancedOversight'].forEach(key => {
+    const solis1 = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
+    const baseKeys = ['funding', 'metal', 'food', 'components', 'electronics', 'glass', 'water', 'androids', 'colonistRocket'];
+    const keys = solis1 ? baseKeys.concat(['research', 'advancedOversight']) : baseKeys;
+    keys.forEach(key => {
       const item = createShopItem(key);
       container.appendChild(item);
-    });
-    const flag = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
-    ['research', 'advancedOversight'].forEach(key => {
-      const el = shopElements[key]?.item;
-      if (el) el.classList.toggle('hidden', !flag);
     });
   }
 
@@ -300,8 +298,19 @@ function updateSolisUI() {
 
   const solis1 = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
   ['research', 'advancedOversight'].forEach(k => {
-    const item = shopElements[k]?.item;
-    if (item) item.classList.toggle('hidden', !solis1);
+    const record = shopElements[k];
+    if (solis1) {
+      if (!record) {
+        const container = document.getElementById('solis-shop-items');
+        if (container) {
+          const item = createShopItem(k);
+          container.appendChild(item);
+        }
+      }
+    } else if (record) {
+      record.item.remove();
+      delete shopElements[k];
+    }
   });
 
   if (pointsSpan) {

--- a/tests/solisUpgrade1ShopOptions.test.js
+++ b/tests/solisUpgrade1ShopOptions.test.js
@@ -35,14 +35,12 @@ describe('solisUpgrade1 shop options', () => {
     ctx.resources = { colony: { research: { value: 0, hasCap: false, increase(v){ this.value += v; } } } };
     ctx.solisManager = new ctx.SolisManager();
     ctx.initializeSolisUI();
-    const researchItem = dom.window.document.querySelector('#solis-shop-research-button').parentElement.parentElement;
-    const advItem = dom.window.document.querySelector('#solis-shop-advancedOversight-button').parentElement.parentElement;
-    expect(researchItem.classList.contains('hidden')).toBe(true);
-    expect(advItem.classList.contains('hidden')).toBe(true);
+    expect(dom.window.document.querySelector('#solis-shop-research-button')).toBeNull();
+    expect(dom.window.document.querySelector('#solis-shop-advancedOversight-button')).toBeNull();
     ctx.solisManager.booleanFlags.add('solisUpgrade1');
     ctx.updateSolisUI();
-    expect(researchItem.classList.contains('hidden')).toBe(false);
-    expect(advItem.classList.contains('hidden')).toBe(false);
+    expect(dom.window.document.querySelector('#solis-shop-research-button')).not.toBeNull();
+    expect(dom.window.document.querySelector('#solis-shop-advancedOversight-button')).not.toBeNull();
   });
 
   test('purchase research adds points', () => {


### PR DESCRIPTION
## Summary
- Only build Solis shop entries for research points and advanced oversight after `solisUpgrade1` is unlocked
- Dynamically add or remove these shop entries when the flag changes
- Adjust tests for new unlock behavior

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b3553f8fac83278f961abd4631b726