### PR TITLE
Refresh reversal button on story unlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,3 +389,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Optical depth display now shows three decimal places.
 - Added a `force` argument to `updateRender` to bypass tab visibility checks for a one-time UI update when pausing via Save & Settings.
 - Journal reconstruction now resolves `$WGC_TEAM_LEADER$` placeholders using current team leader names when loading saves.
+- Reversal buttons now appear immediately when unlocked by story effects, without requiring a reload.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -110,6 +110,9 @@ class Building extends EffectableEntity {
   // External: enable reversal via effect
   enableReversal() {
     this.reversalAvailable = true;
+    if (typeof updateBuildingDisplay === 'function' && typeof buildings !== 'undefined') {
+      updateBuildingDisplay(buildings);
+    }
   }
 
   // External: toggle reversal state (hooked by UI)

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -234,7 +234,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   hideButton.disabled = structure.active > 0;
   leftContainer.appendChild(hideButton);
   cached.hideButton = hideButton;
-  
+
   // Reverse button to the right of Hide
   const reverseInlineBtn = document.createElement('button');
   reverseInlineBtn.classList.add('reverse-button');
@@ -254,6 +254,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
     }
   });
   leftContainer.appendChild(reverseInlineBtn);
+  cached.reverseButton = reverseInlineBtn;
   buttonContainer.appendChild(leftContainer);
 
   //done with first row
@@ -991,10 +992,15 @@ function updateDecreaseButtonText(button, buildCount) {
       const buttonContainer = els.buttonContainer || (structureRow ? structureRow.getElementsByClassName('button-container')[0] : null);
       const hideButton = els.hideButton || (buttonContainer ? buttonContainer.getElementsByClassName('hide-button')[0] : null);
 
-  if (hideButton) {
-    hideButton.style.display = 'inline-block';
-    hideButton.disabled = structure.active > 0;
-  }
+      if (hideButton) {
+        hideButton.style.display = 'inline-block';
+        hideButton.disabled = structure.active > 0;
+      }
+
+      const reverseBtn = els.reverseButton || (buttonContainer ? buttonContainer.getElementsByClassName('reverse-button')[0] : null);
+      if (reverseBtn) {
+        reverseBtn.style.display = structure.reversalAvailable ? 'inline-block' : 'none';
+      }
 
       const upgradeBtn = els.upgradeButton || (buttonContainer ? buttonContainer.querySelector(`#${structureName}-upgrade-button`) : null);
       if (upgradeBtn) {

--- a/tests/buildingEnableReversalEffect.test.js
+++ b/tests/buildingEnableReversalEffect.test.js
@@ -4,7 +4,7 @@ global.maintenanceFraction = 0;
 const { Building } = require('../src/js/building.js');
 
 describe('enableReversal method on Building', () => {
-  test('enableReversal flips reversalAvailable flag', () => {
+  test('enableReversal flips reversalAvailable flag and refreshes UI', () => {
     const cfg = {
       name: 'Black Dust Factory',
       category: 'terraforming',
@@ -35,9 +35,13 @@ describe('enableReversal method on Building', () => {
       }
     };
     const b = new Building(cfg, 'dustFactory');
+    global.buildings = { dustFactory: b };
+    const calls = [];
+    global.updateBuildingDisplay = () => { calls.push('update'); };
     expect(b.reversalAvailable).toBe(false);
     b.enableReversal();
     expect(b.reversalAvailable).toBe(true);
+    expect(calls).toEqual(['update']);
   });
 });
 

--- a/tests/reverseButtonUI.test.js
+++ b/tests/reverseButtonUI.test.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('reverse button visibility', () => {
+  function setup() {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+
+    ctx.formatNumber = n => n;
+    ctx.formatBigInteger = n => String(n);
+    ctx.formatBuildingCount = n => String(n);
+    ctx.multiplyByTen = n => n * 10;
+    ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
+    ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0, cap: 0 } } };
+    ctx.globalEffects = { isBooleanFlagSet: () => false };
+    ctx.dayNightCycle = { isNight: () => false };
+    ctx.toDisplayTemperature = () => 0;
+    ctx.getTemperatureUnit = () => 'K';
+    ctx.formatResourceDetails = () => '';
+    ctx.formatStorageDetails = () => '';
+    ctx.updateColonyDetailsDisplay = () => {};
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+    ctx.ghgFactorySettings.autoDisableAboveTemp = false;
+    ctx.ghgFactorySettings.disableTempThreshold = 0;
+    ctx.Colony = class {};
+    ctx.updateEmptyBuildingMessages = () => {};
+    ctx.updateBuildingDisplay = () => {};
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const structure = {
+      name: 'testStruct',
+      displayName: 'Test Struct',
+      canBeToggled: true,
+      count: 0,
+      active: 0,
+      unlocked: true,
+      isHidden: false,
+      requiresProductivity: false,
+      autoBuildEnabled: false,
+      autoBuildPercent: 0,
+      autoBuildPriority: false,
+      autoActiveEnabled: false,
+      getTotalWorkerNeed: () => 0,
+      getEffectiveWorkerMultiplier: () => 1,
+      getEffectiveCost: () => ({}),
+      canAfford: () => true,
+      canAffordLand: () => true,
+      requiresLand: 0,
+      landAffordCount: () => 10,
+      getModifiedStorage: () => ({}),
+      powerPerBuilding: null,
+      activeEffects: [],
+      getEffectiveProductionMultiplier: () => 1,
+      getModifiedProduction: () => ({}),
+      getModifiedConsumption: () => ({}),
+      requiresMaintenance: false,
+      maintenanceCost: {},
+      updateResourceStorage: () => {},
+      isBooleanFlagSet: () => false,
+      reversalAvailable: false
+    };
+
+    const row = ctx.createStructureRow(structure, () => {}, () => {}, false);
+    dom.window.document.body.appendChild(row);
+
+    return { dom, ctx, structure };
+  }
+
+  test('reverse button becomes visible when reversal unlocked', () => {
+    const { dom, ctx, structure } = setup();
+    const btn = dom.window.document.getElementById(`${structure.name}-reverse-button`);
+    expect(btn.style.display).toBe('none');
+    structure.reversalAvailable = true;
+    ctx.updateStructureDisplay({ [structure.name]: structure });
+    expect(btn.style.display).toBe('inline-block');
+  });
+});


### PR DESCRIPTION
## Summary
- show reversal buttons as soon as chapter 14.3 effects apply
- ensure buildings notify the UI when reversal becomes available
- add tests for immediate reversal button visibility

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b39385dff8832783e7821e7337de2d