### PR TITLE
Add unit selection to pressure automation controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Satellites project now features an Auto Max option that raises build count to the current colonist cap.
 - Space mirror oversight sliders now clamp values so none go negative and their total always sums to 100.
 - Space disposal projects can auto-disable gas exports when atmospheric pressure falls below a configurable kPa threshold.
+- Pressure automation controls on space mining and disposal projects now include a unit dropdown for kPa or Pa, defaulting to kPa.
 - The Any Zone slider in the space mirror facility can be increased, taking percentage from the largest other sliders so the total remains 100%.
 - Land usage recalculates on save load, and inactive structure construction checks land without reserving it.
 - Space mirror facility now verifies slider percentages each tick, clamping out-of-range values and ensuring they total 100%.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -535,6 +535,10 @@
     width: 60px;
 }
 
+.pressure-control .pressure-unit {
+    width: 60px;
+}
+
 .temperature-control {
     display: flex;
     align-items: center;

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -5,6 +5,7 @@ class SpaceExportBaseProject extends SpaceshipProject {
     this.disableTemperatureThreshold = 303.15;
     this.disableBelowPressure = false;
     this.disablePressureThreshold = 0;
+    this.pressureUnit = 'kPa';
   }
   renderUI(container) {
     super.renderUI(container);
@@ -140,19 +141,34 @@ class SpaceExportBaseProject extends SpaceshipProject {
     input.classList.add('pressure-input');
     input.value = this.disablePressureThreshold;
     input.addEventListener('input', () => {
-      this.disablePressureThreshold = parseFloat(input.value) || 0;
+      const val = parseFloat(input.value);
+      this.disablePressureThreshold = this.pressureUnit === 'Pa' ? (val / 1000) : val;
     });
     control.appendChild(input);
 
-    const unit = document.createElement('span');
-    unit.textContent = 'kPa';
-    control.appendChild(unit);
+    const unitSelect = document.createElement('select');
+    unitSelect.classList.add('pressure-unit');
+    ['kPa', 'Pa'].forEach(u => {
+      const option = document.createElement('option');
+      option.value = u;
+      option.textContent = u;
+      unitSelect.appendChild(option);
+    });
+    unitSelect.value = this.pressureUnit;
+    unitSelect.addEventListener('change', () => {
+      this.pressureUnit = unitSelect.value;
+      input.value = this.pressureUnit === 'Pa'
+        ? this.disablePressureThreshold * 1000
+        : this.disablePressureThreshold;
+    });
+    control.appendChild(unitSelect);
 
     projectElements[this.name] = {
       ...projectElements[this.name],
       pressureControl: control,
       pressureCheckbox: checkbox,
       pressureInput: input,
+      pressureUnitSelect: unitSelect,
     };
 
     return control;
@@ -255,8 +271,13 @@ class SpaceExportBaseProject extends SpaceshipProject {
     if (elements.pressureCheckbox) {
       elements.pressureCheckbox.checked = this.disableBelowPressure;
     }
+    if (elements.pressureUnitSelect) {
+      elements.pressureUnitSelect.value = this.pressureUnit;
+    }
     if (elements.pressureInput && document.activeElement !== elements.pressureInput) {
-      elements.pressureInput.value = this.disablePressureThreshold;
+      elements.pressureInput.value = this.pressureUnit === 'Pa'
+        ? this.disablePressureThreshold * 1000
+        : this.disablePressureThreshold;
     }
 
     if (elements.disposalPerShipElement) {
@@ -381,6 +402,7 @@ class SpaceExportBaseProject extends SpaceshipProject {
       disableTemperatureThreshold: this.disableTemperatureThreshold,
       disableBelowPressure: this.disableBelowPressure,
       disablePressureThreshold: this.disablePressureThreshold,
+      pressureUnit: this.pressureUnit,
     };
   }
 
@@ -390,6 +412,7 @@ class SpaceExportBaseProject extends SpaceshipProject {
     this.disableTemperatureThreshold = typeof state.disableTemperatureThreshold === 'number' ? state.disableTemperatureThreshold : 303.15;
     this.disableBelowPressure = state.disableBelowPressure || false;
     this.disablePressureThreshold = typeof state.disablePressureThreshold === 'number' ? state.disablePressureThreshold : 0;
+    this.pressureUnit = state.pressureUnit || 'kPa';
   }
 }
 

--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -6,6 +6,8 @@ class SpaceMiningProject extends SpaceshipProject {
     this.disableAboveOxygenPressure = false;
     this.disableOxygenPressureThreshold = 0;
     this.hasOxygenPressureControl = false;
+    this.pressureUnit = 'kPa';
+    this.oxygenPressureUnit = 'kPa';
     const maxPressure = config.attributes?.maxPressure;
     if (typeof maxPressure === 'number') {
       this.disablePressureThreshold = maxPressure;
@@ -71,19 +73,36 @@ class SpaceMiningProject extends SpaceshipProject {
     input.classList.add(`${key}-input`);
     input.value = this[thresholdProp];
     input.addEventListener('input', () => {
-      this[thresholdProp] = parseFloat(input.value) || 0;
+      const val = parseFloat(input.value);
+      const unitProp = `${key}Unit`;
+      this[thresholdProp] = this[unitProp] === 'Pa' ? (val / 1000) : val;
     });
     control.appendChild(input);
 
-    const unit = document.createElement('span');
-    unit.textContent = 'kPa';
-    control.appendChild(unit);
+    const unitSelect = document.createElement('select');
+    unitSelect.classList.add(`${key}-unit`);
+    ['kPa', 'Pa'].forEach(u => {
+      const option = document.createElement('option');
+      option.value = u;
+      option.textContent = u;
+      unitSelect.appendChild(option);
+    });
+    const unitProp = `${key}Unit`;
+    unitSelect.value = this[unitProp];
+    unitSelect.addEventListener('change', () => {
+      this[unitProp] = unitSelect.value;
+      input.value = this[unitProp] === 'Pa'
+        ? this[thresholdProp] * 1000
+        : this[thresholdProp];
+    });
+    control.appendChild(unitSelect);
 
     projectElements[this.name] = {
       ...projectElements[this.name],
       [`${key}Control`]: control,
       [`${key}Checkbox`]: checkbox,
       [`${key}Input`]: input,
+      [`${key}UnitSelect`]: unitSelect,
     };
 
     return control;
@@ -118,8 +137,13 @@ class SpaceMiningProject extends SpaceshipProject {
     if (elements.pressureCheckbox) {
       elements.pressureCheckbox.checked = this.disableAbovePressure;
     }
+    if (elements.pressureUnitSelect) {
+      elements.pressureUnitSelect.value = this.pressureUnit;
+    }
     if (elements.pressureInput && document.activeElement !== elements.pressureInput) {
-      elements.pressureInput.value = this.disablePressureThreshold;
+      elements.pressureInput.value = this.pressureUnit === 'Pa'
+        ? this.disablePressureThreshold * 1000
+        : this.disablePressureThreshold;
     }
     if (elements.oxygenPressureControl) {
       elements.oxygenPressureControl.style.display = this.isBooleanFlagSet('atmosphericMonitoring') ? 'flex' : 'none';
@@ -127,8 +151,13 @@ class SpaceMiningProject extends SpaceshipProject {
     if (elements.oxygenPressureCheckbox) {
       elements.oxygenPressureCheckbox.checked = this.disableAboveOxygenPressure;
     }
+    if (elements.oxygenPressureUnitSelect) {
+      elements.oxygenPressureUnitSelect.value = this.oxygenPressureUnit;
+    }
     if (elements.oxygenPressureInput && document.activeElement !== elements.oxygenPressureInput) {
-      elements.oxygenPressureInput.value = this.disableOxygenPressureThreshold;
+      elements.oxygenPressureInput.value = this.oxygenPressureUnit === 'Pa'
+        ? this.disableOxygenPressureThreshold * 1000
+        : this.disableOxygenPressureThreshold;
     }
   }
 
@@ -216,6 +245,8 @@ class SpaceMiningProject extends SpaceshipProject {
       disablePressureThreshold: this.disablePressureThreshold,
       disableAboveOxygenPressure: this.disableAboveOxygenPressure,
       disableOxygenPressureThreshold: this.disableOxygenPressureThreshold,
+      pressureUnit: this.pressureUnit,
+      oxygenPressureUnit: this.oxygenPressureUnit,
     };
   }
 
@@ -225,6 +256,8 @@ class SpaceMiningProject extends SpaceshipProject {
     this.disablePressureThreshold = state.disablePressureThreshold || 0;
     this.disableAboveOxygenPressure = state.disableAboveOxygenPressure || false;
     this.disableOxygenPressureThreshold = state.disableOxygenPressureThreshold || 0;
+    this.pressureUnit = state.pressureUnit || 'kPa';
+    this.oxygenPressureUnit = state.oxygenPressureUnit || 'kPa';
   }
 
   calculateSpaceshipGainPerShip() {

--- a/tests/spaceDisposalPressureUnit.test.js
+++ b/tests/spaceDisposalPressureUnit.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceDisposalProject pressure unit control', () => {
+  test('defaults to kPa and converts when switched', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectElements = {};
+    ctx.EffectableEntity = EffectableEntity;
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceExportBaseProject.js'), 'utf8');
+    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+    const disposalCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceDisposalProject.js'), 'utf8');
+    vm.runInContext(disposalCode + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+
+    const config = { name:'Dispose', category:'resources', cost:{}, duration:1, description:'', repeatable:true, maxRepeatCount:Infinity, unlocked:true, attributes:{ spaceExport:true, disposalAmount:1 } };
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    project.disablePressureThreshold = 5;
+    const control = project.createPressureControl();
+    const select = control.querySelector('.pressure-unit');
+    const input = control.querySelector('.pressure-input');
+    expect(select.value).toBe('kPa');
+    select.value = 'Pa';
+    select.dispatchEvent(new dom.window.Event('change'));
+    expect(input.value).toBe('5000');
+    input.value = '6000';
+    input.dispatchEvent(new dom.window.Event('input'));
+    expect(project.disablePressureThreshold).toBeCloseTo(6);
+  });
+});

--- a/tests/spaceMiningPressureUnit.test.js
+++ b/tests/spaceMiningPressureUnit.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceMiningProject pressure unit control', () => {
+  test('defaults to kPa and converts when switched', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectElements = {};
+    ctx.EffectableEntity = EffectableEntity;
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+
+    const config = {
+      name: 'Mine',
+      category: 'resources',
+      cost: {},
+      duration: 1,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: { spaceMining: true }
+    };
+    const project = new ctx.SpaceMiningProject(config, 'mine');
+    project.disablePressureThreshold = 2;
+    const control = project.createPressureControl();
+    const select = control.querySelector('.pressure-unit');
+    const input = control.querySelector('.pressure-input');
+    expect(select.value).toBe('kPa');
+    select.value = 'Pa';
+    select.dispatchEvent(new dom.window.Event('change'));
+    expect(input.value).toBe('2000');
+    input.value = '4000';
+    input.dispatchEvent(new dom.window.Event('input'));
+    expect(project.disablePressureThreshold).toBeCloseTo(4);
+  });
+});


### PR DESCRIPTION
## Summary
- allow space mining and disposal projects to choose pressure units (kPa or Pa) for automation thresholds
- document pressure unit option and style new dropdown
- add tests for pressure unit conversion

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b47b8103a88327961e25abeec792e6