### PR TITLE
Add space storage strategic reserve

### DIFF
--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -150,7 +150,9 @@ class Project extends EffectableEntity {
         if (storageProj) {
           const key = resource === 'water' ? 'liquidWater' : resource;
           const stored = storageProj.resourceUsage[key] || 0;
-          const available = resources[category][resource].value + stored;
+          const reserve = storageProj.strategicReserve || 0;
+          const usable = Math.max(0, stored - reserve);
+          const available = resources[category][resource].value + usable;
           if (available < required) {
             return false;
           }
@@ -172,8 +174,10 @@ class Project extends EffectableEntity {
         let remaining = cost[category][resource];
         if (storageProj) {
           const key = resource === 'water' ? 'liquidWater' : resource;
+          const reserve = storageProj.strategicReserve || 0;
+          const availableFromStorage = Math.max(0, (storageProj.resourceUsage[key] || 0) - reserve);
           if (storageProj.prioritizeMegaProjects) {
-            const fromStorage = Math.min(storageProj.resourceUsage[key] || 0, remaining);
+            const fromStorage = Math.min(availableFromStorage, remaining);
             if (fromStorage > 0) {
               storageProj.resourceUsage[key] -= fromStorage;
               storageProj.usedStorage = Math.max(0, storageProj.usedStorage - fromStorage);
@@ -190,7 +194,7 @@ class Project extends EffectableEntity {
               remaining -= fromColony;
             }
             if (remaining > 0) {
-              const fromStorage = Math.min(storageProj.resourceUsage[key] || 0, remaining);
+              const fromStorage = Math.min(availableFromStorage, remaining);
               if (fromStorage > 0) {
                 storageProj.resourceUsage[key] -= fromStorage;
                 storageProj.usedStorage = Math.max(0, storageProj.usedStorage - fromStorage);
@@ -419,12 +423,14 @@ class Project extends EffectableEntity {
     if (!storageProj) return false;
     const key = resource === 'water' ? 'liquidWater' : resource;
     const stored = storageProj.resourceUsage[key] || 0;
+    const reserve = storageProj.strategicReserve || 0;
+    const usable = Math.max(0, stored - reserve);
     if (storageProj.prioritizeMegaProjects) {
-      return stored >= amount;
+      return usable >= amount;
     }
     const colonyAvailable = resources[category]?.[resource]?.value || 0;
     if (colonyAvailable >= amount) return false;
-    return stored >= amount - colonyAvailable;
+    return usable >= amount - colonyAvailable;
   }
 
 

--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -16,6 +16,7 @@ class SpaceStorageProject extends SpaceshipProject {
     this.pendingTransfers = [];
     this.prioritizeMegaProjects = false;
     this.waterWithdrawTarget = 'colony';
+    this.strategicReserve = 0;
   }
 
   getDurationWithTerraformBonus(baseDuration) {
@@ -463,6 +464,7 @@ class SpaceStorageProject extends SpaceshipProject {
       resourceUsage: this.resourceUsage,
       pendingTransfers: this.pendingTransfers,
       prioritizeMegaProjects: this.prioritizeMegaProjects,
+      strategicReserve: this.strategicReserve,
       waterWithdrawTarget: this.waterWithdrawTarget,
       shipOperation: {
         remainingTime: this.shipOperationRemainingTime,
@@ -482,6 +484,7 @@ class SpaceStorageProject extends SpaceshipProject {
     this.resourceUsage = state.resourceUsage || {};
     this.pendingTransfers = state.pendingTransfers || [];
     this.prioritizeMegaProjects = state.prioritizeMegaProjects || false;
+    this.strategicReserve = state.strategicReserve || 0;
     this.waterWithdrawTarget = state.waterWithdrawTarget || 'colony';
     const ship = state.shipOperation || {};
     this.shipOperationRemainingTime = ship.remainingTime || 0;

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -59,6 +59,30 @@ if (typeof SpaceStorageProject !== 'undefined') {
     return container;
   };
 
+  SpaceStorageProject.prototype.createStrategicReserveInput = function () {
+    const container = document.createElement('div');
+    container.classList.add('checkbox-container');
+    const label = document.createElement('label');
+    label.htmlFor = `${this.name}-strategic-reserve`;
+    label.textContent = 'Strategic reserve';
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = '0';
+    input.id = `${this.name}-strategic-reserve`;
+    input.value = this.strategicReserve;
+    input.addEventListener('change', (e) => {
+      const val = parseFloat(e.target.value);
+      this.strategicReserve = isNaN(val) ? 0 : Math.max(0, val);
+    });
+    container.append(label, input);
+    projectElements[this.name] = {
+      ...projectElements[this.name],
+      strategicReserveInput: input,
+      strategicReserveContainer: container,
+    };
+    return container;
+  };
+
   SpaceStorageProject.prototype.renderAutomationUI = function (container) {
     const els = projectElements[this.name] || {};
     if (
@@ -70,11 +94,14 @@ if (typeof SpaceStorageProject !== 'undefined') {
       delete els.shipAutoStartContainer;
       delete els.prioritizeMegaCheckbox;
       delete els.prioritizeMegaContainer;
+      delete els.strategicReserveInput;
+      delete els.strategicReserveContainer;
     }
     if (!els.shipAutoStartContainer) {
       const ship = this.createShipAutoStartCheckbox();
       const prioritize = this.createPrioritizeMegaCheckbox();
-      container.append(ship, prioritize);
+      const reserve = this.createStrategicReserveInput();
+      container.append(ship, prioritize, reserve);
     }
     invalidateAutomationSettingsCache(this.name);
   };

--- a/tests/automationSettingsCache.test.js
+++ b/tests/automationSettingsCache.test.js
@@ -55,13 +55,13 @@ describe('automation settings cache', () => {
     ctx.updateProjectUI('spaceStorage');
     const els = ctx.projectElements[project.name];
 
-    expect(els.cachedAutomationItems.length).toBe(3);
+    expect(els.cachedAutomationItems.length).toBe(4);
 
     while (els.automationSettingsContainer.firstChild) {
       els.automationSettingsContainer.firstChild.remove();
     }
     ctx.updateProjectUI('spaceStorage');
-    expect(els.cachedAutomationItems.length).toBe(3);
+    expect(els.cachedAutomationItems.length).toBe(4);
     expect(els.automationSettingsContainer.style.display).toBe('flex');
 
     ctx.invalidateAutomationSettingsCache(project.name);

--- a/tests/spaceStorageAutomationSettings.test.js
+++ b/tests/spaceStorageAutomationSettings.test.js
@@ -58,7 +58,8 @@ describe('Space Storage automation settings', () => {
     expect(labels).toEqual([
       'Auto Start Expansion',
       'Auto Start Ships',
-      'Prioritize space resources for mega projects'
+      'Prioritize space resources for mega projects',
+      'Strategic reserve'
     ]);
 
     els.shipAutoStartCheckbox.checked = true;
@@ -68,5 +69,9 @@ describe('Space Storage automation settings', () => {
     els.prioritizeMegaCheckbox.checked = true;
     els.prioritizeMegaCheckbox.dispatchEvent(new dom.window.Event('change'));
     expect(project.prioritizeMegaProjects).toBe(true);
+
+    els.strategicReserveInput.value = '42';
+    els.strategicReserveInput.dispatchEvent(new dom.window.Event('change'));
+    expect(project.strategicReserve).toBe(42);
   });
 });

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -66,6 +66,7 @@ describe('Space Storage project', () => {
     project.resourceUsage = { metal: 100 };
     project.shipWithdrawMode = true;
     project.waterWithdrawTarget = 'surface';
+    project.strategicReserve = 12;
     const saved = project.saveState();
     const loaded = new ctx.SpaceStorageProject(params, 'spaceStorage');
     loaded.loadState(saved);
@@ -73,6 +74,7 @@ describe('Space Storage project', () => {
     expect(loaded.resourceUsage.metal).toBe(100);
     expect(loaded.shipWithdrawMode).toBe(true);
     expect(loaded.waterWithdrawTarget).toBe('surface');
+    expect(loaded.strategicReserve).toBe(12);
   });
 
   test('renders assignment UI with resource checkboxes', () => {


### PR DESCRIPTION
## Summary
- add strategic reserve amount to space storage with save/load support
- expose strategic reserve input in space storage automation settings
- restrict mega projects to consume space storage only above the strategic reserve

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b5cdb3a0848327aafc34981df93da0