### PR TITLE
Display mechanical assistance slider only when unlocked

### DIFF
--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -193,7 +193,8 @@ class ColonySlidersManager extends EffectableEntity {
     if (effect.flagId === 'mechanicalAssistance' && typeof document !== 'undefined') {
       const row = document.getElementById('mechanical-assistance-row');
       if (row) {
-        row.classList.toggle('invisible', !effect.value);
+        // Use 'hidden' to fully remove the slider from layout when locked
+        row.classList.toggle('hidden', !effect.value);
       }
     }
   }

--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -352,7 +352,8 @@ function initializeColonySlidersUI() {
   }
   container.appendChild(mechList);
   if (!colonySliderSettings.isBooleanFlagSet('mechanicalAssistance')) {
-    mechRow.classList.add('invisible');
+    // Hide the slider entirely until mechanical assistance is unlocked
+    mechRow.classList.add('hidden');
   }
   body.appendChild(mechRow);
 

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -313,11 +313,11 @@ describe('colony sliders', () => {
 
     ctx.initializeColonySlidersUI();
     let row = dom.window.document.getElementById('mechanical-assistance-row');
-    expect(row.classList.contains('invisible')).toBe(true);
+    expect(row.classList.contains('hidden')).toBe(true);
 
     ctx.colonySliderSettings.sortAllResearches = () => {};
     ctx.colonySliderSettings.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
     row = dom.window.document.getElementById('mechanical-assistance-row');
-    expect(row.classList.contains('invisible')).toBe(false);
+    expect(row.classList.contains('hidden')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Hide mechanical assistance slider using `hidden` class until its research flag is enabled
- Toggle visibility through colony slider flag updates
- Adjust tests for new hidden behavior

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bb883e4ec88327b85ce569cd388d73