### PR TITLE
Fix space mirror auto checkbox initialization

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -782,6 +782,7 @@ function initializeMirrorOversightUI(container) {
   updateZonalFluxTable();
   // Build cache of frequently used nodes inside the oversight UI
   rebuildMirrorOversightCache();
+  updateMirrorOversightUI();
 }
 
 let mirrorOversightCache = null;
@@ -797,7 +798,7 @@ function rebuildMirrorOversightCache() {
     availableLanternCells: Array.from(document.querySelectorAll('.available-lantern-cell')),
     reversalHeader: document.querySelector('#assignment-grid .grid-header:nth-child(4)') || null,
     reversalCells: Array.from(document.querySelectorAll('#assignment-grid .grid-reversal-cell')),
-    autoAssignBoxes: Array.from(document.querySelectorAll('#assignment-table .auto-assign')),
+    autoAssignBoxes: Array.from(document.querySelectorAll('#assignment-grid .auto-assign')),
     assignmentControls: Array.from(document.querySelectorAll('#mirror-finer-content button, #mirror-finer-content input[type="checkbox"]:not(#mirror-use-finer)')),
     focusZoneCells: Array.from(document.querySelectorAll('#assignment-grid > div[data-zone="focus"]')),
     fluxTempHeader: document.querySelector('#mirror-flux-table thead tr th:nth-child(3)') || null,

--- a/tests/spaceMirrorAutoCheckboxLoad.test.js
+++ b/tests/spaceMirrorAutoCheckboxLoad.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('space mirror auto checkbox load', () => {
+  test('auto checkbox reflects loaded state', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.toDisplayTemperature = numbers.toDisplayTemperature;
+    ctx.getTemperatureUnit = numbers.getTemperatureUnit;
+    ctx.projectElements = {};
+    ctx.buildings = { spaceMirror: { active: 10 }, hyperionLantern: { active: 0, unlocked: false } };
+    ctx.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      calculateZoneSolarFlux: () => 0,
+      celestialParameters: { crossSectionArea: 100, surfaceArea: 100 },
+      temperature: { zones: { tropical: { value: 0 }, temperate: { value: 0 }, polar: { value: 0 } } }
+    };
+    ctx.projectManager = { isBooleanFlagSet: () => true };
+
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const mirrorCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMirrorFacilityProject.js'), 'utf8');
+    vm.runInContext(mirrorCode + '; this.SpaceMirrorFacilityProject = SpaceMirrorFacilityProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.spaceMirrorFacility;
+    const project = new ctx.SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    ctx.mirrorOversightSettings = project.mirrorOversightSettings;
+
+    const state = project.saveState();
+    state.mirrorOversightSettings.autoAssign.tropical = true;
+    project.loadState(state);
+    ctx.mirrorOversightSettings = project.mirrorOversightSettings;
+
+    const container = dom.window.document.getElementById('container');
+    project.renderUI(container);
+    ctx.projectElements = vm.runInContext('projectElements', ctx);
+    project.updateUI();
+
+    const autoBox = dom.window.document.querySelector('.auto-assign[data-zone="tropical"]');
+    expect(autoBox.checked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Initialize mirror oversight checkboxes, including auto-assign, after UI creation
- Fix auto-assign checkbox cache to target assignment grid
- Add regression test ensuring auto checkbox state loads from saves

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8c80d27008327b07c291244a43941