### PR TITLE
feat: add ResourceCycle base class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,3 +401,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Life growth and decay now interpolate across a ±0.5 K band around survivable temperature limits, showing a warning icon when growth is reduced.
 - Biomass resource display shows red exclamation marks for zones with net decay.
 - Zonal resource changes now use nested maps grouped by resource, simplifying atmospheric and precipitation handling.
+- Added ResourceCycle base class to centralize per-zone phase-change calculations.

--- a/src/js/terraforming/resource-cycle.js
+++ b/src/js/terraforming/resource-cycle.js
@@ -1,0 +1,106 @@
+// Base class for resource cycle phase-change calculations
+const isNodeResourceCycle = (typeof module !== 'undefined' && module.exports);
+let penmanRate = globalThis.penmanRate;
+let condensationRateFactor = globalThis.condensationRateFactor;
+let meltingFreezingRatesUtil = globalThis.meltingFreezingRates;
+if (isNodeResourceCycle) {
+  try {
+    const phaseUtils = require('./phase-change-utils.js');
+    penmanRate = phaseUtils.penmanRate;
+    meltingFreezingRatesUtil = phaseUtils.meltingFreezingRates;
+    condensationRateFactor = require('./condensation-utils.js').condensationRateFactor;
+  } catch (e) {
+    // fall back to globals if require fails
+  }
+}
+
+class ResourceCycle {
+  constructor({
+    latentHeatVaporization,
+    latentHeatSublimation,
+    saturationVaporPressureFn,
+    slopeSaturationVaporPressureFn,
+    freezePoint,
+    sublimationPoint,
+    rapidSublimationMultiplier = 0,
+    evaporationAlbedo = 0.6,
+    sublimationAlbedo = 0.6,
+  } = {}) {
+    this.latentHeatVaporization = latentHeatVaporization;
+    this.latentHeatSublimation = latentHeatSublimation;
+    this.saturationVaporPressureFn = saturationVaporPressureFn;
+    this.slopeSaturationVaporPressureFn = slopeSaturationVaporPressureFn;
+    this.freezePoint = freezePoint;
+    this.sublimationPoint = sublimationPoint;
+    this.rapidSublimationMultiplier = rapidSublimationMultiplier;
+    this.evaporationAlbedo = evaporationAlbedo;
+    this.sublimationAlbedo = sublimationAlbedo;
+  }
+
+  evaporationRate({ T, solarFlux, atmPressure, vaporPressure: e_a, r_a = 100, albedo = this.evaporationAlbedo }) {
+    const Delta_s = this.slopeSaturationVaporPressureFn(T);
+    const e_s = this.saturationVaporPressureFn(T);
+    return penmanRate({
+      T,
+      solarFlux,
+      atmPressure,
+      e_a,
+      latentHeat: this.latentHeatVaporization,
+      albedo,
+      r_a,
+      Delta_s,
+      e_s,
+    });
+  }
+
+  condensationRateFactor({ zoneArea, vaporPressure, gravity, dayTemp, nightTemp, transitionRange, maxDiff, boilingPoint, boilTransitionRange }) {
+    return condensationRateFactor({
+      zoneArea,
+      vaporPressure,
+      gravity,
+      dayTemp,
+      nightTemp,
+      saturationFn: this.saturationVaporPressureFn,
+      freezePoint: this.freezePoint,
+      transitionRange,
+      maxDiff,
+      boilingPoint,
+      boilTransitionRange,
+    });
+  }
+
+  meltingFreezingRates(args) {
+    return meltingFreezingRatesUtil({ ...args, freezingPoint: this.freezePoint });
+  }
+
+  sublimationRate({ T, solarFlux, atmPressure, vaporPressure: e_a, r_a = 100, albedo = this.sublimationAlbedo }) {
+    const Delta_s = this.slopeSaturationVaporPressureFn(T);
+    const e_s = this.saturationVaporPressureFn(T);
+    return penmanRate({
+      T,
+      solarFlux,
+      atmPressure,
+      e_a,
+      latentHeat: this.latentHeatSublimation,
+      albedo,
+      r_a,
+      Delta_s,
+      e_s,
+    });
+  }
+
+  rapidSublimationRate(temperature, availableIce) {
+    if (temperature > this.sublimationPoint && availableIce > 0) {
+      const diff = temperature - this.sublimationPoint;
+      return availableIce * this.rapidSublimationMultiplier * diff;
+    }
+    return 0;
+  }
+}
+
+if (isNodeResourceCycle) {
+  module.exports = ResourceCycle;
+} else {
+  globalThis.ResourceCycle = ResourceCycle;
+}
+

