### PR TITLE
Ensure integer android unassignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,3 +429,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added `reinitializeDisplayElements` to Resource for resetting default display names and margins after travel.
 - Resource `reinitializeDisplayElements` now pulls display defaults from `defaultPlanetParameters` instead of storing them on each resource.
 - Life growth rate tooltip now reflects ecumenopolis land coverage and shows land reduction percentage.
+- forceUnassignAndroids unassigns the ceiling of assigned androids minus effective capacity and only accepts integer counts.

--- a/src/js/population.js
+++ b/src/js/population.js
@@ -148,7 +148,8 @@ class PopulationModule extends EffectableEntity {
 
     if (typeof projectManager !== 'undefined' && typeof projectManager.forceUnassignAndroids === 'function') {
       if (assignedAndroids > effectiveAndroids) {
-        projectManager.forceUnassignAndroids(assignedAndroids - effectiveAndroids);
+        const toUnassign = Math.ceil(assignedAndroids - effectiveAndroids);
+        projectManager.forceUnassignAndroids(toUnassign);
         assignedAndroids = projectManager.getAssignedAndroids();
       }
     }

--- a/tests/forceUnassignAndroidsInteger.test.js
+++ b/tests/forceUnassignAndroidsInteger.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('forceUnassignAndroids ceiling enforcement', () => {
+  test('unassigns the ceiling of the over-cap difference using an integer', () => {
+    const ctx = { console, EffectableEntity };
+    ctx.resources = {
+      colony: {
+        colonists: { value: 10, cap: 100 },
+        workers: { value: 0, cap: 0 },
+        androids: { value: 3, cap: 10 }
+      }
+    };
+
+    const getAssignedAndroids = jest.fn();
+    getAssignedAndroids.mockReturnValueOnce(5).mockReturnValue(3);
+    const forceUnassignAndroids = jest.fn();
+    ctx.projectManager = { getAssignedAndroids, forceUnassignAndroids };
+
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'population.js'), 'utf8');
+    vm.runInContext(code + '; this.PopulationModule = PopulationModule;', ctx);
+    const module = new ctx.PopulationModule(ctx.resources, { workerRatio: 0.5 });
+
+    module.updateWorkerCap();
+
+    expect(forceUnassignAndroids).toHaveBeenCalledWith(2);
+    const arg = forceUnassignAndroids.mock.calls[0][0];
+    expect(Number.isInteger(arg)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Use the ceiling of the over-cap android difference to determine how many to unassign
- Align over-cap android test expectations and verify ceiling logic
- Document ceiling-based android unassignment in AGENTS notes

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b714cf053483278dc7cebddd229a88