### PR TITLE
feat: add mechanical assistance colony slider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,6 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket project resource selection now uses 0/-1/+1,/10,x10 controls for consistency.
 - Space storage ship assignment multiplier persists through save and load.
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
-- Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders.
+- Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders and unlocking a "Mechanical Assistance" slider ranging from 0 to 2 in 0.2 steps.
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.

--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -7,6 +7,7 @@ class ColonySlidersManager extends EffectableEntity {
     this.foodConsumption = 1;
     this.luxuryWater = 1;
     this.oreMineWorkers = 0;
+    this.mechanicalAssistance = 0;
   }
 
   setWorkforceRatio(value) {
@@ -171,11 +172,38 @@ class ColonySlidersManager extends EffectableEntity {
     }
   }
 
+  setMechanicalAssistance(value) {
+    value = Math.min(2, Math.max(0, value));
+    this.mechanicalAssistance = value;
+
+    if (typeof document !== 'undefined') {
+      const input = document.getElementById('mechanical-assistance-slider');
+      if (input) input.value = value.toString();
+      const valueSpan = document.getElementById('mechanical-assistance-slider-value');
+      const effectSpan = document.getElementById('mechanical-assistance-slider-effect');
+      if (valueSpan && effectSpan) {
+        valueSpan.textContent = `${value.toFixed(1)}x`;
+        effectSpan.textContent = '';
+      }
+    }
+  }
+
+  applyBooleanFlag(effect) {
+    super.applyBooleanFlag(effect);
+    if (effect.flagId === 'mechanicalAssistance' && typeof document !== 'undefined') {
+      const row = document.getElementById('mechanical-assistance-row');
+      if (row) {
+        row.classList.toggle('invisible', !effect.value);
+      }
+    }
+  }
+
   reset() {
     this.setWorkforceRatio(0.5);
     this.setFoodConsumptionMultiplier(1);
     this.setLuxuryWaterMultiplier(1);
     this.setOreMineWorkerAssist(0);
+    this.setMechanicalAssistance(0);
   }
 }
 
@@ -199,6 +227,10 @@ function setOreMineWorkerAssist(value) {
   colonySliderSettings.setOreMineWorkerAssist(value);
 }
 
+function setMechanicalAssistance(value) {
+  colonySliderSettings.setMechanicalAssistance(value);
+}
+
 function resetColonySliders() {
   colonySliderSettings.reset();
 }
@@ -211,6 +243,7 @@ if (typeof module !== 'undefined' && module.exports) {
     setFoodConsumptionMultiplier,
     setLuxuryWaterMultiplier,
     setOreMineWorkerAssist,
+    setMechanicalAssistance,
     resetColonySliders
   };
 }

