### PR TITLE
refactor: use cycle condensation methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,3 +404,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added ResourceCycle base class to centralize per-zone phase-change calculations.
 - Introduced WaterCycle class extending ResourceCycle with an exported instance for evaporation and sublimation calculations.
 - Added MethaneCycle and CO2Cycle subclasses extending ResourceCycle for hydrocarbon and dry ice modeling.
+- Deprecated standalone condensation helpers in favor of using each cycle instance's `condensationRateFactor` method directly.

--- a/src/js/rwgEquilibrate.js
+++ b/src/js/rwgEquilibrate.js
@@ -43,14 +43,20 @@
         const dryIce = require('./terraforming/dry-ice-cycle.js');
         if (typeof globalThis.sublimationRateCO2 === 'undefined') globalThis.sublimationRateCO2 = dryIce.sublimationRateCO2 || globalThis.sublimationRateCO2;
         if (typeof globalThis.rapidSublimationRateCO2 === 'undefined') globalThis.rapidSublimationRateCO2 = dryIce.rapidSublimationRateCO2 || globalThis.rapidSublimationRateCO2;
-        if (typeof globalThis.calculateCO2CondensationRateFactor === 'undefined') globalThis.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor || globalThis.calculateCO2CondensationRateFactor;
+        if (typeof globalThis.co2Cycle === 'undefined') globalThis.co2Cycle = dryIce.co2Cycle || globalThis.co2Cycle;
       } catch (_) {}
       try {
         const water = require('./terraforming/water-cycle.js');
         if (typeof globalThis.sublimationRateWater === 'undefined') globalThis.sublimationRateWater = water.sublimationRateWater || globalThis.sublimationRateWater;
         if (typeof globalThis.evaporationRateWater === 'undefined') globalThis.evaporationRateWater = water.evaporationRateWater || globalThis.evaporationRateWater;
         if (typeof globalThis.calculateEvaporationSublimationRates === 'undefined') globalThis.calculateEvaporationSublimationRates = water.calculateEvaporationSublimationRates || globalThis.calculateEvaporationSublimationRates;
-        if (typeof globalThis.calculatePrecipitationRateFactor === 'undefined') globalThis.calculatePrecipitationRateFactor = water.calculatePrecipitationRateFactor || globalThis.calculatePrecipitationRateFactor;
+        if (typeof globalThis.waterCycle === 'undefined') globalThis.waterCycle = water.waterCycle || globalThis.waterCycle;
+        if (typeof globalThis.boilingPointWater === 'undefined') globalThis.boilingPointWater = water.boilingPointWater || globalThis.boilingPointWater;
+      } catch (_) {}
+      try {
+        const hydro = require('./terraforming/hydrocarbon-cycle.js');
+        if (typeof globalThis.methaneCycle === 'undefined') globalThis.methaneCycle = hydro.methaneCycle || globalThis.methaneCycle;
+        if (typeof globalThis.boilingPointMethane === 'undefined') globalThis.boilingPointMethane = hydro.boilingPointMethane || globalThis.boilingPointMethane;
       } catch (_) {}
       // Hydrology functions for surface flow
       try {

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -144,7 +144,8 @@ class CO2Cycle extends ResourceCycleClass {
     const nightPotential = calculatePotential(nightTemperature);
     const dayPotential = calculatePotential(dayTemperature);
 
-    return (nightPotential + dayPotential) / 2;
+    const rate = (nightPotential + dayPotential) / 2;
+    return { iceRate: rate };
   }
 }
 
@@ -167,23 +168,6 @@ function rapidSublimationRateCO2(temperature, availableDryIce) {
     return co2Cycle.rapidSublimationRate(temperature, availableDryIce);
 }
 
