### PR TITLE
Force UI render after loading saves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,3 +420,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Buildings now feature collapse arrows hiding cost, production, consumption, maintenance, description and advanced autobuild controls.
 - Reducing a space mirror oversight slider now transfers the removed percentage to Unassigned.
 - Space mirror oversight settings persist through save and load as part of the project state.
+- Loading a saved game now triggers a one-time forced render to refresh the UI.

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -417,6 +417,9 @@ function loadGame(slotOrCustomString) {
     }
 
     globalGameIsLoadingFromSave = false;
+    if (typeof updateRender === 'function') {
+      updateRender(true);
+    }
 
       console.log('Game loaded successfully (DayNightCycle, resources, buildings, projects, colonies, and research).');
   } else {

--- a/tests/loadGameForceRender.test.js
+++ b/tests/loadGameForceRender.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('loadGame render', () => {
+  test('forces a render once after loading', () => {
+    const dom = new JSDOM('<!DOCTYPE html>', { url: 'https://example.com', runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.console = console;
+    ctx.initializeGameState = () => {};
+    ctx.tabParameters = {};
+    ctx.tabManager = { resetVisibility: () => {}, activateTab: () => {} };
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.createBuildingButtons = () => {};
+    ctx.createColonyButtons = () => {};
+    ctx.recalculateLandUsage = () => {};
+    const calls = [];
+    ctx.updateRender = flag => calls.push(flag);
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'save.js'), 'utf8');
+    vm.runInContext(code + '; this.loadGame = loadGame;', ctx);
+    ctx.recalculateLandUsage = () => {};
+
+    ctx.loadGame('{}');
+    expect(calls).toEqual([true]);
+  });
+});

--- a/tests/loadGamePlanet.test.js
+++ b/tests/loadGamePlanet.test.js
@@ -104,12 +104,13 @@ describe('load game planet initialization', () => {
     const savedString = vm.runInContext('savedString', ctx);
 
     // Reset to Mars and load the Titan save
-    vm.runInContext(`
-      defaultPlanet = 'mars';
-      currentPlanetParameters = planetParameters.mars;
-      initializeGameState();
-      loadGame(savedString);
-    `, ctx);
+      vm.runInContext(`
+        defaultPlanet = 'mars';
+        currentPlanetParameters = planetParameters.mars;
+        initializeGameState();
+        updateRender = () => {};
+        loadGame(savedString);
+      `, ctx);
 
     const radius = vm.runInContext('terraforming.celestialParameters.radius', ctx);
 

--- a/tests/playTimeSave.test.js
+++ b/tests/playTimeSave.test.js
@@ -89,7 +89,7 @@ describe('play time persistence', () => {
     vm.runInContext('playTimeSeconds = 730; totalPlayTimeSeconds = 1000;', ctx);
     vm.runInContext('var saved = JSON.stringify(getGameState());', ctx);
     vm.runInContext('playTimeSeconds = 0; totalPlayTimeSeconds = 0;', ctx);
-    vm.runInContext('loadGame(saved);', ctx);
+    vm.runInContext('updateRender = () => {}; loadGame(saved);', ctx);
     const result = vm.runInContext('playTimeSeconds', ctx);
     const totalResult = vm.runInContext('totalPlayTimeSeconds', ctx);
 

--- a/tests/skillPointsSave.test.js
+++ b/tests/skillPointsSave.test.js
@@ -88,7 +88,7 @@ describe('skillPoints save/load', () => {
     vm.runInContext('skillManager.skillPoints = 5;', ctx);
     vm.runInContext('var saved = JSON.stringify(getGameState());', ctx);
     vm.runInContext('skillManager.skillPoints = 0;', ctx);
-    vm.runInContext('loadGame(saved);', ctx);
+    vm.runInContext('updateRender = () => {}; loadGame(saved);', ctx);
     const result = vm.runInContext('skillManager.skillPoints', ctx);
 
     global.window = originalWindow;

--- a/tests/wgcSaveLoad.test.js
+++ b/tests/wgcSaveLoad.test.js
@@ -90,7 +90,7 @@ describe('warpGateCommand save/load', () => {
     vm.runInContext("warpGateCommand.recruitMember(0,0, WGCTeamMember.create('Bob','', 'Soldier', {}));", ctx);
     vm.runInContext('var saved = JSON.stringify(getGameState());', ctx);
     vm.runInContext('warpGateCommand.dismissMember(0,0); warpGateCommand.enabled=false;', ctx);
-    vm.runInContext('loadGame(saved);', ctx);
+    vm.runInContext('updateRender = () => {}; loadGame(saved);', ctx);
     const name = vm.runInContext("warpGateCommand.teams[0][0] && warpGateCommand.teams[0][0].firstName", ctx);
     const enabled = vm.runInContext('warpGateCommand.enabled', ctx);
 


### PR DESCRIPTION
## Summary
- Force a one-time render after loading a saved game to refresh UI
- Document forced render behavior in AGENTS notes
- Add regression test covering loadGame render call

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b5ba529edc8327ab9617a4d0e78709