### PR TITLE
refactor: reuse ResourceCycle base class in cycle modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,3 +406,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added MethaneCycle and CO2Cycle subclasses extending ResourceCycle for hydrocarbon and dry ice modeling.
 - Deprecated standalone condensation helpers in favor of using each cycle instance's `condensationRateFactor` method directly.
 - Split water evaporation and sublimation calculations into separate `waterCycle.evaporationRate` and `waterCycle.sublimationRate` methods.
+- Water, methane, and CO₂ cycle modules now import the shared `ResourceCycle` base class instead of defining it inline.
+- index.html loads `resource-cycle.js` before cycle modules so subclasses can extend the base class in browser environments.

--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
     <script src="src/js/terraforming/phase-change-utils.js"></script>
     <script src="src/js/terraforming/hydrology.js"></script>
     <script src="src/js/terraforming/condensation-utils.js"></script>
+    <script src="src/js/terraforming/resource-cycle.js"></script>
     <script src="src/js/terraforming/water-cycle.js"></script>
     <script src="src/js/atmo-collector-trigger.js"></script>
     <script src="src/js/terraforming/dry-ice-cycle.js"></script>

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -3,27 +3,24 @@ const R_CO2 = 188.9; // J/kg·K (specific gas constant for CO2)
 
 
 const isNodeDryIce = (typeof module !== 'undefined' && module.exports);
-var penmanRate = globalThis.penmanRate;
 var psychrometricConstant = globalThis.psychrometricConstant;
