### PR TITLE
Remember subtab scroll positions

### DIFF
--- a/src/js/ui-utils.js
+++ b/src/js/ui-utils.js
@@ -4,7 +4,10 @@ function activateSubtab(subtabClass, contentClass, subtabId, unhide = false) {
   const activeContent = document.querySelector(`.${contentClass}.active`);
   if (activeContent) {
     const id = activeContent.getAttribute && activeContent.getAttribute('id');
-    if (typeof id === 'string') subtabScrollPositions[id] = activeContent.scrollTop;
+    const container = activeContent.closest('.tab-content');
+    if (typeof id === 'string' && container) {
+      subtabScrollPositions[id] = container.scrollTop;
+    }
   }
 
   document.querySelectorAll(`.${subtabClass}`).forEach(t => t.classList.remove('active'));
@@ -20,7 +23,8 @@ function activateSubtab(subtabClass, contentClass, subtabId, unhide = false) {
     }
     subtab.classList.add('active');
     content.classList.add('active');
-    content.scrollTop = subtabScrollPositions[subtabId] || 0;
+    const container = content.closest('.tab-content');
+    if (container) container.scrollTop = subtabScrollPositions[subtabId] || 0;
   }
 }
 

--- a/tests/uiUtils.test.js
+++ b/tests/uiUtils.test.js
@@ -1,9 +1,13 @@
 const path = require('path');
 const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
 const { JSDOM } = require(jsdomPath);
-const { activateSubtab } = require('../src/js/ui-utils.js');
+const { activateSubtab, subtabScrollPositions } = require('../src/js/ui-utils.js');
 
 describe('activateSubtab utility', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(subtabScrollPositions)) delete subtabScrollPositions[k];
+  });
+
   test('activates subtab without unhiding', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
       <div class="a-subtab active" data-subtab="first"></div>
@@ -38,5 +42,26 @@ describe('activateSubtab utility', () => {
     expect(content.classList.contains('hidden')).toBe(false);
     expect(subtab.classList.contains('active')).toBe(true);
     expect(content.classList.contains('active')).toBe(true);
+  });
+
+  test('remembers scroll positions per subtab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="c-subtab active" data-subtab="first"></div>
+      <div class="c-subtab" data-subtab="second"></div>
+      <div class="tab-content">
+        <div id="first" class="c-content active"></div>
+        <div id="second" class="c-content"></div>
+      </div>`);
+    global.document = dom.window.document;
+
+    const container = dom.window.document.querySelector('.tab-content');
+    container.scrollTop = 50;
+
+    activateSubtab('c-subtab', 'c-content', 'second');
+    container.scrollTop = 120;
+    activateSubtab('c-subtab', 'c-content', 'first');
+    expect(container.scrollTop).toBe(50);
+    activateSubtab('c-subtab', 'c-content', 'second');
+    expect(container.scrollTop).toBe(120);
   });
 });


### PR DESCRIPTION
## Summary
- Track scroll offset for each subtab using its parent `.tab-content`
- Restore stored scroll positions when switching subtabs
- Test scroll position memory for subtabs

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b5a9e3255c83279cdfa924d34733b2