### PR TITLE
Allow sustain-cost projects to use production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - WGC team cards cache DOM nodes for buttons, inputs, selects, progress bars, logs and HP bars, rebuilding these caches when cards redraw or team counts change for faster updates.
 - Methane melting and freezing now respect methane ice coverage.
 - Planetary thrusters operate as a continuous project, drawing power from ongoing energy production instead of only stored energy.
+- Projects with sustain costs draw from current production as well as stored resources so they can run continuously.
 - Planetary thrusters appear in the Energy resource rate tooltip, listing their consumption.
 - Freezing processes scale with liquid surface area and accept liquid coverage functions.
 - Added decillion, undecillion, and duodecillion number units.

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -212,11 +212,16 @@ class Project extends EffectableEntity {
 
   hasSustainResources(deltaTime = 1000) {
     if (!this.sustainCost) return true;
-    const seconds = 1;
+    const seconds = deltaTime / 1000;
     for (const category in this.sustainCost) {
       for (const resource in this.sustainCost[category]) {
-        const required = this.sustainCost[category][resource] * seconds;
-        if (resources[category][resource].value < required) {
+        const costRate = this.sustainCost[category][resource];
+        const res = resources[category][resource];
+        const prod = res.productionRate || 0;
+        const cons = res.consumptionRate || 0;
+        const available = res.value + prod * seconds;
+        const required = (cons + costRate) * seconds;
+        if (available < required) {
           return false;
         }
       }

--- a/tests/projectSustainRateDisplay.test.js
+++ b/tests/projectSustainRateDisplay.test.js
@@ -14,6 +14,8 @@ describe('project sustain cost rates', () => {
       colony: {
         energy: {
           value: 100,
+          productionRate: 0,
+          consumptionRate: 0,
           decrease(v){ this.value -= v; },
           updateStorageCap: () => {},
           modifyRate: jest.fn()

--- a/tests/sustainCostPause.test.js
+++ b/tests/sustainCostPause.test.js
@@ -12,7 +12,13 @@ describe('project sustain cost pause', () => {
     vm.runInContext(code + '; this.Project = Project;', ctx);
     ctx.resources = {
       colony: {
-        energy: { value: 1000, decrease(v){ this.value -= v; }, updateStorageCap: () => {} }
+        energy: {
+          value: 1000,
+          productionRate: 0,
+          consumptionRate: 0,
+          decrease(v){ this.value -= v; },
+          updateStorageCap: () => {}
+        }
       }
     };
     global.resources = ctx.resources;
@@ -32,6 +38,7 @@ describe('project sustain cost pause', () => {
     const project = new ctx.Project(config, 'test');
     project.start(ctx.resources);
     expect(project.isActive).toBe(true);
+    ctx.resources.colony.energy.productionRate = 0;
     project.update(1000); // deduct one second of sustain cost
     expect(ctx.resources.colony.energy.value).toBeCloseTo(990);
     project.update(1000); // deduct another second of sustain cost
@@ -41,5 +48,26 @@ describe('project sustain cost pause', () => {
     project.update(1000); // not enough energy -> pause
     expect(project.isPaused).toBe(true);
     expect(project.isActive).toBe(false);
+  });
+
+  test('uses production to cover sustain cost', () => {
+    const config = {
+      name: 'Test',
+      category: 'story',
+      cost: { colony: { energy: 0 } },
+      sustainCost: { colony: { energy: 10 } },
+      duration: 200000,
+      description: '',
+      repeatable: false,
+      unlocked: true
+    };
+    const project = new ctx.Project(config, 'test');
+    project.start(ctx.resources);
+    ctx.resources.colony.energy.value = 0;
+    ctx.resources.colony.energy.productionRate = 10;
+    ctx.resources.colony.energy.consumptionRate = 0;
+    project.update(1000);
+    expect(project.isPaused).toBe(false);
+    expect(project.isActive).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Let projects with sustain costs draw from both stored resources and current production for uninterrupted operation
- Document continuous sustain-cost behavior in AGENTS notes
- Test sustain-cost projects pausing and continuing based on production

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b357d54b508327a08a81bc150663f6