### PR TITLE
Persist space storage assignment multiplier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,3 +437,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - GHG factory temperature disable controls now accept decimal values.
 - GHG factory temperature inputs no longer overwrite user edits while focused, enabling decimal adjustments.
 - Solis shop displays "Purchased" instead of a count when an upgrade reaches its maximum purchases.
+- Space storage ship assignment multiplier persists through save and load.

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -776,6 +776,7 @@ class SpaceshipProject extends Project {
       autoAssignSpaceships: this.autoAssignSpaceships,
       selectedDisposalResource: this.selectedDisposalResource,
       waitForCapacity: this.waitForCapacity,
+      assignmentMultiplier: this.assignmentMultiplier,
     };
   }
 
@@ -786,6 +787,9 @@ class SpaceshipProject extends Project {
     this.selectedDisposalResource = state.selectedDisposalResource || this.attributes.defaultDisposal;
     if (state.waitForCapacity !== undefined) {
       this.waitForCapacity = state.waitForCapacity;
+    }
+    if (state.assignmentMultiplier !== undefined) {
+      this.assignmentMultiplier = state.assignmentMultiplier;
     }
   }
 }

--- a/tests/spaceStorageAssignmentMultiplierSave.test.js
+++ b/tests/spaceStorageAssignmentMultiplierSave.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('space storage assignment multiplier persistence', () => {
+  test('assignment multiplier persists through save and load', () => {
+    const ctx = {
+      console,
+      EffectableEntity: require('../src/js/effectable-entity.js'),
+      resources: { special: { spaceships: { value: 0 } } },
+      buildings: {},
+      colonies: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false,
+      spaceManager: {
+        getTerraformedPlanetCount: () => 1,
+        getTerraformedPlanetCountIncludingCurrent: () => 1,
+      },
+      projectManager: { durationMultiplier: 1 },
+      formatNumber: numbers.formatNumber,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(
+      'function capitalizeFirstLetter(s){ return s.charAt(0).toUpperCase() + s.slice(1); }',
+      ctx
+    );
+    const projectsCode = fs.readFileSync(
+      path.join(__dirname, '..', 'src/js', 'projects.js'),
+      'utf8'
+    );
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const shipCode = fs.readFileSync(
+      path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js'),
+      'utf8'
+    );
+    vm.runInContext(shipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const storageCode = fs.readFileSync(
+      path.join(__dirname, '..', 'src/js/projects', 'SpaceStorageProject.js'),
+      'utf8'
+    );
+    vm.runInContext(storageCode + '; this.SpaceStorageProject = SpaceStorageProject;', ctx);
+
+    const params = {
+      name: 'spaceStorage',
+      category: 'mega',
+      cost: {},
+      duration: 300000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        costPerShip: { colony: { energy: 1 } },
+        transportPerShip: 1,
+      },
+    };
+    const project = new ctx.SpaceStorageProject(params, 'spaceStorage');
+    project.assignmentMultiplier = 1000;
+    const saved = project.saveState();
+    const loaded = new ctx.SpaceStorageProject(params, 'spaceStorage');
+    loaded.loadState(saved);
+    expect(loaded.assignmentMultiplier).toBe(1000);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Save and restore the ship assignment multiplier so space storage's x10 and /10 settings persist after loading a save
- Document persistence of the space storage ship assignment multiplier

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bb1a620fe483279842341ed02e0d62