-if (typeof ResourceCycleClass === 'undefined') {
-  var ResourceCycleClass = globalThis.ResourceCycle;
-  if (isNodeDryIce) {
-    try {
-      ({ penmanRate, psychrometricConstant } = require('./phase-change-utils.js'));
-      ResourceCycleClass = require('./resource-cycle.js');
-    } catch (e) {
-      // fall back to globals if require fails
-    }
+var ResourceCycleClass = globalThis.ResourceCycle;
+if (isNodeDryIce) {
+  try {
+    ({ psychrometricConstant } = require('./phase-change-utils.js'));
+    ResourceCycleClass = require('./resource-cycle.js');
+  } catch (e) {
+    // fall back to globals if require fails
   }
-  if (!ResourceCycleClass && typeof require === 'function') {
+}
+if (!ResourceCycleClass && typeof require === 'function') {
+  try {
+    ResourceCycleClass = require('./resource-cycle.js');
+  } catch (e) {
     try {
-      ResourceCycleClass = require('./resource-cycle.js');
-    } catch (e) {
-      try {
-        ResourceCycleClass = require('./src/js/terraforming/resource-cycle.js');
-      } catch (e2) {
-        // ignore
-      }
+      ResourceCycleClass = require('./src/js/terraforming/resource-cycle.js');
+    } catch (e2) {
+      // ignore
     }
   }
 }

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -3,12 +3,11 @@ const L_V_METHANE = 5.1e5; // Latent heat of vaporization for methane (J/kg)
 const L_S_METHANE = 5.87e5; // Latent heat of sublimation for methane (J/kg)
 
 const isNodeHydrocarbon = (typeof module !== 'undefined' && module.exports);
-var penmanRate = globalThis.penmanRate;
 var psychrometricConstant = globalThis.psychrometricConstant;
 var ResourceCycleClass = globalThis.ResourceCycle;
 if (isNodeHydrocarbon) {
   try {
-    ({ penmanRate, psychrometricConstant } = require('./phase-change-utils.js'));
+    ({ psychrometricConstant } = require('./phase-change-utils.js'));
     ResourceCycleClass = require('./resource-cycle.js');
   } catch (e) {
     // fall back to globals if require fails

--- a/src/js/terraforming/resource-cycle.js
+++ b/src/js/terraforming/resource-cycle.js
@@ -1,14 +1,14 @@
 // Base class for resource cycle phase-change calculations
 const isNodeResourceCycle = (typeof module !== 'undefined' && module.exports);
-let penmanRate = globalThis.penmanRate;
-let condensationRateFactor = globalThis.condensationRateFactor;
-let meltingFreezingRatesUtil = globalThis.meltingFreezingRates;
+let penmanRateFn = globalThis.penmanRate;
+let condensationRateFactorFn = globalThis.condensationRateFactor;
+let meltingFreezingRatesFn = globalThis.meltingFreezingRates;
 if (isNodeResourceCycle) {
   try {
     const phaseUtils = require('./phase-change-utils.js');
-    penmanRate = phaseUtils.penmanRate;
-    meltingFreezingRatesUtil = phaseUtils.meltingFreezingRates;
-    condensationRateFactor = require('./condensation-utils.js').condensationRateFactor;
+    penmanRateFn = phaseUtils.penmanRate;
+    meltingFreezingRatesFn = phaseUtils.meltingFreezingRates;
+    condensationRateFactorFn = require('./condensation-utils.js').condensationRateFactor;
   } catch (e) {
     // fall back to globals if require fails
   }
@@ -40,7 +40,7 @@ class ResourceCycle {
   evaporationRate({ T, solarFlux, atmPressure, vaporPressure: e_a, r_a = 100, albedo = this.evaporationAlbedo }) {
     const Delta_s = this.slopeSaturationVaporPressureFn(T);
     const e_s = this.saturationVaporPressureFn(T);
-    return penmanRate({
+    return penmanRateFn({
       T,
       solarFlux,
       atmPressure,
@@ -54,7 +54,7 @@ class ResourceCycle {
   }
 
   condensationRateFactor({ zoneArea, vaporPressure, gravity, dayTemp, nightTemp, transitionRange, maxDiff, boilingPoint, boilTransitionRange }) {
-    return condensationRateFactor({
+    return condensationRateFactorFn({
       zoneArea,
       vaporPressure,
       gravity,
@@ -70,13 +70,13 @@ class ResourceCycle {
   }
 
   meltingFreezingRates(args) {
-    return meltingFreezingRatesUtil({ ...args, freezingPoint: this.freezePoint });
+    return meltingFreezingRatesFn({ ...args, freezingPoint: this.freezePoint });
   }
 
   sublimationRate({ T, solarFlux, atmPressure, vaporPressure: e_a, r_a = 100, albedo = this.sublimationAlbedo }) {
     const Delta_s = this.slopeSaturationVaporPressureFn(T);
     const e_s = this.saturationVaporPressureFn(T);
-    return penmanRate({
+    return penmanRateFn({
       T,
       solarFlux,
       atmPressure,

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -4,6 +4,14 @@ const L_V_WATER = 2.45e6; // Latent heat of vaporization for water (J/kg)
 const isNodeWaterCycle = (typeof module !== 'undefined' && module.exports);
 var psychrometricConstant = globalThis.psychrometricConstant;
 var ResourceCycleClass = globalThis.ResourceCycle;
+if (isNodeWaterCycle) {
+  try {
+    ({ psychrometricConstant } = require('./phase-change-utils.js'));
+    ResourceCycleClass = require('./resource-cycle.js');
+  } catch (e) {
+    // fall back to globals if require fails
+  }
+}
 if (!ResourceCycleClass && typeof require === 'function') {
   try {
     ResourceCycleClass = require('./resource-cycle.js');
@@ -14,114 +22,6 @@ if (!ResourceCycleClass && typeof require === 'function') {
       // ignore
     }
   }
-}
-if (isNodeWaterCycle) {
-  try {
-    psychrometricConstant = require('./phase-change-utils.js').psychrometricConstant;
-  } catch (e) {
-    // fall back to globals if require fails
-  }
-}
-
-if (!ResourceCycleClass) {
-  let penmanRate = globalThis.penmanRate;
-  let condensationRateFactor = globalThis.condensationRateFactor;
-  let meltingFreezingRates = globalThis.meltingFreezingRates;
-  if (typeof require === 'function') {
-    try {
-      const phaseUtils = require('./phase-change-utils.js');
-      penmanRate = phaseUtils.penmanRate;
-      meltingFreezingRates = phaseUtils.meltingFreezingRates;
-      condensationRateFactor = require('./condensation-utils.js').condensationRateFactor;
-    } catch (e) {
-      // ignore
-    }
-  }
-  class ResourceCycle {
-    constructor({
-      latentHeatVaporization,
-      latentHeatSublimation,
-      saturationVaporPressureFn,
-      slopeSaturationVaporPressureFn,
-      freezePoint,
-      sublimationPoint,
-      rapidSublimationMultiplier = 0,
-      evaporationAlbedo = 0.6,
-      sublimationAlbedo = 0.6,
-    } = {}) {
-      this.latentHeatVaporization = latentHeatVaporization;
-      this.latentHeatSublimation = latentHeatSublimation;
-      this.saturationVaporPressureFn = saturationVaporPressureFn;
-      this.slopeSaturationVaporPressureFn = slopeSaturationVaporPressureFn;
-      this.freezePoint = freezePoint;
-      this.sublimationPoint = sublimationPoint;
-      this.rapidSublimationMultiplier = rapidSublimationMultiplier;
-      this.evaporationAlbedo = evaporationAlbedo;
-      this.sublimationAlbedo = sublimationAlbedo;
-    }
-
-    evaporationRate({ T, solarFlux, atmPressure, vaporPressure: e_a, r_a = 100, albedo = this.evaporationAlbedo }) {
-      const Delta_s = this.slopeSaturationVaporPressureFn(T);
-      const e_s = this.saturationVaporPressureFn(T);
-      return penmanRate({
-        T,
-        solarFlux,
-        atmPressure,
-        e_a,
-        latentHeat: this.latentHeatVaporization,
-        albedo,
-        r_a,
-        Delta_s,
-        e_s,
-      });
-    }
-
-    condensationRateFactor({ zoneArea, vaporPressure, gravity, dayTemp, nightTemp, transitionRange, maxDiff, boilingPoint, boilTransitionRange }) {
-      return condensationRateFactor({
-        zoneArea,
-        vaporPressure,
-        gravity,
-        dayTemp,
-        nightTemp,
-        saturationFn: this.saturationVaporPressureFn,
-        freezePoint: this.freezePoint,
-        transitionRange,
-        maxDiff,
-        boilingPoint,
-        boilTransitionRange,
-      });
-    }
-
-    meltingFreezingRates(args) {
-      return meltingFreezingRates({ ...args, freezingPoint: this.freezePoint });
-    }
-
-    sublimationRate({ T, solarFlux, atmPressure, vaporPressure: e_a, r_a = 100, albedo = this.sublimationAlbedo }) {
-      const Delta_s = this.slopeSaturationVaporPressureFn(T);
-      const e_s = this.saturationVaporPressureFn(T);
-      return penmanRate({
-        T,
-        solarFlux,
-        atmPressure,
-        e_a,
-        latentHeat: this.latentHeatSublimation,
-        albedo,
-        r_a,
-        Delta_s,
-        e_s,
-      });
-    }
-
-    rapidSublimationRate(temperature, availableIce) {
-      if (temperature > this.sublimationPoint && availableIce > 0) {
-        const diff = temperature - this.sublimationPoint;
-        return availableIce * this.rapidSublimationMultiplier * diff;
-      }
-      return 0;
-    }
-  }
-  ResourceCycleClass = ResourceCycle;
-  globalThis.ResourceCycle = ResourceCycle;
 }
 
 

--- a/tests/equilibriumConstants.test.js
+++ b/tests/equilibriumConstants.test.js
@@ -27,6 +27,7 @@ global.psychrometricConstant = phaseUtils.psychrometricConstant;
 global.condensationRateFactor = require('../src/js/condensation-utils.js').condensationRateFactor;
 // water-cycle functions
 const fs = require('fs');
+global.ResourceCycle = require('../src/js/terraforming/resource-cycle.js');
 eval(fs.readFileSync(require.resolve('../src/js/terraforming/water-cycle.js'), 'utf8'));
 global.saturationVaporPressureBuck = saturationVaporPressureBuck;
 eval(fs.readFileSync(require.resolve('../src/js/terraforming/dry-ice-cycle.js'), 'utf8'));


### PR DESCRIPTION
## Summary
- Load ResourceCycle class before cycle scripts for browser environments
- Prevent global function name clashes inside ResourceCycle implementation
- Ensure tests import ResourceCycle so cycle subclasses can extend it
- Document new script ordering in project guidelines

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b51e4774f48327a8c952ac35121c06