### PR TITLE
Improve project header contrast

### DIFF
--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -60,12 +60,13 @@ body.dark-mode {
 }
 
 .dark-mode .card-header {
-    background-color: #1e1e1e;
+    background-color: #141414;
     border-bottom-color: #444;
+    color: #ffffff;
 }
 
 .dark-mode .card-title {
-    color: #ffffff;
+    color: inherit;
 }
 
 .dark-mode .card-footer {

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -15,12 +15,13 @@
 }
 
 .card-header {
-    background-color: #e9ecef;
+    background-color: #ced4da;
     padding: 8px 12px;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid #adb5bd;
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    color: #212529;
 }
 
 .collapse-arrow {
@@ -39,7 +40,7 @@
 .card-title {
     font-weight: bold;
     font-size: 1.1em;
-    color: #495057;
+    color: inherit;
 }
 
 .card-body {


### PR DESCRIPTION
## Summary
- Increase project card header contrast in light mode
- Adjust dark mode card headers to match new contrast

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b5f3a91a0883278606180b7c18e19a