### PR TITLE
feat: add Mechanical Assistance research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,4 +441,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket project resource selection now uses 0/-1/+1,/10,x10 controls for consistency.
 - Space storage ship assignment multiplier persists through save and load.
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
+- Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders.
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1462,6 +1462,21 @@ const researchParameters = {
         ]
       },
       {
+        id: 'mechanical_assistance',
+        name: 'Mechanical Assistance',
+        description: 'Placeholder description.',
+        cost: { advancedResearch: 175000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'colonySliders',
+            type: 'booleanFlag',
+            flagId: 'mechanicalAssistance',
+            value: true
+          }
+        ]
+      },
+      {
         id: 'self_replicating_ships_concept',
         name: 'Self Replicating Ships',
         description: 'Opens research into autonomous self-building spacecraft.',

--- a/tests/mechanicalAssistanceResearch.test.js
+++ b/tests/mechanicalAssistanceResearch.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Mechanical Assistance research', () => {
+  test('exists in advanced research with colony slider flag effect', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const adv = ctx.researchParameters.advanced;
+    const research = adv.find(r => r.id === 'mechanical_assistance');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(175000);
+    const flag = research.effects.find(e => e.target === 'colonySliders' && e.type === 'booleanFlag' && e.flagId === 'mechanicalAssistance' && e.value === true);
+    expect(flag).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add Mechanical Assistance advanced research costing 175k points
- flag colony sliders with `mechanicalAssistance`
- test coverage for new research

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bb84207560832788c7d0de90b9bad5