### PR TITLE
style: shrink space storage warning icon

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -706,11 +706,13 @@
     color: #ffc107;
     cursor: help;
     margin-left: 4px;
+    font-size: 14px;
 }
 .storage-full-icon {
     color: #ffc107;
     cursor: help;
     margin-left: 4px;
+    font-size: 14px;
 }
 /* Finer Controls Grid */
 #assignment-grid {

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -150,6 +150,7 @@ function renderSpaceStorageUI(project, container) {
     fullIcon.innerHTML = '&#9888;&#xFE0E;';
     fullIcon.title = 'Colony storage full';
     fullIcon.style.display = 'none';
+    fullIcon.style.fontSize = '14px';
 
     const usage = document.createElement('span');
     usage.id = `${project.name}-usage-${opt.resource}`;

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -126,6 +126,7 @@ describe('Space Storage project', () => {
     const label = items[0].children[1];
     const fullIcon = label.querySelector('.storage-full-icon');
     expect(fullIcon).toBeDefined();
+    expect(fullIcon.style.fontSize).toBe('14px');
     visibleCheckboxes[0].checked = true;
     visibleCheckboxes[0].dispatchEvent(new dom.window.Event('change'));
     expect(project.selectedResources).toContainEqual({ category: 'colony', resource: 'metal' });

--- a/tests/spaceStorageUI.test.js
+++ b/tests/spaceStorageUI.test.js
@@ -75,6 +75,7 @@ describe('Space Storage UI', () => {
     const label = firstItem.children[1];
     const fullIcon = label.querySelector('.storage-full-icon');
     expect(fullIcon).toBeDefined();
+    expect(fullIcon.style.fontSize).toBe('14px');
     expect(fullIcon.style.display).toBe('none');
     expect(firstItem.children[2].textContent).toBe(String(numbers.formatNumber(0, false, 2)));
     expect(els.shipProgressButton).toBeDefined();
@@ -140,6 +141,7 @@ describe('Space Storage UI', () => {
     const els = ctx.projectElements[project.name];
     const icon = els.resourceGrid.querySelector('.storage-resource-item .storage-full-icon');
     expect(icon.style.display).toBe('none');
+    expect(icon.style.fontSize).toBe('14px');
 
     project.shipWithdrawMode = true;
     ctx.updateSpaceStorageUI(project);


### PR DESCRIPTION
## Summary
- reduce space storage full warning icon size to 14px
- verify icon sizing with updated unit tests

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b5a912d2e48327a78d172ff10b98ab