### PR TITLE
Redirect reduced space mirror slider to Unassigned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,3 +415,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource panel margins are now configurable; default planet parameters add 5px spacing after workers, glass and food, and before androids.
 - Subtabs now remember and restore their vertical scroll position when revisited.
 - Space mirror facility adds an Unassigned slider leaving a portion of mirrors and lanterns idle.
+- Reducing a space mirror oversight slider now transfers the removed percentage to Unassigned.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -63,7 +63,12 @@ function setMirrorDistribution(zone, value) {
         });
     }
   } else if (zones.includes(zone)) {
+    const prev = dist[zone];
     dist[zone] = v;
+    if (v < prev) {
+      const add = Math.min(prev - v, 1 - dist.unassigned);
+      dist.unassigned += add;
+    }
     let total = dist.tropical + dist.temperate + dist.polar + dist.focus + dist.unassigned;
     if (total > 1) {
       let excess = total - 1;

--- a/tests/spaceMirrorSliderReduction.test.js
+++ b/tests/spaceMirrorSliderReduction.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('space mirror slider reduction', () => {
+  test('reduced value goes to unassigned slider', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.projectElements = {};
+    ctx.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 0, unlocked: false } };
+    ctx.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      calculateZoneSolarFlux: () => 0,
+      celestialParameters: { crossSectionArea: 100, surfaceArea: 100 },
+      temperature: { zones: { tropical: { value: 0 }, temperate: { value: 0 }, polar: { value: 0 } } }
+    };
+    ctx.projectManager = { isBooleanFlagSet: () => true };
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const mirrorCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMirrorFacilityProject.js'), 'utf8');
+    vm.runInContext(mirrorCode + '; this.SpaceMirrorFacilityProject = SpaceMirrorFacilityProject; this.setMirrorDistribution = setMirrorDistribution; this.distributeAssignmentsFromSliders = distributeAssignmentsFromSliders;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.spaceMirrorFacility;
+    const project = new ctx.SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    project.updateUI();
+
+    ctx.setMirrorDistribution('tropical', 40);
+    ctx.setMirrorDistribution('temperate', 30);
+    ctx.setMirrorDistribution('polar', 10);
+    ctx.setMirrorDistribution('unassigned', 20);
+    ctx.setMirrorDistribution('temperate', 10);
+    ctx.distributeAssignmentsFromSliders('mirrors');
+
+    const getVal = z => Number(dom.window.document.getElementById(`mirror-oversight-${z}`).value);
+    expect(getVal('unassigned')).toBe(40);
+    const total = ['tropical', 'temperate', 'polar', 'focus', 'any', 'unassigned'].reduce((s, z) => s + getVal(z), 0);
+    expect(total).toBe(100);
+    expect(ctx.mirrorOversightSettings.assignments.mirrors.unassigned).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure lowering a space mirror oversight slider moves the freed percentage to the Unassigned slider
- document this oversight change
- add regression test covering slider reduction behavior

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b5ae3c0e2083279a8fb023aab58648