### PR TITLE
Add unassigned space mirror slider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,3 +414,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - MethaneCycle constructor now accepts transitionRange, maxDiff, boilingPointFn, and boilTransitionRange options used during zonal processing.
 - Resource panel margins are now configurable; default planet parameters add 5px spacing after workers, glass and food, and before androids.
 - Subtabs now remember and restore their vertical scroll position when revisited.
+- Space mirror facility adds an Unassigned slider leaving a portion of mirrors and lanterns idle.

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -103,7 +103,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
 
   expect(settings).toEqual({ workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 });
   expect(oversight).toEqual({
-    distribution: { tropical: 0, temperate: 0, polar: 0, focus: 0 },
+    distribution: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0 },
     applyToLantern: false,
     useFinerControls: false,
     assignmentStep: 1,
@@ -113,8 +113,8 @@ test('initializeGameState resets colony sliders to defaults', () => {
     priority: { tropical: 1, temperate: 1, polar: 1, focus: 1 },
     autoAssign: { tropical: false, temperate: false, polar: false, focus: false, any: false },
     assignments: {
-      mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
-      lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 },
+      mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
+      lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
       reversalMode: { tropical: false, temperate: false, polar: false, focus: false, any: false }
     }
   });

--- a/tests/mirrorOversightSettings.test.js
+++ b/tests/mirrorOversightSettings.test.js
@@ -33,6 +33,7 @@ describe('mirror oversight settings', () => {
     expect(mirrorOversightSettings.distribution.tropical).toBeCloseTo(0.4);
     expect(mirrorOversightSettings.distribution.temperate).toBeCloseTo(0.3);
     expect(mirrorOversightSettings.distribution.focus).toBeCloseTo(0.1);
+    expect(mirrorOversightSettings.distribution.unassigned).toBeCloseTo(0);
     expect(mirrorOversightSettings.applyToLantern).toBe(true);
   });
 
@@ -41,9 +42,10 @@ describe('mirror oversight settings', () => {
     mirrorOversightSettings.distribution.temperate = 0.3;
     mirrorOversightSettings.distribution.polar = 0.4;
     mirrorOversightSettings.distribution.focus = 0.1;
+    mirrorOversightSettings.distribution.unassigned = 0.0;
     mirrorOversightSettings.applyToLantern = true;
     resetMirrorOversightSettings();
-    expect(mirrorOversightSettings.distribution).toEqual({ tropical: 0, temperate: 0, polar: 0, focus: 0 });
+    expect(mirrorOversightSettings.distribution).toEqual({ tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0 });
     expect(mirrorOversightSettings.applyToLantern).toBe(false);
   });
 });

--- a/tests/runAdvancedOversightAssignments.test.js
+++ b/tests/runAdvancedOversightAssignments.test.js
@@ -9,8 +9,8 @@ describe('runAdvancedOversightAssignments', () => {
     mirrorOversightSettings.applyToLantern = false;
     mirrorOversightSettings.targets = { tropical: 230, temperate: 220, polar: 0, focus: 0 };
     mirrorOversightSettings.priority = { tropical: 1, temperate: 2, polar: 3, focus: 4 };
-    mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
-    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
+    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
     mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
     mirrorOversightSettings.tempMode = { tropical: 'average', temperate: 'average', polar: 'average' };
 

--- a/tests/spaceMirrorAnySlider.test.js
+++ b/tests/spaceMirrorAnySlider.test.js
@@ -52,7 +52,8 @@ describe('space mirror any zone slider', () => {
     expect(getVal('tropical')).toBe(0);
     expect(getVal('temperate')).toBe(20);
     expect(getVal('polar')).toBe(10);
-    const total = ['tropical', 'temperate', 'polar', 'focus', 'any'].reduce((s, z) => s + getVal(z), 0);
+    expect(getVal('unassigned')).toBe(0);
+    const total = ['tropical', 'temperate', 'polar', 'focus', 'any', 'unassigned'].reduce((s, z) => s + getVal(z), 0);
     expect(total).toBe(100);
   });
 });

--- a/tests/spaceMirrorAvailableCount.test.js
+++ b/tests/spaceMirrorAvailableCount.test.js
@@ -21,8 +21,8 @@ describe('space mirror available counts', () => {
     const container = document.getElementById('container');
     global.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 5 } };
     initializeMirrorOversightUI(container);
-    mirrorOversightSettings.assignments.mirrors = { tropical: 3, temperate: 0, polar: 0, focus: 0, any: 0 };
-    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 2, focus: 0, any: 0 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 3, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
+    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 2, focus: 0, unassigned: 0, any: 0 };
     updateAssignmentDisplays();
     expect(document.getElementById('available-mirrors').textContent).toBe('7');
     expect(document.getElementById('available-lanterns').textContent).toBe('3');

