### PR TITLE
Allow decimal thresholds for GHG factory temperature control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,3 +435,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - forceUnassignAndroids unassigns the ceiling of assigned androids minus effective capacity and only accepts integer counts.
 - Building production and consumption displays color-code resources: green for production fixing deficits and red for costs that would cause deficits.
 - Resources with `marginTop` or `marginBottom` now show a thin separator line centered within that margin that only appears when the resource is visible.
+- GHG factory temperature disable controls now accept decimal values.

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -538,7 +538,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
     const tempInput = document.createElement('input');
     tempInput.type = 'number';
-    tempInput.step = 1;
+    tempInput.step = 0.1;
     tempInput.classList.add('ghg-temp-input');
     tempControl.appendChild(tempInput);
 
@@ -548,7 +548,7 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
     const tempInputB = document.createElement('input');
     tempInputB.type = 'number';
-    tempInputB.step = 1;
+    tempInputB.step = 0.1;
     tempInputB.classList.add('ghg-temp-input');
     tempControl.appendChild(tempInputB);
 

--- a/tests/ghgFactoryTemperatureInput.test.js
+++ b/tests/ghgFactoryTemperatureInput.test.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+function setup() {
+  const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.document = dom.window.document;
+  ctx.console = console;
+  ctx.gameSettings = { useCelsius: true };
+  ctx.formatNumber = n => n;
+  ctx.formatBigInteger = n => String(n);
+  ctx.formatBuildingCount = n => String(n);
+  ctx.multiplyByTen = n => n * 10;
+  ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
+  ctx.resources = { colony: { colonists: { value: 50 }, workers: { value: 0 } } };
+  ctx.globalEffects = { isBooleanFlagSet: () => false };
+  ctx.dayNightCycle = { isNight: () => false };
+  ctx.toDisplayTemperature = k => ctx.gameSettings.useCelsius ? k - 273.15 : k;
+  ctx.getTemperatureUnit = () => ctx.gameSettings.useCelsius ? '°C' : 'K';
+  ctx.formatResourceDetails = () => '';
+  ctx.formatStorageDetails = () => '';
+  ctx.updateColonyDetailsDisplay = () => {};
+  ctx.updateEmptyBuildingMessages = () => {};
+  ctx.updateBuildingDisplay = () => {};
+  ctx.adjustStructureActivation = () => {};
+  ctx.buildings = {};
+
+  const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+  vm.runInContext(factorySettings, ctx);
+
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+
+  const structure = {
+    name: 'ghgFactory',
+    displayName: 'GHG Factory',
+    canBeToggled: true,
+    count: 1,
+    active: 0,
+    unlocked: true,
+    isHidden: false,
+    obsolete: false,
+    requiresProductivity: false,
+    autoBuildEnabled: true,
+    autoBuildPercent: 0,
+    autoBuildPriority: false,
+    autoActiveEnabled: false,
+    getTotalWorkerNeed: () => 0,
+    getEffectiveWorkerMultiplier: () => 1,
+    getEffectiveCost: () => ({}),
+    canAfford: () => true,
+    canAffordLand: () => true,
+    requiresLand: 0,
+    landAffordCount: () => 10,
+    getModifiedStorage: () => ({}),
+    powerPerBuilding: null,
+    activeEffects: [],
+    getEffectiveProductionMultiplier: () => 1,
+    getModifiedProduction: () => ({}),
+    getModifiedConsumption: () => ({}),
+    requiresMaintenance: false,
+    maintenanceCost: {},
+    updateResourceStorage: () => {},
+    reversalAvailable: false,
+    isBooleanFlagSet: flag => flag === 'terraformingBureauFeature',
+  };
+
+  const row = ctx.createStructureRow(structure, () => {}, () => {}, false);
+  dom.window.document.body.appendChild(row);
+
+  return { dom, ctx };
+}
+
+describe('GHG factory temperature control', () => {
+  test('allows decimal thresholds', () => {
+    const { dom, ctx } = setup();
+    const inputs = dom.window.document.querySelectorAll('.ghg-temp-input');
+    const inputA = inputs[0];
+    const inputB = inputs[1];
+    expect(inputA.step).toBe('0.1');
+    expect(inputB.step).toBe('0.1');
+    inputA.value = '25.5';
+    inputA.dispatchEvent(new dom.window.Event('input'));
+    expect(ctx.ghgFactorySettings.disableTempThreshold).toBeCloseTo(298.65, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- Permit fractional values for GHG factory disable temperature settings
- Document decimal support in development notes
- Test GHG factory temperature control accepts decimals

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68b902ec698c8327a2b6c1311c5e9db4