### PR TITLE
Fix Chapter 14.3 space mirror reversal target

### DIFF
--- a/src/js/story/vega2.js
+++ b/src/js/story/vega2.js
@@ -197,7 +197,7 @@ progressVega2.chapters.push(
     ),
     prerequisites: ['chapter14.2'],
     objectives: [],
-    reward: [      { target: 'building', targetId: 'spaceMirror', type: 'enableReversal' },
+    reward: [ { target: 'project', targetId: 'spaceMirrorFacility', type: 'enableReversal' },
       { target: 'building', targetId: 'ghgFactory', type: 'enableReversal' },
       { target: 'building', targetId: 'dustFactory', type: 'enableReversal' }]
   },

--- a/tests/chapter14_3ReversalEffect.test.js
+++ b/tests/chapter14_3ReversalEffect.test.js
@@ -1,0 +1,18 @@
+const progressVega2 = require('../src/js/story/vega2.js');
+
+describe('chapter 14.3 reversal effect', () => {
+  test('applies reversal to space mirror facility project', () => {
+    const chapter = progressVega2.chapters.find(c => c.id === 'chapter14.3');
+    expect(chapter).toBeDefined();
+    expect(chapter.reward).toContainEqual({
+      target: 'project',
+      targetId: 'spaceMirrorFacility',
+      type: 'enableReversal'
+    });
+    const buildingReward = chapter.reward.find(
+      r => r.target === 'building' && r.targetId === 'spaceMirror'
+    );
+    expect(buildingReward).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Ensure Chapter 14.3 enables reversal on the Space Mirror Facility project instead of the Space Mirror building
- Add regression test verifying the story reward targets the facility and not the building

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b39ef5900883278b2bcad85053559f