### PR TITLE
Allow scientific notation for space storage and nanobot energy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,3 +422,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space mirror oversight settings persist through save and load as part of the project state.
 - Loading a saved game now triggers a one-time forced render to refresh the UI.
 - Special project cards like Mirror Oversight, Planetary Thrusters, Space Storage, and Dyson Swarm now feature collapsible headers.
+- Space storage strategic reserve and nanobot energy limit inputs now accept scientific notation (e.g., 1e3 for 1000).

--- a/src/js/nanotech.js
+++ b/src/js/nanotech.js
@@ -201,7 +201,7 @@ class NanotechManager extends EffectableEntity {
           <div class="control-group">
             <label for="nanotech-energy-limit">Energy Use Limit <span class="info-tooltip-icon" title="Percentage of power: Maximum percentage of total energy production the swarm may consume per second. Absolute (MW): Fixed energy limit in megawatts the swarm may consume per second.">&#9432;</span></label>
             <div style="display: flex; gap: 4px;">
-              <input type="number" id="nanotech-energy-limit" min="0" max="100" step="any" value="${this.maxEnergyPercent}" style="flex:1;">
+              <input type="text" id="nanotech-energy-limit" value="${this.maxEnergyPercent}" style="flex:1;">
               <select id="nanotech-energy-limit-mode" style="flex:1;">
                 <option value="percent" selected>percentage of power</option>
                 <option value="absolute">absolute (MW)</option>
@@ -265,11 +265,14 @@ class NanotechManager extends EffectableEntity {
       document
         .getElementById('nanotech-energy-limit')
         .addEventListener('input', (e) => {
-          const val = parseFloat(e.target.value) || 0;
+          const val = parseFloat(e.target.value);
           if (this.energyLimitMode === 'absolute') {
-            this.maxEnergyAbsolute = val * 1e6;
+            this.maxEnergyAbsolute = isNaN(val) ? 0 : val * 1e6;
+            e.target.value = isNaN(val) ? '' : val.toString();
           } else {
-            this.maxEnergyPercent = val;
+            const pct = isNaN(val) ? 0 : Math.max(0, Math.min(100, val));
+            this.maxEnergyPercent = pct;
+            e.target.value = isNaN(val) ? '' : pct.toString();
           }
           this.updateUI();
         });
@@ -317,10 +320,12 @@ class NanotechManager extends EffectableEntity {
     if (C.eMode) C.eMode.value = this.energyLimitMode;
     if (C.eLimit && document.activeElement !== C.eLimit) {
       if (this.energyLimitMode === 'absolute') {
-        C.eLimit.value = this.maxEnergyAbsolute / 1e6;
+        C.eLimit.value = (this.maxEnergyAbsolute / 1e6).toString();
         C.eLimit.removeAttribute('max');
       } else {
-        C.eLimit.value = this.maxEnergyPercent;
+        const pct = Math.max(0, Math.min(100, this.maxEnergyPercent));
+        this.maxEnergyPercent = pct;
+        C.eLimit.value = pct.toString();
         C.eLimit.max = 100;
       }
     }

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -77,13 +77,13 @@ if (typeof SpaceStorageProject !== 'undefined') {
     label.htmlFor = `${this.name}-strategic-reserve`;
     label.textContent = 'Strategic reserve';
     const input = document.createElement('input');
-    input.type = 'number';
-    input.min = '0';
+    input.type = 'text';
     input.id = `${this.name}-strategic-reserve`;
     input.value = this.strategicReserve;
     input.addEventListener('change', (e) => {
       const val = parseFloat(e.target.value);
       this.strategicReserve = isNaN(val) ? 0 : Math.max(0, val);
+      e.target.value = isNaN(val) ? '' : this.strategicReserve.toString();
     });
     container.append(label, input);
     projectElements[this.name] = {

--- a/tests/nanotechEnergyLimit.test.js
+++ b/tests/nanotechEnergyLimit.test.js
@@ -71,4 +71,30 @@ describe('nanotech energy usage limit', () => {
     nm.updateUI();
     expect(input.value).toBe('5');
   });
+
+  test('absolute energy limit accepts scientific notation', () => {
+    const { JSDOM } = require('jsdom');
+    const dom = new JSDOM('<!DOCTYPE html><div id="colony-structures-section"><div id="colony-buildings-buttons"></div></div><div id="colony-controls-section"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.Event = dom.window.Event;
+    const energy = new Resource({ name: 'energy', category: 'colony', initialValue: 0 });
+    global.resources = { colony: { energy }, surface: { land: new Resource({ name: 'land', category: 'surface', initialValue: 1, hasCap: true, baseCap: 1 }) } };
+    global.structures = {};
+    global.colonies = {};
+    global.buildings = {};
+    global.addEffect = jest.fn();
+    global.removeEffect = jest.fn();
+    global.formatNumber = (n) => n;
+    const nm = new NanotechManager();
+    nm.enable();
+    nm.energyLimitMode = 'absolute';
+    nm.updateUI();
+    const input = document.getElementById('nanotech-energy-limit');
+    input.value = '1e3';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(nm.maxEnergyAbsolute).toBeCloseTo(1e9);
+    nm.updateUI();
+    expect(input.value).toBe('1000');
+  });
 });

--- a/tests/spaceStorageScientificNotation.test.js
+++ b/tests/spaceStorageScientificNotation.test.js
@@ -1,0 +1,33 @@
+const { JSDOM } = require('jsdom');
+
+describe('space storage strategic reserve input', () => {
+  test('accepts scientific notation', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.projectElements = {};
+
+    class SpaceStorageProject {
+      constructor() {
+        this.name = 'spaceStorage';
+        this.strategicReserve = 0;
+      }
+    }
+    global.SpaceStorageProject = SpaceStorageProject;
+
+    require('../src/js/projects/spaceStorageUI.js');
+    const project = new SpaceStorageProject();
+    const container = document.getElementById('root');
+    const inputContainer = project.createStrategicReserveInput();
+    container.appendChild(inputContainer);
+    const input = projectElements[project.name].strategicReserveInput;
+    input.value = '1e3';
+    input.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    expect(project.strategicReserve).toBe(1000);
+    expect(input.value).toBe('1000');
+    delete global.document;
+    delete global.window;
+    delete global.projectElements;
+    delete global.SpaceStorageProject;
+  });
+});


### PR DESCRIPTION
## Summary
- Accept and normalize scientific notation in nanobot energy limit input
- Support scientific notation for space storage strategic reserves
- Test coverage for both scientific-notation inputs

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b5d569331c8327ad3cb98330c4a727