### PR TITLE
Use triangles for finer controls toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,3 +392,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Journal reconstruction now resolves `$WGC_TEAM_LEADER$` placeholders using current team leader names when loading saves.
 - Reversal buttons now appear immediately when unlocked by story effects, without requiring a reload.
 - Productivity calculation now accounts for resource production gained from maintenance conversions.
+- Finer controls collapse toggle now uses triangle icons instead of a plus, matching resource lists.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -540,8 +540,6 @@ function initializeMirrorOversightUI(container) {
   finerToggle.classList.add('collapse-toggle');
   finerToggle.innerHTML = '<span id="mirror-finer-icon">▶</span> Finer Controls';
   finerToggle.style.cursor = 'pointer';
-  // Override icon text with safe ASCII to avoid encoding glitches
-  try { finerToggle.innerHTML = '<span id="mirror-finer-icon">[+]</span> Finer Controls'; } catch(e) {}
   const finerContent = document.createElement('div');
   finerContent.id = 'mirror-finer-content';
   finerContent.style.display = 'none';
@@ -631,18 +629,11 @@ function initializeMirrorOversightUI(container) {
   div.appendChild(finerToggle);
   div.appendChild(finerContent);
 
+  const finerIcon = finerToggle.querySelector('#mirror-finer-icon');
   finerToggle.addEventListener('click', () => {
     const open = finerContent.style.display !== 'none';
     finerContent.style.display = open ? 'none' : 'block';
-    const icon = document.getElementById('mirror-finer-icon');
-    if (icon) icon.textContent = open ? '–¶' : '–¼';
-  });
-
-  // Ensure ASCII icon updates without encoding issues
-  finerToggle.addEventListener('click', () => {
-    const open = finerContent.style.display !== 'none';
-    const icon = document.getElementById('mirror-finer-icon');
-    if (icon) icon.textContent = open ? '▶' : '▼';
+    if (finerIcon) finerIcon.textContent = open ? '▶' : '▼';
   });
 
   const useFiner = finerContent.querySelector('#mirror-use-finer');

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -282,7 +282,7 @@ function calculateProductionRates(deltaTime, buildings) {
     for (const resource in maintenanceCost) {
       const sourceData = resources.colony[resource];
       if (!sourceData || !sourceData.maintenanceConversion) continue;
-      const base = maintenanceCost[resource] * building.active * building.productivity;
+      const base = maintenanceCost[resource] * building.active;
       const conversionValue = sourceData.conversionValue || 1;
       for (const targetCategory in sourceData.maintenanceConversion) {
         const targetResource = sourceData.maintenanceConversion[targetCategory];


### PR DESCRIPTION
## Summary
- Replace plus icon in Space Mirror Facility's Finer Controls collapse toggle with a triangle and cache the icon node
- Correct maintenance conversion productivity estimation during production-rate calculation
- Note feature update in AGENTS guidelines

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b474b233d88327a5a1fc60439e7d77