### PR TITLE
Refactor dry ice cycle to use processZone

### DIFF
--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -208,7 +208,6 @@ class CO2Cycle extends ResourceCycleClass {
     });
     const potentialCond = iceRate * condensationParameter * durationSeconds;
     changes.atmosphere.co2 -= potentialCond;
-    changes.water.dryIce += potentialCond;
     changes.potentialCO2Condensation = potentialCond;
 
     // Rapid sublimation
@@ -220,7 +219,10 @@ class CO2Cycle extends ResourceCycleClass {
       changes.atmosphere.co2 += rapidAmount;
     }
 
-    return changes;
+    return {
+      ...changes,
+      sublimationAmount: sublimationAmount + rapidAmount,
+    };
   }
 }
 

--- a/tests/calciteDecay.test.js
+++ b/tests/calciteDecay.test.js
@@ -49,10 +49,13 @@ jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
 
 jest.mock('../src/js/dry-ice-cycle.js', () => ({
   co2Cycle: {
-    condensationRateFactor: jest.fn(() => ({ iceRate: 0 })),
-    sublimationRate: jest.fn(() => 0),
+    processZone: jest.fn(() => ({
+      atmosphere: { co2: 0 },
+      water: { dryIce: 0 },
+      potentialCO2Condensation: 0,
+      sublimationAmount: 0,
+    })),
   },
-  rapidSublimationRateCO2: jest.fn(() => 0)
 }));
 
 jest.mock('../src/js/radiation-utils.js', () => ({

--- a/tests/oxygenMethaneCombustion.test.js
+++ b/tests/oxygenMethaneCombustion.test.js
@@ -49,10 +49,13 @@ jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
 
 jest.mock('../src/js/dry-ice-cycle.js', () => ({
   co2Cycle: {
-    condensationRateFactor: jest.fn(() => ({ iceRate: 0 })),
-    sublimationRate: jest.fn(() => 0),
+    processZone: jest.fn(() => ({
+      atmosphere: { co2: 0 },
+      water: { dryIce: 0 },
+      potentialCO2Condensation: 0,
+      sublimationAmount: 0,
+    })),
   },
-  rapidSublimationRateCO2: jest.fn(() => 0)
 }));
 
 jest.mock('../src/js/radiation-utils.js', () => ({

--- a/tests/processZoneCycles.test.js
+++ b/tests/processZoneCycles.test.js
@@ -147,6 +147,25 @@ describe('CO2 cycle processZone', () => {
     expect(changes.atmosphere.co2).toBeGreaterThan(0);
     const total = changes.atmosphere.co2 + (changes.water.dryIce || 0);
     expect(total).toBeCloseTo(0, 6);
+    expect(changes).toHaveProperty('sublimationAmount');
+  });
+
+  test('records condensation potential without altering dry ice', () => {
+    const changes = co2Cycle.processZone({
+      zoneArea: 1,
+      dryIceCoverage: 0,
+      dayTemperature: 180,
+      nightTemperature: 170,
+      zoneTemperature: 175,
+      atmPressure: 100000,
+      vaporPressure: 100000,
+      availableDryIce: 0,
+      zonalSolarFlux: 0,
+      durationSeconds: 1,
+      condensationParameter: 1,
+    });
+    expect(changes.potentialCO2Condensation).toBeGreaterThan(0);
+    expect(changes.water.dryIce).toBeCloseTo(0, 6);
   });
 });
 


### PR DESCRIPTION
## Summary
- delegate CO₂ sublimation and condensation handling to `co2Cycle.processZone`
- expose total sublimation from CO₂ cycle
- cover CO₂ cycle processZone in tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b532fcf2188327b9d07c33b5807476