### PR TITLE
Use orange for building deficit display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,7 +432,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource `reinitializeDisplayElements` now pulls display defaults from `defaultPlanetParameters` instead of storing them on each resource.
 - Life growth rate tooltip now reflects ecumenopolis land coverage and shows land reduction percentage.
 - forceUnassignAndroids unassigns the ceiling of assigned androids minus effective capacity and only accepts integer counts.
-- Building production and consumption displays color-code resources: green for production fixing deficits and red for costs that would cause deficits.
+- Building production and consumption displays color-code resources: green for production fixing deficits and orange for costs that would cause deficits.
 - Resources with `marginTop` or `marginBottom` now show a thin separator line centered within that margin that only appears when the resource is visible.
 - GHG factory temperature disable controls now accept decimal values.
 - GHG factory temperature inputs no longer overwrite user edits while focused, enabling decimal adjustments.

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -1220,7 +1220,7 @@ function updateDecreaseButtonText(button, buildCount) {
             } else if (sec.key === 'consumption' || sec.key === 'maintenance') {
               const totalCost = combinedCosts[`${category}.${resource}`] || amount;
               const projectedNet = netRate - totalCost;
-              span.style.color = projectedNet < 0 ? 'red' : '';
+              span.style.color = projectedNet < 0 ? 'orange' : '';
             } else {
               span.style.color = '';
             }

--- a/tests/buildingProdConsColor.test.js
+++ b/tests/buildingProdConsColor.test.js
@@ -24,7 +24,7 @@ const structuresUI = (() => {
 })();
 
 describe('production/consumption color coding', () => {
-  test('negative net production turns green and projected negative consumption turns red', () => {
+  test('negative net production turns green and projected negative consumption turns orange', () => {
     const structure = {
       name: 'testStruct',
       getModifiedStorage: () => ({}),
@@ -46,10 +46,10 @@ describe('production/consumption color coding', () => {
 
     // buildCount 2: metal would go negative
     structuresUI.updateProductionConsumptionDetails(structure, element, 2);
-    expect(metalSpan.style.color).toBe('red');
+    expect(metalSpan.style.color).toBe('orange');
   });
 
-  test('consumption and maintenance combine to show deficit in red', () => {
+  test('consumption and maintenance combine to show deficit in orange', () => {
     const structure = {
       name: 'consMaint',
       getModifiedStorage: () => ({}),
@@ -67,8 +67,8 @@ describe('production/consumption color coding', () => {
     structuresUI.updateProductionConsumptionDetails(structure, element, 1);
     const consSpan = element._sections.consumption.spans.get('colony.metal');
     const maintSpan = element._sections.maintenance.spans.get('colony.metal');
-    expect(consSpan.style.color).toBe('red');
-    expect(maintSpan.style.color).toBe('red');
+    expect(consSpan.style.color).toBe('orange');
+    expect(maintSpan.style.color).toBe('orange');
   });
 });
 


### PR DESCRIPTION
## Summary
- Change structure consumption/maintenance deficit color from red to orange
- Update tests for new orange deficit behavior
- Document new color behavior in AGENTS

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb1b85f7948327a44c683dcc19d1ae