-// Calculate potential CO₂ condensation rate factor for a zone. The returned
-// value represents the rate (in tons/s) that would occur if the condensation
-// parameter were equal to 1.
-function calculateCO2CondensationRateFactor({
-    zoneArea,
-    co2VaporPressure,
-    dayTemperature,
-    nightTemperature
-}) {
-    return co2Cycle.condensationRateFactor({
-        zoneArea,
-        co2VaporPressure,
-        dayTemperature,
-        nightTemperature
-    });
-}
-
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         CO2Cycle,
@@ -192,8 +176,7 @@ if (typeof module !== 'undefined' && module.exports) {
         slopeSVPCO2,
         psychrometricConstantCO2,
         sublimationRateCO2,
-        rapidSublimationRateCO2,
-        calculateCO2CondensationRateFactor
+        rapidSublimationRateCO2
     };
 } else {
     // Expose functions globally for browser usage
@@ -204,5 +187,4 @@ if (typeof module !== 'undefined' && module.exports) {
     globalThis.psychrometricConstantCO2 = psychrometricConstantCO2;
     globalThis.sublimationRateCO2 = sublimationRateCO2;
     globalThis.rapidSublimationRateCO2 = rapidSublimationRateCO2;
-    globalThis.calculateCO2CondensationRateFactor = calculateCO2CondensationRateFactor;
 }

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -200,33 +200,6 @@ function calculateMethaneSublimationRate({
     return (daySublimationRate + nightSublimationRate) / 2;
 }
 
-// Calculate potential methane condensation rate factor for a zone
-function calculateMethaneCondensationRateFactor({
-    zoneArea,
-    methaneVaporPressure,
-    dayTemperature,
-    nightTemperature,
-    atmPressure
-}) {
-    const boilingPoint = boilingPointMethane(atmPressure);
-    const res = methaneCycle.condensationRateFactor({
-        zoneArea,
-        vaporPressure: methaneVaporPressure,
-        gravity: 1,
-        dayTemp: dayTemperature,
-        nightTemp: nightTemperature,
-        transitionRange: 2,
-        maxDiff: 10,
-        boilingPoint,
-        boilTransitionRange: 5
-    });
-    return {
-        liquidRateFactor: res.liquidRate,
-        iceRateFactor: res.iceRate
-    };
-}
-
-
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         MethaneCycle,
@@ -235,7 +208,6 @@ if (typeof module !== 'undefined' && module.exports) {
         slopeSVPMethane,
         psychrometricConstantMethane,
         evaporationRateMethane,
-        calculateMethaneCondensationRateFactor,
         calculateMethaneEvaporationRate,
         sublimationRateMethane,
         rapidSublimationRateMethane,
@@ -250,7 +222,6 @@ if (typeof module !== 'undefined' && module.exports) {
     globalThis.slopeSVPMethane = slopeSVPMethane;
     globalThis.psychrometricConstantMethane = psychrometricConstantMethane;
     globalThis.evaporationRateMethane = evaporationRateMethane;
-    globalThis.calculateMethaneCondensationRateFactor = calculateMethaneCondensationRateFactor;
     globalThis.calculateMethaneEvaporationRate = calculateMethaneEvaporationRate;
     globalThis.sublimationRateMethane = sublimationRateMethane;
     globalThis.rapidSublimationRateMethane = rapidSublimationRateMethane;

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -322,30 +322,6 @@ function calculateEvaporationSublimationRates({
     };
 }
 
-// Calculate potential precipitation rate factors for a zone
-function calculatePrecipitationRateFactor({
-    zoneArea,
-    waterVaporPressure,
-    gravity,
-    dayTemperature,
-    nightTemperature,
-    atmPressure
-}) {
-    const boilingPoint = boilingPointWater(atmPressure);
-    const res = waterCycle.condensationRateFactor({
-        zoneArea,
-        vaporPressure: waterVaporPressure,
-        gravity,
-        dayTemp: dayTemperature,
-        nightTemp: nightTemperature,
-        transitionRange: 2,
-        maxDiff: 10,
-        boilingPoint,
-        boilTransitionRange: 5
-    });
-    return { rainfallRateFactor: res.liquidRate, snowfallRateFactor: res.iceRate };
-}
-
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         WaterCycle,
@@ -357,7 +333,6 @@ if (typeof module !== 'undefined' && module.exports) {
         sublimationRateWater,
         evaporationRateWater,
         calculateEvaporationSublimationRates,
-        calculatePrecipitationRateFactor,
         boilingPointWater
     };
 } else {
@@ -371,6 +346,5 @@ if (typeof module !== 'undefined' && module.exports) {
     globalThis.sublimationRateWater = sublimationRateWater;
     globalThis.evaporationRateWater = evaporationRateWater;
     globalThis.calculateEvaporationSublimationRates = calculateEvaporationSublimationRates;
-    globalThis.calculatePrecipitationRateFactor = calculatePrecipitationRateFactor;
     globalThis.boilingPointWater = boilingPointWater;
 }

--- a/tests/calciteDecay.test.js
+++ b/tests/calciteDecay.test.js
@@ -19,20 +19,22 @@ jest.mock('../src/js/terraforming-utils.js', () => ({
 
 jest.mock('../src/js/terraforming/water-cycle.js', () => ({
   calculateEvaporationSublimationRates: jest.fn(() => ({ evaporationRate: 0, waterSublimationRate: 0, co2SublimationRate: 0 })),
-  calculatePrecipitationRateFactor: jest.fn(() => ({ rainfallRateFactor: 0, snowfallRateFactor: 0 }))
+  waterCycle: { condensationRateFactor: jest.fn(() => ({ liquidRate: 0, iceRate: 0 })) },
+  boilingPointWater: jest.fn(() => 373.15)
 }));
 
 jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
   evaporationRateMethane: jest.fn(() => 0),
-  calculateMethaneCondensationRateFactor: jest.fn(() => ({ liquidRateFactor: 0, iceRateFactor: 0 })),
+  methaneCycle: { condensationRateFactor: jest.fn(() => ({ liquidRate: 0, iceRate: 0 })) },
   calculateMethaneEvaporationRate: jest.fn(() => 0),
   sublimationRateMethane: jest.fn(() => 0),
   rapidSublimationRateMethane: jest.fn(() => 0),
-  calculateMethaneSublimationRate: jest.fn(() => 0)
+  calculateMethaneSublimationRate: jest.fn(() => 0),
+  boilingPointMethane: jest.fn(() => 112)
 }));
 
 jest.mock('../src/js/dry-ice-cycle.js', () => ({
-  calculateCO2CondensationRateFactor: jest.fn(() => 0),
+  co2Cycle: { condensationRateFactor: jest.fn(() => ({ iceRate: 0 })) },
   rapidSublimationRateCO2: jest.fn(() => 0)
 }));
 

--- a/tests/condensationBoiling.test.js
+++ b/tests/condensationBoiling.test.js
@@ -1,33 +1,40 @@
-const { calculatePrecipitationRateFactor, boilingPointWater } = require('../src/js/water-cycle.js');
-const { calculateMethaneCondensationRateFactor, boilingPointMethane } = require('../src/js/hydrocarbon-cycle.js');
+const { waterCycle, boilingPointWater } = require('../src/js/water-cycle.js');
+const { methaneCycle, boilingPointMethane } = require('../src/js/hydrocarbon-cycle.js');
 
 describe('condensation stops above boiling point', () => {
   test('water precipitation zero when above boiling', () => {
     const atmPressure = 101325; // Pa
     const boil = boilingPointWater(atmPressure);
-    const res = calculatePrecipitationRateFactor({
+    const { liquidRate, iceRate } = waterCycle.condensationRateFactor({
       zoneArea: 1e6,
-      waterVaporPressure: 150000,
+      vaporPressure: 150000,
       gravity: 9.81,
-      dayTemperature: boil + 6,
-      nightTemperature: boil + 6,
-      atmPressure
+      dayTemp: boil + 6,
+      nightTemp: boil + 6,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boil,
+      boilTransitionRange: 5
     });
-    expect(res.rainfallRateFactor).toBe(0);
-    expect(res.snowfallRateFactor).toBe(0);
+    expect(liquidRate).toBe(0);
+    expect(iceRate).toBe(0);
   });
 
   test('methane condensation zero when above boiling', () => {
     const atmPressure = 101325;
     const boil = boilingPointMethane(atmPressure);
-    const res = calculateMethaneCondensationRateFactor({
+    const { liquidRate, iceRate } = methaneCycle.condensationRateFactor({
       zoneArea: 1e6,
-      methaneVaporPressure: 100000,
-      dayTemperature: boil + 6,
-      nightTemperature: boil + 6,
-      atmPressure
+      vaporPressure: 100000,
+      gravity: 1,
+      dayTemp: boil + 6,
+      nightTemp: boil + 6,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boil,
+      boilTransitionRange: 5
     });
-    expect(res.liquidRateFactor).toBe(0);
-    expect(res.iceRateFactor).toBe(0);
+    expect(liquidRate).toBe(0);
+    expect(iceRate).toBe(0);
   });
 });

--- a/tests/condensationUtils.test.js
+++ b/tests/condensationUtils.test.js
@@ -59,9 +59,19 @@ describe('cycle wrappers match helper output', () => {
       boilingPoint: water.boilingPointWater(params.atmPressure),
       boilTransitionRange: 5
     });
-    const res = water.calculatePrecipitationRateFactor(params);
-    expect(res.rainfallRateFactor).toBeCloseTo(expected.liquidRate);
-    expect(res.snowfallRateFactor).toBeCloseTo(expected.iceRate);
+    const res = water.waterCycle.condensationRateFactor({
+      zoneArea: params.zoneArea,
+      vaporPressure: params.waterVaporPressure,
+      gravity: params.gravity,
+      dayTemp: params.dayTemperature,
+      nightTemp: params.nightTemperature,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: water.boilingPointWater(params.atmPressure),
+      boilTransitionRange: 5
+    });
+    expect(res.liquidRate).toBeCloseTo(expected.liquidRate);
+    expect(res.iceRate).toBeCloseTo(expected.iceRate);
   });
 
   test('methane wrapper delegates correctly', () => {
@@ -83,8 +93,18 @@ describe('cycle wrappers match helper output', () => {
       boilingPoint: hydrocarbon.boilingPointMethane(params.atmPressure),
       boilTransitionRange: 5
     });
-    const res = hydrocarbon.calculateMethaneCondensationRateFactor(params);
-    expect(res.liquidRateFactor).toBeCloseTo(expected.liquidRate);
-    expect(res.iceRateFactor).toBeCloseTo(expected.iceRate);
+    const res = hydrocarbon.methaneCycle.condensationRateFactor({
+      zoneArea: params.zoneArea,
+      vaporPressure: params.methaneVaporPressure,
+      gravity: 1,
+      dayTemp: params.dayTemperature,
+      nightTemp: params.nightTemperature,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: hydrocarbon.boilingPointMethane(params.atmPressure),
+      boilTransitionRange: 5
+    });
+    expect(res.liquidRate).toBeCloseTo(expected.liquidRate);
+    expect(res.iceRate).toBeCloseTo(expected.iceRate);
   });
 });

--- a/tests/flowMeltRate.test.js
+++ b/tests/flowMeltRate.test.js
@@ -22,7 +22,7 @@ global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
 global.airDensity = physics.airDensity;
 
 global.sublimationRateCO2 = dryIce.sublimationRateCO2;
-global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+global.co2Cycle = dryIce.co2Cycle;
 
 global.C_P_AIR = 1004;
 global.EPSILON = 0.622;

--- a/tests/methaneCondensationSmoothing.test.js
+++ b/tests/methaneCondensationSmoothing.test.js
@@ -1,4 +1,4 @@
-const { calculateMethaneCondensationRateFactor } = require('../src/js/hydrocarbon-cycle.js');
+const { methaneCycle, boilingPointMethane } = require('../src/js/hydrocarbon-cycle.js');
 
 describe('methane condensation smoothing around freezing', () => {
   const zoneArea = 1e6; // m^2
@@ -6,38 +6,50 @@ describe('methane condensation smoothing around freezing', () => {
   const atmPressure = 101325;
 
   test('above freezing favors liquid', () => {
-    const res = calculateMethaneCondensationRateFactor({
+    const { liquidRate, iceRate } = methaneCycle.condensationRateFactor({
       zoneArea,
-      methaneVaporPressure,
-      dayTemperature: 94,
-      nightTemperature: 93,
-      atmPressure,
+      vaporPressure: methaneVaporPressure,
+      gravity: 1,
+      dayTemp: 94,
+      nightTemp: 93,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boilingPointMethane(atmPressure),
+      boilTransitionRange: 5
     });
-    expect(res.liquidRateFactor).toBeGreaterThan(0);
-    expect(res.liquidRateFactor).toBeGreaterThan(res.iceRateFactor);
+    expect(liquidRate).toBeGreaterThan(0);
+    expect(liquidRate).toBeGreaterThan(iceRate);
   });
 
   test('below freezing gives mostly ice', () => {
-    const res = calculateMethaneCondensationRateFactor({
+    const { liquidRate, iceRate } = methaneCycle.condensationRateFactor({
       zoneArea,
-      methaneVaporPressure,
-      dayTemperature: 88,
-      nightTemperature: 89,
-      atmPressure,
+      vaporPressure: methaneVaporPressure,
+      gravity: 1,
+      dayTemp: 88,
+      nightTemp: 89,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boilingPointMethane(atmPressure),
+      boilTransitionRange: 5
     });
-    expect(res.iceRateFactor).toBeGreaterThan(res.liquidRateFactor);
-    expect(res.iceRateFactor).toBeGreaterThan(0);
+    expect(iceRate).toBeGreaterThan(liquidRate);
+    expect(iceRate).toBeGreaterThan(0);
   });
 
   test('temperatures near freezing mix liquid and ice', () => {
-    const res = calculateMethaneCondensationRateFactor({
+    const { liquidRate, iceRate } = methaneCycle.condensationRateFactor({
       zoneArea,
-      methaneVaporPressure,
-      dayTemperature: 91,
-      nightTemperature: 90,
-      atmPressure,
+      vaporPressure: methaneVaporPressure,
+      gravity: 1,
+      dayTemp: 91,
+      nightTemp: 90,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boilingPointMethane(atmPressure),
+      boilTransitionRange: 5
     });
-    expect(res.liquidRateFactor).toBeGreaterThan(0);
-    expect(res.iceRateFactor).toBeGreaterThan(0);
+    expect(liquidRate).toBeGreaterThan(0);
+    expect(iceRate).toBeGreaterThan(0);
   });
 });

--- a/tests/methaneRates.test.js
+++ b/tests/methaneRates.test.js
@@ -35,10 +35,11 @@ global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
 global.airDensity = physics.airDensity;
 
 global.sublimationRateCO2 = dryIce.sublimationRateCO2;
-global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+global.co2Cycle = dryIce.co2Cycle;
 
 global.evaporationRateMethane = hydrocarbon.evaporationRateMethane;
-global.calculateMethaneCondensationRateFactor = hydrocarbon.calculateMethaneCondensationRateFactor;
+global.methaneCycle = hydrocarbon.methaneCycle;
+global.boilingPointMethane = hydrocarbon.boilingPointMethane;
 
 global.C_P_AIR = 1004;
 global.EPSILON = 0.622;

--- a/tests/oxygenMethaneCombustion.test.js
+++ b/tests/oxygenMethaneCombustion.test.js
@@ -19,20 +19,22 @@ jest.mock('../src/js/terraforming-utils.js', () => ({
 
 jest.mock('../src/js/terraforming/water-cycle.js', () => ({
   calculateEvaporationSublimationRates: jest.fn(() => ({ evaporationRate: 0, waterSublimationRate: 0, co2SublimationRate: 0 })),
-  calculatePrecipitationRateFactor: jest.fn(() => ({ rainfallRateFactor: 0, snowfallRateFactor: 0 }))
+  waterCycle: { condensationRateFactor: jest.fn(() => ({ liquidRate: 0, iceRate: 0 })) },
+  boilingPointWater: jest.fn(() => 373.15)
 }));
 
 jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
   evaporationRateMethane: jest.fn(() => 0),
-  calculateMethaneCondensationRateFactor: jest.fn(() => ({ liquidRateFactor: 0, iceRateFactor: 0 })),
+  methaneCycle: { condensationRateFactor: jest.fn(() => ({ liquidRate: 0, iceRate: 0 })) },
   calculateMethaneEvaporationRate: jest.fn(() => 0),
   sublimationRateMethane: jest.fn(() => 0),
   rapidSublimationRateMethane: jest.fn(() => 0),
-  calculateMethaneSublimationRate: jest.fn(() => 0)
+  calculateMethaneSublimationRate: jest.fn(() => 0),
+  boilingPointMethane: jest.fn(() => 112)
 }));
 
 jest.mock('../src/js/dry-ice-cycle.js', () => ({
-  calculateCO2CondensationRateFactor: jest.fn(() => 0),
+  co2Cycle: { condensationRateFactor: jest.fn(() => ({ iceRate: 0 })) },
   rapidSublimationRateCO2: jest.fn(() => 0)
 }));
 

--- a/tests/precipitationSmoothing.test.js
+++ b/tests/precipitationSmoothing.test.js
@@ -1,4 +1,4 @@
-const { calculatePrecipitationRateFactor } = require('../src/js/water-cycle.js');
+const { waterCycle, boilingPointWater } = require('../src/js/water-cycle.js');
 
 describe('precipitation smoothing around freezing', () => {
   const zoneArea = 1e6; // m^2
@@ -7,41 +7,50 @@ describe('precipitation smoothing around freezing', () => {
   const atmPressure = 101325;
 
   test('above freezing gives predominantly rain', () => {
-    const res = calculatePrecipitationRateFactor({
+    const { liquidRate, iceRate } = waterCycle.condensationRateFactor({
       zoneArea,
-      waterVaporPressure,
+      vaporPressure: waterVaporPressure,
       gravity,
-      dayTemperature: 276,
-      nightTemperature: 275,
-      atmPressure,
+      dayTemp: 276,
+      nightTemp: 275,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boilingPointWater(atmPressure),
+      boilTransitionRange: 5
     });
-    expect(res.rainfallRateFactor).toBeGreaterThan(0);
-    expect(res.rainfallRateFactor).toBeGreaterThan(res.snowfallRateFactor);
+    expect(liquidRate).toBeGreaterThan(0);
+    expect(liquidRate).toBeGreaterThan(iceRate);
   });
 
   test('below freezing gives snow only', () => {
-    const res = calculatePrecipitationRateFactor({
+    const { liquidRate, iceRate } = waterCycle.condensationRateFactor({
       zoneArea,
-      waterVaporPressure,
+      vaporPressure: waterVaporPressure,
       gravity,
-      dayTemperature: 270,
-      nightTemperature: 271,
-      atmPressure,
+      dayTemp: 270,
+      nightTemp: 271,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boilingPointWater(atmPressure),
+      boilTransitionRange: 5
     });
-    expect(res.rainfallRateFactor).toBe(0);
-    expect(res.snowfallRateFactor).toBeGreaterThan(0);
+    expect(liquidRate).toBe(0);
+    expect(iceRate).toBeGreaterThan(0);
   });
 
   test('temperatures straddling freezing mix rain and snow', () => {
-    const res = calculatePrecipitationRateFactor({
+    const { liquidRate, iceRate } = waterCycle.condensationRateFactor({
       zoneArea,
-      waterVaporPressure,
+      vaporPressure: waterVaporPressure,
       gravity,
-      dayTemperature: 274,
-      nightTemperature: 272,
-      atmPressure,
+      dayTemp: 274,
+      nightTemp: 272,
+      transitionRange: 2,
+      maxDiff: 10,
+      boilingPoint: boilingPointWater(atmPressure),
+      boilTransitionRange: 5
     });
-    expect(res.rainfallRateFactor).toBeGreaterThan(0);
-    expect(res.snowfallRateFactor).toBeGreaterThan(0);
+    expect(liquidRate).toBeGreaterThan(0);
+    expect(iceRate).toBeGreaterThan(0);
   });
 });

--- a/tests/resourceCycleInterfaces.test.js
+++ b/tests/resourceCycleInterfaces.test.js
@@ -28,19 +28,14 @@ test('CO2 cycle instance matches helper sublimation', () => {
   expect(rateFunc).toBeCloseTo(rateObj);
 });
 
-test('CO2 cycle instance matches helper condensation factor', () => {
-  const factorObj = dryIce.co2Cycle.condensationRateFactor({
+test('CO2 cycle condensation factor provides ice rate', () => {
+  const res = dryIce.co2Cycle.condensationRateFactor({
     zoneArea: 10,
     co2VaporPressure: 5,
     dayTemperature: 180,
     nightTemperature: 170,
   });
-  const factorFunc = dryIce.calculateCO2CondensationRateFactor({
-    zoneArea: 10,
-    co2VaporPressure: 5,
-    dayTemperature: 180,
-    nightTemperature: 170,
-  });
-  expect(factorFunc).toBeCloseTo(factorObj);
+  expect(res).toHaveProperty('iceRate');
+  expect(typeof res.iceRate).toBe('number');
 });
 

--- a/tests/spaceMirrorFocusingEffect.test.js
+++ b/tests/spaceMirrorFocusingEffect.test.js
@@ -34,7 +34,7 @@ global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
 global.airDensity = physics.airDensity;
 
 global.sublimationRateCO2 = dryIce.sublimationRateCO2;
-global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+global.co2Cycle = dryIce.co2Cycle;
 
 global.C_P_AIR = 1004;
 global.EPSILON = 0.622;

--- a/tests/surfaceMeltProportional.test.js
+++ b/tests/surfaceMeltProportional.test.js
@@ -20,7 +20,7 @@ global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
 global.airDensity = physics.airDensity;
 
 global.sublimationRateCO2 = dryIce.sublimationRateCO2;
-global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+global.co2Cycle = dryIce.co2Cycle;
 
 global.C_P_AIR = 1004;
 global.EPSILON = 0.622;

--- a/tests/terraformingUtilsIntegration.test.js
+++ b/tests/terraformingUtilsIntegration.test.js
@@ -25,7 +25,7 @@ global.EPSILON = 0.622;
 global.R_AIR = 287;
 global.airDensity = physics.airDensity;
 global.sublimationRateCO2 = dryIce.sublimationRateCO2;
-global.calculateCO2CondensationRateFactor = dryIce.calculateCO2CondensationRateFactor;
+global.co2Cycle = dryIce.co2Cycle;
 
 const Terraforming = require('../src/js/terraforming.js');
 


### PR DESCRIPTION
## Summary
- call condensationRateFactor directly on water, methane, and CO₂ cycles
- drop legacy condensation helper exports
- update tests and tooling to new cycle API

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b517c6bf948327bf69549223729d67