### PR TITLE
Move cargo rocket increment controls to header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,3 +440,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket project resource selection now uses 0/-1/+1,/10,x10 controls for consistency.
 - Space storage ship assignment multiplier persists through save and load.
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
+- Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -21,16 +21,60 @@ class CargoRocketProject extends Project {
       ...projectElements[this.name],
       selectionInputs: [],
       priceSpans: [],
+      minusButtons: [],
+      plusButtons: [],
+      increment: 1,
+    };
+
+    const updateIncrementButtons = () => {
+      elements.minusButtons.forEach((btn) => {
+        btn.textContent = `-${formatNumber(elements.increment, true)}`;
+      });
+      elements.plusButtons.forEach((btn) => {
+        btn.textContent = `+${formatNumber(elements.increment, true)}`;
+      });
     };
 
     const headerRow = document.createElement('div');
     headerRow.classList.add('cargo-resource-row', 'cargo-grid-header');
-    headerRow.innerHTML = `
-        <span>Resource</span>
-        <span>Amount</span>
-        <span>Price (Funding)</span>
-        <span></span>
-    `;
+
+    const resourceHeader = document.createElement('span');
+    resourceHeader.textContent = 'Resource';
+    headerRow.appendChild(resourceHeader);
+
+    const amountHeader = document.createElement('span');
+    amountHeader.textContent = 'Amount';
+    headerRow.appendChild(amountHeader);
+
+    const priceHeader = document.createElement('span');
+    priceHeader.textContent = 'Price (Funding)';
+    headerRow.appendChild(priceHeader);
+
+    const headerButtons = document.createElement('div');
+    headerButtons.classList.add('cargo-buttons-container');
+    headerRow.appendChild(headerButtons);
+
+    const createHeaderButton = (text, onClick) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.classList.add('increment-button');
+      button.textContent = text;
+      button.addEventListener('click', () => {
+        onClick();
+        updateIncrementButtons();
+      });
+      headerButtons.appendChild(button);
+      return button;
+    };
+
+    createHeaderButton('/10', () => {
+      elements.increment = Math.max(1, Math.floor(elements.increment / 10));
+    });
+
+    createHeaderButton('x10', () => {
+      elements.increment *= 10;
+    });
+
     selectionGrid.appendChild(headerRow);
 
     for (const category in this.attributes.resourceChoiceGainCost) {
@@ -97,36 +141,23 @@ class CargoRocketProject extends Project {
           quantityInput.value = 0;
         });
 
-        let increment = 1;
-
-        const minusButton = createButton(`-${formatNumber(increment, true)}`, () => {
+        const minusButton = createButton(`-${formatNumber(elements.increment, true)}`, () => {
           const current = parseInt(quantityInput.value, 10) || 0;
-          quantityInput.value = Math.max(0, current - increment);
+          quantityInput.value = Math.max(0, current - elements.increment);
         });
 
-        const plusButton = createButton(`+${formatNumber(increment, true)}`, () => {
-          quantityInput.value = (parseInt(quantityInput.value, 10) || 0) + increment;
+        const plusButton = createButton(`+${formatNumber(elements.increment, true)}`, () => {
+          quantityInput.value = (parseInt(quantityInput.value, 10) || 0) + elements.increment;
         });
 
-        const updateIncrementButtons = () => {
-          minusButton.textContent = `-${formatNumber(increment, true)}`;
-          plusButton.textContent = `+${formatNumber(increment, true)}`;
-        };
-
-        createButton('/10', () => {
-          increment = Math.max(1, Math.floor(increment / 10));
-          updateIncrementButtons();
-        });
-
-        createButton('x10', () => {
-          increment *= 10;
-          updateIncrementButtons();
-        });
+        elements.minusButtons.push(minusButton);
+        elements.plusButtons.push(plusButton);
 
         resourceRow.appendChild(buttonsContainer);
         selectionGrid.appendChild(resourceRow);
       }
     }
+    updateIncrementButtons();
     sectionContainer.appendChild(selectionGrid);
     container.appendChild(sectionContainer);
   }

--- a/tests/cargoRocketButtons.test.js
+++ b/tests/cargoRocketButtons.test.js
@@ -54,10 +54,11 @@ describe('Cargo rocket quantity buttons', () => {
     const input = row.querySelector('input');
     const buttons = Array.from(row.querySelectorAll('button'));
     const zeroBtn = buttons.find(b => b.textContent === '0');
-    const minusBtn = buttons.find(b => b.textContent === '-1');
-    const plusBtn = buttons.find(b => b.textContent === '+1');
-    const divBtn = buttons.find(b => b.textContent === '/10');
-    const mulBtn = buttons.find(b => b.textContent === 'x10');
+    const minusBtn = buttons.find(b => b.textContent.startsWith('-'));
+    const plusBtn = buttons.find(b => b.textContent.startsWith('+'));
+    const headerButtons = Array.from(elements.resourceSelectionContainer.querySelector('.cargo-grid-header').querySelectorAll('button'));
+    const divBtn = headerButtons.find(b => b.textContent === '/10');
+    const mulBtn = headerButtons.find(b => b.textContent === 'x10');
 
     input.value = 5;
     zeroBtn.click();


### PR DESCRIPTION
## Summary
- Make cargo rocket x10 and /10 buttons global and place them in the selection grid header
- Update cargo rocket quantity button test for global increment controls
- Document cargo rocket global increment buttons in AGENTS instructions

## Testing
- `npm ci --no-audit --no-fund`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bb1f8c7384832780d432cba88cf729