### PR TITLE
Allow selecting RWG history seeds

### DIFF
--- a/src/css/space.css
+++ b/src/css/space.css
@@ -117,7 +117,7 @@ body:not(.dark-mode) .planet-stats p > strong {
 .rwg-history-row:nth-child(odd):not(.rwg-history-head) { background: var(--rwg-muted); }
 .rwg-history-controls { display:flex; gap:8px; align-items:center; margin-top:8px; }
 #rwg-history-page { color: var(--rwg-fg); font-weight: 600; }
-.rwg-history-row .seed { font-family: monospace; color: var(--rwg-fg-dim); white-space:normal; word-break:break-all; overflow:visible; }
+.rwg-history-row .seed { font-family: monospace; color: var(--rwg-fg-dim); white-space:normal; word-break:break-all; overflow:visible; user-select:text; cursor:text; }
 .rwg-history-row .pop { text-align:right; }
 .rwg-history-row .name { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:600; color: var(--rwg-fg); }
 .rwg-history-row .state-current, .state-current { color:#9bd36a; font-weight:600; }

--- a/tests/rwgHistorySeedSelectable.test.js
+++ b/tests/rwgHistorySeedSelectable.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('RWG history seed selection', () => {
+  test('seed column text is selectable', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><head></head><div id="space-random"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+
+    // Inject CSS for computed style evaluation
+    const css = fs.readFileSync(path.join(__dirname, '..', 'src/css', 'space.css'), 'utf8');
+    const styleEl = dom.window.document.createElement('style');
+    styleEl.textContent = css;
+    dom.window.document.head.appendChild(styleEl);
+
+    // Prepare minimal status data
+    ctx.spaceManager = {
+      randomWorldStatuses: {
+        '123': {
+          name: 'World123',
+          original: { classification: { archetype: 'mars-like' } },
+          visited: true,
+          departedAt: 0
+        }
+      }
+    };
+    ctx.rwgManager = { isOrbitLocked: () => false, isTypeLocked: () => false };
+
+    const rwgUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+    vm.runInContext(`${rwgUICode} initializeRandomWorldUI(); updateRandomWorldUI();`, ctx);
+
+    const seedEl = dom.window.document.querySelector('.rwg-history-row .seed');
+    const userSelect = dom.window.getComputedStyle(seedEl).userSelect;
+    expect(userSelect).toBe('text');
+  });
+});


### PR DESCRIPTION
## Summary
- Make Random World Generator history seeds selectable to allow easy copying
- Add test ensuring the seed column is selectable

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b5a9738d6c8327b7da1f8b2a5dea01