### PR TITLE
Show optical depth with three decimal places

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,3 +386,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space mirror facility advanced oversight now allocates mirrors and lanterns via bisection on zone temperature using `updateSurfaceTemperature`.
 - Solis shop offers research points, and the advanced oversight upgrade now appears under Research Upgrades beneath the research auto-complete upgrade once `solisUpgrade1` is set.
 - Space mirror reversal column hides until reversal is unlocked, removing its checkboxes when unavailable.
+- Optical depth display now shows three decimal places.

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -349,7 +349,7 @@ function createTemperatureBox(row) {
     els.current.textContent = terraforming.calculateTotalPressure().toFixed(2);
 
     if (els.opticalDepth) {
-      els.opticalDepth.textContent = terraforming.temperature.opticalDepth.toFixed(2);
+      els.opticalDepth.textContent = terraforming.temperature.opticalDepth.toFixed(3);
     }
     if (els.opticalDepthInfo) {
       const contributions = terraforming.temperature.opticalDepthContributions || {};
@@ -365,7 +365,7 @@ function createTemperatureBox(row) {
           const displayName = resourceKey && resources.atmospheric[resourceKey]
             ? resources.atmospheric[resourceKey].displayName
             : gas.toUpperCase();
-          return `${displayName}: ${val.toFixed(2)}`;
+          return `${displayName}: ${val.toFixed(3)}`;
         });
       if (els.opticalDepthTooltip) {
         els.opticalDepthTooltip.innerHTML = lines.join('<br>');

--- a/tests/atmosphereOpticalDepthUI.test.js
+++ b/tests/atmosphereOpticalDepthUI.test.js
@@ -70,8 +70,8 @@ describe('atmosphere UI optical depth', () => {
     expect(info.getAttribute('title')).toBeNull();
     const tooltip = pEls[1].querySelector('#optical-depth-tooltip');
     expect(tooltip).not.toBeNull();
-    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.30');
-    expect(tooltip.textContent).toContain('Water Vap.: 0.20');
+    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.300');
+    expect(tooltip.textContent).toContain('Water Vap.: 0.200');
     expect(box.querySelector('#emissivity')).toBeNull();
     expect(pEls[2].querySelector('#wind-turbine-multiplier')).not.toBeNull();
     expect(pEls[1].classList.contains('no-margin')).toBe(true);
@@ -134,10 +134,10 @@ describe('atmosphere UI optical depth', () => {
     ctx.updateAtmosphereBox();
 
     const tooltip = dom.window.document.getElementById('optical-depth-tooltip');
-    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.30');
+    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.300');
     ctx.terraforming.temperature.opticalDepthContributions = { co2: 0.1, h2o: 0.4 };
     ctx.updateAtmosphereBox();
-    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.10');
-    expect(tooltip.textContent).toContain('Water Vap.: 0.40');
+    expect(tooltip.textContent).toContain('Carbon Dioxide: 0.100');
+    expect(tooltip.textContent).toContain('Water Vap.: 0.400');
   });
 });


### PR DESCRIPTION
## Summary
- Display optical depth and its gas contributions with three decimal places
- Update atmosphere optical depth tests to use three-decimal precision
- Note precision change in project documentation

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b35b05e1a88327bb25072032e09a09