### PR TITLE
Add collapsible headers to special project cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,3 +421,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Reducing a space mirror oversight slider now transfers the removed percentage to Unassigned.
 - Space mirror oversight settings persist through save and load as part of the project state.
 - Loading a saved game now triggers a one-time forced render to refresh the UI.
+- Special project cards like Mirror Oversight, Planetary Thrusters, Space Storage, and Dyson Swarm now feature collapsible headers.

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -29,7 +29,10 @@
 }
 
 .project-card.collapsed .card-body,
-.project-card.collapsed .progress-button-container {
+.project-card.collapsed .progress-button-container,
+.info-card.collapsed .card-body,
+.mirror-oversight-card.collapsed .card-body,
+.dyson-swarm-card.collapsed .card-body {
     display: none;
 }
 

--- a/src/js/projects/PlanetaryThrustersProject.js
+++ b/src/js/projects/PlanetaryThrustersProject.js
@@ -19,6 +19,17 @@ try {
   }
 } catch (e) {}
 
+if (typeof makeCollapsibleCard === 'undefined') {
+  var makeCollapsibleCard = (typeof globalThis !== 'undefined' && globalThis.makeCollapsibleCard)
+    ? globalThis.makeCollapsibleCard
+    : null;
+  try {
+    if (!makeCollapsibleCard && typeof require === 'function') {
+      ({ makeCollapsibleCard } = require('../ui-utils.js'));
+    }
+  } catch (e) {}
+}
+
 /* ---------- helpers ---------------------------------------------------- */
 const fmt=(n,int=false,d=0)=>isNaN(n)?"–":
   n.toLocaleString(undefined,int?{maximumFractionDigits:0}:
@@ -130,6 +141,7 @@ class PlanetaryThrustersProject extends Project{
       <div class="invest-container left"><label><input id="rotInvest" type="checkbox"> Invest</label></div>
     </div>`;
     const spinCard=document.createElement('div');spinCard.className="info-card";spinCard.innerHTML=spinHTML;c.appendChild(spinCard);
+    if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(spinCard);
     spinCard.style.display=this.isCompleted?"block":"none";
 
     /* motion */
@@ -157,6 +169,7 @@ class PlanetaryThrustersProject extends Project{
       <div id="moonWarn" class="moon-warning" style="display:none;">⚠ Escape parent first</div>
     </div>`;
     const motCard=document.createElement('div');motCard.className="info-card";motCard.innerHTML=motHTML;c.appendChild(motCard);
+    if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(motCard);
     motCard.style.display=this.isCompleted?"block":"none";
 
     /* power */
@@ -180,6 +193,7 @@ class PlanetaryThrustersProject extends Project{
       </div>
     </div>`;
     const pwrCard=document.createElement('div');pwrCard.className="info-card";pwrCard.innerHTML=pwrHTML;c.appendChild(pwrCard);
+    if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(pwrCard);
     pwrCard.style.display=this.isCompleted?"block":"none";
 
     /* refs */

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -1,4 +1,15 @@
-﻿// Mirror oversight controls
+﻿if (typeof makeCollapsibleCard === 'undefined') {
+  var makeCollapsibleCard = (typeof globalThis !== 'undefined' && globalThis.makeCollapsibleCard)
+    ? globalThis.makeCollapsibleCard
+    : null;
+  try {
+    if (!makeCollapsibleCard && typeof require === 'function') {
+      ({ makeCollapsibleCard } = require('../ui-utils.js'));
+    }
+  } catch (e) {}
+}
+
+// Mirror oversight controls
 function createDefaultMirrorOversightSettings() {
   return {
     distribution: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0 },
@@ -386,6 +397,7 @@ function initializeMirrorOversightUI(container) {
       </div>
     </div>
   `;
+  if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(div);
 
   const sliders = {
     tropical: div.querySelector('#mirror-oversight-tropical'),
@@ -1358,6 +1370,7 @@ class SpaceMirrorFacilityProject extends Project {
         </div>
       </div>
     `;
+    if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(mirrorDetails);
     container.appendChild(mirrorDetails);
 
     const lanternDetails = document.createElement('div');
@@ -1392,6 +1405,7 @@ class SpaceMirrorFacilityProject extends Project {
         </div>
       </div>
     `;
+    if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(lanternDetails);
     container.appendChild(lanternDetails);
 
     if (typeof initializeMirrorOversightUI === 'function') {

--- a/src/js/projects/dysonswarmUI.js
+++ b/src/js/projects/dysonswarmUI.js
@@ -1,3 +1,14 @@
+if (typeof makeCollapsibleCard === 'undefined') {
+  var makeCollapsibleCard = (typeof globalThis !== 'undefined' && globalThis.makeCollapsibleCard)
+    ? globalThis.makeCollapsibleCard
+    : null;
+  try {
+    if (!makeCollapsibleCard && typeof require === 'function') {
+      ({ makeCollapsibleCard } = require('../ui-utils.js'));
+    }
+  } catch (e) {}
+}
+
 function renderDysonSwarmUI(project, container) {
   const card = document.createElement('div');
   card.classList.add('dyson-swarm-card');
@@ -15,6 +26,7 @@ function renderDysonSwarmUI(project, container) {
       <div class="progress-button-container"><button id="ds-start" class="progress-button"></button></div>
       <div class="checkbox-container"><input type="checkbox" id="ds-auto"><label for="ds-auto">Auto start</label></div>
     </div>`;
+  if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(card);
   container.appendChild(card);
 
   projectElements[project.name] = {

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -1,3 +1,14 @@
+if (typeof makeCollapsibleCard === 'undefined') {
+  var makeCollapsibleCard = (typeof globalThis !== 'undefined' && globalThis.makeCollapsibleCard)
+    ? globalThis.makeCollapsibleCard
+    : null;
+  try {
+    if (!makeCollapsibleCard && typeof require === 'function') {
+      ({ makeCollapsibleCard } = require('../ui-utils.js'));
+    }
+  } catch (e) {}
+}
+
 const storageResourceOptions = [
   { label: 'Metal', category: 'colony', resource: 'metal' },
   { label: 'Glass', category: 'colony', resource: 'glass' },
@@ -95,6 +106,7 @@ function renderSpaceStorageUI(project, container) {
       </div>
       <div id="ss-resource-grid"></div>
     </div>`;
+  if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(card);
   const cardBody = card.querySelector('.card-body');
 
   const topSection = document.createElement('div');

--- a/src/js/ui-utils.js
+++ b/src/js/ui-utils.js
@@ -119,6 +119,25 @@ function addTooltipHover(anchor, tooltip) {
   });
 }
 
+function makeCollapsibleCard(card) {
+  if (!card) return;
+  const header = card.querySelector('.card-header');
+  if (!header) return;
+  const arrow = document.createElement('span');
+  arrow.classList.add('collapse-arrow');
+  arrow.innerHTML = '&#9660;';
+  header.insertBefore(arrow, header.firstChild);
+
+  const title = header.querySelector('.card-title');
+  const toggleTarget = title || header;
+  const toggle = () => {
+    card.classList.toggle('collapsed');
+    arrow.innerHTML = card.classList.contains('collapsed') ? '&#9654;' : '&#9660;';
+  };
+  arrow.addEventListener('click', toggle);
+  if (toggleTarget !== arrow) toggleTarget.addEventListener('click', toggle);
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { activateSubtab, addTooltipHover, subtabScrollPositions };
+  module.exports = { activateSubtab, addTooltipHover, subtabScrollPositions, makeCollapsibleCard };
 }


### PR DESCRIPTION
## Summary
- add reusable `makeCollapsibleCard` helper and CSS so info cards can collapse
- apply collapsible headers to Space Mirror oversight, Planetary Thrusters, Space Storage, and Dyson Swarm cards
- document special project card collapse in AGENTS instructions

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b5cd1d1950832798eb1cbe52efa209