### PR TITLE
Add reversal checkboxes for space mirror sliders

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -12,7 +12,7 @@ var mirrorOversightSettings = globalThis.mirrorOversightSettings || {
   assignments: {
     mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
     lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
-    reversalMode: { tropical: false, temperate: false, polar: false, focus: false }
+    reversalMode: { tropical: false, temperate: false, polar: false, focus: false, any: false }
   }
 };
 
@@ -88,7 +88,7 @@ function resetMirrorOversightSettings() {
   mirrorOversightSettings.autoAssign = { tropical: false, temperate: false, polar: false, focus: false, any: false };
   mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
   mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
-  mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false };
+  mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
   updateMirrorOversightUI();
 }
 
@@ -259,7 +259,7 @@ function updateAssignmentDisplays() {
     });
     const checkbox = document.querySelector(`.reversal-checkbox[data-zone="${zone}"]`);
     if (checkbox) {
-      if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false };
+      if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
       checkbox.checked = !!mirrorOversightSettings.assignments.reversalMode[zone];
     }
   });
@@ -316,26 +316,36 @@ function initializeMirrorOversightUI(container) {
         <label for="mirror-oversight-tropical">Tropical:</label>
         <input type="range" id="mirror-oversight-tropical" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-tropical-value" class="slider-value">0%</span>
+        <input type="checkbox" id="mirror-oversight-tropical-reverse" class="slider-reversal-checkbox" data-zone="tropical" style="display:none;">
+        <label for="mirror-oversight-tropical-reverse" class="slider-reverse-label" style="display:none;">Reverse</label>
       </div>
       <div class="control-group">
         <label for="mirror-oversight-temperate">Temperate:</label>
         <input type="range" id="mirror-oversight-temperate" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-temperate-value" class="slider-value">0%</span>
+        <input type="checkbox" id="mirror-oversight-temperate-reverse" class="slider-reversal-checkbox" data-zone="temperate" style="display:none;">
+        <label for="mirror-oversight-temperate-reverse" class="slider-reverse-label" style="display:none;">Reverse</label>
       </div>
       <div class="control-group">
         <label for="mirror-oversight-polar">Polar:</label>
         <input type="range" id="mirror-oversight-polar" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-polar-value" class="slider-value">0%</span>
+        <input type="checkbox" id="mirror-oversight-polar-reverse" class="slider-reversal-checkbox" data-zone="polar" style="display:none;">
+        <label for="mirror-oversight-polar-reverse" class="slider-reverse-label" style="display:none;">Reverse</label>
       </div>
       <div id="mirror-oversight-focus-group" class="control-group" style="display:none;">
         <label for="mirror-oversight-focus">Focusing:<span class="info-tooltip-icon" title="Concentrate mirror and lantern energy on a single point to melt surface ice into liquid water. Only surface ice melts and the warmest zone with ice is targeted first. Uses the heat required to warm the ice to 0°C plus the energy of fusion/melting.">&#9432;</span></label>
         <input type="range" id="mirror-oversight-focus" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-focus-value" class="slider-value">0%</span>
+        <input type="checkbox" id="mirror-oversight-focus-reverse" class="slider-reversal-checkbox" data-zone="focus" style="display:none;">
+        <label for="mirror-oversight-focus-reverse" class="slider-reverse-label" style="display:none;">Reverse</label>
       </div>
       <div class="control-group">
         <label for="mirror-oversight-any">Any Zone:</label>
         <input type="range" id="mirror-oversight-any" min="0" max="100" step="1" value="100">
         <span id="mirror-oversight-any-value" class="slider-value">100%</span>
+        <input type="checkbox" id="mirror-oversight-any-reverse" class="slider-reversal-checkbox" data-zone="any" style="display:none;">
+        <label for="mirror-oversight-any-reverse" class="slider-reverse-label" style="display:none;">Reverse</label>
       </div>
       </div>
       <div id="mirror-oversight-lantern-div" class="control-group">
@@ -359,6 +369,26 @@ function initializeMirrorOversightUI(container) {
       val < 0 ? 0 : val;
       val > 1 ? 1 : val;
       setMirrorDistribution(zone, val);
+    });
+  });
+
+  const sliderReverse = {
+    tropical: div.querySelector('#mirror-oversight-tropical-reverse'),
+    temperate: div.querySelector('#mirror-oversight-temperate-reverse'),
+    polar: div.querySelector('#mirror-oversight-polar-reverse'),
+    focus: div.querySelector('#mirror-oversight-focus-reverse'),
+    any: div.querySelector('#mirror-oversight-any-reverse'),
+  };
+  Object.keys(sliderReverse).forEach(zone => {
+    const box = sliderReverse[zone];
+    if (!box) return;
+    if (!mirrorOversightSettings.assignments.reversalMode) {
+      mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
+    }
+    box.checked = !!mirrorOversightSettings.assignments.reversalMode[zone];
+    box.addEventListener('change', () => {
+      mirrorOversightSettings.assignments.reversalMode[zone] = box.checked;
+      updateZonalFluxTable();
     });
   });
 
