### PR TITLE
Highlight building resource rate status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,3 +430,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource `reinitializeDisplayElements` now pulls display defaults from `defaultPlanetParameters` instead of storing them on each resource.
 - Life growth rate tooltip now reflects ecumenopolis land coverage and shows land reduction percentage.
 - forceUnassignAndroids unassigns the ceiling of assigned androids minus effective capacity and only accepts integer counts.
+- Building production and consumption displays color-code resources: green for production fixing deficits and red for costs that would cause deficits.

--- a/tests/buildingProdConsColor.test.js
+++ b/tests/buildingProdConsColor.test.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+// load structuresUI.js within a jsdom context
+const structuresUI = (() => {
+  const dom = new JSDOM('<!DOCTYPE html><div></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.formatNumber = n => n;
+  ctx.formatStorageDetails = () => '';
+  ctx.resources = {
+    colony: {
+      water: { displayName: 'Water', productionRate: 1, consumptionRate: 2 },
+      metal: { displayName: 'Metal', productionRate: 5, consumptionRate: 2 }
+    }
+  };
+  ctx.terraforming = { celestialParameters: {} };
+  ctx.Colony = class {};
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+  return ctx;
+})();
+
+describe('production/consumption color coding', () => {
+  test('negative net production turns green and projected negative consumption turns red', () => {
+    const structure = {
+      name: 'testStruct',
+      getModifiedStorage: () => ({}),
+      powerPerBuilding: null,
+      requiresMaintenance: false,
+      maintenanceCost: {},
+      getModifiedProduction: () => ({ colony: { water: 1 } }),
+      getModifiedConsumption: () => ({ colony: { metal: 2 } }),
+    };
+
+    const element = structuresUI.document.createElement('div');
+
+    // buildCount 1: metal remains positive, water negative
+    structuresUI.updateProductionConsumptionDetails(structure, element, 1);
+    const waterSpan = element._sections.production.spans.get('colony.water');
+    const metalSpan = element._sections.consumption.spans.get('colony.metal');
+    expect(waterSpan.style.color).toBe('green');
+    expect(metalSpan.style.color).toBe('');
+
+    // buildCount 2: metal would go negative
+    structuresUI.updateProductionConsumptionDetails(structure, element, 2);
+    expect(metalSpan.style.color).toBe('red');
+  });
+
+  test('consumption and maintenance combine to show deficit in red', () => {
+    const structure = {
+      name: 'consMaint',
+      getModifiedStorage: () => ({}),
+      powerPerBuilding: null,
+      requiresMaintenance: true,
+      maintenanceCost: { metal: 3 },
+      getModifiedProduction: () => ({}),
+      getModifiedConsumption: () => ({ colony: { metal: 2 } }),
+    };
+
+    const element = structuresUI.document.createElement('div');
+    structuresUI.resources.colony.metal.productionRate = 6;
+    structuresUI.resources.colony.metal.consumptionRate = 2; // net 4
+
+    structuresUI.updateProductionConsumptionDetails(structure, element, 1);
+    const consSpan = element._sections.consumption.spans.get('colony.metal');
+    const maintSpan = element._sections.maintenance.spans.get('colony.metal');
+    expect(consSpan.style.color).toBe('red');
+    expect(maintSpan.style.color).toBe('red');
+  });
+});
+


### PR DESCRIPTION
## Summary
- color-code building production green when resource net rate is negative
- flag consumption or maintenance red when combined cost would drive resource net rate below zero
- test production/consumption/maintenance color indicators

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b74a7b837c8327a5ac11494a914cad