### PR TITLE
Add tooltip for space storage strategic reserve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,3 +423,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Loading a saved game now triggers a one-time forced render to refresh the UI.
 - Special project cards like Mirror Oversight, Planetary Thrusters, Space Storage, and Dyson Swarm now feature collapsible headers.
 - Space storage strategic reserve and nanobot energy limit inputs now accept scientific notation (e.g., 1e3 for 1000).
+- Space storage strategic reserve input includes a tooltip noting that mega projects respect the reserve while transfers do not, and explaining scientific notation support.

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -75,7 +75,13 @@ if (typeof SpaceStorageProject !== 'undefined') {
     container.classList.add('checkbox-container');
     const label = document.createElement('label');
     label.htmlFor = `${this.name}-strategic-reserve`;
-    label.textContent = 'Strategic reserve';
+    label.textContent = 'Strategic reserve ';
+    const info = document.createElement('span');
+    info.classList.add('info-tooltip-icon');
+    info.innerHTML = '&#9432;';
+    info.title =
+      'Minimum space storage kept in reserve for mega projects; transfers ignore this reserve. Accepts scientific notation (e.g., 1e3 for 1000).';
+    label.appendChild(info);
     const input = document.createElement('input');
     input.type = 'text';
     input.id = `${this.name}-strategic-reserve`;

--- a/tests/spaceStorageAutomationSettings.test.js
+++ b/tests/spaceStorageAutomationSettings.test.js
@@ -54,13 +54,13 @@ describe('Space Storage automation settings', () => {
     ctx.createProjectItem(project);
     ctx.updateProjectUI('spaceStorage');
     const els = ctx.projectElements[project.name];
-    const labels = Array.from(els.automationSettingsContainer.querySelectorAll('label')).map(l => l.textContent);
-    expect(labels).toEqual([
-      'Auto Start Expansion',
-      'Auto Start Ships',
-      'Prioritize space resources for mega projects',
-      'Strategic reserve'
-    ]);
+    const labels = Array.from(
+      els.automationSettingsContainer.querySelectorAll('label')
+    ).map(l => l.textContent);
+    expect(labels[0]).toBe('Auto Start Expansion');
+    expect(labels[1]).toBe('Auto Start Ships');
+    expect(labels[2]).toBe('Prioritize space resources for mega projects');
+    expect(labels[3].startsWith('Strategic reserve')).toBe(true);
 
     els.shipAutoStartCheckbox.checked = true;
     els.shipAutoStartCheckbox.dispatchEvent(new dom.window.Event('change'));

--- a/tests/spaceStorageScientificNotation.test.js
+++ b/tests/spaceStorageScientificNotation.test.js
@@ -1,21 +1,24 @@
 const { JSDOM } = require('jsdom');
 
+class SpaceStorageProject {
+  constructor() {
+    this.name = 'spaceStorage';
+    this.strategicReserve = 0;
+  }
+}
+
+global.SpaceStorageProject = SpaceStorageProject;
+global.projectElements = {};
+require('../src/js/projects/spaceStorageUI.js');
+delete global.SpaceStorageProject;
+delete global.projectElements;
+
 describe('space storage strategic reserve input', () => {
   test('accepts scientific notation', () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
     global.document = dom.window.document;
     global.window = dom.window;
     global.projectElements = {};
-
-    class SpaceStorageProject {
-      constructor() {
-        this.name = 'spaceStorage';
-        this.strategicReserve = 0;
-      }
-    }
-    global.SpaceStorageProject = SpaceStorageProject;
-
-    require('../src/js/projects/spaceStorageUI.js');
     const project = new SpaceStorageProject();
     const container = document.getElementById('root');
     const inputContainer = project.createStrategicReserveInput();
@@ -28,6 +31,25 @@ describe('space storage strategic reserve input', () => {
     delete global.document;
     delete global.window;
     delete global.projectElements;
-    delete global.SpaceStorageProject;
+  });
+
+  test('includes tooltip describing reserve and scientific notation', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.projectElements = {};
+    const project = new SpaceStorageProject();
+    const container = document.getElementById('root');
+    const inputContainer = project.createStrategicReserveInput();
+    container.appendChild(inputContainer);
+    const label = projectElements[project.name].strategicReserveContainer.querySelector('label');
+    const icon = label.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    expect(icon.title).toContain('mega project');
+    expect(icon.title).toContain('transfers ignore');
+    expect(icon.title).toContain('scientific notation');
+    delete global.document;
+    delete global.window;
+    delete global.projectElements;
   });
 });


### PR DESCRIPTION
## Summary
- Add informative tooltip to space storage strategic reserve input, noting transfers ignore the reserve and support for scientific notation
- Cover new tooltip with tests
- Document behavior in AGENTS instructions

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b5d7d64af883278849df3f43343204