### PR TITLE
Limit Solis shop upgrades to max purchases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,3 +394,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Productivity calculation now accounts for resource production gained from maintenance conversions.
 - Finer controls collapse toggle now uses triangle icons instead of a plus, matching resource lists.
 - dayNightTemperaturesModel now forwards aerosol column mass to albedo calculations.
+- Solis shop upgrades respect max purchase limits, hiding cost and buy buttons once the limit is reached.

--- a/src/js/solis.js
+++ b/src/js/solis.js
@@ -52,8 +52,8 @@ class SolisManager extends EffectableEntity {
       androids: { baseCost: 10, purchases: 0 },
       colonistRocket: { baseCost: 1, purchases: 0 },
       research: { baseCost: 10, purchases: 0 },
-      advancedOversight: { baseCost: 1000, purchases: 0 },
-      researchUpgrade: { baseCost: 100, purchases: 0 }
+      advancedOversight: { baseCost: 1000, purchases: 0, max: 1 },
+      researchUpgrade: { baseCost: 100, purchases: 0, max: RESEARCH_UPGRADE_ORDER.length }
     };
   }
 
@@ -154,16 +154,15 @@ class SolisManager extends EffectableEntity {
 
   getUpgradeCost(key) {
     const up = this.shopUpgrades[key];
-    return up ? up.baseCost * (up.purchases + 1) : 0;
+    if (!up) return 0;
+    if (typeof up.max === 'number' && up.purchases >= up.max) return 0;
+    return up.baseCost * (up.purchases + 1);
   }
 
   purchaseUpgrade(key) {
     const up = this.shopUpgrades[key];
     if (!up) return false;
-    if (key === 'researchUpgrade' && up.purchases >= RESEARCH_UPGRADE_ORDER.length) {
-      return false;
-    }
-    if (key === 'advancedOversight' && up.purchases >= 1) {
+    if (typeof up.max === 'number' && up.purchases >= up.max) {
       return false;
     }
     const cost = this.getUpgradeCost(key);

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -85,9 +85,10 @@ function createShopItem(key) {
 
   item.appendChild(actions);
 
-  const costSpan = label.querySelector(`#solis-shop-${key}-cost`);
+  const costWrapper = label.querySelector('.solis-shop-item-cost');
+  const costSpan = costWrapper.querySelector(`#solis-shop-${key}-cost`);
   const countSpan = purchased.querySelector(`#solis-shop-${key}-count`);
-  const elementRecord = { button, cost: costSpan, count: countSpan, item };
+  const elementRecord = { button, cost: costSpan, costWrapper, count: countSpan, item };
 
   if (key === 'researchUpgrade') {
     const list = document.createElement('ul');
@@ -405,12 +406,19 @@ function updateSolisUI() {
   for (const key in shopElements) {
     const el = shopElements[key];
     if (!el) continue;
-    if (el.cost) el.cost.textContent = solisManager.getUpgradeCost(key);
-    if (el.count) el.count.textContent = solisManager.shopUpgrades[key].purchases;
-    if (el.button) {
-      el.button.disabled = solisManager.solisPoints < solisManager.getUpgradeCost(key);
-      if (key === 'advancedOversight' && solisManager.shopUpgrades.advancedOversight.purchases >= 1) {
-        el.button.disabled = true;
+    const up = solisManager.shopUpgrades[key];
+    if (!up) continue;
+    if (el.count) el.count.textContent = up.purchases;
+    const atMax = typeof up.max === 'number' && up.purchases >= up.max;
+    if (atMax) {
+      if (el.button) el.button.classList.add('hidden');
+      if (el.costWrapper) el.costWrapper.classList.add('hidden');
+    } else {
+      if (el.cost) el.cost.textContent = solisManager.getUpgradeCost(key);
+      if (el.costWrapper) el.costWrapper.classList.remove('hidden');
+      if (el.button) {
+        el.button.classList.remove('hidden');
+        el.button.disabled = solisManager.solisPoints < solisManager.getUpgradeCost(key);
       }
     }
     if (key === 'researchUpgrade' && el.listItems) {

--- a/tests/solisShopMaxPurchaseUI.test.js
+++ b/tests/solisShopMaxPurchaseUI.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+
+describe('solis shop max purchase UI', () => {
+  test('hides cost and button after max purchase', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div id="solis-shop-items"></div>
+      <div id="solis-donation-items"></div>
+      <div id="solis-research-shop-items"></div>
+      <div id="solis-quest-text"></div>
+      <div id="solis-cooldown"></div>
+      <div id="solis-donation-section"></div>
+      <div id="solis-research-shop"></div>
+      <button id="solis-refresh-button"></button>
+      <button id="solis-complete-button"></button>
+      <span id="solis-points-value"></span>
+      <span id="solis-reward"></span>
+      <span id="solis-cooldown-text"></span>
+      <div id="solis-cooldown-bar"></div>
+      <span id="solis-donation-count"></span>
+      <input id="solis-donation-input" />
+      <button id="solis-donation-button"></button>
+    `, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    const solisCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/solis.js'), 'utf8');
+    const solisUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js/solisUI.js'), 'utf8');
+    vm.runInContext(`${solisCode}\n${solisUICode}; this.SolisManager = SolisManager;`, ctx);
+
+    ctx.solisManager = new ctx.SolisManager();
+    ctx.solisManager.booleanFlags.add('solisUpgrade1');
+    ctx.solisManager.booleanFlags.add('solisAlienArtifactUpgrade');
+    ctx.resources = { colony: { research: { value: 0, hasCap: false, increase() {} } } };
+    ctx.researchManager = { completeResearchInstant() {} };
+    ctx.addEffect = () => {};
+
+    ctx.initializeSolisUI();
+    ctx.updateSolisUI();
+
+    ctx.solisManager.solisPoints = 5000;
+    ctx.solisManager.purchaseUpgrade('advancedOversight');
+    const max = ctx.solisManager.shopUpgrades.researchUpgrade.max;
+    for (let i = 0; i < max; i++) {
+      ctx.solisManager.purchaseUpgrade('researchUpgrade');
+    }
+    ctx.updateSolisUI();
+
+    const advButton = dom.window.document.getElementById('solis-shop-advancedOversight-button');
+    const advCost = dom.window.document.getElementById('solis-shop-advancedOversight-cost').parentElement;
+    expect(advButton.classList.contains('hidden')).toBe(true);
+    expect(advCost.classList.contains('hidden')).toBe(true);
+
+    const resButton = dom.window.document.getElementById('solis-shop-researchUpgrade-button');
+    const resCost = dom.window.document.getElementById('solis-shop-researchUpgrade-cost').parentElement;
+    expect(resButton.classList.contains('hidden')).toBe(true);
+    expect(resCost.classList.contains('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add max purchase tracking for Solis shop upgrades and apply to advanced oversight and research auto-complete
- hide Solis shop costs and buy buttons once an upgrade reaches its purchase cap
- test that capped upgrades no longer display cost or buy controls

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b479a9825083278f682fc881f7f6ae