### PR TITLE
Adjust cargo rocket increment controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,3 +439,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Solis shop displays "Purchased" instead of a count when an upgrade reaches its maximum purchases.
 - Cargo rocket project resource selection now uses 0/-1/+1,/10,x10 controls for consistency.
 - Space storage ship assignment multiplier persists through save and load.
+- Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -97,23 +97,30 @@ class CargoRocketProject extends Project {
           quantityInput.value = 0;
         });
 
-        createButton('-1', () => {
+        let increment = 1;
+
+        const minusButton = createButton(`-${formatNumber(increment, true)}`, () => {
           const current = parseInt(quantityInput.value, 10) || 0;
-          quantityInput.value = Math.max(0, current - 1);
+          quantityInput.value = Math.max(0, current - increment);
         });
 
-        createButton('+1', () => {
-          quantityInput.value = (parseInt(quantityInput.value, 10) || 0) + 1;
+        const plusButton = createButton(`+${formatNumber(increment, true)}`, () => {
+          quantityInput.value = (parseInt(quantityInput.value, 10) || 0) + increment;
         });
+
+        const updateIncrementButtons = () => {
+          minusButton.textContent = `-${formatNumber(increment, true)}`;
+          plusButton.textContent = `+${formatNumber(increment, true)}`;
+        };
 
         createButton('/10', () => {
-          const current = parseInt(quantityInput.value, 10) || 0;
-          quantityInput.value = Math.floor(current / 10);
+          increment = Math.max(1, Math.floor(increment / 10));
+          updateIncrementButtons();
         });
 
         createButton('x10', () => {
-          const current = parseInt(quantityInput.value, 10) || 0;
-          quantityInput.value = current * 10;
+          increment *= 10;
+          updateIncrementButtons();
         });
 
         resourceRow.appendChild(buttonsContainer);

--- a/tests/cargoRocketButtons.test.js
+++ b/tests/cargoRocketButtons.test.js
@@ -5,7 +5,7 @@ const vm = require('vm');
 const numbers = require('../src/js/numbers.js');
 
 describe('Cargo rocket quantity buttons', () => {
-  test('adjust resource input values', () => {
+  test('quantity buttons use adjustable increment', () => {
     const dom = new JSDOM(`<!DOCTYPE html><div class="projects-subtab-content-wrapper"><div id="resources-projects-list" class="projects-list"></div></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.document = dom.window.document;
@@ -75,12 +75,18 @@ describe('Cargo rocket quantity buttons', () => {
     plusBtn.click();
     expect(input.value).toBe('6');
 
-    input.value = 50;
-    divBtn.click();
-    expect(input.value).toBe('5');
-
-    input.value = 7;
+    input.value = '5';
     mulBtn.click();
-    expect(input.value).toBe('70');
+    expect(input.value).toBe('5');
+    expect(minusBtn.textContent).toBe('-10');
+    expect(plusBtn.textContent).toBe('+10');
+    plusBtn.click();
+    expect(input.value).toBe('15');
+
+    divBtn.click();
+    expect(minusBtn.textContent).toBe('-1');
+    expect(plusBtn.textContent).toBe('+1');
+    minusBtn.click();
+    expect(input.value).toBe('14');
   });
 });


### PR DESCRIPTION
## Summary
- Make cargo rocket x10 and /10 buttons modify the increment used by the ± buttons instead of the current quantity
- Update cargo rocket button tests to cover new increment behavior
- Document cargo rocket increment change in project notes

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bb1de122f0832789b14f8e42a42c9d