### PR TITLE
Fix water destination dropdown font size

### DIFF
--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -205,6 +205,7 @@ function renderSpaceStorageUI(project, container) {
     if (opt.resource === 'liquidWater') {
       waterSelect = document.createElement('select');
       waterSelect.id = `${project.name}-water-destination`;
+      waterSelect.style.fontSize = '12px';
       const colonyOpt = document.createElement('option');
       colonyOpt.value = 'colony';
       colonyOpt.textContent = 'Colony';

--- a/tests/spaceStorageWaterDestinationFont.test.js
+++ b/tests/spaceStorageWaterDestinationFont.test.js
@@ -1,0 +1,24 @@
+const { JSDOM } = require('jsdom');
+
+describe('space storage water destination dropdown', () => {
+  test('uses 12px font size', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.projectElements = {};
+    const { renderSpaceStorageUI } = require('../src/js/projects/spaceStorageUI.js');
+    const project = {
+      name: 'spaceStorage',
+      toggleResourceSelection: jest.fn(),
+      waterWithdrawTarget: 'colony'
+    };
+    const container = document.getElementById('root');
+    renderSpaceStorageUI(project, container);
+    const select = projectElements[project.name].waterDestinationSelect;
+    expect(select).not.toBeUndefined();
+    expect(select.style.fontSize).toBe('12px');
+    delete global.document;
+    delete global.window;
+    delete global.projectElements;
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure space storage's water destination selector renders with 12px text
- Add regression test verifying dropdown font size

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b5e33b1a3c83279c199ac2cc02b1ea