### PR TITLE
Enable configurable parameters for methane cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,3 +410,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Water, methane, and CO₂ cycle modules now import the shared `ResourceCycle` base class instead of defining it inline.
 - index.html loads `resource-cycle.js` before cycle modules so subclasses can extend the base class in browser environments.
 - Added `processZone` methods to water, methane, and CO₂ cycles, composing base helpers to generate zonal change objects.
+- MethaneCycle constructor now accepts transitionRange, maxDiff, boilingPointFn, and boilTransitionRange options used during zonal processing.

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -84,7 +84,12 @@ function slopeSVPMethane(temperature) {
 }
 
 class MethaneCycle extends ResourceCycleClass {
-  constructor() {
+  constructor({
+    transitionRange = 2,
+    maxDiff = 10,
+    boilingPointFn = boilingPointMethane,
+    boilTransitionRange = 5,
+  } = {}) {
     super({
       latentHeatVaporization: L_V_METHANE,
       latentHeatSublimation: L_S_METHANE,
@@ -96,6 +101,10 @@ class MethaneCycle extends ResourceCycleClass {
       evaporationAlbedo: 0.1,
       sublimationAlbedo: 0.6,
     });
+    this.transitionRange = transitionRange;
+    this.maxDiff = maxDiff;
+    this.boilingPointFn = boilingPointFn;
+    this.boilTransitionRange = boilTransitionRange;
   }
 
   /**
@@ -118,10 +127,6 @@ class MethaneCycle extends ResourceCycleClass {
     durationSeconds = 1,
     gravity = 1,
     condensationParameter = 1,
-    transitionRange,
-    maxDiff,
-    boilingPoint,
-    boilTransitionRange,
   }) {
     const changes = {
       atmosphere: { methane: 0 },
@@ -171,10 +176,10 @@ class MethaneCycle extends ResourceCycleClass {
       gravity,
       dayTemp: dayTemperature,
       nightTemp: nightTemperature,
-      transitionRange,
-      maxDiff,
-      boilingPoint,
-      boilTransitionRange,
+      transitionRange: this.transitionRange,
+      maxDiff: this.maxDiff,
+      boilingPoint: this.boilingPointFn(atmPressure),
+      boilTransitionRange: this.boilTransitionRange,
     });
     const potentialRain = liquidRate * condensationParameter * durationSeconds;
     const potentialSnow = iceRate * condensationParameter * durationSeconds;

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -12,7 +12,6 @@ const AU_METER = 149597870700;
 
 // Load utility functions when running under Node for tests
 var getZonePercentage, estimateCoverage, waterCycleInstance, methaneCycleInstance, co2CycleInstance;
-var boilingPointWater, boilingPointMethane;
 if (typeof module !== 'undefined' && module.exports) {
     const hydrology = require('./hydrology.js');
     var simulateSurfaceWaterFlow = hydrology.simulateSurfaceWaterFlow;
@@ -20,11 +19,9 @@ if (typeof module !== 'undefined' && module.exports) {
 
     const waterCycleMod = require('./water-cycle.js');
     waterCycleInstance = waterCycleMod.waterCycle;
-    boilingPointWater = waterCycleMod.boilingPointWater;
 
     const hydrocarbonCycleMod = require('./hydrocarbon-cycle.js');
     methaneCycleInstance = hydrocarbonCycleMod.methaneCycle;
-    boilingPointMethane = hydrocarbonCycleMod.boilingPointMethane;
 
     const dryIceCycleMod = require('./dry-ice-cycle.js');
     co2CycleInstance = dryIceCycleMod.co2Cycle;
@@ -65,8 +62,6 @@ if (typeof module !== 'undefined' && module.exports) {
     waterCycleInstance = globalThis.waterCycle;
     methaneCycleInstance = globalThis.methaneCycle;
     co2CycleInstance = globalThis.co2Cycle;
-    boilingPointWater = globalThis.boilingPointWater;
-    boilingPointMethane = globalThis.boilingPointMethane;
 }
 
 var getEcumenopolisLandFraction;
@@ -654,10 +649,6 @@ class Terraforming extends EffectableEntity{
                 durationSeconds,
                 gravity,
                 condensationParameter: methaneCondensationParameter,
-                transitionRange: 2,
-                maxDiff: 10,
-                boilingPoint: boilingPointMethane(globalTotalPressurePa),
-                boilTransitionRange: 5,
             });
 
             zonalChanges[zone].atmosphere.methane += methaneResult.atmosphere.methane;

--- a/tests/processZoneCycles.test.js
+++ b/tests/processZoneCycles.test.js
@@ -6,7 +6,7 @@ const hydro = require('../src/js/terraforming/hydrocarbon-cycle.js');
 const dryIce = require('../src/js/terraforming/dry-ice-cycle.js');
 
 const { waterCycle } = water;
-const { methaneCycle, boilingPointMethane } = hydro;
+const { methaneCycle } = hydro;
 const { co2Cycle } = dryIce;
 
 describe('water cycle processZone', () => {
@@ -118,10 +118,6 @@ describe('methane cycle processZone', () => {
       durationSeconds: 1,
       gravity: 1,
       condensationParameter: 1,
-      transitionRange: 2,
-      maxDiff: 10,
-      boilingPoint: boilingPointMethane(100000),
-      boilTransitionRange: 5,
     });
     const potential = changes.precipitation.potentialMethaneRain + changes.precipitation.potentialMethaneSnow;
     expect(potential).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Support constructor options for methane cycle transition range, condensation smoothing limits, boiling point function, and boiling transition range
- Use methane cycle instance properties when processing a zone and drop per-call phase-change arguments in terraforming
- Update processZoneCycles test for the new methane cycle signature

## Testing
- `CI=true npm test 2>&1 | tee test.log` *(failed: SpaceshipProject continuous cost and gain, productivity includes maintenance production, project productivity)*

------
https://chatgpt.com/codex/tasks/task_b_68b537f1feac83279f86c30e83e6d827