### PR TITLE
Use direct water-cycle and hydrology functions

### DIFF
--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -14,9 +14,10 @@
       reconstructJournalState,
       calculateAtmosphericPressure;
   if (isNode) {
+    const waterCycle = require('./terraforming/water-cycle.js');
+    calculateEvaporationSublimationRates = waterCycle.calculateEvaporationSublimationRates;
+    calculatePrecipitationRateFactor = waterCycle.calculatePrecipitationRateFactor;
     const utils = require('./terraforming/terraforming-utils.js');
-    calculateEvaporationSublimationRates = utils.calculateEvaporationSublimationRates;
-    calculatePrecipitationRateFactor = utils.calculatePrecipitationRateFactor;
     calculateZonalCoverage = utils.calculateZonalCoverage;
 
     const dryIceCycle = require('./terraforming/dry-ice-cycle.js');

--- a/tests/calciteDecay.test.js
+++ b/tests/calciteDecay.test.js
@@ -7,17 +7,20 @@ const physics = require('../src/js/physics.js');
 jest.mock('../src/js/hydrology.js', () => ({
   simulateSurfaceWaterFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
   simulateSurfaceHydrocarbonFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
-  calculateMethaneMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 }))
+  calculateMethaneMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 })),
+  calculateMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 }))
 }));
 
 jest.mock('../src/js/terraforming-utils.js', () => ({
   calculateAverageCoverage: jest.fn(() => 0),
   calculateZonalCoverage: jest.fn(() => ({})),
   calculateSurfaceFractions: jest.fn(() => ({})),
-  calculateZonalSurfaceFractions: jest.fn(() => ({})),
-  calculateEvaporationSublimationRates: jest.fn(() => ({ evaporationRate: 0, sublimationRate: 0 })),
-  calculatePrecipitationRateFactor: jest.fn(() => 0),
-  calculateMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 })),
+  calculateZonalSurfaceFractions: jest.fn(() => ({}))
+}));
+
+jest.mock('../src/js/terraforming/water-cycle.js', () => ({
+  calculateEvaporationSublimationRates: jest.fn(() => ({ evaporationRate: 0, waterSublimationRate: 0, co2SublimationRate: 0 })),
+  calculatePrecipitationRateFactor: jest.fn(() => ({ rainfallRateFactor: 0, snowfallRateFactor: 0 }))
 }));
 
 jest.mock('../src/js/hydrocarbon-cycle.js', () => ({

--- a/tests/hydrology.test.js
+++ b/tests/hydrology.test.js
@@ -1,5 +1,5 @@
 const { calculateMeltingFreezingRates, simulateSurfaceWaterFlow, simulateSurfaceHydrocarbonFlow } = require('../src/js/hydrology.js');
-const { calculateMeltingFreezingRates: zonalRates, calculateZonalCoverage } = require('../src/js/terraforming-utils.js');
+const { calculateZonalCoverage } = require('../src/js/terraforming-utils.js');
 const { getZonePercentage, estimateCoverage } = require('../src/js/zones.js');
 
 global.getZonePercentage = getZonePercentage;
@@ -72,7 +72,15 @@ describe('hydrology melting with buried ice', () => {
     const meltCap = zoneArea * coverage * 0.1;
     const diff = T - 273.15;
     const expected = meltCap * 0.000001 * diff;
-    const res = zonalRates(terra, 'polar', T);
+    const res = calculateMeltingFreezingRates(
+      T,
+      terra.zonalWater.polar.ice,
+      terra.zonalWater.polar.liquid,
+      terra.zonalWater.polar.buriedIce,
+      zoneArea,
+      coverage,
+      terra.zonalCoverageCache.polar.liquidWater || 0
+    );
     expect(res.meltingRate).toBeCloseTo(expected);
   });
 

--- a/tests/oxygenMethaneCombustion.test.js
+++ b/tests/oxygenMethaneCombustion.test.js
@@ -7,17 +7,20 @@ const physics = require('../src/js/physics.js');
 jest.mock('../src/js/hydrology.js', () => ({
   simulateSurfaceWaterFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
   simulateSurfaceHydrocarbonFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
-  calculateMethaneMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 }))
+  calculateMethaneMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 })),
+  calculateMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 }))
 }));
 
 jest.mock('../src/js/terraforming-utils.js', () => ({
   calculateAverageCoverage: jest.fn(() => 0),
   calculateZonalCoverage: jest.fn(() => ({})),
   calculateSurfaceFractions: jest.fn(() => ({})),
-  calculateZonalSurfaceFractions: jest.fn(() => ({})),
-  calculateEvaporationSublimationRates: jest.fn(() => ({ evaporationRate: 0, sublimationRate: 0 })),
-  calculatePrecipitationRateFactor: jest.fn(() => 0),
-  calculateMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 })),
+  calculateZonalSurfaceFractions: jest.fn(() => ({}))
+}));
+
+jest.mock('../src/js/terraforming/water-cycle.js', () => ({
+  calculateEvaporationSublimationRates: jest.fn(() => ({ evaporationRate: 0, waterSublimationRate: 0, co2SublimationRate: 0 })),
+  calculatePrecipitationRateFactor: jest.fn(() => ({ rainfallRateFactor: 0, snowfallRateFactor: 0 }))
 }));
 
 jest.mock('../src/js/hydrocarbon-cycle.js', () => ({

--- a/tests/terraformingUtilsIntegration.test.js
+++ b/tests/terraformingUtilsIntegration.test.js
@@ -4,7 +4,8 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 const lifeParameters = require('../src/js/life-parameters.js');
 const physics = require('../src/js/physics.js');
 const dryIce = require('../src/js/dry-ice-cycle.js');
-const { calculateAverageCoverage, calculateZonalCoverage, calculateEvaporationSublimationRates } = require('../src/js/terraforming-utils.js');
+const { calculateAverageCoverage, calculateZonalCoverage } = require('../src/js/terraforming-utils.js');
+const { calculateEvaporationSublimationRates } = require('../src/js/terraforming/water-cycle.js');
 
 // globals expected by terraforming.js
 global.getZoneRatio = getZoneRatio;
@@ -92,16 +93,19 @@ describe('terraforming-utils integration', () => {
 
     terra._updateZonalCoverageCache();
 
-    const rates = calculateEvaporationSublimationRates(
-      terra,
-      'polar',
-      260,
-      250,
-      0,
-      0,
-      600,
-      1000
-    );
+    const cache = terra.zonalCoverageCache.polar;
+    const rates = calculateEvaporationSublimationRates({
+      zoneArea: cache.zoneArea,
+      liquidWaterCoverage: cache.liquidWater,
+      iceCoverage: cache.ice,
+      dryIceCoverage: cache.dryIce,
+      dayTemperature: 260,
+      nightTemperature: 250,
+      waterVaporPressure: 0,
+      co2VaporPressure: 0,
+      avgAtmPressure: 600,
+      zonalSolarFlux: 1000
+    });
     expect(rates.waterSublimationRate).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Call base water-cycle and hydrology functions directly in terraforming calculations
- Simplify terraforming-utils by removing unused zonal wrappers
- Update debug tools and tests for new function signatures

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b4e764b3a48327bcc13d7e38f0596a