### PR TITLE
Reset resource display elements on travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,3 +426,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage strategic reserve and nanobot energy limit inputs now accept scientific notation (e.g., 1e3 for 1000).
 - Space storage strategic reserve input includes a tooltip noting that mega projects respect the reserve while transfers do not, and explaining scientific notation support.
 - Space mirror facility's unassigned slider matches the width of other sliders and locks when finer controls are enabled.
+- Added `reinitializeDisplayElements` to Resource for resetting default display names and margins after travel.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -179,9 +179,19 @@ function initializeGameState(options = {}) {
         if (!resources[category][resourceName]) {
           // If the resource doesn't exist in the new defaults, add it directly from the save.
           resources[category][resourceName] = savedResource;
-          }
         }
       }
+    }
+  }
+
+  // Restore default display values for all resources
+  for (const category in resources) {
+    for (const resourceName in resources[category]) {
+      const res = resources[category][resourceName];
+      if (res && typeof res.reinitializeDisplayElements === 'function') {
+        res.reinitializeDisplayElements();
+      }
+    }
   }
   if (savedAdvancedResearch) {
     resources.colony.advancedResearch.value = savedAdvancedResearch.value;

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -6,6 +6,7 @@ class Resource extends EffectableEntity {
     this.name = resourceData.name || '';
     this.category = resourceData.category;
     this.displayName = resourceData.displayName || resourceData.name || '';
+    this.defaultDisplayName = this.displayName;
     this.unit = resourceData.unit || null;
     this.value = resourceData.initialValue || 0;
     this.hasCap = resourceData.hasCap || false;
@@ -29,12 +30,15 @@ class Resource extends EffectableEntity {
     this.rateHistory = []; // Keep history of recent net rates
     this.marginTop = resourceData.marginTop || 0;
     this.marginBottom = resourceData.marginBottom || 0;
+    this.defaultMarginTop = this.marginTop;
+    this.defaultMarginBottom = this.marginBottom;
   }
 
   // Method to initialize configurable properties
   initializeFromConfig(name, config) {
     if (config.displayName !== undefined) {
       this.displayName = config.displayName || config.name || this.displayName;
+      this.defaultDisplayName = config.displayName || config.name || this.defaultDisplayName;
     }
     if (config.category !== undefined) {
       this.category = config.category;
@@ -68,9 +72,11 @@ class Resource extends EffectableEntity {
     }
     if (config.marginTop !== undefined) {
       this.marginTop = config.marginTop;
+      this.defaultMarginTop = config.marginTop;
     }
     if (config.marginBottom !== undefined) {
       this.marginBottom = config.marginBottom;
+      this.defaultMarginBottom = config.marginBottom;
     }
 
     if (this.name === 'land' && config.initialValue !== undefined) {
@@ -82,6 +88,13 @@ class Resource extends EffectableEntity {
     if(amount > 0){
       this.value = Math.min(this.value + amount, this.cap);
     }
+  }
+
+  // Reset display-related properties to their default values
+  reinitializeDisplayElements() {
+    this.displayName = this.defaultDisplayName;
+    this.marginTop = this.defaultMarginTop;
+    this.marginBottom = this.defaultMarginBottom;
   }
 
   decrease(amount) {

--- a/tests/reinitializeDisplayElements.test.js
+++ b/tests/reinitializeDisplayElements.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+test('reinitializeDisplayElements restores default name and margins', () => {
+  const context = {};
+  const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+  const resourceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resource.js'), 'utf8');
+  vm.runInNewContext(effectCode, context);
+  vm.runInNewContext(resourceCode + '\nthis.Resource = Resource;', context);
+
+  const Resource = context.Resource;
+  const res = new Resource({
+    name: 'foo',
+    category: 'colony',
+    displayName: 'Foo',
+    marginTop: 3,
+    marginBottom: 4,
+  });
+
+  res.displayName = 'Bar';
+  res.marginTop = 10;
+  res.marginBottom = 11;
+  res.reinitializeDisplayElements();
+  expect(res.displayName).toBe('Foo');
+  expect(res.marginTop).toBe(3);
+  expect(res.marginBottom).toBe(4);
+
+  res.initializeFromConfig('foo', { displayName: 'Baz', marginTop: 1, marginBottom: 2 });
+  res.displayName = 'Qux';
+  res.marginTop = 7;
+  res.marginBottom = 8;
+  res.reinitializeDisplayElements();
+  expect(res.displayName).toBe('Baz');
+  expect(res.marginTop).toBe(1);
+  expect(res.marginBottom).toBe(2);
+});


### PR DESCRIPTION
## Summary
- add `reinitializeDisplayElements` to Resource to reset default name and margins
- call the reset for every resource during `initializeGameState`
- test resource display reinitialization

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b5fa41edb483279894d1bcd1b21c3c