### PR TITLE
Place Solis advanced oversight upgrade in research shop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,5 +383,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage total cost display now shows cost per second in continuous mode.
 - Random World Generator re-renders after travel to respect new travel locks.
 - Space mirror facility advanced oversight now allocates mirrors and lanterns via bisection on zone temperature using `updateSurfaceTemperature`.
-- Solis shop offers research points and an advanced oversight upgrade once `solisUpgrade1` is set.
+- Solis shop offers research points, and the advanced oversight upgrade now appears under Research Upgrades beneath the research auto-complete upgrade once `solisUpgrade1` is set.
 - Space mirror reversal column hides until reversal is unlocked, removing its checkboxes when unavailable.

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -158,6 +158,7 @@ function initializeSolisUI() {
     });
   }
 
+  const solis1 = typeof solisManager !== 'undefined' && solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
   const container = document.getElementById('solis-shop-items');
   if (container) {
     const shopContainer = container.parentElement;
@@ -166,10 +167,9 @@ function initializeSolisUI() {
     const title = document.createElement('h3');
     title.textContent = 'Solis Shop';
     shopContainer.insertBefore(title, container);
-    
-    const solis1 = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
+
     const baseKeys = ['funding', 'metal', 'food', 'components', 'electronics', 'glass', 'water', 'androids', 'colonistRocket'];
-    const keys = solis1 ? baseKeys.concat(['research', 'advancedOversight']) : baseKeys;
+    const keys = solis1 ? baseKeys.concat(['research']) : baseKeys;
     keys.forEach(key => {
       const item = createShopItem(key);
       container.appendChild(item);
@@ -230,6 +230,9 @@ function initializeSolisUI() {
     title.textContent = 'Research Upgrades';
     parent.insertBefore(title, researchShopItems);
     researchShopItems.appendChild(createShopItem('researchUpgrade'));
+    if (solis1) {
+      researchShopItems.appendChild(createShopItem('advancedOversight'));
+    }
   }
 
   const questText = document.getElementById('solis-quest-text');
@@ -291,13 +294,14 @@ function updateSolisUI() {
   const donationButton = document.getElementById('solis-donation-button');
   const donationLabel = document.getElementById('solis-donation-label');
   const researchShop = document.getElementById('solis-research-shop');
+  const researchShopItems = document.getElementById('solis-research-shop-items');
 
   const flag = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisAlienArtifactUpgrade');
   if (donationSection) donationSection.classList.toggle('hidden', !flag);
   if (researchShop) researchShop.classList.toggle('hidden', !flag);
 
-  const solis1 = solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
-  ['research', 'advancedOversight'].forEach(k => {
+  const solis1 = typeof solisManager !== 'undefined' && solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
+  ['research'].forEach(k => {
     const record = shopElements[k];
     if (solis1) {
       if (!record) {
@@ -312,6 +316,15 @@ function updateSolisUI() {
       delete shopElements[k];
     }
   });
+  const advRecord = shopElements.advancedOversight;
+  if (solis1) {
+    if (!advRecord && researchShopItems) {
+      researchShopItems.appendChild(createShopItem('advancedOversight'));
+    }
+  } else if (advRecord) {
+    advRecord.item.remove();
+    delete shopElements.advancedOversight;
+  }
 
   if (pointsSpan) {
     const format = typeof formatNumber === 'function'

--- a/tests/solisUpgrade1ShopOptions.test.js
+++ b/tests/solisUpgrade1ShopOptions.test.js
@@ -39,8 +39,12 @@ describe('solisUpgrade1 shop options', () => {
     expect(dom.window.document.querySelector('#solis-shop-advancedOversight-button')).toBeNull();
     ctx.solisManager.booleanFlags.add('solisUpgrade1');
     ctx.updateSolisUI();
-    expect(dom.window.document.querySelector('#solis-shop-research-button')).not.toBeNull();
-    expect(dom.window.document.querySelector('#solis-shop-advancedOversight-button')).not.toBeNull();
+    const researchButton = dom.window.document.querySelector('#solis-shop-research-button');
+    const advButton = dom.window.document.querySelector('#solis-shop-advancedOversight-button');
+    expect(researchButton).not.toBeNull();
+    expect(advButton).not.toBeNull();
+    expect(dom.window.document.getElementById('solis-research-shop-items').contains(advButton)).toBe(true);
+    expect(dom.window.document.getElementById('solis-shop-items').contains(advButton)).toBe(false);
   });
 
   test('purchase research adds points', () => {


### PR DESCRIPTION
## Summary
- Move advanced oversight upgrade from main Solis shop to Research Upgrades section
- Ensure UI dynamically adds advanced oversight beneath research auto-complete upgrade
- Update test to verify new placement and document change in AGENTS

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b358bdab948327824d4630919cfa9b