### PR TITLE
Standardize project continuity handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Keep checks of the kind (typeof something === 'function') and if(resources && resources.special && resources.special.spaceships) to a minimum.  If the checks fail, the code fails and it is better to catch it than let it fail.
 - All UI elements should be cached and reused instead of using querySelector.
 - Story objectives can compare against a resource's cap by adding `checkCap: true`.
+- All project classes implement an `isContinuous()` method. The base implementation returns `false` while continuous projects override to return `true`.
 
 # Overview of code
 This repository contains a browser-based incremental game written in JavaScript. The

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -87,6 +87,10 @@ class Project extends EffectableEntity {
     }
   }
 
+  isContinuous() {
+    return false;
+  }
+
   // Method to calculate scaled cost if costScaling is enabled
   getScaledCost() {
     const cost = this.getEffectiveCost();
@@ -601,7 +605,6 @@ class ProjectManager extends EffectableEntity {
       project.update(deltaTime);
 
       if (
-        typeof project.isContinuous === 'function' &&
         project.isContinuous() &&
         !project.autoStart &&
         project.isActive

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -562,8 +562,7 @@ function updateProjectUI(projectName) {
     elements.autoStartCheckbox.checked = project.autoStart || false;
   }
   if (elements.autoStartLabel) {
-    const continuous =
-      typeof project.isContinuous === 'function' && project.isContinuous();
+    const continuous = project.isContinuous();
     elements.autoStartLabel.textContent = continuous ? 'Run' : 'Auto start';
   }
 
@@ -629,7 +628,6 @@ function updateProjectUI(projectName) {
       // Update the duration in the progress bar display
       if (elements.progressButton) {
         const isContinuousProject =
-          typeof project.isContinuous === 'function' &&
           project.isContinuous() &&
           ((typeof SpaceshipProject !== 'undefined' && project instanceof SpaceshipProject) ||
             (typeof CargoRocketProject !== 'undefined' && project instanceof CargoRocketProject));

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -554,7 +554,7 @@ function calculateProjectProductivities(resources, accumulatedChanges, projectDa
   const production = {};
   for (const name in projectData) {
     const project = projectData[name].project;
-    if (project && typeof project.isContinuous === 'function' && !project.isContinuous()) {
+    if (!project.isContinuous()) {
       continue;
     }
     const { cost = {}, gain = {} } = projectData[name];
@@ -601,7 +601,7 @@ function calculateProjectProductivities(resources, accumulatedChanges, projectDa
   const productivityMap = {};
   for (const name in projectData) {
     const { cost = {}, gain = {}, project } = projectData[name];
-    if (project && typeof project.isContinuous === 'function' && !project.isContinuous()) {
+    if (!project.isContinuous()) {
       continue;
     }
     let productivity = 1;

--- a/tests/automationSettingsCache.test.js
+++ b/tests/automationSettingsCache.test.js
@@ -42,6 +42,7 @@ describe('automation settings cache', () => {
       unlocked: true,
       attributes: {},
       assignedSpaceships: 0,
+      isContinuous: () => false,
       isShipOperationContinuous() { return false; }
     });
 

--- a/tests/dysonSwarmLockedProjectUI.test.js
+++ b/tests/dysonSwarmLockedProjectUI.test.js
@@ -39,6 +39,7 @@ describe('Dyson Swarm project visibility without tech', () => {
       maxRepeatCount: 1,
       autoStart: false,
       isActive: false,
+      isContinuous: () => false,
       getEffectiveCost: () => ({}),
       getScaledCost: () => ({}),
       getEffectiveDuration: () => 1000,

--- a/tests/projectAutoStartTooltip.test.js
+++ b/tests/projectAutoStartTooltip.test.js
@@ -24,6 +24,7 @@ describe('resource tooltip hides non-auto-start project rates', () => {
       isActive: true,
       isCompleted: false,
       autoStart: false,
+      isContinuous: () => true,
       estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
         const cost = { colony: { energy: 100 } };
         if (applyRates) {
@@ -52,6 +53,7 @@ describe('resource tooltip hides non-auto-start project rates', () => {
       isActive: true,
       isCompleted: false,
       autoStart: false,
+      isContinuous: () => true,
       estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
         const gain = { colony: { energy: 100 } };
         if (applyRates) {
@@ -80,6 +82,7 @@ describe('resource tooltip hides non-auto-start project rates', () => {
       isActive: true,
       isCompleted: false,
       autoStart: true,
+      isContinuous: () => true,
       estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
         const cost = { colony: { energy: 100 } };
         if (applyRates) {
@@ -108,6 +111,7 @@ describe('resource tooltip hides non-auto-start project rates', () => {
       isCompleted: false,
       autoStart: false,
       treatAsBuilding: true,
+      isContinuous: () => true,
       estimateCostAndGain(deltaTime = 1000, applyRates = true, productivity = 1) {
         const cost = { colony: { energy: 100 } };
         if (applyRates) {
@@ -136,6 +140,7 @@ describe('resource tooltip hides non-auto-start project rates', () => {
       isActive: true,
       isCompleted: false,
       autoStart: false,
+      isContinuous: () => true,
       estimateCostAndGain,
       applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
         accumulatedChanges.colony.energy -= 100 * productivity;

--- a/tests/projectIsContinuous.test.js
+++ b/tests/projectIsContinuous.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Project isContinuous default', () => {
+  test('returns false for base Project', () => {
+    const ctx = { console, EffectableEntity };
+    vm.createContext(ctx);
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(code + '; this.Project = Project;', ctx);
+    const config = {
+      name: 'Test',
+      cost: {},
+      duration: 1000,
+      description: '',
+      attributes: {},
+      repeatable: false,
+      unlocked: true,
+      category: 'test',
+    };
+    const project = new ctx.Project(config, 'test');
+    expect(typeof project.isContinuous).toBe('function');
+    expect(project.isContinuous()).toBe(false);
+  });
+});

--- a/tests/projectProductivityScaling.test.js
+++ b/tests/projectProductivityScaling.test.js
@@ -13,8 +13,8 @@ describe('project productivity', () => {
     const changes = { colony: { energy: 10, metal: 0 } };
 
     const projectData = {
-      A: { cost: { colony: { energy: 200, metal: 30 } }, gain: { colony: { metal: 10 } } },
-      B: { cost: {}, gain: { colony: { energy: 10 } } },
+      A: { project: { isContinuous: () => true }, cost: { colony: { energy: 200, metal: 30 } }, gain: { colony: { metal: 10 } } },
+      B: { project: { isContinuous: () => true }, cost: {}, gain: { colony: { energy: 10 } } },
     };
     const productivities = calculateProjectProductivities(resources, changes, projectData);
     expect(productivities.A).toBeCloseTo(110 / 200);

--- a/tests/projectReorderSkipInvisible.test.js
+++ b/tests/projectReorderSkipInvisible.test.js
@@ -35,7 +35,8 @@ describe('project reorder ignores invisible projects', () => {
       duration: 100,
       getEffectiveDuration() { return this.duration; },
       canStart() { return true; },
-      getProgress() { return 0; }
+      getProgress() { return 0; },
+      isContinuous() { return false; }
     });
 
     ctx.projectManager.projects = {

--- a/tests/projectReorderVisibleLocked.test.js
+++ b/tests/projectReorderVisibleLocked.test.js
@@ -35,7 +35,8 @@ describe('project reorder includes visible locked projects', () => {
       duration: 100,
       getEffectiveDuration() { return this.duration; },
       canStart() { return true; },
-      getProgress() { return 0; }
+      getProgress() { return 0; },
+      isContinuous() { return false; }
     });
 
     ctx.projectManager.projects = {

--- a/tests/spaceStorageAutomationRebuild.test.js
+++ b/tests/spaceStorageAutomationRebuild.test.js
@@ -43,6 +43,7 @@ describe('Space Storage automation UI recreation', () => {
       unlocked: true,
       attributes: {},
       assignedSpaceships: 0,
+      isContinuous: () => false,
       isShipOperationContinuous() { return this.assignedSpaceships > 100; }
     });
 

--- a/tests/spaceStorageAutomationSettings.test.js
+++ b/tests/spaceStorageAutomationSettings.test.js
@@ -42,6 +42,7 @@ describe('Space Storage automation settings', () => {
       unlocked: true,
       attributes: {},
       assignedSpaceships: 0,
+      isContinuous: () => false,
       isShipOperationContinuous() { return this.assignedSpaceships > 100; }
     });
 

--- a/tests/spaceStorageRunLabel.test.js
+++ b/tests/spaceStorageRunLabel.test.js
@@ -42,6 +42,7 @@ describe('Space Storage ship auto-start label', () => {
       unlocked: true,
       attributes: {},
       assignedSpaceships: 50,
+      isContinuous: () => false,
       isShipOperationContinuous() { return this.assignedSpaceships > 100; }
     });
 

--- a/tests/spaceshipProjectContinuous.test.js
+++ b/tests/spaceshipProjectContinuous.test.js
@@ -79,7 +79,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     const changes = createChanges(ctx.resources);
     changes.colony.energy = 200;
     const totals = project.estimateCostAndGain(duration / 2);
-    const prodMap = calculateProjectProductivities(ctx.resources, changes, { p: totals });
+    const prodMap = calculateProjectProductivities(ctx.resources, changes, { p: { ...totals, project } });
     const prod = prodMap.p;
     project.applyCostAndGain(duration / 2, changes, prod);
     expect(changes.colony.energy).toBeCloseTo(0);
@@ -127,7 +127,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.update(duration / 2);
     let changes = createChanges(ctx.resources);
     let totals = project.estimateCostAndGain(duration / 2);
-    let prod = calculateProjectProductivities(ctx.resources, changes, { p: totals }).p;
+    let prod = calculateProjectProductivities(ctx.resources, changes, { p: { ...totals, project } }).p;
     project.applyCostAndGain(duration / 2, changes, prod);
     applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.energy.value).toBeCloseTo(495);
@@ -174,7 +174,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.update(duration / 2);
     const changes = createChanges(ctx.resources);
     const totals = project.estimateCostAndGain(duration / 2, false);
-    const prod = calculateProjectProductivities(ctx.resources, changes, { p: totals }).p;
+    const prod = calculateProjectProductivities(ctx.resources, changes, { p: { ...totals, project } }).p;
     ctx.resources.colony.energy.modifyRate.mockClear();
     ctx.resources.colony.metal.modifyRate.mockClear();
     project.estimateCostAndGain(duration / 2, true, prod);
@@ -227,7 +227,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.update(duration / 2);
     let changes = createChanges(ctx.resources);
     let totals = project.estimateCostAndGain(duration / 2);
-    let prod = calculateProjectProductivities(ctx.resources, changes, { p: totals }).p;
+    let prod = calculateProjectProductivities(ctx.resources, changes, { p: { ...totals, project } }).p;
     project.applyCostAndGain(duration / 2, changes, prod);
     applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.energy.value).toBeCloseTo(990);
@@ -235,7 +235,7 @@ describe('SpaceshipProject continuous cost and gain', () => {
     project.update(duration / 2);
     changes = createChanges(ctx.resources);
     totals = project.estimateCostAndGain(duration / 2);
-    prod = calculateProjectProductivities(ctx.resources, changes, { p: totals }).p;
+    prod = calculateProjectProductivities(ctx.resources, changes, { p: { ...totals, project } }).p;
     project.applyCostAndGain(duration / 2, changes, prod);
     applyChanges(ctx.resources, changes);
     expect(ctx.resources.colony.metal.value).toBeCloseTo(20);

--- a/tests/treatAsBuildingProject.test.js
+++ b/tests/treatAsBuildingProject.test.js
@@ -64,6 +64,7 @@ describe('treatAsBuilding flag', () => {
     const normal = {
       estimateCostAndGain: jest.fn(() => ({ cost: {}, gain: {} })),
       applyCostAndGain: jest.fn(),
+      isContinuous: () => true,
     };
 
     ctx.projectManager.projects = { dyson, normal };


### PR DESCRIPTION
## Summary
- add default `isContinuous()` method to `Project` and rely on it throughout
- simplify UI and resource code by removing `typeof` guards
- cover project continuity with new and updated tests

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b9a69276848327a93ebd82ed7c86dd