### PR TITLE
Check worker cap for Vega-2 referendum chapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Tooltips should use a `<span class="info-tooltip-icon">&#9432;</span>` element with a descriptive `title`.
 - Keep checks of the kind (typeof something === 'function') and if(resources && resources.special && resources.special.spaceships) to a minimum.  If the checks fail, the code fails and it is better to catch it than let it fail.
 - All UI elements should be cached and reused instead of using querySelector.
+- Story objectives can compare against a resource's cap by adding `checkCap: true`.
 
 # Overview of code
 This repository contains a browser-based incremental game written in JavaScript. The

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -274,7 +274,10 @@ class StoryManager {
                     console.error(`Resource check failed: ${objective.resourceType}.${objective.resource} not found.`);
                     return false;
                 }
-                return compareValues(resourceCategory[objective.resource].value, objective.quantity, objective.comparison);
+                // Allow objectives to compare against a resource's cap instead of its value
+                const resourceObj = resourceCategory[objective.resource];
+                const targetValue = objective.checkCap ? resourceObj.cap : resourceObj.value;
+                return compareValues(targetValue, objective.quantity, objective.comparison);
             case 'building':
                 const building = buildings[objective.buildingName];
                 return building ? building.count >= objective.quantity : false;

--- a/src/js/story/vega2.js
+++ b/src/js/story/vega2.js
@@ -438,7 +438,7 @@ progressVega2.chapters.push(
     ),
     prerequisites: ['chapter16.4'],
     objectives: [
-      { type: 'collection', resourceType: 'colony', resource: 'colonists', quantity: 10_000_000_000 }
+      { type: 'collection', resourceType: 'colony', resource: 'workers', quantity: 10_000_000_000, checkCap: true }
     ],
     reward: []
   },
@@ -455,7 +455,7 @@ progressVega2.chapters.push(
     ),
     prerequisites: ['chapter16.5'],
     objectives: [
-      { type: 'collection', resourceType: 'colony', resource: 'colonists', quantity: 20_000_000_000 }
+      { type: 'collection', resourceType: 'colony', resource: 'workers', quantity: 20_000_000_000, checkCap: true }
     ],
     reward: []
   },

--- a/tests/collectionObjectiveCap.test.js
+++ b/tests/collectionObjectiveCap.test.js
@@ -1,0 +1,14 @@
+const { StoryManager } = require('../src/js/progress.js');
+
+describe('collection objective checkCap', () => {
+  test('uses resource cap when checkCap is true', () => {
+    global.resources = { colony: { workers: { value: 0, cap: 100 } } };
+    const originalDocument = global.document;
+    global.document = { addEventListener: jest.fn(), removeEventListener: jest.fn() };
+    const sm = new StoryManager({ chapters: [] });
+    const objective = { type: 'collection', resourceType: 'colony', resource: 'workers', quantity: 50, checkCap: true };
+    expect(sm.isObjectiveComplete(objective)).toBe(true);
+    sm.destroy();
+    global.document = originalDocument;
+  });
+});


### PR DESCRIPTION
## Summary
- Allow story objectives to compare against a resource's cap via `checkCap`
- Use worker cap thresholds instead of colonist counts for Vega-2 chapters 16.5 and 16.6
- Cover cap-based objectives with a new unit test

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b48fac6f7083278e42bfa18976f632