--- a/tests/spaceMirrorDistributionSafeguard.test.js
+++ b/tests/spaceMirrorDistributionSafeguard.test.js
@@ -17,10 +17,10 @@ afterAll(() => {
 describe('Space mirror distribution safeguard', () => {
   test('clamps invalid slider values each tick', () => {
     const project = new SpaceMirrorFacilityProject({ name: 'Space Mirror Facility', cost: {}, duration: 0 }, 'spaceMirrorFacility');
-    mirrorOversightSettings.distribution = { tropical: 1.2, temperate: -0.1, polar: 0.3, focus: 0.3 };
+    mirrorOversightSettings.distribution = { tropical: 1.2, temperate: -0.1, polar: 0.3, focus: 0.3, unassigned: 0.4 };
     project.update(1000);
     const dist = mirrorOversightSettings.distribution;
-    const total = dist.tropical + dist.temperate + dist.polar + dist.focus;
+    const total = dist.tropical + dist.temperate + dist.polar + dist.focus + dist.unassigned;
     Object.values(dist).forEach(v => {
       expect(v).toBeGreaterThanOrEqual(0);
       expect(v).toBeLessThanOrEqual(1);

--- a/tests/spaceMirrorFinerControls.test.js
+++ b/tests/spaceMirrorFinerControls.test.js
@@ -71,8 +71,8 @@ describe('Space Mirror finer controls', () => {
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
     mirrorOversightSettings.useFinerControls = true;
-    mirrorOversightSettings.assignments.mirrors = { tropical: 10, temperate: 0, polar: 0, focus: 0, any: 0 };
-    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 10, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
+    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -105,8 +105,8 @@ describe('Space Mirror finer controls', () => {
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
     mirrorOversightSettings.useFinerControls = true;
-    mirrorOversightSettings.assignments.mirrors = { tropical: 5, temperate: 0, polar: 0, focus: 0, any: 0 };
-    mirrorOversightSettings.assignments.lanterns = { tropical: 3, temperate: 0, polar: 0, focus: 0, any: 0 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 5, temperate: 0, polar: 0, focus: 0, unassigned: 5, any: 0 };
+    mirrorOversightSettings.assignments.lanterns = { tropical: 3, temperate: 0, polar: 0, focus: 0, unassigned: 3, any: 0 };
 
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
@@ -138,21 +138,21 @@ describe('Space Mirror finer controls', () => {
 
   test('auto-assign zones distributes remaining units', () => {
     resetMirrorOversightSettings();
-    mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 3, any: 0 };
-    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 1, any: 0 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 3, unassigned: 0, any: 0 };
+    mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 1, unassigned: 0, any: 0 };
     mirrorOversightSettings.autoAssign.tropical = true;
     mirrorOversightSettings.autoAssign.temperate = true;
     global.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 6 } };
     distributeAutoAssignments('mirrors');
     distributeAutoAssignments('lanterns');
-    expect(mirrorOversightSettings.assignments.mirrors).toEqual({ tropical: 4, temperate: 3, polar: 0, focus: 3, any: 0 });
-    expect(mirrorOversightSettings.assignments.lanterns).toEqual({ tropical: 3, temperate: 2, polar: 0, focus: 1, any: 0 });
+    expect(mirrorOversightSettings.assignments.mirrors).toEqual({ tropical: 4, temperate: 3, polar: 0, focus: 3, unassigned: 0, any: 0 });
+    expect(mirrorOversightSettings.assignments.lanterns).toEqual({ tropical: 3, temperate: 2, polar: 0, focus: 1, unassigned: 0, any: 0 });
   });
 
   test('auto-assign focus distributes remaining units', () => {
     resetMirrorOversightSettings();
-    mirrorOversightSettings.assignments.mirrors = { tropical: 4, temperate: 3, polar: 0, focus: 0, any: 0 };
-    mirrorOversightSettings.assignments.lanterns = { tropical: 3, temperate: 2, polar: 0, focus: 0, any: 0 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 4, temperate: 3, polar: 0, focus: 0, unassigned: 0, any: 0 };
+    mirrorOversightSettings.assignments.lanterns = { tropical: 3, temperate: 2, polar: 0, focus: 0, unassigned: 0, any: 0 };
     mirrorOversightSettings.autoAssign.focus = true;
     global.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 6 } };
     distributeAutoAssignments('mirrors');
@@ -169,7 +169,7 @@ describe('Space Mirror finer controls', () => {
     mirrorOversightSettings.distribution.temperate = 0.2;
     mirrorOversightSettings.distribution.polar = 0.1;
     mirrorOversightSettings.distribution.focus = 0;
-    mirrorOversightSettings.assignments.mirrors = { tropical: 3, temperate: 2, polar: 1, focus: 0, any: 0 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 3, temperate: 2, polar: 1, focus: 0, unassigned: 0, any: 0 };
     mirrorOversightSettings.autoAssign.any = true;
     global.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 0 } };
     distributeAutoAssignments('mirrors');
@@ -205,7 +205,7 @@ describe('Space Mirror finer controls', () => {
       isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight'
     };
     mirrorOversightSettings.useFinerControls = true;
-    mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 10 };
+    mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 10 };
     terra.luminosity.solarFlux = terra.calculateSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     terra.luminosity.modifiedSolarFlux = terra.calculateModifiedSolarFlux(terra.celestialParameters.distanceFromSun * 149597870700);
     const ratio = getZoneRatio('tropical') / 0.25;

--- a/tests/spaceMirrorReverseFlux.test.js
+++ b/tests/spaceMirrorReverseFlux.test.js
@@ -26,11 +26,12 @@ afterEach(() => {
   mirrorOversightSettings.distribution.temperate = 0;
   mirrorOversightSettings.distribution.polar = 0;
   mirrorOversightSettings.distribution.focus = 0;
+  mirrorOversightSettings.distribution.unassigned = 0;
   mirrorOversightSettings.applyToLantern = false;
   mirrorOversightSettings.useFinerControls = false;
   mirrorOversightSettings.advancedOversight = false;
-  mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
-  mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, any: 0 };
+  mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
+  mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
   mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
   delete global.buildings;
   delete global.projectManager;


### PR DESCRIPTION
## Summary
- allow the Space Mirror Facility to reserve a portion of mirrors and lanterns via a new **Unassigned** slider
- factor unassigned percentage into distribution and auto-assignment logic
- cover unassigned slider behaviour with tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b5ab62480083278827f1f698bec42f