### PR TITLE
Add Vega star details

### DIFF
--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -553,6 +553,15 @@ const vega2Overrides = {
     polar: { liquid: 0, ice: 0 }
   },
 
+  star: {
+    name: 'Vega',
+    spectralType: 'A0V',
+    luminositySolar: 40,
+    massSolar: 2.135,
+    temperatureK: 9602,
+    habitableZone: { inner: 6, outer: 9 }
+  },
+
   celestialParameters: {
     // Venus-like size and orbit. No clouds/greenhouse by composition above.
     distanceFromSun: 4, // AU

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -235,7 +235,12 @@ class SpaceManager extends EffectableEntity {
         merged.resources.surface.liquidMethane.initialValue = totalLiquidMethane;
         merged.resources.surface.hydrocarbonIce.initialValue = totalHydrocarbonIce;
 
-        return { merged, override, star: SOL_STAR };
+        let star = override?.star || base?.star || SOL_STAR;
+        star = JSON.parse(JSON.stringify(star));
+        if (merged.celestialParameters?.starLuminosity != null && star.luminositySolar == null) {
+            star.luminositySolar = merged.celestialParameters.starLuminosity;
+        }
+        return { merged, override, star };
     }
 
     getCurrentRandomSeed() {

--- a/tests/vegaStarDisplay.test.js
+++ b/tests/vegaStarDisplay.test.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+
+describe('Vega-2 star details', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    global.document = { addEventListener: () => {} };
+    global.formatNumber = numbers.formatNumber;
+    global.calculateAtmosphericPressure = () => 0;
+    global.dayNightTemperaturesModel = () => ({ mean: 0, day: 0, night: 0 });
+  });
+
+  test('Space UI original includes Vega star info', () => {
+    const { planetParameters } = require('../src/js/planet-parameters.js');
+    const EffectableEntity = require('../src/js/effectable-entity.js');
+    global.EffectableEntity = EffectableEntity;
+    const SpaceManager = require('../src/js/space.js');
+    const { renderWorldDetail } = require('../src/js/rwgUI.js');
+    const sm = new SpaceManager(planetParameters);
+    sm.currentPlanetKey = 'vega2';
+    const original = sm.getCurrentWorldOriginal();
+    expect(original.star.name).toBe('Vega');
+    const html = renderWorldDetail(original);
+    const dom = new JSDOM(html);
+    const starHeading = Array.from(dom.window.document.querySelectorAll('.rwg-card h3')).find(h => h.textContent.startsWith('Star:'));
+    expect(starHeading).toBeTruthy();
+    expect(starHeading.textContent).toBe('Star: Vega');
+    delete global.EffectableEntity;
+  });
+});


### PR DESCRIPTION
## Summary
- add Vega star characteristics to Vega-2 planet parameters
- return planet-specific star data from `getCurrentWorldOriginal` for accurate space summaries
- verify Vega-2 star info renders in space UI

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b3968c39f08327ba8d6549b497779a