### PR TITLE
Account for maintenance conversion production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,3 +391,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added a `force` argument to `updateRender` to bypass tab visibility checks for a one-time UI update when pausing via Save & Settings.
 - Journal reconstruction now resolves `$WGC_TEAM_LEADER$` placeholders using current team leader names when loading saves.
 - Reversal buttons now appear immediately when unlocked by story effects, without requiring a reload.
+- Productivity calculation now accounts for resource production gained from maintenance conversions.

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -276,6 +276,23 @@ function calculateProductionRates(deltaTime, buildings) {
         resources[category][resource].modifyRate(-actualConsumption, building.displayName, 'building');
       }
     }
+
+    // Include production from maintenance conversions but ignore maintenance costs
+    const maintenanceCost = typeof building.calculateMaintenanceCost === 'function' ? building.calculateMaintenanceCost() : {};
+    for (const resource in maintenanceCost) {
+      const sourceData = resources.colony[resource];
+      if (!sourceData || !sourceData.maintenanceConversion) continue;
+      const base = maintenanceCost[resource] * building.active;
+      const conversionValue = sourceData.conversionValue || 1;
+      for (const targetCategory in sourceData.maintenanceConversion) {
+        const targetResource = sourceData.maintenanceConversion[targetCategory];
+        resources[targetCategory][targetResource].modifyRate(
+          base * conversionValue,
+          building.displayName,
+          'building'
+        );
+      }
+    }
   }
 
   if (projectManager) {

--- a/tests/productivityMaintenanceProduction.test.js
+++ b/tests/productivityMaintenanceProduction.test.js
@@ -1,0 +1,75 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Resource, produceResources } = require('../src/js/resource.js');
+const { Building } = require('../src/js/building.js');
+
+describe('productivity includes maintenance production', () => {
+  beforeEach(() => {
+    global.resources = {
+      colony: {
+        metal: new Resource({ name: 'metal', category: 'colony', initialValue: 1000, maintenanceConversion: { surface: 'scrapMetal' } })
+      },
+      surface: {
+        scrapMetal: new Resource({ name: 'scrapMetal', category: 'surface', initialValue: 0 })
+      },
+      underground: {},
+      atmospheric: {}
+    };
+    global.structures = {};
+    global.dayNightCycle = { isDay: () => true };
+    global.fundingModule = null;
+    global.terraforming = { updateResources: () => {}, distributeGlobalChangesToZones: () => {} };
+    global.lifeManager = null;
+    global.researchManager = null;
+    global.lifeDesigner = {};
+    global.updateShipReplication = null;
+    global.updateAndroidResearch = null;
+    global.globalEffects = new EffectableEntity({ description: 'global' });
+    global.projectManager = { projects: {} };
+    global.populationModule = { getWorkerAvailabilityRatio: () => 1 };
+    global.oreScanner = {};
+    global.maintenanceFraction = 0.1;
+  });
+
+  test('maintenance conversion contributes to productivity', () => {
+    const maintProducer = new Building({
+      name: 'MaintProd',
+      category: 'test',
+      cost: { colony: { metal: 100 } },
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: false,
+      requiresMaintenance: true,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true
+    }, 'maintProducer');
+    maintProducer.count = 1;
+    maintProducer.active = 1;
+
+    const consumer = new Building({
+      name: 'Consumer',
+      category: 'test',
+      cost: {},
+      consumption: { surface: { scrapMetal: 5 } },
+      production: {},
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: false,
+      requiresMaintenance: false,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true
+    }, 'consumer');
+    consumer.count = 1;
+    consumer.active = 1;
+
+    const buildings = { maintProducer, consumer };
+    produceResources(1000, buildings);
+    expect(consumer.productivity).toBeCloseTo(0.1);
+  });
+});


### PR DESCRIPTION
## Summary
- include resource production from maintenance conversions when computing productivity, without counting maintenance costs
- document new productivity behavior
- test productivity when maintenance output feeds consumers

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b3ad9e3d88832794cd624914a2f040