### PR TITLE
Add ResourceCycle subclasses for methane and CO2

### DIFF
--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -1,19 +1,19 @@
-// Constants
-const STEFAN_BOLTZMANN = 5.67e-8; // W/m²·K⁴
 const L_S_CO2 = 574000; // J/kg (latent heat of sublimation for CO2)
 const R_CO2 = 188.9; // J/kg·K (specific gas constant for CO2)
-
 
 const isNodeDryIce = (typeof module !== 'undefined' && module.exports);
 var penmanRate = globalThis.penmanRate;
 var psychrometricConstant = globalThis.psychrometricConstant;
+var ResourceCycle = globalThis.ResourceCycle;
 if (isNodeDryIce) {
   try {
     ({ penmanRate, psychrometricConstant } = require('./phase-change-utils.js'));
+    ResourceCycle = require('./resource-cycle.js');
   } catch (e) {
     // fall back to globals if require fails
   }
 }
+ResourceCycle = ResourceCycle || class {};
 
 
 function calculateSaturationPressureCO2(temperature) {
@@ -87,8 +87,34 @@ function psychrometricConstantCO2(atmPressure) {
   return psychrometricConstant(atmPressure, L_S_CO2); // Pa/K
 }
 
+class CO2Cycle extends ResourceCycle {
+  constructor() {
+    super({
+      latentHeatVaporization: L_S_CO2,
+      latentHeatSublimation: L_S_CO2,
+      saturationVaporPressureFn: calculateSaturationPressureCO2,
+      slopeSaturationVaporPressureFn: slopeSVPCO2,
+      freezePoint: 195,
+      sublimationPoint: 195,
+      rapidSublimationMultiplier: 0.00000001,
+      sublimationAlbedo: 0.6,
+    });
+  }
+}
+
+const co2Cycle = new CO2Cycle();
+
 // Function to calculate sublimation rate (E_sub) using the modified Penman equation
 function sublimationRateCO2(T, solarFlux, atmPressure, e_a, r_a = 100) {
+  if (typeof co2Cycle.sublimationRate === 'function') {
+    return co2Cycle.sublimationRate({
+      T,
+      solarFlux,
+      atmPressure,
+      vaporPressure: e_a,
+      r_a,
+    });
+  }
   const Delta_s = slopeSVPCO2(T); // Pa/K
   const e_s = calculateSaturationPressureCO2(T); // Pa
   return penmanRate({
@@ -108,6 +134,9 @@ function sublimationRateCO2(T, solarFlux, atmPressure, e_a, r_a = 100) {
 // rises well above the sublimation point. Modeled similar to water melting in
 // hydrology.js using a simple linear multiplier.
 function rapidSublimationRateCO2(temperature, availableDryIce) {
+    if (typeof co2Cycle.rapidSublimationRate === 'function') {
+        return co2Cycle.rapidSublimationRate(temperature, availableDryIce);
+    }
     const sublimationPoint = 195; // K
     const sublimationRateMultiplier = 0.00000001; // per K per second
 
@@ -125,8 +154,20 @@ function calculateCO2CondensationRateFactor({
     zoneArea,
     co2VaporPressure,
     dayTemperature,
-    nightTemperature
+    nightTemperature,
 }) {
+    if (typeof co2Cycle.condensationRateFactor === 'function') {
+        const res = co2Cycle.condensationRateFactor({
+            zoneArea,
+            vaporPressure: co2VaporPressure,
+            gravity: 1,
+            dayTemp: dayTemperature,
+            nightTemp: nightTemperature,
+            transitionRange: 2,
+            maxDiff: 10,
+        });
+        return res.iceRate;
+    }
     const condensationTemperatureCO2 = 195; // K
 
     const calculatePotential = (temp) => {
@@ -169,7 +210,9 @@ if (typeof module !== 'undefined' && module.exports) {
         psychrometricConstantCO2,
         sublimationRateCO2,
         rapidSublimationRateCO2,
-        calculateCO2CondensationRateFactor
+        calculateCO2CondensationRateFactor,
+        CO2Cycle,
+        co2Cycle,
     };
 } else {
     // Expose functions globally for browser usage
@@ -179,4 +222,6 @@ if (typeof module !== 'undefined' && module.exports) {
     globalThis.sublimationRateCO2 = sublimationRateCO2;
     globalThis.rapidSublimationRateCO2 = rapidSublimationRateCO2;
     globalThis.calculateCO2CondensationRateFactor = calculateCO2CondensationRateFactor;
+    globalThis.CO2Cycle = CO2Cycle;
+    globalThis.co2Cycle = co2Cycle;
 }

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -6,14 +6,17 @@ const isNodeHydrocarbon = (typeof module !== 'undefined' && module.exports);
 var penmanRate = globalThis.penmanRate;
 var psychrometricConstant = globalThis.psychrometricConstant;
 var condensationRateFactorUtil = globalThis.condensationRateFactor;
+var ResourceCycle = globalThis.ResourceCycle;
 if (isNodeHydrocarbon) {
   try {
     ({ penmanRate, psychrometricConstant } = require('./phase-change-utils.js'));
     condensationRateFactorUtil = require('./condensation-utils.js').condensationRateFactor;
+    ResourceCycle = require('./resource-cycle.js');
   } catch (e) {
     // fall back to globals if require fails
   }
 }
+ResourceCycle = ResourceCycle || class {};
 
 // Function to calculate saturation vapor pressure of methane using the Wagner equation
 function calculateSaturationPressureMethane(temperature) {
@@ -88,8 +91,35 @@ function boilingPointMethane(atmPressure) {
   return B / (A - Math.log(atmPressure));
 }
 
+class MethaneCycle extends ResourceCycle {
+  constructor() {
+    super({
+      latentHeatVaporization: L_V_METHANE,
+      latentHeatSublimation: L_S_METHANE,
+      saturationVaporPressureFn: calculateSaturationPressureMethane,
+      slopeSaturationVaporPressureFn: slopeSVPMethane,
+      freezePoint: 90.7,
+      sublimationPoint: 90.7,
+      rapidSublimationMultiplier: 0.000001,
+      evaporationAlbedo: 0.1,
+      sublimationAlbedo: 0.6,
+    });
+  }
+}
+
+const methaneCycle = new MethaneCycle();
+
 // Function to calculate evaporation rate for methane using the modified Penman equation
 function evaporationRateMethane(T, solarFlux, atmPressure, e_a, r_a = 100) {
+    if (typeof methaneCycle.evaporationRate === 'function') {
+        return methaneCycle.evaporationRate({
+            T,
+            solarFlux,
+            atmPressure,
+            vaporPressure: e_a,
+            r_a,
+        });
+    }
     const Delta_s = slopeSVPMethane(T);
     const e_s = calculateSaturationPressureMethane(T);
     return penmanRate({
@@ -112,6 +142,15 @@ function psychrometricConstantMethaneSublimation(atmPressure) {
 
 // Function to calculate sublimation rate for methane using the modified Penman equation
 function sublimationRateMethane(T, solarFlux, atmPressure, e_a, r_a = 100) {
+    if (typeof methaneCycle.sublimationRate === 'function') {
+        return methaneCycle.sublimationRate({
+            T,
+            solarFlux,
+            atmPressure,
+            vaporPressure: e_a,
+            r_a,
+        });
+    }
     const Delta_s = slopeSVPMethane(T);
     const e_s = calculateSaturationPressureMethane(T);
     return penmanRate({
@@ -128,6 +167,9 @@ function sublimationRateMethane(T, solarFlux, atmPressure, e_a, r_a = 100) {
 }
 
 function rapidSublimationRateMethane(temperature, availableMethaneIce) {
+    if (typeof methaneCycle.rapidSublimationRate === 'function') {
+        return methaneCycle.rapidSublimationRate(temperature, availableMethaneIce);
+    }
     const sublimationPoint = 90.7; // K
     const sublimationRateMultiplier = 0.000001; // per K per second
 
@@ -211,6 +253,23 @@ function calculateMethaneCondensationRateFactor({
     atmPressure
 }) {
     const boilingPoint = boilingPointMethane(atmPressure);
+    if (typeof methaneCycle.condensationRateFactor === 'function') {
+        const res = methaneCycle.condensationRateFactor({
+            zoneArea,
+            vaporPressure: methaneVaporPressure,
+            gravity: 1,
+            dayTemp: dayTemperature,
+            nightTemp: nightTemperature,
+            transitionRange: 2,
+            maxDiff: 10,
+            boilingPoint,
+            boilTransitionRange: 5,
+        });
+        return {
+            liquidRateFactor: res.liquidRate,
+            iceRateFactor: res.iceRate,
+        };
+    }
     const res = condensationRateFactorUtil({
         zoneArea,
         vaporPressure: methaneVaporPressure,
@@ -222,11 +281,11 @@ function calculateMethaneCondensationRateFactor({
         transitionRange: 2,
         maxDiff: 10,
         boilingPoint,
-        boilTransitionRange: 5
+        boilTransitionRange: 5,
     });
     return {
         liquidRateFactor: res.liquidRate,
-        iceRateFactor: res.iceRate
+        iceRateFactor: res.iceRate,
     };
 }
 
@@ -242,7 +301,9 @@ if (typeof module !== 'undefined' && module.exports) {
         sublimationRateMethane,
         rapidSublimationRateMethane,
         calculateMethaneSublimationRate,
-        boilingPointMethane
+        boilingPointMethane,
+        MethaneCycle,
+        methaneCycle,
     };
 } else {
     // Expose functions globally for browser usage
@@ -256,4 +317,6 @@ if (typeof module !== 'undefined' && module.exports) {
     globalThis.rapidSublimationRateMethane = rapidSublimationRateMethane;
     globalThis.calculateMethaneSublimationRate = calculateMethaneSublimationRate;
     globalThis.boilingPointMethane = boilingPointMethane;
+    globalThis.MethaneCycle = MethaneCycle;
+    globalThis.methaneCycle = methaneCycle;
 }


### PR DESCRIPTION
## Summary
- implement `MethaneCycle` and `CO2Cycle` classes extending `ResourceCycle`
- delegate evaporation, sublimation, and condensation helpers to cycle instances with legacy fallbacks

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b50daed4288327bb932b8255d09e7e