### PR TITLE
Display Purchased for maxed Solis upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,3 +436,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resources with `marginTop` or `marginBottom` now show a thin separator line centered within that margin that only appears when the resource is visible.
 - GHG factory temperature disable controls now accept decimal values.
 - GHG factory temperature inputs no longer overwrite user edits while focused, enabling decimal adjustments.
+- Solis shop displays "Purchased" instead of a count when an upgrade reaches its maximum purchases.

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -88,15 +88,17 @@ function createShopItem(key) {
 
   const purchased = document.createElement('span');
   purchased.classList.add('solis-shop-item-count');
-  purchased.innerHTML = `Purchased: <span id="solis-shop-${key}-count">0</span>`;
+  purchased.textContent = 'Purchased: ';
+  const countSpan = document.createElement('span');
+  countSpan.id = `solis-shop-${key}-count`;
+  purchased.appendChild(countSpan);
   actions.appendChild(purchased);
 
   item.appendChild(actions);
 
   const costWrapper = label.querySelector('.solis-shop-item-cost');
   const costSpan = costWrapper.querySelector(`#solis-shop-${key}-cost`);
-  const countSpan = purchased.querySelector(`#solis-shop-${key}-count`);
-  const elementRecord = { button, cost: costSpan, costWrapper, count: countSpan, item };
+  const elementRecord = { button, cost: costSpan, costWrapper, count: countSpan, purchased, item };
 
   if (key === 'researchUpgrade') {
     const list = document.createElement('ul');
@@ -416,8 +418,16 @@ function updateSolisUI() {
     if (!el) continue;
     const up = solisManager.shopUpgrades[key];
     if (!up) continue;
-    if (el.count) el.count.textContent = up.purchases;
     const atMax = typeof up.max === 'number' && up.purchases >= up.max;
+    if (el.purchased && el.count) {
+      if (atMax) {
+        el.purchased.textContent = 'Purchased';
+      } else {
+        el.purchased.textContent = 'Purchased: ';
+        el.purchased.appendChild(el.count);
+        el.count.textContent = up.purchases;
+      }
+    }
     if (atMax) {
       if (el.button) el.button.classList.add('hidden');
       if (el.costWrapper) el.costWrapper.classList.add('hidden');

--- a/tests/solisShopMaxPurchaseUI.test.js
+++ b/tests/solisShopMaxPurchaseUI.test.js
@@ -7,7 +7,7 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 
 describe('solis shop max purchase UI', () => {
-  test('hides cost and button after max purchase', () => {
+  test('hides cost and button after max purchase and shows Purchased text', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
       <div id="solis-shop-items"></div>
       <div id="solis-donation-items"></div>
@@ -59,5 +59,14 @@ describe('solis shop max purchase UI', () => {
     const resCost = dom.window.document.getElementById('solis-shop-researchUpgrade-cost').parentElement;
     expect(resButton.classList.contains('hidden')).toBe(true);
     expect(resCost.classList.contains('hidden')).toBe(true);
+
+    const advPurchased = advButton.parentElement.querySelector('.solis-shop-item-count');
+    const resPurchased = resButton.parentElement.querySelector('.solis-shop-item-count');
+    const fundPurchased = dom.window.document
+      .getElementById('solis-shop-funding-button')
+      .parentElement.querySelector('.solis-shop-item-count');
+    expect(advPurchased.textContent).toBe('Purchased');
+    expect(resPurchased.textContent).toBe('Purchased');
+    expect(fundPurchased.textContent).toBe('Purchased: 0');
   });
 });


### PR DESCRIPTION
## Summary
- show "Purchased" instead of a count for maxed Solis shop upgrades
- test Solis shop purchased text after reaching max

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68ba27d5d3888327b3157204fd1f334b