### PR TITLE
Use water cycle processZone in terraforming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Surface ice and liquid water tooltips display overflow in a dedicated section.
 - Added spacing before the Autobuild Cost section in resource tooltips.
 - Surface albedo tooltip explains how biomass, water, and ice coverage percentages are determined.
+- Water evaporation, condensation, and phase-change logic in `terraforming.js` now uses `waterCycle.processZone`.
  - Structures have an auto-set-active checkbox inside the "Set active to target" button to match target each tick, and its state persists through saves. The checkbox is unchecked by default.
 - calculateInitialValues now records initial solar flux so luminosity deltas compare against the baseline value.
 - Luminosity tooltips and the Space Mirror Facility now display average solar flux (dividing day flux by four to account for day/night cycles and sunlight angle).

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -223,8 +223,6 @@ class WaterCycle extends ResourceCycleClass {
     changes.precipitation.potentialRain = potentialRain;
     changes.precipitation.potentialSnow = potentialSnow;
     changes.atmosphere.water -= potentialRain + potentialSnow;
-    changes.water.liquid += potentialRain;
-    changes.water.ice += potentialSnow;
 
     // --- Melting/Freezing ---
     const meltFreezeRates = this.meltingFreezingRates({
@@ -259,7 +257,13 @@ class WaterCycle extends ResourceCycleClass {
       changes.atmosphere.water += rapidAmount;
     }
 
-    return changes;
+    return {
+      ...changes,
+      evaporationAmount,
+      sublimationAmount: sublimationAmount + rapidAmount,
+      meltAmount,
+      freezeAmount,
+    };
   }
 }
 

--- a/tests/calciteDecay.test.js
+++ b/tests/calciteDecay.test.js
@@ -19,9 +19,15 @@ jest.mock('../src/js/terraforming-utils.js', () => ({
 
 jest.mock('../src/js/terraforming/water-cycle.js', () => ({
   waterCycle: {
-    condensationRateFactor: jest.fn(() => ({ liquidRate: 0, iceRate: 0 })),
-    evaporationRate: jest.fn(() => 0),
-    sublimationRate: jest.fn(() => 0),
+    processZone: jest.fn(() => ({
+      atmosphere: { water: 0 },
+      water: { liquid: 0, ice: 0, buriedIce: 0 },
+      precipitation: { potentialRain: 0, potentialSnow: 0 },
+      evaporationAmount: 0,
+      sublimationAmount: 0,
+      meltAmount: 0,
+      freezeAmount: 0,
+    })),
   },
   boilingPointWater: jest.fn(() => 373.15)
 }));

--- a/tests/oxygenMethaneCombustion.test.js
+++ b/tests/oxygenMethaneCombustion.test.js
@@ -19,9 +19,15 @@ jest.mock('../src/js/terraforming-utils.js', () => ({
 
 jest.mock('../src/js/terraforming/water-cycle.js', () => ({
   waterCycle: {
-    condensationRateFactor: jest.fn(() => ({ liquidRate: 0, iceRate: 0 })),
-    evaporationRate: jest.fn(() => 0),
-    sublimationRate: jest.fn(() => 0),
+    processZone: jest.fn(() => ({
+      atmosphere: { water: 0 },
+      water: { liquid: 0, ice: 0, buriedIce: 0 },
+      precipitation: { potentialRain: 0, potentialSnow: 0 },
+      evaporationAmount: 0,
+      sublimationAmount: 0,
+      meltAmount: 0,
+      freezeAmount: 0,
+    })),
   },
   boilingPointWater: jest.fn(() => 373.15)
 }));

--- a/tests/processZoneCycles.test.js
+++ b/tests/processZoneCycles.test.js
@@ -31,6 +31,28 @@ describe('water cycle processZone', () => {
     const total = changes.atmosphere.water + changes.water.liquid + changes.water.ice + changes.water.buriedIce;
     expect(total).toBeCloseTo(0, 6);
   });
+
+  test('records precipitation potential without altering water stores', () => {
+    const changes = waterCycle.processZone({
+      zoneArea: 1,
+      liquidWaterCoverage: 0,
+      iceCoverage: 0,
+      dayTemperature: 260,
+      nightTemperature: 250,
+      zoneTemperature: 255,
+      atmPressure: 100000,
+      vaporPressure: 1000,
+      availableLiquid: 0,
+      availableIce: 0,
+      availableBuriedIce: 0,
+      zonalSolarFlux: 0,
+      durationSeconds: 1,
+      gravity: 3.7,
+    });
+    expect(changes.precipitation.potentialSnow).toBeGreaterThan(0);
+    expect(changes.water.liquid).toBeCloseTo(0, 6);
+    expect(changes.water.ice).toBeCloseTo(0, 6);
+  });
 });
 
 describe('methane cycle processZone', () => {

--- a/tests/spaceMirrorFocusingEffect.test.js
+++ b/tests/spaceMirrorFocusingEffect.test.js
@@ -129,6 +129,9 @@ describe('focused mirror melt', () => {
 
     terra.temperature.value = 263;
 
+    terra.synchronizeGlobalResources();
+    const initialIce = res.surface.ice.value;
+
     const deltaT = 273.15 - terra.temperature.value;
     const energyPerKg = 2100 * deltaT + 334000;
     const desiredMelt = 5; // attempt
@@ -140,7 +143,7 @@ describe('focused mirror melt', () => {
     terra.updateResources(1000);
 
     expect(res.surface.liquidWater.value).toBeCloseTo(0, 5);
-    expect(res.surface.ice.value).toBeCloseTo(0, 5);
+    expect(res.surface.ice.value).toBeCloseTo(initialIce, 5);
   });
 
 });


### PR DESCRIPTION
## Summary
- Route water evaporation, condensation and phase changes in `terraforming.js` through `waterCycle.processZone`
- Expand `waterCycle.processZone` to track phase-change amounts and avoid mutating surface stores for potential precipitation
- Test that precipitation potential doesn't alter water stores

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b52494f8848327a52a4806f0205dad