### PR TITLE
Show biomass decay warning in resource list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,3 +397,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - dayNightTemperaturesModel now forwards aerosol column mass to albedo calculations.
 - Solis shop upgrades respect max purchase limits, hiding cost and buy buttons once the limit is reached.
 - Life growth and decay now interpolate across a ±0.5 K band around survivable temperature limits, showing a warning icon when growth is reduced.
+- Biomass resource display shows red exclamation marks for zones with net decay.

--- a/src/css/resource.css
+++ b/src/css/resource.css
@@ -73,6 +73,11 @@
     text-shadow: 1px 1px 2px darkgoldenrod;
   }
 
+  .resource-warning {
+    color: red;
+    margin-left: 2px;
+  }
+
   .resource-wrapper {
     background-color: #f4f4f4;
     padding-right: 5px;

--- a/src/js/life.js
+++ b/src/js/life.js
@@ -636,10 +636,12 @@ class LifeManager extends EffectableEntity {
         const biomassRatio = 1.66612;
         const oxygenRatio = 1.77388;
 
-        const secondsMultiplier = deltaTime / 1000;
+          const secondsMultiplier = deltaTime / 1000;
+          terraforming.biomassDyingZones = terraforming.biomassDyingZones || { tropical: false, temperate: false, polar: false };
 
-        for (const zoneName of ['tropical', 'temperate', 'polar']) {
+          for (const zoneName of ['tropical', 'temperate', 'polar']) {
             let usedLiquidWater = false;
+            terraforming.biomassDyingZones[zoneName] = false;
             const zonalBiomass = terraforming.zonalSurface[zoneName].biomass || 0;
             if (zonalBiomass <= 0) continue;
 
@@ -726,6 +728,9 @@ class LifeManager extends EffectableEntity {
             }
 
             const biomassChange = growthBiomass + decayBiomass;
+            if (biomassChange < -1e-9) {
+                terraforming.biomassDyingZones[zoneName] = true;
+            }
             const co2Change = growthCO2 + decayCO2;
             const oxygenChange = growthOxygen + decayOxygen;
 

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -545,7 +545,7 @@ function createResourceElement(category, resourceObj, resourceName) {
     // Special display for population (colonists) as an integer
     resourceElement.innerHTML = `
       <div class="resource-row ${!resourceObj.hasCap ? 'no-cap' : ''}">
-        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong></div>
+        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong>${resourceName === 'biomass' ? ' <span class="resource-warning" id="biomass-warning"></span>' : ''}</div>
         <div class="resource-value" id="${resourceName}-resources-container">${Math.floor(resourceObj.value)}</div>
         ${resourceObj.hasCap ? `
           <div class="resource-slash">/</div>
@@ -589,7 +589,7 @@ function createResourceElement(category, resourceObj, resourceName) {
   } else {
     resourceElement.innerHTML = `
       <div class="resource-row ${!resourceObj.hasCap ? 'no-cap' : ''}">
-        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong></div>
+        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong>${resourceName === 'biomass' ? ' <span class="resource-warning" id="biomass-warning"></span>' : ''}</div>
         <div class="resource-value" id="${resourceName}-resources-container">${resourceObj.value.toFixed(2)}</div>
         ${resourceObj.hasCap ? `
           <div class="resource-slash">/</div>
@@ -680,6 +680,13 @@ function updateResourceDisplay(resources) {
         resourceNameElement.classList.add('sparkling-gold');
       } else if (resourceNameElement) {
         resourceNameElement.classList.remove('sparkling-gold');
+      }
+
+      if (resourceName === 'biomass' && entry.warningEl) {
+        const zones = terraforming?.biomassDyingZones || {};
+        const count = ['tropical', 'temperate', 'polar'].reduce((n, z) => n + (zones[z] ? 1 : 0), 0);
+        const text = '!'.repeat(count);
+        if (entry.warningEl.textContent !== text) entry.warningEl.textContent = text;
       }
 
       if (resourceName === 'colonists') {
@@ -1027,7 +1034,7 @@ function capitalizeFirstLetter(string) {
 
 const resourceUICache = {
   categories: {}, // { [category]: { container, header } }
-  resources: {},  // { [resourceName]: { container, nameEl, valueEl, capEl, ppsEl, availableEl, totalEl, scanEl, tooltip: {...} } }
+  resources: {},  // { [resourceName]: { container, nameEl, warningEl, valueEl, capEl, ppsEl, availableEl, totalEl, scanEl, tooltip: {...} } }
 };
 
 function cacheResourceCategory(category) {
@@ -1042,6 +1049,7 @@ function cacheSingleResource(category, resourceName) {
   const entry = {
     container: document.getElementById(`${resourceName}-container`),
     nameEl: document.getElementById(`${resourceName}-name`),
+    warningEl: document.getElementById(`${resourceName}-warning`),
     valueEl: document.getElementById(`${resourceName}-resources-container`),
     capEl: document.getElementById(`${resourceName}-cap-resources-container`),
     ppsEl: document.getElementById(`${resourceName}-pps-resources-container`),

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -263,12 +263,14 @@ class Terraforming extends EffectableEntity{
     };
     // Zonal Surface Data (Life, Dry Ice) - Replaces global this.life coverages
     this.zonalSurface = {};
-     ['tropical', 'temperate', 'polar'].forEach(zone => {
+    this.biomassDyingZones = {};
+    ['tropical', 'temperate', 'polar'].forEach(zone => {
         this.zonalSurface[zone] = {
             dryIce: 0,  // Represents amount/mass in the zone
             biomass: 0 // Represents amount/mass in the zone
             // Zonal coverage values can be calculated from these amounts when needed
         };
+        this.biomassDyingZones[zone] = false;
     });
     // Global life properties (name, target, unlock status)
     this.life = {

--- a/tests/biomassWarningDisplay.test.js
+++ b/tests/biomassWarningDisplay.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('biomass warning display', () => {
+  function setup(dyingZones) {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.oreScanner = { scanData: {} };
+    ctx.terraforming = { biomassDyingZones: dyingZones };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const res = {
+      name: 'biomass',
+      displayName: 'Biomass',
+      category: 'surface',
+      value: 10,
+      cap: 0,
+      hasCap: false,
+      reserved: 0,
+      unlocked: true,
+      hideWhenSmall: false,
+      productionRate: 0,
+      consumptionRate: 0,
+      productionRateBySource: {},
+      consumptionRateBySource: {},
+      isBooleanFlagSet: () => false
+    };
+
+    ctx.createResourceDisplay({ surface: { biomass: res } });
+    ctx.updateResourceDisplay({ surface: { biomass: res } });
+    return { dom };
+  }
+
+  test('shows exclamation marks for each dying zone', () => {
+    const { dom } = setup({ tropical: true, temperate: false, polar: true });
+    const warn = dom.window.document.getElementById('biomass-warning');
+    expect(warn.textContent).toBe('!!');
+  });
+
+  test('no exclamation marks when no zones are dying', () => {
+    const { dom } = setup({ tropical: false, temperate: false, polar: false });
+    const warn = dom.window.document.getElementById('biomass-warning');
+    expect(warn.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- track zonal biomass decay and expose `biomassDyingZones`
- display red exclamation marks next to Biomass for each decaying zone
- test biomass warning rendering

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b48b1dcba083279c840231fd2bd1cd