### PR TITLE
Refactor zonal change tracking into nested resource maps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,3 +400,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Solis shop upgrades respect max purchase limits, hiding cost and buy buttons once the limit is reached.
 - Life growth and decay now interpolate across a ±0.5 K band around survivable temperature limits, showing a warning icon when growth is reduced.
 - Biomass resource display shows red exclamation marks for zones with net decay.
+- Zonal resource changes now use nested maps grouped by resource, simplifying atmospheric and precipitation handling.

--- a/tests/redistributePrecipitationNested.test.js
+++ b/tests/redistributePrecipitationNested.test.js
@@ -1,0 +1,40 @@
+const { redistributePrecipitation } = require('../src/js/terraforming/phase-change-utils.js');
+
+describe('redistributePrecipitation nested structure', () => {
+  function makeZone() {
+    return {
+      water: { liquid: 0, ice: 0, buriedIce: 0, dryIce: 0 },
+      methane: { liquid: 0, ice: 0, buriedIce: 0 },
+      atmosphere: { water: 0, co2: 0, methane: 0, oxygen: 0 },
+      precipitation: { rain: 0, snow: 0, methaneRain: 0, methaneSnow: 0 },
+      potentialCO2Condensation: 0
+    };
+  }
+
+  test('total precipitation conserved and distributed', () => {
+    const terraforming = { zonalCoverageCache: {
+      tropical: { liquidWater: 1 },
+      temperate: { liquidWater: 0 },
+      polar: { liquidWater: 0 }
+    } };
+    const zonalTemperatures = {
+      tropical: { value: 300 },
+      temperate: { value: 250 },
+      polar: { value: 250 }
+    };
+    const zonalChanges = {
+      tropical: makeZone(),
+      temperate: makeZone(),
+      polar: makeZone()
+    };
+    zonalChanges.tropical.precipitation.rain = 10;
+    redistributePrecipitation(terraforming, 'water', zonalChanges, zonalTemperatures);
+    const total = ['tropical','temperate','polar']
+      .reduce((sum,z)=> sum + zonalChanges[z].precipitation.rain + zonalChanges[z].precipitation.snow,0);
+    expect(total).toBeCloseTo(10);
+    // Some precipitation should move out of tropical zone
+    const moved = zonalChanges.temperate.precipitation.rain + zonalChanges.temperate.precipitation.snow +
+      zonalChanges.polar.precipitation.rain + zonalChanges.polar.precipitation.snow;
+    expect(moved).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Group zonal surface, atmospheric and precipitation changes into resource-specific maps
- Update precipitation redistribution to work with nested precipitation data
- Apply zonal resource changes generically and add test for new precipitation structure

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b4f802e5988327a60b9d3112439445