--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -301,6 +301,61 @@ function initializeColonySlidersUI() {
   container.appendChild(oreList);
   body.appendChild(oreRow);
 
+  // Mechanical assistance slider
+  const mechRow = document.createElement('div');
+  mechRow.classList.add('colony-slider');
+  mechRow.id = 'mechanical-assistance-row';
+  const mechLabel = document.createElement('label');
+  mechLabel.htmlFor = 'mechanical-assistance-slider';
+  mechLabel.textContent = 'Mechanical Assistance';
+  mechRow.appendChild(mechLabel);
+
+  const mechValue = document.createElement('span');
+  mechValue.id = 'mechanical-assistance-slider-value';
+  mechValue.classList.add('slider-value');
+  mechRow.appendChild(mechValue);
+
+  const mechInput = document.createElement('input');
+  mechInput.type = 'range';
+  mechInput.min = 0;
+  mechInput.max = 2;
+  mechInput.step = 0.2;
+  mechInput.id = 'mechanical-assistance-slider';
+  mechInput.value = colonySliderSettings.mechanicalAssistance;
+  mechInput.setAttribute('list', 'mechanical-assistance-slider-ticks');
+  mechInput.classList.add('pretty-slider');
+
+  const mechSliderContainer = document.createElement('div');
+  mechSliderContainer.classList.add('slider-container');
+  mechSliderContainer.appendChild(mechInput);
+
+  const mechTickMarks = document.createElement('div');
+  mechTickMarks.classList.add('tick-marks');
+  for (let i = 0; i <= 2; i += 0.2) {
+    const tick = document.createElement('span');
+    mechTickMarks.appendChild(tick);
+  }
+  mechSliderContainer.appendChild(mechTickMarks);
+  mechRow.appendChild(mechSliderContainer);
+
+  const mechEffect = document.createElement('span');
+  mechEffect.id = 'mechanical-assistance-slider-effect';
+  mechEffect.classList.add('slider-effect');
+  mechRow.appendChild(mechEffect);
+
+  const mechList = document.createElement('datalist');
+  mechList.id = 'mechanical-assistance-slider-ticks';
+  for (let i = 0; i <= 2; i += 0.2) {
+    const option = document.createElement('option');
+    option.value = i.toFixed(1);
+    mechList.appendChild(option);
+  }
+  container.appendChild(mechList);
+  if (!colonySliderSettings.isBooleanFlagSet('mechanicalAssistance')) {
+    mechRow.classList.add('invisible');
+  }
+  body.appendChild(mechRow);
+
   card.appendChild(body);
   container.appendChild(card);
 
@@ -329,6 +384,30 @@ function initializeColonySlidersUI() {
     try { v = parseFloat(oreInput.value); } catch (e) { v = NaN; }
     if (isNaN(v)) v = colonySliderSettings.oreMineWorkers;
     setOreMineWorkerAssist(v);
+  });
+
+  const updateMechanicalValue = (val) => {
+    if (mechValue && mechEffect) {
+      mechValue.textContent = `${val.toFixed(1)}x`;
+      mechEffect.textContent = '';
+    }
+  };
+
+  let initialMech;
+  try { initialMech = parseFloat(mechInput.value); } catch (e) { initialMech = NaN; }
+  if (isNaN(initialMech)) initialMech = colonySliderSettings.mechanicalAssistance;
+  updateMechanicalValue(initialMech);
+  mechInput.addEventListener('input', () => {
+    let v;
+    try { v = parseFloat(mechInput.value); } catch (e) { v = NaN; }
+    if (isNaN(v)) v = colonySliderSettings.mechanicalAssistance;
+    updateMechanicalValue(v);
+  });
+  mechInput.addEventListener('change', () => {
+    let v;
+    try { v = parseFloat(mechInput.value); } catch (e) { v = NaN; }
+    if (isNaN(v)) v = colonySliderSettings.mechanicalAssistance;
+    setMechanicalAssistance(v);
   });
 }
 

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -377,6 +377,7 @@ function loadGame(slotOrCustomString) {
       setFoodConsumptionMultiplier(colonySliderSettings.foodConsumption);
       setLuxuryWaterMultiplier(colonySliderSettings.luxuryWater);
       setOreMineWorkerAssist(colonySliderSettings.oreMineWorkers);
+      setMechanicalAssistance(colonySliderSettings.mechanicalAssistance);
     }
 
     if(gameState.ghgFactorySettings){

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -5,6 +5,7 @@ const {
   setFoodConsumptionMultiplier,
   setLuxuryWaterMultiplier,
   setOreMineWorkerAssist,
+  setMechanicalAssistance,
   resetColonySliders,
   colonySliderSettings,
   ColonySlidersManager
@@ -113,16 +114,29 @@ describe('colony sliders', () => {
     }));
   });
 