--- a/tests/resourceCycle.test.js
+++ b/tests/resourceCycle.test.js
@@ -1,0 +1,83 @@
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+const ResourceCycle = require('../src/js/terraforming/resource-cycle.js');
+const { penmanRate, meltingFreezingRates } = require('../src/js/terraforming/phase-change-utils.js');
+const { condensationRateFactor } = require('../src/js/terraforming/condensation-utils.js');
+
+describe('ResourceCycle base class', () => {
+  const saturationFn = T => T * 10;
+  const slopeFn = () => 10;
+  const rc = new ResourceCycle({
+    latentHeatVaporization: 1e6,
+    latentHeatSublimation: 2e6,
+    saturationVaporPressureFn: saturationFn,
+    slopeSaturationVaporPressureFn: slopeFn,
+    freezePoint: 273.15,
+    sublimationPoint: 195,
+    rapidSublimationMultiplier: 0.1,
+  });
+
+  test('evaporationRate matches penmanRate', () => {
+    const args = { T: 300, solarFlux: 500, atmPressure: 100000, vaporPressure: 1000 };
+    const expected = penmanRate({
+      T: 300,
+      solarFlux: 500,
+      atmPressure: 100000,
+      e_a: 1000,
+      latentHeat: 1e6,
+      albedo: 0.6,
+      r_a: 100,
+      Delta_s: slopeFn(300),
+      e_s: saturationFn(300),
+    });
+    expect(rc.evaporationRate(args)).toBeCloseTo(expected);
+  });
+
+  test('condensationRateFactor uses provided functions', () => {
+    const args = { zoneArea: 100, vaporPressure: 2000, gravity: 9.81, dayTemp: 280, nightTemp: 270 };
+    const expected = condensationRateFactor({
+      ...args,
+      saturationFn,
+      freezePoint: 273.15,
+    });
+    const result = rc.condensationRateFactor(args);
+    expect(result.liquidRate).toBeCloseTo(expected.liquidRate);
+    expect(result.iceRate).toBeCloseTo(expected.iceRate);
+  });
+
+  test('meltingFreezingRates delegates to util', () => {
+    const args = {
+      temperature: 270,
+      availableIce: 100,
+      availableLiquid: 50,
+      availableBuriedIce: 0,
+      zoneArea: 1,
+      iceCoverage: 1,
+      liquidCoverage: 1,
+    };
+    const expected = meltingFreezingRates({ ...args, freezingPoint: 273.15 });
+    expect(rc.meltingFreezingRates(args)).toEqual(expected);
+  });
+
+  test('sublimationRate matches penmanRate', () => {
+    const args = { T: 200, solarFlux: 400, atmPressure: 100000, vaporPressure: 1000 };
+    const expected = penmanRate({
+      T: 200,
+      solarFlux: 400,
+      atmPressure: 100000,
+      e_a: 1000,
+      latentHeat: 2e6,
+      albedo: 0.6,
+      r_a: 100,
+      Delta_s: slopeFn(200),
+      e_s: saturationFn(200),
+    });
+    expect(rc.sublimationRate(args)).toBeCloseTo(expected);
+  });
+
+  test('rapidSublimationRate uses linear model', () => {
+    const rate = rc.rapidSublimationRate(200, 50);
+    expect(rate).toBeCloseTo(50 * 0.1 * 5);
+    expect(rc.rapidSublimationRate(190, 50)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add ResourceCycle base class for shared phase-change calculations
- cover new class with unit tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b50a70afc48327826ec86baf7b5a23