### PR TITLE
Collapse additional elements in mirror oversight and space storage cards

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -603,7 +603,7 @@ function initializeMirrorOversightUI(container) {
       <tr><td>Polar</td><td id="mirror-flux-polar">0</td><td id="mirror-temp-polar">0</td><td id="mirror-day-temp-polar">0</td></tr>
     </tbody>
   `;
-  div.appendChild(fluxTable);
+  cardBody.appendChild(fluxTable);
   // Fix mis-encoded units in header
   try {
     const fluxHeader = fluxTable.querySelector('thead tr th:nth-child(2)');
@@ -701,8 +701,8 @@ function initializeMirrorOversightUI(container) {
       </div>
     </div>
   `;
-  div.appendChild(finerToggle);
-  div.appendChild(finerContent);
+  cardBody.appendChild(finerToggle);
+  cardBody.appendChild(finerContent);
 
   const finerIcon = finerToggle.querySelector('#mirror-finer-icon');
   finerToggle.addEventListener('click', () => {

--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -314,7 +314,7 @@ function renderSpaceStorageUI(project, container) {
 
   updateModeButtons();
 
-  card.appendChild(shipFooter);
+  cardBody.appendChild(shipFooter);
   container.appendChild(card);
   projectElements[project.name] = {
     ...projectElements[project.name],

--- a/tests/mirrorOversightCollapse.test.js
+++ b/tests/mirrorOversightCollapse.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('mirror oversight collapse', () => {
+  test('flux table and finer controls reside inside card body', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+
+    ctx.Project = class {};
+    ctx.makeCollapsibleCard = (card) => {
+      const arrow = ctx.document.createElement('span');
+      arrow.classList.add('collapse-arrow');
+      card.querySelector('.card-header').prepend(arrow);
+      arrow.addEventListener('click', () => {
+        card.classList.toggle('collapsed');
+      });
+    };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects/SpaceMirrorFacilityProject.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.mirrorOversightSettings = ctx.createDefaultMirrorOversightSettings();
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+    ctx.terraforming = {
+      calculateZoneSolarFlux: () => 0,
+      temperature: { zones: { tropical: { value: 0, day: 0 }, temperate: { value: 0, day: 0 }, polar: { value: 0, day: 0 } } }
+    };
+    ctx.formatNumber = n => String(n);
+    ctx.toDisplayTemperature = v => v;
+    ctx.getTemperatureUnit = () => 'K';
+
+    const container = dom.window.document.getElementById('root');
+    ctx.initializeMirrorOversightUI(container);
+
+    const card = dom.window.document.getElementById('mirror-oversight-container');
+    const cardBody = card.querySelector('.card-body');
+    const fluxTable = dom.window.document.getElementById('mirror-flux-table');
+    const finerToggle = dom.window.document.getElementById('mirror-finer-toggle');
+    const finerContent = dom.window.document.getElementById('mirror-finer-content');
+
+    expect(cardBody.contains(fluxTable)).toBe(true);
+    expect(cardBody.contains(finerToggle)).toBe(true);
+    expect(cardBody.contains(finerContent)).toBe(true);
+
+    const arrow = card.querySelector('.collapse-arrow');
+    arrow.dispatchEvent(new dom.window.Event('click'));
+    expect(card.classList.contains('collapsed')).toBe(true);
+  });
+});

--- a/tests/spaceStorageCollapse.test.js
+++ b/tests/spaceStorageCollapse.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('space storage collapse', () => {
+  test('mode and progress bar reside inside card body', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.projectElements = {};
+
+    ctx.makeCollapsibleCard = (card) => {
+      const arrow = ctx.document.createElement('span');
+      arrow.classList.add('collapse-arrow');
+      card.querySelector('.card-header').prepend(arrow);
+      arrow.addEventListener('click', () => {
+        card.classList.toggle('collapsed');
+      });
+    };
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects/spaceStorageUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const container = dom.window.document.getElementById('root');
+    const project = {
+      name: 'test',
+      shipWithdrawMode: false,
+      isShipOperationContinuous: () => false,
+      shipOperationIsPaused: false,
+      shipOperationIsActive: false,
+      startShipOperation: () => {},
+      resumeShipOperation: () => {},
+      toggleResourceSelection: () => {}
+    };
+
+    ctx.renderSpaceStorageUI(project, container);
+
+    const card = container.querySelector('.space-storage-card');
+    const cardBody = card.querySelector('.card-body');
+    const shipFooter = card.querySelector('.card-footer');
+
+    expect(cardBody.contains(shipFooter)).toBe(true);
+    expect(shipFooter.querySelector('.progress-button')).not.toBeNull();
+    expect(shipFooter.querySelector('.mode-selection')).not.toBeNull();
+
+    const arrow = card.querySelector('.collapse-arrow');
+    arrow.dispatchEvent(new dom.window.Event('click'));
+    expect(card.classList.contains('collapsed')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure mirror oversight collapse hides flux table and finer controls by nesting them in the card body
- Move space storage transfer footer into card body so collapsing hides mode and progress controls
- Add tests for mirror oversight and space storage card collapsing behavior

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b5e2811898832783ed6922286b4a8e