### PR TITLE
Add zonal process methods for resource cycles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,3 +408,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Split water evaporation and sublimation calculations into separate `waterCycle.evaporationRate` and `waterCycle.sublimationRate` methods.
 - Water, methane, and CO₂ cycle modules now import the shared `ResourceCycle` base class instead of defining it inline.
 - index.html loads `resource-cycle.js` before cycle modules so subclasses can extend the base class in browser environments.
+- Added `processZone` methods to water, methane, and CO₂ cycles, composing base helpers to generate zonal change objects.

--- a/tests/processZoneCycles.test.js
+++ b/tests/processZoneCycles.test.js
@@ -1,0 +1,79 @@
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+
+const water = require('../src/js/terraforming/water-cycle.js');
+const hydro = require('../src/js/terraforming/hydrocarbon-cycle.js');
+const dryIce = require('../src/js/terraforming/dry-ice-cycle.js');
+
+const { waterCycle } = water;
+const { methaneCycle } = hydro;
+const { co2Cycle } = dryIce;
+
+describe('water cycle processZone', () => {
+  test('conserves mass under evaporation', () => {
+    const changes = waterCycle.processZone({
+      zoneArea: 1,
+      liquidWaterCoverage: 1,
+      iceCoverage: 0,
+      dayTemperature: 300,
+      nightTemperature: 290,
+      zoneTemperature: 295,
+      atmPressure: 100000,
+      vaporPressure: 1000,
+      availableLiquid: 10,
+      availableIce: 0,
+      availableBuriedIce: 0,
+      zonalSolarFlux: 200,
+      durationSeconds: 1,
+      gravity: 3.7,
+    });
+    expect(changes.atmosphere.water).toBeGreaterThan(0);
+    const total = changes.atmosphere.water + changes.water.liquid + changes.water.ice + changes.water.buriedIce;
+    expect(total).toBeCloseTo(0, 6);
+  });
+});
+
+describe('methane cycle processZone', () => {
+  test('conserves mass under evaporation', () => {
+    const changes = methaneCycle.processZone({
+      zoneArea: 1,
+      liquidMethaneCoverage: 1,
+      hydrocarbonIceCoverage: 0,
+      dayTemperature: 110,
+      nightTemperature: 100,
+      zoneTemperature: 105,
+      atmPressure: 100000,
+      vaporPressure: 1000,
+      availableLiquid: 10,
+      availableIce: 0,
+      availableBuriedIce: 0,
+      zonalSolarFlux: 200,
+      durationSeconds: 1,
+      gravity: 1,
+    });
+    expect(changes.atmosphere.methane).toBeGreaterThan(0);
+    const total = changes.atmosphere.methane + changes.methane.liquid + changes.methane.ice + changes.methane.buriedIce;
+    expect(total).toBeCloseTo(0, 6);
+  });
+});
+
+describe('CO2 cycle processZone', () => {
+  test('conserves mass under sublimation', () => {
+    const changes = co2Cycle.processZone({
+      zoneArea: 1,
+      dryIceCoverage: 1,
+      dayTemperature: 210,
+      nightTemperature: 200,
+      zoneTemperature: 210,
+      atmPressure: 100000,
+      vaporPressure: 100,
+      availableDryIce: 10,
+      zonalSolarFlux: 200,
+      durationSeconds: 1,
+    });
+    expect(changes.atmosphere.co2).toBeGreaterThan(0);
+    const total = changes.atmosphere.co2 + (changes.water.dryIce || 0);
+    expect(total).toBeCloseTo(0, 6);
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement `processZone` methods for water, methane, and CO₂ cycles using shared phase-change helpers
- track zonal evaporation, condensation, melting/freezing, and rapid sublimation in change objects
- test mass conservation of cycle zone processing

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b522c034808327b90b905c7e5c7b33