### PR TITLE
Lock unassigned mirror slider during finer controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,3 +424,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Special project cards like Mirror Oversight, Planetary Thrusters, Space Storage, and Dyson Swarm now feature collapsible headers.
 - Space storage strategic reserve and nanobot energy limit inputs now accept scientific notation (e.g., 1e3 for 1000).
 - Space storage strategic reserve input includes a tooltip noting that mega projects respect the reserve while transfers do not, and explaining scientific notation support.
+- Space mirror facility's unassigned slider matches the width of other sliders and locks when finer controls are enabled.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -389,6 +389,8 @@ function initializeMirrorOversightUI(container) {
         <label for="mirror-oversight-unassigned">Unassigned:</label>
         <input type="range" id="mirror-oversight-unassigned" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-unassigned-value" class="slider-value">0%</span>
+        <input type="checkbox" id="mirror-oversight-unassigned-reverse" class="slider-reversal-checkbox" data-zone="unassigned" style="display:none; visibility:hidden;">
+        <label for="mirror-oversight-unassigned-reverse" class="slider-reverse-label" style="display:none; visibility:hidden;">Reverse</label>
       </div>
       </div>
       <div id="mirror-oversight-lantern-div" class="control-group">
@@ -949,7 +951,7 @@ function updateMirrorOversightUI() {
   }
 
   const useFiner = mirrorOversightSettings.useFinerControls;
-  ['tropical','temperate','polar','focus','any'].forEach(zone => {
+  ['tropical','temperate','polar','focus','any','unassigned'].forEach(zone => {
     const slider = document.getElementById(`mirror-oversight-${zone}`);
     if (slider) slider.disabled = useFiner;
   });

--- a/tests/spaceMirrorUnassignedLock.test.js
+++ b/tests/spaceMirrorUnassignedLock.test.js
@@ -1,0 +1,78 @@
+const numbers = require('../src/js/numbers.js');
+const { JSDOM } = require('jsdom');
+
+global.Project = class {};
+global.projectElements = {};
+global.formatNumber = numbers.formatNumber;
+global.formatBuildingCount = numbers.formatBuildingCount;
+global.toDisplayTemperature = numbers.toDisplayTemperature;
+global.getTemperatureUnit = numbers.getTemperatureUnit;
+
+const {
+  SpaceMirrorFacilityProject,
+  initializeMirrorOversightUI,
+  updateMirrorOversightUI,
+  toggleFinerControls,
+  resetMirrorOversightSettings
+} = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+
+const project = new SpaceMirrorFacilityProject({ name: 'Mirror', cost: {}, duration: 0 }, 'spaceMirrorFacility');
+const mirrorOversightSettings = project.mirrorOversightSettings;
+global.mirrorOversightSettings = mirrorOversightSettings;
+
+describe('space mirror unassigned slider ui', () => {
+  beforeEach(() => {
+    resetMirrorOversightSettings();
+  });
+
+  test('shows hidden reversal placeholder for consistent width', () => {
+    const dom = new JSDOM('<div id="container"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: false } };
+    global.projectManager = {
+      isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight',
+      projects: { spaceMirrorFacility: { isBooleanFlagSet: () => true, reversalAvailable: true } }
+    };
+
+    const container = document.getElementById('container');
+    initializeMirrorOversightUI(container);
+    updateMirrorOversightUI();
+
+    const group = document.getElementById('mirror-oversight-unassigned').parentElement;
+    const checkbox = group.querySelector('.slider-reversal-checkbox');
+    const label = group.querySelector('.slider-reverse-label');
+    expect(checkbox.style.display).toBe('');
+    expect(label.style.display).toBe('');
+    expect(checkbox.style.visibility).toBe('hidden');
+    expect(label.style.visibility).toBe('hidden');
+    expect(group.children.length).toBe(5);
+
+    delete global.window;
+    delete global.document;
+    delete global.buildings;
+    delete global.projectManager;
+  });
+
+  test('unassigned slider locks in finer controls mode', () => {
+    const dom = new JSDOM('<div id="container"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: false } };
+    global.projectManager = { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight' };
+
+    const container = document.getElementById('container');
+    initializeMirrorOversightUI(container);
+    updateMirrorOversightUI();
+
+    const slider = document.getElementById('mirror-oversight-unassigned');
+    expect(slider.disabled).toBe(false);
+    toggleFinerControls(true);
+    expect(slider.disabled).toBe(true);
+
+    delete global.window;
+    delete global.document;
+    delete global.buildings;
+    delete global.projectManager;
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the space mirror facility's unassigned slider the same width as other sliders
- Disable the unassigned slider when finer controls are active
- Test unassigned slider placeholder and finer control lock

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b5f48a63588327b46aa5c687a0318d