### PR TITLE
Remember subtab scroll positions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,3 +412,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - index.html loads `resource-cycle.js` before cycle modules so subclasses can extend the base class in browser environments.
 - Added `processZone` methods to water, methane, and CO₂ cycles, composing base helpers to generate zonal change objects.
 - MethaneCycle constructor now accepts transitionRange, maxDiff, boilingPointFn, and boilTransitionRange options used during zonal processing.
+- Subtabs now remember and restore their vertical scroll position when revisited.

--- a/src/js/buildingUI.js
+++ b/src/js/buildingUI.js
@@ -1,36 +1,6 @@
 // Subtab functionality to show/hide building categories
-document.querySelectorAll('.buildings-subtabs .building-subtab').forEach(tab => {
-    tab.addEventListener('click', function () {
-        // Remove the 'active' class from all subtabs
-        document.querySelectorAll('.buildings-subtabs .building-subtab').forEach(t => t.classList.remove('active'));
-
-        // Add the 'active' class to the clicked subtab
-        this.classList.add('active');
-
-        // Get the corresponding content element ID from the data attribute
-        const category = this.dataset.subtab;
-
-        // Hide all subtab contents
-        document.querySelectorAll('.building-subtab-content-wrapper .building-subtab-content').forEach(content => {
-            content.classList.remove('active');
-        });
-
-        // Show the content of the selected subtab
-        document.getElementById(category).classList.add('active');
-        if (typeof markBuildingSubtabViewed === 'function') {
-            markBuildingSubtabViewed(category);
-        }
-    });
-});
-
 function activateBuildingSubtab(subtabId) {
-    // Deactivate all subtabs and subtab-content elements
-    document.querySelectorAll('.building-subtab').forEach((tab) => tab.classList.remove('active'));
-    document.querySelectorAll('.building-subtab-content').forEach((content) => content.classList.remove('active'));
-
-    // Activate the clicked subtab and corresponding content
-    document.getElementById(subtabId + '-tab').classList.add('active'); // Activate the subtab by concatenating '-tab'
-    document.getElementById(subtabId).classList.add('active'); // Activate the corresponding content
+    activateSubtab('building-subtab', 'building-subtab-content', subtabId);
     if (typeof markBuildingSubtabViewed === 'function') {
         markBuildingSubtabViewed(subtabId);
     }
@@ -40,21 +10,8 @@ function initializeBuildingTabs() {
     // Set the default active subtab for buildings
     activateBuildingSubtab('resource-buildings'); // Make 'resource' tab active by default
 
-    document.getElementById('resource-buildings-tab').addEventListener('click', () => {
-        activateBuildingSubtab('resource-buildings');
-    });
-    // Add event listeners to each subtab for switching
-    document.getElementById('storage-buildings-tab').addEventListener('click', () => {
-        activateBuildingSubtab('storage-buildings');
-    });
-    document.getElementById('production-buildings-tab').addEventListener('click', () => {
-        activateBuildingSubtab('production-buildings');
-    });
-    document.getElementById('energy-buildings-tab').addEventListener('click', () => {
-        activateBuildingSubtab('energy-buildings');
-    });
-    document.getElementById('terraforming-buildings-tab').addEventListener('click', () => {
-        activateBuildingSubtab('terraforming-buildings');
+    document.querySelectorAll('.buildings-subtabs .building-subtab').forEach(tab => {
+        tab.addEventListener('click', () => activateBuildingSubtab(tab.dataset.subtab));
     });
 }
 

--- a/src/js/ui-utils.js
+++ b/src/js/ui-utils.js
@@ -1,4 +1,12 @@
+const subtabScrollPositions = {};
+
 function activateSubtab(subtabClass, contentClass, subtabId, unhide = false) {
+  const activeContent = document.querySelector(`.${contentClass}.active`);
+  if (activeContent) {
+    const id = activeContent.getAttribute && activeContent.getAttribute('id');
+    if (typeof id === 'string') subtabScrollPositions[id] = activeContent.scrollTop;
+  }
+
   document.querySelectorAll(`.${subtabClass}`).forEach(t => t.classList.remove('active'));
   document.querySelectorAll(`.${contentClass}`).forEach(c => c.classList.remove('active'));
 
@@ -12,6 +20,7 @@ function activateSubtab(subtabClass, contentClass, subtabId, unhide = false) {
     }
     subtab.classList.add('active');
     content.classList.add('active');
+    content.scrollTop = subtabScrollPositions[subtabId] || 0;
   }
 }
 
@@ -107,5 +116,5 @@ function addTooltipHover(anchor, tooltip) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { activateSubtab, addTooltipHover };
+  module.exports = { activateSubtab, addTooltipHover, subtabScrollPositions };
 }

--- a/tests/buildingSubtabScrollMemory.test.js
+++ b/tests/buildingSubtabScrollMemory.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('building subtab scroll restoration', () => {
+  test('remembers scroll position per subtab', () => {
+    const html = `<!DOCTYPE html>
+      <div class="buildings-subtabs">
+        <div id="resource-buildings-tab" class="building-subtab active" data-subtab="resource-buildings">Resources</div>
+        <div id="storage-buildings-tab" class="building-subtab" data-subtab="storage-buildings">Storage</div>
+      </div>
+      <div class="building-subtab-content-wrapper">
+        <div id="resource-buildings" class="building-subtab-content active"></div>
+        <div id="storage-buildings" class="building-subtab-content"></div>
+      </div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.markBuildingSubtabViewed = () => {};
+    ctx.buildings = {};
+    const uiUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ui-utils.js'), 'utf8');
+    vm.runInContext(uiUtilsCode, ctx);
+    const buildingUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildingUI.js'), 'utf8');
+    vm.runInContext(buildingUICode, ctx);
+
+    const resContent = dom.window.document.getElementById('resource-buildings');
+    const storageContent = dom.window.document.getElementById('storage-buildings');
+
+    resContent.scrollTop = 42;
+    ctx.activateBuildingSubtab('storage-buildings');
+    storageContent.scrollTop = 17;
+    ctx.activateBuildingSubtab('resource-buildings');
+
+    expect(resContent.scrollTop).toBe(42);
+  });
+});

--- a/tests/buildingSubtabSwitchClearsAlert.test.js
+++ b/tests/buildingSubtabSwitchClearsAlert.test.js
@@ -15,6 +15,8 @@ describe('building subtab alert clears on subtab switch', () => {
     const ctx = dom.getInternalVMContext();
     ctx.gameSettings = { silenceUnlockAlert: false };
     ctx.buildings = { mine: { category: 'resource', unlocked: true, alertedWhenUnlocked: false } };
+    const uiUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ui-utils.js'), 'utf8');
+    vm.runInContext(uiUtilsCode, ctx);
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildingUI.js'), 'utf8');
     vm.runInContext(code, ctx);
 


### PR DESCRIPTION
## Summary
- preserve and restore vertical scroll when switching UI subtabs
- unify building subtab switching logic with shared activateSubtab
- test scroll position persistence and update existing subtab alert test

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b5a7e052088327b1c59885eec872cf