+  test('setMechanicalAssistance stores value and clamps', () => {
+    addEffect.mockClear();
+    setMechanicalAssistance(1.2);
+    expect(colonySliderSettings.mechanicalAssistance).toBeCloseTo(1.2);
+    setMechanicalAssistance(-1);
+    expect(colonySliderSettings.mechanicalAssistance).toBe(0);
+    setMechanicalAssistance(5);
+    expect(colonySliderSettings.mechanicalAssistance).toBe(2);
+    expect(addEffect).not.toHaveBeenCalled();
+  });
+
   test('resetColonySliders resets to default', () => {
     colonySliderSettings.workerRatio = 0.7;
     colonySliderSettings.foodConsumption = 2;
     colonySliderSettings.luxuryWater = 3;
     colonySliderSettings.oreMineWorkers = 5;
+    colonySliderSettings.mechanicalAssistance = 1;
     resetColonySliders();
     expect(colonySliderSettings.workerRatio).toBe(0.5);
     expect(colonySliderSettings.foodConsumption).toBe(1);
     expect(colonySliderSettings.luxuryWater).toBe(1);
     expect(colonySliderSettings.oreMineWorkers).toBe(0);
+    expect(colonySliderSettings.mechanicalAssistance).toBe(0);
   });
 
   test('initializeColonySlidersUI sets default text values', () => {
@@ -135,7 +149,14 @@ describe('colony sliders', () => {
     const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>` , { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.EffectableEntity = EffectableEntity;
-    ctx.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 };
+    ctx.colonySliderSettings = {
+      workerRatio: 0.5,
+      foodConsumption: 1,
+      luxuryWater: 1,
+      oreMineWorkers: 0,
+      mechanicalAssistance: 0,
+      isBooleanFlagSet: (flag) => flag === 'mechanicalAssistance'
+    };
     const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
     vm.runInContext(logicCode, ctx);
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
@@ -148,12 +169,16 @@ describe('colony sliders', () => {
     const waterEffect = dom.window.document.getElementById('water-slider-effect').textContent;
     const oreWorkers = dom.window.document.getElementById('ore-worker-slider-value').textContent;
     const oreBoost = dom.window.document.getElementById('ore-worker-slider-effect').textContent;
+    const mechVal = dom.window.document.getElementById('mechanical-assistance-slider-value').textContent;
+    const mechEffect = dom.window.document.getElementById('mechanical-assistance-slider-effect').textContent;
     expect(worker).toBe('Workers: 50%');
     expect(scientist).toBe('Scientists: 50%');
     expect(foodEffect).toBe('Growth: +0.0%');
     expect(waterEffect).toBe('Growth: +0.0%');
     expect(oreWorkers).toBe('0');
     expect(oreBoost).toBe('Boost: 0%');
+    expect(mechVal).toBe('0.0x');
+    expect(mechEffect).toBe('');
   });
 
   test('initializeColonySlidersUI keeps container hidden', () => {
@@ -166,7 +191,14 @@ describe('colony sliders', () => {
     const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.EffectableEntity = EffectableEntity;
-    ctx.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 };
+    ctx.colonySliderSettings = {
+      workerRatio: 0.5,
+      foodConsumption: 1,
+      luxuryWater: 1,
+      oreMineWorkers: 0,
+      mechanicalAssistance: 0,
+      isBooleanFlagSet: () => false
+    };
     const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
     vm.runInContext(logicCode, ctx);
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
@@ -187,7 +219,14 @@ describe('colony sliders', () => {
     const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.EffectableEntity = EffectableEntity;
-    ctx.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 };
+    ctx.colonySliderSettings = {
+      workerRatio: 0.5,
+      foodConsumption: 1,
+      luxuryWater: 1,
+      oreMineWorkers: 0,
+      mechanicalAssistance: 0,
+      isBooleanFlagSet: () => false
+    };
     const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
     vm.runInContext(logicCode, ctx);
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
@@ -213,7 +252,14 @@ describe('colony sliders', () => {
     const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.EffectableEntity = EffectableEntity;
-    ctx.colonySliderSettings = { workerRatio: 0.5, foodConsumption: 1, luxuryWater: 1, oreMineWorkers: 0 };
+    ctx.colonySliderSettings = {
+      workerRatio: 0.5,
+      foodConsumption: 1,
+      luxuryWater: 1,
+      oreMineWorkers: 0,
+      mechanicalAssistance: 0,
+      isBooleanFlagSet: (flag) => flag === 'mechanicalAssistance'
+    };
     ctx.addEffect = jest.fn();
     const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
     vm.runInContext(logicCode, ctx);
@@ -225,6 +271,7 @@ describe('colony sliders', () => {
     ctx.setFoodConsumptionMultiplier(2);
     ctx.setLuxuryWaterMultiplier(3);
     ctx.setOreMineWorkerAssist(4);
+    ctx.setMechanicalAssistance(1.2);
 
     const worker = dom.window.document.getElementById('workforce-slider-value').textContent;
     const scientist = dom.window.document.getElementById('workforce-slider-effect').textContent;
@@ -234,6 +281,8 @@ describe('colony sliders', () => {
     const waterEffect = dom.window.document.getElementById('water-slider-effect').textContent;
     const oreWorkers = dom.window.document.getElementById('ore-worker-slider-value').textContent;
     const oreBoost = dom.window.document.getElementById('ore-worker-slider-effect').textContent;
+    const mechVal = dom.window.document.getElementById('mechanical-assistance-slider-value').textContent;
+    const mechEffect = dom.window.document.getElementById('mechanical-assistance-slider-effect').textContent;
 
     expect(worker).toBe('Workers: 70%');
     expect(scientist).toBe('Scientists: 30%');
@@ -243,5 +292,32 @@ describe('colony sliders', () => {
     expect(waterEffect).toBe('Growth: +2.0%');
     expect(oreWorkers).toBe('40');
     expect(oreBoost).toBe('Boost: 400%');
+    expect(mechVal).toBe('1.2x');
+    expect(mechEffect).toBe('');
+  });
+
+  test('mechanical assistance slider visibility toggles with flag', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+    const { JSDOM } = require(jsdomPath);
+    const vm = require('vm');
+
+    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>` , { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
+    vm.runInContext(logicCode, ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+
+    ctx.initializeColonySlidersUI();
+    let row = dom.window.document.getElementById('mechanical-assistance-row');
+    expect(row.classList.contains('invisible')).toBe(true);
+
+    ctx.colonySliderSettings.sortAllResearches = () => {};
+    ctx.colonySliderSettings.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
+    row = dom.window.document.getElementById('mechanical-assistance-row');
+    expect(row.classList.contains('invisible')).toBe(false);
   });
 });

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -58,7 +58,14 @@ test('initializeGameState resets colony sliders to defaults', () => {
 
   const ctx = dom.getInternalVMContext();
   ctx.structuredClone = structuredClone;
-  ctx.colonySliderSettings = { workerRatio: 0.7, foodConsumption: 2, luxuryWater: 3, oreMineWorkers: 5 };
+  ctx.colonySliderSettings = {
+    workerRatio: 0.7,
+    foodConsumption: 2,
+    luxuryWater: 3,
+    oreMineWorkers: 5,
+    mechanicalAssistance: 1,
+    isBooleanFlagSet: () => false
+  };
 
   const errors = [];
   for (const src of sources) {
@@ -105,6 +112,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
   expect(settings.foodConsumption).toBe(1);
   expect(settings.luxuryWater).toBe(1);
   expect(settings.oreMineWorkers).toBe(0);
+  expect(settings.mechanicalAssistance).toBe(0);
   expect(oversight).toEqual({
     distribution: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0 },
     applyToLantern: false,


### PR DESCRIPTION
## Summary
- expose Mechanical Assistance colony slider unlocked by advanced research flag
- persist and reset slider value alongside other colony sliders
- display Mechanical Assistance control when flag is active

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb85f9bf88832789463f557af571f4