### PR TITLE
Handle WGC leader placeholder during journal reconstruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,3 +388,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space mirror reversal column hides until reversal is unlocked, removing its checkboxes when unavailable.
 - Optical depth display now shows three decimal places.
 - Added a `force` argument to `updateRender` to bypass tab visibility checks for a one-time UI update when pausing via Save & Settings.
+- Journal reconstruction now resolves `$WGC_TEAM_LEADER$` placeholders using current team leader names when loading saves.

--- a/src/js/journal-reconstruction.js
+++ b/src/js/journal-reconstruction.js
@@ -9,6 +9,10 @@
     const historySources = [];
     if (!sm || !data) return { entries, sources, historyEntries, historySources };
 
+    const resolve = typeof resolveStoryPlaceholders === 'function'
+      ? resolveStoryPlaceholders
+      : (t => t);
+
     const completed = new Set([
       ...(sm.completedEventIds instanceof Set ? Array.from(sm.completedEventIds) : sm.completedEventIds || []),
       ...(sm.activeEventIds instanceof Set ? Array.from(sm.activeEventIds) : sm.activeEventIds || [])
@@ -27,7 +31,8 @@
           sources.length = 0;
         }
         const lines = ch.narrativeLines || [ch.narrative];
-        const text = ch.title ? joinLines([`${ch.title}:`, ...lines]) : joinLines(lines);
+        const textRaw = ch.title ? joinLines([`${ch.title}:`, ...lines]) : joinLines(lines);
+        const text = textRaw != null ? resolve(textRaw) : textRaw;
         if (text != null) {
           entries.push(text);
           sources.push({ type: 'chapter', id: ch.id });
@@ -51,6 +56,7 @@
                   if (projName) {
                     textStr = `${projName} ${i + 1}/${total}: ${textStr}`;
                   }
+                  textStr = resolve(textStr);
                   entries.push(textStr);
                   sources.push({ type: 'project', id: obj.projectId, step: i });
                   historyEntries.push(textStr);

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -22,7 +22,10 @@ function getWGCTeamLeaderName(index) {
 }
 
 function resolveStoryPlaceholders(text) {
-    return text.replace(/\$WGC_TEAM1_LEADER\$/g, getWGCTeamLeaderName(0));
+    const leaderName = getWGCTeamLeaderName(0);
+    return text
+        .replace(/\$WGC_TEAM1_LEADER\$/g, leaderName)
+        .replace(/\$WGC_TEAM_LEADER\$/g, leaderName);
 }
 
 function compareValues(current, target, comparison = 'gte') {

--- a/tests/reconstructJournalStateLoad.test.js
+++ b/tests/reconstructJournalStateLoad.test.js
@@ -29,4 +29,30 @@ describe('reconstructJournalState UI update', () => {
     expect(entries.length).toBe(1);
     expect(entries[0].textContent).toBe('alpha');
   });
+
+  test('resolves WGC leader placeholder during reconstruction', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="journal"><div id="journal-entries"></div></div>
+    </body></html>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const journalCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal.js'), 'utf8');
+    vm.runInContext(journalCode, ctx);
+    const reconCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'journal-reconstruction.js'), 'utf8');
+    vm.runInContext(reconCode, ctx);
+    const debugCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'debug-tools.js'), 'utf8');
+    vm.runInContext(debugCode, ctx);
+
+    ctx.resolveStoryPlaceholders = txt => txt.replace(/\$WGC_TEAM_LEADER\$/g, 'Alice Smith');
+    ctx.progressData = {
+      chapters: [{ id: 'c1', type: 'journal', narrative: 'Leader: $WGC_TEAM_LEADER$.' }],
+      storyProjects: {}
+    };
+    const sm = { completedEventIds: new Set(['c1']), activeEventIds: new Set() };
+
+    ctx.reconstructJournalState(sm, null);
+
+    const entries = dom.window.document.querySelectorAll('#journal-entries p');
+    expect(entries.length).toBe(1);
+    expect(entries[0].textContent).toBe('Leader: Alice Smith.');
+  });
 });

--- a/tests/wgcTeamLeaderPlaceholder.test.js
+++ b/tests/wgcTeamLeaderPlaceholder.test.js
@@ -36,4 +36,14 @@ describe('WGC team leader placeholder', () => {
     event.trigger();
     expect(ctx.addJournalEntry).toHaveBeenCalledWith('Team Leader 1', 'd', { type: 'chapter', id: 'd' });
   });
+
+  test('replaces generic placeholder with leader name', () => {
+    const ctx = createContext({ teams: [[{ firstName: 'Eve', lastName: 'Doe' }]] });
+    const progressData = { chapters: [{ id: 'e', type: 'journal', narrative: 'Leader: $WGC_TEAM_LEADER$.' }] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.window.storyManager = manager;
+    const event = manager.findEventById('e');
+    event.trigger();
+    expect(ctx.addJournalEntry).toHaveBeenCalledWith('Leader: Eve Doe.', 'e', { type: 'chapter', id: 'e' });
+  });
 });


### PR DESCRIPTION
## Summary
- Support the generic `$WGC_TEAM_LEADER$` token alongside `$WGC_TEAM1_LEADER$`
- Resolve story placeholders when rebuilding the journal so saved entries show current team leader names
- Test placeholder replacement for both story events and reconstructed journals

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b3865dd6a083278b70236081004d9d