### PR TITLE
Avoid negative inputs for pressure calculations

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -537,7 +537,12 @@ class Building extends EffectableEntity {
         const tolerance = 0.001;
         for (let i = 0; i < 10 && Math.abs(fx) > tolerance; i++) {
           const h = Math.max(maxProduction * 0.01, 1e-6);
-          const derivative = (f(x + h) - f(x - h)) / (2 * h);
+          let derivative;
+          if (x - h >= 0) {
+            derivative = (f(x + h) - f(x - h)) / (2 * h);
+          } else {
+            derivative = (f(x + h) - fx) / h;
+          }
           if (derivative === 0 || !isFinite(derivative)) break;
           x = x - fx / derivative;
           if (x < 0) x = 0;

--- a/tests/oxygenFactoryDerivative.test.js
+++ b/tests/oxygenFactoryDerivative.test.js
@@ -1,0 +1,57 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { oxygenFactorySettings } = require('../src/js/ghg-automation.js');
+const { Building } = require('../src/js/building.js');
+
+describe('Oxygen factory pressure derivative', () => {
+  beforeEach(() => {
+    global.resources = { colony: {}, atmospheric: { oxygen: { value: 0 } }, surface: {}, underground: {} };
+    global.populationModule = { getWorkerAvailabilityRatio: () => 1 };
+    global.terraforming = { celestialParameters: { gravity: 1, radius: 1 } };
+    global.researchManager = { getResearchById: () => ({ isResearched: true }) };
+    oxygenFactorySettings.autoDisableAbovePressure = true;
+    oxygenFactorySettings.disablePressureThreshold = 1;
+  });
+
+  afterEach(() => {
+    delete global.researchManager;
+    delete global.populationModule;
+    delete global.calculateAtmosphericPressure;
+    delete global.terraforming;
+    delete global.resources;
+  });
+
+  test('calculateAtmosphericPressure never receives negative values', () => {
+    const called = [];
+    global.calculateAtmosphericPressure = (amount) => {
+      called.push(amount);
+      return amount;
+    };
+
+    const config = {
+      name: 'Oxygen factory',
+      category: 'terraforming',
+      cost: {},
+      consumption: {},
+      production: { atmospheric: { oxygen: 10 } },
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true,
+    };
+
+    const building = new Building(config, 'oxygenFactory');
+    building.active = 1;
+    building.addEffect({ type: 'booleanFlag', flagId: 'terraformingBureauFeature', value: true });
+
+    building.updateProductivity(global.resources, 1000);
+
+    expect(called.length).toBeGreaterThan(0);
+    expect(called.every(v => v >= 0)).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Guard `solveRequired` derivative from sampling negative resource amounts
- Test oxygen factory automation to ensure only non-negative values feed atmospheric pressure calculations

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b4a22e356083279029b9a3619d864f