### PR TITLE
Add force flag to updateRender for pause rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,3 +387,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Solis shop offers research points, and the advanced oversight upgrade now appears under Research Upgrades beneath the research auto-complete upgrade once `solisUpgrade1` is set.
 - Space mirror reversal column hides until reversal is unlocked, removing its checkboxes when unavailable.
 - Optical depth display now shows three decimal places.
+- Added a `force` argument to `updateRender` to bypass tab visibility checks for a one-time UI update when pausing via Save & Settings.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -349,7 +349,7 @@ function updateLogic(delta) {
 
 }
 
-function updateRender() {
+function updateRender(force = false) {
   // Always-on UI pieces
   updateDayNightDisplay();           // Day/night display is global
   updateResourceDisplay(resources);  // Resources are global
@@ -363,6 +363,7 @@ function updateRender() {
   // Gate heavy per-tab UI updates behind tab visibility
   if (typeof document !== 'undefined') {
     const isActive = (id) => {
+      if (force) return true;
       const el = document.getElementById(id);
       return !!(el && el.classList.contains('active'));
     };

--- a/src/js/pause.js
+++ b/src/js/pause.js
@@ -15,6 +15,9 @@
       }
       if(btn){ btn.textContent = 'Resume'; }
       if(alertBox){ alertBox.innerHTML = '<div class="pause-message">PAUSED</div>'; }
+      if (typeof updateRender === 'function') {
+        updateRender(true);
+      }
     } else {
       if(globalThis.game && game.scene){
         game.scene.resume('mainScene');

--- a/tests/pauseUpdateRender.test.js
+++ b/tests/pauseUpdateRender.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('pause button render', () => {
+  test('calls updateRender once when pausing', () => {
+    const dom = new JSDOM('<!DOCTYPE html><button id="pause-button">Pause</button><div id="pause-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.game = { scene: { pause: () => {}, resume: () => {} } };
+    ctx.setGameSpeed = () => {};
+    const calls = [];
+    ctx.updateRender = (flag) => calls.push(flag);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'pause.js'), 'utf8');
+    vm.runInContext(code + '; this.togglePause = togglePause;', ctx);
+
+    ctx.togglePause();
+    expect(calls).toEqual([true]);
+
+    ctx.togglePause();
+    expect(calls).toEqual([true]);
+  });
+});

--- a/tests/updateRenderForce.test.js
+++ b/tests/updateRenderForce.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+test('updateRender bypasses tab checks when forced', () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="buildings"></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.document = dom.window.document;
+  ctx.globalThis = ctx;
+  ctx.updateDayNightDisplay = () => {};
+  ctx.updateResourceDisplay = () => {};
+  ctx.updateWarnings = () => {};
+  ctx.updateBuildingAlert = () => {};
+  ctx.updateProjectAlert = () => {};
+  ctx.updateResearchAlert = () => {};
+  ctx.updateHopeAlert = () => {};
+  ctx.updateColonyDisplay = () => {};
+  ctx.updateGrowthRateDisplay = () => {};
+  ctx.renderProjects = () => {};
+  ctx.updateResearchUI = () => {};
+  ctx.updateTerraformingUI = () => {};
+  ctx.updateSpaceUI = () => {};
+  ctx.updateHopeUI = () => {};
+  ctx.updateStatisticsDisplay = () => {};
+  ctx.updateMilestonesUI = () => {};
+  const calls = [];
+  ctx.updateBuildingDisplay = () => calls.push('buildings');
+  ctx.resources = {};
+  ctx.buildings = {};
+  ctx.colonies = {};
+  ctx.Phaser = { AUTO: 0, Game: function(){ this.scene = {}; } };
+
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'game.js'), 'utf8');
+  vm.runInContext(code + '; this.updateRender = updateRender;', ctx);
+
+  ctx.updateRender();
+  expect(calls).toEqual([]);
+
+  ctx.updateRender(true);
+  expect(calls).toEqual(['buildings']);
+});


### PR DESCRIPTION
## Summary
- add `force` argument to `updateRender` to bypass tab visibility when needed
- invoke `updateRender(true)` when pausing the game for a final UI refresh
- test forced rendering and the pause call

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b36be8e61483278f6e6b12864883ee