### PR TITLE
Allow recipe toggle without built factories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Workers tooltip lists how many workers come from colonists above the android count.
 - Resource tooltips only update while hovered, reducing unnecessary DOM work.
 - GHG and oxygen factory settings now export from src/js/ghg-automation.js.
+- Reverse button toggles dust or GHG factory recipes even when no factories are built.
 - Random World Generator history lists visited worlds with names, types, seeds, states and departure times.
 - Random world departures now log timestamp and Ecumenopolis land coverage.
 - Space storage total cost display now shows cost per second in continuous mode.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -114,6 +114,13 @@ class Building extends EffectableEntity {
 
   // External: toggle reversal state (hooked by UI)
   setReverseEnabled(value) {
+    // If no structures have been built yet, use the reverse button to
+    // swap the active recipe instead so players can pre-select the desired
+    // direction before construction (e.g. dust and GHG factories).
+    if (this.count === 0 && typeof this._toggleRecipe === 'function') {
+      this._toggleRecipe();
+      return;
+    }
     this.reverseEnabled = !!value;
   }
 

--- a/tests/reverseRecipeToggle.test.js
+++ b/tests/reverseRecipeToggle.test.js
@@ -1,0 +1,73 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+
+function createGHGFactory(){
+  const config = {
+    name: 'Greenhouse Gas factory',
+    category: 'terraforming',
+    cost: {},
+    consumption: {},
+    production: { atmospheric: { greenhouseGas: 10 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true,
+    reversalAvailable: true,
+    defaultRecipe: 'ghg',
+    recipes: {
+      ghg: { production: { atmospheric: { greenhouseGas: 10 } }, reverseTarget: { category: 'atmospheric', resource: 'greenhouseGas' } },
+      calcite: { production: { atmospheric: { calciteAerosol: 10 } }, reverseTarget: { category: 'atmospheric', resource: 'calciteAerosol' } }
+    }
+  };
+  return new Building(config, 'ghgFactory');
+}
+
+function createDustFactory(){
+  const config = {
+    name: 'Black Dust Factory',
+    category: 'terraforming',
+    cost: {},
+    consumption: {},
+    production: { special: { albedoUpgrades: 100 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true,
+    reversalAvailable: true,
+    defaultRecipe: 'black',
+    recipes: {
+      black: { production: { special: { albedoUpgrades: 100 } }, reverseTarget: { category: 'special', resource: 'albedoUpgrades' } },
+      white: { production: { special: { whiteDust: 100 } }, reverseTarget: { category: 'special', resource: 'whiteDust' } }
+    }
+  };
+  return new Building(config, 'dustFactory');
+}
+
+describe('Reverse button toggles recipe when no factories are built', () => {
+  test('GHG factory recipe swaps', () => {
+    const fac = createGHGFactory();
+    expect(fac.currentRecipeKey).toBe('ghg');
+    fac.setReverseEnabled(true);
+    expect(fac.currentRecipeKey).toBe('calcite');
+    fac.setReverseEnabled(true);
+    expect(fac.currentRecipeKey).toBe('ghg');
+  });
+
+  test('Dust factory recipe swaps', () => {
+    const fac = createDustFactory();
+    expect(fac.currentRecipeKey).toBe('black');
+    fac.setReverseEnabled(true);
+    expect(fac.currentRecipeKey).toBe('white');
+    fac.setReverseEnabled(true);
+    expect(fac.currentRecipeKey).toBe('black');
+  });
+});


### PR DESCRIPTION
## Summary
- Use reverse button to swap recipes when a factory hasn't been constructed yet
- Document reverse-button behavior in AGENTS notes
- Test GHG and dust factories for recipe swapping with zero buildings

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b393aab06c8327a006431f0bfae1c6