### PR TITLE
Refactor water cycle to use ResourceCycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,3 +402,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Biomass resource display shows red exclamation marks for zones with net decay.
 - Zonal resource changes now use nested maps grouped by resource, simplifying atmospheric and precipitation handling.
 - Added ResourceCycle base class to centralize per-zone phase-change calculations.
+- Introduced WaterCycle class extending ResourceCycle with an exported instance for evaporation and sublimation calculations.


### PR DESCRIPTION
## Summary
- Add `WaterCycle` class extending new `ResourceCycle` and expose shared instance
- Delegate water phase-change helpers to the `WaterCycle` instance
- Document new `WaterCycle` feature in AGENTS instructions

## Testing
- `npm ci`
- `CI=true npx jest tests/planetSelection.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b50d944348832780ea74335d9efa84