### PR TITLE
Pass aerosol columns to day-night temperature model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,3 +393,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Reversal buttons now appear immediately when unlocked by story effects, without requiring a reload.
 - Productivity calculation now accounts for resource production gained from maintenance conversions.
 - Finer controls collapse toggle now uses triangle icons instead of a plus, matching resource lists.
+- dayNightTemperaturesModel now forwards aerosol column mass to albedo calculations.

--- a/src/js/terraforming/physics.js
+++ b/src/js/terraforming/physics.js
@@ -316,7 +316,8 @@ function dayNightTemperaturesModel({
   slabHeatCapacity = null,
   surfaceFractions = null,
   surfaceAlbedos = null,
-  gSurface = 9.81
+  gSurface = 9.81,
+  aerosolsSW = {}
 }) {
   if (slabHeatCapacity === null) {
     slabHeatCapacity = autoSlabHeatCapacity(
@@ -329,7 +330,8 @@ function dayNightTemperaturesModel({
     surfaceAlbedo: aSurf,
     pressureBar: surfacePressureBar,
     composition,
-    gSurface
+    gSurface,
+    aerosolsSW
   });
 
   // IR greenhouse as before

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -1140,13 +1140,23 @@ class Terraforming extends EffectableEntity{
       this.temperature.opticalDepth = tau;
       this.temperature.opticalDepthContributions = contributions;
 
+      // Build aerosols (shortwave) columns in kg/m^2
+      const aerosolsSW = {};
+      const area_m2 = 4 * Math.PI * Math.pow((this.celestialParameters.radius || 1) * 1000, 2);
+      if (this.resources?.atmospheric?.calciteAerosol) {
+        const mass_ton = this.resources.atmospheric.calciteAerosol.value || 0;
+        const column = area_m2 > 0 ? (mass_ton * 1000) / area_m2 : 0; // kg/m^2
+        aerosolsSW.calcite = column;
+      }
+
       const baseParams = {
         groundAlbedo: groundAlbedo,
         flux: modifiedSolarFlux,
         rotationPeriodH: rotationPeriod,
         surfacePressureBar: surfacePressureBar,
         composition: composition,
-        gSurface: gSurface
+        gSurface: gSurface,
+        aerosolsSW
       };
 
       this.luminosity.zonalFluxes = {};

--- a/tests/dayNightAerosolAlbedo.test.js
+++ b/tests/dayNightAerosolAlbedo.test.js
@@ -1,0 +1,28 @@
+const physics = require('../src/js/physics.js');
+
+test('dayNightTemperaturesModel accounts for aerosol column mass', () => {
+  const params = {
+    groundAlbedo: 0.2,
+    flux: 100,
+    rotationPeriodH: 24,
+    surfacePressureBar: 1,
+    composition: {},
+    gSurface: 9.81,
+    aerosolsSW: { calcite: 0.001 }
+  };
+
+  const noAerosols = physics.dayNightTemperaturesModel({ ...params, aerosolsSW: {} });
+  const withAerosols = physics.dayNightTemperaturesModel(params);
+
+  expect(withAerosols.albedo).toBeGreaterThan(noAerosols.albedo);
+
+  const expected = physics.albedoAdditive({
+    surfaceAlbedo: params.groundAlbedo,
+    pressureBar: params.surfacePressureBar,
+    composition: params.composition,
+    gSurface: params.gSurface,
+    aerosolsSW: params.aerosolsSW
+  }).albedo;
+
+  expect(withAerosols.albedo).toBeCloseTo(expected);
+});


### PR DESCRIPTION
## Summary
- Allow dayNightTemperaturesModel to accept aerosol column masses and forward them to albedoAdditive
- Include atmospheric calcite aerosol columns when computing surface temperatures
- Test that aerosol mass increases modeled albedo

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b477c649048327a2ad6c7a821acfaa