### PR TITLE
Display cap in collection objectives

### DIFF
--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -356,9 +356,10 @@ class StoryManager {
             case 'collection': {
                 const resCat = resources[objective.resourceType] || {};
                 const resObj = resCat[objective.resource] || {};
-                const current = resObj.value || 0;
+                const current = objective.checkCap ? (resObj.cap || 0) : (resObj.value || 0);
                 const name = resObj.displayName || objective.resource;
-                return `${name}: ${format(Math.floor(current), true)}/${format(objective.quantity, true)}`;
+                const label = objective.checkCap ? `${name} Cap` : name;
+                return `${label}: ${format(Math.floor(current), true)}/${format(objective.quantity, true)}`;
             }
             case 'building': {
                 const b = buildings[objective.buildingName];

--- a/tests/collectionObjectiveCap.test.js
+++ b/tests/collectionObjectiveCap.test.js
@@ -11,4 +11,15 @@ describe('collection objective checkCap', () => {
     sm.destroy();
     global.document = originalDocument;
   });
+
+  test('describeObjective shows cap progress when checkCap is true', () => {
+    global.resources = { colony: { workers: { value: 0, cap: 40, displayName: 'Workers' } } };
+    const originalDocument = global.document;
+    global.document = { addEventListener: jest.fn(), removeEventListener: jest.fn() };
+    const sm = new StoryManager({ chapters: [] });
+    const objective = { type: 'collection', resourceType: 'colony', resource: 'workers', quantity: 50, checkCap: true };
+    expect(sm.describeObjective(objective)).toBe('Workers Cap: 40/50');
+    sm.destroy();
+    global.document = originalDocument;
+  });
 });


### PR DESCRIPTION
## Summary
- Show resource cap progress for collection objectives when `checkCap` is used.
- Add test covering cap-based objective description.

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b492f29b9c83279b29e66b6834e838