### PR TITLE
Exclude zero-weight WGC events

### DIFF
--- a/src/js/wgc.js
+++ b/src/js/wgc.js
@@ -94,13 +94,14 @@ class WarpGateCommand extends EffectableEntity {
       }
       return e;
     });
-    const total = events.reduce((s, e) => s + (e.weight || 1), 0);
+    const weightedEvents = events.filter(e => (e.weight ?? 1) > 0);
+    const total = weightedEvents.reduce((s, e) => s + (e.weight ?? 1), 0);
     let r = Math.random() * total;
-    for (const ev of events) {
-      r -= ev.weight || 1;
+    for (const ev of weightedEvents) {
+      r -= ev.weight ?? 1;
       if (r < 0) return ev;
     }
-    return events[0];
+    return weightedEvents[0];
   }
 
   roll(dice) {

--- a/tests/wgcZeroWeightEvent.test.js
+++ b/tests/wgcZeroWeightEvent.test.js
@@ -1,0 +1,15 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { WarpGateCommand } = require('../src/js/wgc.js');
+
+describe('WGC zero weight event exclusion', () => {
+  test('Social Science challenge is excluded when weight is 0', () => {
+    const wgc = new WarpGateCommand();
+    wgc.stances[0].hazardousBiomass = 'Aggressive';
+    const originalRandom = Math.random;
+    Math.random = () => 0.6875;
+    const event = wgc.chooseEvent(0);
+    Math.random = originalRandom;
+    expect(event.name).toBe('Natural Science challenge');
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure WGC event selection filters out event types with zero weight instead of defaulting to one
- Add regression test confirming zero-weight events are never chosen

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68b8356a81a88327b480c69e5011f428