### PR TITLE
refactor: use planet defaults for resource display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,3 +427,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage strategic reserve input includes a tooltip noting that mega projects respect the reserve while transfers do not, and explaining scientific notation support.
 - Space mirror facility's unassigned slider matches the width of other sliders and locks when finer controls are enabled.
 - Added `reinitializeDisplayElements` to Resource for resetting default display names and margins after travel.
+- Resource `reinitializeDisplayElements` now pulls display defaults from `defaultPlanetParameters` instead of storing them on each resource.

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -6,7 +6,6 @@ class Resource extends EffectableEntity {
     this.name = resourceData.name || '';
     this.category = resourceData.category;
     this.displayName = resourceData.displayName || resourceData.name || '';
-    this.defaultDisplayName = this.displayName;
     this.unit = resourceData.unit || null;
     this.value = resourceData.initialValue || 0;
     this.hasCap = resourceData.hasCap || false;
@@ -30,15 +29,12 @@ class Resource extends EffectableEntity {
     this.rateHistory = []; // Keep history of recent net rates
     this.marginTop = resourceData.marginTop || 0;
     this.marginBottom = resourceData.marginBottom || 0;
-    this.defaultMarginTop = this.marginTop;
-    this.defaultMarginBottom = this.marginBottom;
   }
 
   // Method to initialize configurable properties
   initializeFromConfig(name, config) {
     if (config.displayName !== undefined) {
       this.displayName = config.displayName || config.name || this.displayName;
-      this.defaultDisplayName = config.displayName || config.name || this.defaultDisplayName;
     }
     if (config.category !== undefined) {
       this.category = config.category;
@@ -72,11 +68,9 @@ class Resource extends EffectableEntity {
     }
     if (config.marginTop !== undefined) {
       this.marginTop = config.marginTop;
-      this.defaultMarginTop = config.marginTop;
     }
     if (config.marginBottom !== undefined) {
       this.marginBottom = config.marginBottom;
-      this.defaultMarginBottom = config.marginBottom;
     }
 
     if (this.name === 'land' && config.initialValue !== undefined) {
@@ -90,11 +84,24 @@ class Resource extends EffectableEntity {
     }
   }
 
-  // Reset display-related properties to their default values
+  // Reset display-related properties to defaults from planet parameters
   reinitializeDisplayElements() {
-    this.displayName = this.defaultDisplayName;
-    this.marginTop = this.defaultMarginTop;
-    this.marginBottom = this.defaultMarginBottom;
+    const defaultResource =
+      defaultPlanetParameters &&
+      defaultPlanetParameters.resources &&
+      defaultPlanetParameters.resources[this.category] &&
+      defaultPlanetParameters.resources[this.category][this.name];
+
+    if (defaultResource) {
+      this.displayName =
+        defaultResource.displayName || defaultResource.name || this.name;
+      this.marginTop = defaultResource.marginTop || 0;
+      this.marginBottom = defaultResource.marginBottom || 0;
+    } else {
+      this.displayName = this.displayName || this.name;
+      this.marginTop = this.marginTop || 0;
+      this.marginBottom = this.marginBottom || 0;
+    }
   }
 
   decrease(amount) {

--- a/tests/reinitializeDisplayElements.test.js
+++ b/tests/reinitializeDisplayElements.test.js
@@ -3,9 +3,23 @@ const path = require('path');
 const vm = require('vm');
 
 test('reinitializeDisplayElements restores default name and margins', () => {
-  const context = {};
-  const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
-  const resourceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resource.js'), 'utf8');
+  const context = {
+    defaultPlanetParameters: {
+      resources: {
+        colony: {
+          foo: { displayName: 'Foo', marginTop: 3, marginBottom: 4 },
+        },
+      },
+    },
+  };
+  const effectCode = fs.readFileSync(
+    path.join(__dirname, '..', 'src/js', 'effectable-entity.js'),
+    'utf8'
+  );
+  const resourceCode = fs.readFileSync(
+    path.join(__dirname, '..', 'src/js', 'resource.js'),
+    'utf8'
+  );
   vm.runInNewContext(effectCode, context);
   vm.runInNewContext(resourceCode + '\nthis.Resource = Resource;', context);
 
@@ -26,12 +40,17 @@ test('reinitializeDisplayElements restores default name and margins', () => {
   expect(res.marginTop).toBe(3);
   expect(res.marginBottom).toBe(4);
 
-  res.initializeFromConfig('foo', { displayName: 'Baz', marginTop: 1, marginBottom: 2 });
+  res.initializeFromConfig('foo', {
+    displayName: 'Baz',
+    marginTop: 1,
+    marginBottom: 2,
+  });
   res.displayName = 'Qux';
   res.marginTop = 7;
   res.marginBottom = 8;
   res.reinitializeDisplayElements();
-  expect(res.displayName).toBe('Baz');
-  expect(res.marginTop).toBe(1);
-  expect(res.marginBottom).toBe(2);
+  expect(res.displayName).toBe('Foo');
+  expect(res.marginTop).toBe(3);
+  expect(res.marginBottom).toBe(4);
 });
+


### PR DESCRIPTION
## Summary
- reset resource display name and margins using default planet parameters
- drop stored default attributes and adjust tests

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b600bd11648327a7adee1446d2a67c