@@ -655,7 +685,7 @@ function initializeMirrorOversightUI(container) {
   finerContent.querySelectorAll('.reversal-checkbox').forEach(box => {
     box.addEventListener('change', () => {
       const zone = box.dataset.zone;
-      if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false };
+      if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
       mirrorOversightSettings.assignments.reversalMode[zone] = box.checked;
       updateZonalFluxTable();
     });
@@ -724,6 +754,8 @@ function rebuildMirrorOversightCache() {
     assignmentControls: Array.from(document.querySelectorAll('#mirror-finer-content button, #mirror-finer-content input[type="checkbox"]:not(#mirror-use-finer)')),
     focusZoneCells: Array.from(document.querySelectorAll('#assignment-grid > div[data-zone="focus"]')),
     fluxTempHeader: document.querySelector('#mirror-flux-table thead tr th:nth-child(3)') || null,
+    sliderReverseBoxes: Array.from(document.querySelectorAll('#mirror-oversight-sliders .slider-reversal-checkbox')),
+    sliderReverseLabels: Array.from(document.querySelectorAll('#mirror-oversight-sliders .slider-reverse-label')),
   };
 }
 
@@ -801,6 +833,19 @@ function updateMirrorOversightUI() {
     ? projectManager.projects.spaceMirrorFacility
     : null;
   const reversalAvailable = !!(smfProject && smfProject.reversalAvailable);
+  const C = mirrorOversightCache || {};
+  if (C.sliderReverseBoxes) {
+    C.sliderReverseBoxes.forEach(box => {
+      const zone = box.dataset.zone;
+      box.checked = !!mirrorOversightSettings.assignments.reversalMode?.[zone];
+      box.style.display = reversalAvailable ? '' : 'none';
+    });
+  }
+  if (C.sliderReverseLabels) {
+    C.sliderReverseLabels.forEach(label => {
+      label.style.display = reversalAvailable ? '' : 'none';
+    });
+  }
   // Advanced oversight unlock check (boolean flag name: advancedOversight)
   let advancedUnlocked = false;
   if (typeof projectManager !== 'undefined') {
@@ -837,7 +882,6 @@ function updateMirrorOversightUI() {
   if (waterInput && mirrorOversightSettings.targets && document.activeElement !== waterInput) {
     waterInput.value = Number(mirrorOversightSettings.targets.water || 0);
   }
-  const C = mirrorOversightCache || {};
   if (C.lanternHeader) C.lanternHeader.style.display = lanternUnlocked ? '' : 'none';
   if (C.lanternCells) C.lanternCells.forEach(cell => { cell.style.display = lanternUnlocked ? 'flex' : 'none'; });
   if (C.availableLanternCells) C.availableLanternCells.forEach(cell => { cell.style.display = lanternUnlocked ? 'flex' : 'none'; });
@@ -1075,16 +1119,11 @@ function calculateZoneSolarFluxWithFacility(terraforming, zone, angleAdjusted = 
     }
   }
 
-  const project = projectManager?.projects?.spaceMirrorFacility;
-  const globalReverse = !!project?.reverseEnabled;
-
-  let zoneReverse = globalReverse;
-  if (mirrorOversightSettings.useFinerControls || mirrorOversightSettings.advancedOversight) {
-    zoneReverse = !!mirrorOversightSettings.assignments.reversalMode?.[zone];
-  }
+  const anyReverse = !!mirrorOversightSettings.assignments.reversalMode?.any;
+  const zoneReverse = !!mirrorOversightSettings.assignments.reversalMode?.[zone];
 
   const distributedMirrorFlux = totalSurfaceArea > 0
-    ? (globalReverse ? -4 * distributedMirrorPower / totalSurfaceArea : 4 * distributedMirrorPower / totalSurfaceArea)
+    ? ((anyReverse ? -4 : 4) * distributedMirrorPower / totalSurfaceArea)
     : 0;
   const distributedLanternFlux = totalSurfaceArea > 0 ? 4 * distributedLanternPower / totalSurfaceArea : 0;
 
@@ -1116,7 +1155,7 @@ function calculateZoneSolarFluxWithFacility(terraforming, zone, angleAdjusted = 
 
       const assignM = mirrorOversightSettings.assignments.mirrors;
       const assignL = mirrorOversightSettings.assignments.lanterns;
-      const reverse = (mirrorOversightSettings.assignments.reversalMode ||= { tropical: false, temperate: false, polar: false, focus: false });
+      const reverse = (mirrorOversightSettings.assignments.reversalMode ||= { tropical: false, temperate: false, polar: false, focus: false, any: false });
 
       // Reset all assignments and compute baseline temperature
       ['tropical', 'temperate', 'polar', 'focus'].forEach(z => {
@@ -1216,26 +1255,12 @@ class SpaceMirrorFacilityProject extends Project {
   constructor(config, name) {
     super(config, name);
     this.reversalAvailable = false;
-    this.reverseEnabled = false;
   }
 
   enableReversal() {
     this.reversalAvailable = true;
-    const elements = projectElements[this.name];
-    if (elements && elements.reflectMode) {
-      elements.reflectMode.container.style.display = '';
-      elements.reflectMode.update();
-    }
     if (typeof updateMirrorOversightUI === 'function') {
       updateMirrorOversightUI();
-    }
-  }
-
-  setReverseEnabled(value) {
-    this.reverseEnabled = !!value;
-    const elements = projectElements[this.name];
-    if (elements && elements.reflectMode) {
-      elements.reflectMode.update();
     }
   }
 
@@ -1282,31 +1307,6 @@ class SpaceMirrorFacilityProject extends Project {
       </div>
     `;
     container.appendChild(mirrorDetails);
-
-    const modeContainer = document.createElement('div');
-    modeContainer.classList.add('mode-selection');
-    const modeLabel = document.createElement('span');
-    modeLabel.textContent = 'Reflect Mode:';
-    const towardButton = document.createElement('button');
-    towardButton.textContent = 'Toward World';
-    towardButton.classList.add('mode-button');
-    const awayButton = document.createElement('button');
-    awayButton.textContent = 'Away From World';
-    awayButton.classList.add('mode-button');
-    const updateModeButtons = () => {
-      if (this.reverseEnabled) {
-        awayButton.classList.add('selected');
-        towardButton.classList.remove('selected');
-      } else {
-        towardButton.classList.add('selected');
-        awayButton.classList.remove('selected');
-      }
-    };
-    towardButton.addEventListener('click', () => this.setReverseEnabled(false));
-    awayButton.addEventListener('click', () => this.setReverseEnabled(true));
-    modeContainer.append(modeLabel, towardButton, awayButton);
-    modeContainer.style.display = this.reversalAvailable ? '' : 'none';
-    mirrorDetails.querySelector('.card-body').appendChild(modeContainer);
 
     const lanternDetails = document.createElement('div');
     lanternDetails.classList.add('info-card', 'lantern-details-card');
@@ -1362,12 +1362,6 @@ class SpaceMirrorFacilityProject extends Project {
         totalPower: lanternDetails.querySelector('#total-lantern-power'),
         totalPowerArea: lanternDetails.querySelector('#total-lantern-area'),
       },
-      reflectMode: {
-        container: modeContainer,
-        towardButton,
-        awayButton,
-        update: updateModeButtons,
-      },
     };
   }
 
@@ -1421,11 +1415,6 @@ class SpaceMirrorFacilityProject extends Project {
       }
     }
 
-    if (elements.reflectMode) {
-      elements.reflectMode.container.style.display = this.reversalAvailable ? '' : 'none';
-      elements.reflectMode.update();
-    }
-
     if (typeof updateMirrorOversightUI === 'function') {
       updateMirrorOversightUI();
     }
@@ -1434,13 +1423,11 @@ class SpaceMirrorFacilityProject extends Project {
   saveState() {
     return {
       ...super.saveState(),
-      reverseEnabled: this.reverseEnabled,
     };
   }
 
   loadState(state) {
     super.loadState(state);
-    this.reverseEnabled = state.reverseEnabled || false;
   }
 }
 

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -115,7 +115,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
     assignments: {
       mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
       lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
-      reversalMode: { tropical: false, temperate: false, polar: false, focus: false }
+      reversalMode: { tropical: false, temperate: false, polar: false, focus: false, any: false }
     }
   });
 });

--- a/tests/runAdvancedOversightAssignments.test.js
+++ b/tests/runAdvancedOversightAssignments.test.js
@@ -11,7 +11,7 @@ describe('runAdvancedOversightAssignments', () => {
     mirrorOversightSettings.priority = { tropical: 1, temperate: 2, polar: 3, focus: 4 };
     mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
     mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
-    mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false };
+    mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
     mirrorOversightSettings.tempMode = { tropical: 'average', temperate: 'average', polar: 'average' };
 
     global.buildings = {

--- a/tests/spaceMirrorReflectMode.test.js
+++ b/tests/spaceMirrorReflectMode.test.js
@@ -3,7 +3,7 @@ const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules',
 const { JSDOM } = require(jsdomPath);
 
 describe('space mirror reflect mode', () => {
-  test('enableReversal shows reflect mode and saves selection', () => {
+  test('enableReversal shows slider reversal checkboxes', () => {
     const originalDocument = global.document;
     const originalProject = global.Project;
     const originalFormat = global.formatNumber;
@@ -24,28 +24,23 @@ describe('space mirror reflect mode', () => {
     };
     global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { unlocked: false } };
     global.projectElements = {};
+    global.updateZonalFluxTable = () => {};
 
     const { SpaceMirrorFacilityProject } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
     const config = { name: 'Space Mirror Facility', cost: {}, duration: 0 };
     const project = new SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    global.projectManager = { projects: { spaceMirrorFacility: project }, isBooleanFlagSet: () => false };
     project.enableReversal();
 
     const container = document.getElementById('root');
     project.renderUI(container);
     project.updateUI();
 
-    const modeContainer = dom.window.document.querySelector('.mirror-details-card .mode-selection');
-    expect(modeContainer).not.toBeNull();
-    const buttons = modeContainer.querySelectorAll('button');
-    expect(buttons[0].textContent).toBe('Toward World');
-    expect(buttons[1].textContent).toBe('Away From World');
-
-    buttons[1].click();
-    expect(project.reverseEnabled).toBe(true);
-    const saved = project.saveState();
-    const loaded = new SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
-    loaded.loadState(saved);
-    expect(loaded.reverseEnabled).toBe(true);
+    const checkbox = dom.window.document.getElementById('mirror-oversight-tropical-reverse');
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.style.display).not.toBe('none');
+    checkbox.click();
+    expect(global.mirrorOversightSettings.assignments.reversalMode.tropical).toBe(true);
 
     global.document = originalDocument;
     global.Project = originalProject;
@@ -53,6 +48,7 @@ describe('space mirror reflect mode', () => {
     global.terraforming = originalTerraforming;
     global.buildings = originalBuildings;
     global.projectElements = originalProjectElements || {};
+    delete global.projectManager;
     delete global.mirrorOversightSettings;
     delete global.setMirrorDistribution;
     delete global.resetMirrorOversightSettings;

--- a/tests/spaceMirrorReverseFlux.test.js
+++ b/tests/spaceMirrorReverseFlux.test.js
@@ -31,7 +31,7 @@ afterEach(() => {
   mirrorOversightSettings.advancedOversight = false;
   mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
   mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
-  mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false };
+  mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
   delete global.buildings;
   delete global.projectManager;
 });
@@ -56,10 +56,11 @@ describe('space mirror reversal', () => {
       spaceMirror: { surfaceArea: 1, active: 1 }
     };
     global.projectManager = {
-      projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight', reverseEnabled: true } },
+      projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
     mirrorOversightSettings.distribution.tropical = 1;
+    mirrorOversightSettings.assignments.reversalMode.tropical = true;
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
 
@@ -111,7 +112,7 @@ describe('space mirror reversal', () => {
       hyperionLantern: { active: 1, powerPerBuilding: 100 }
     };
     global.projectManager = {
-      projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight', reverseEnabled: true } },
+      projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
     mirrorOversightSettings.advancedOversight = true;
@@ -144,7 +145,7 @@ describe('space mirror reversal', () => {
     const terra = createTerraforming();
     global.buildings = { spaceMirror: { surfaceArea: 100, active: 10 } };
     global.projectManager = {
-      projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight', reverseEnabled: true } },
+      projects: { spaceMirrorFacility: { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight' } },
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
     mirrorOversightSettings.advancedOversight = true;


### PR DESCRIPTION
## Summary
- Replace Toward/Away buttons with per-slider "Reverse" checkboxes on the Space Mirror oversight sliders
- Track per-zone reversal state and update solar flux calculations accordingly
- Extend tests for mirror reversal UI and flux handling

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b5a7ae71148327bc725238a130c9fa