### PR TITLE
feat: add mechanical assistance components cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,5 +442,6 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage ship assignment multiplier persists through save and load.
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
 - Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders and unlocking a "Mechanical Assistance" slider ranging from 0 to 2 in 0.2 steps.
+- Mechanical Assistance slider increases components consumption for all colonies by the slider's value.
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.

--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -176,6 +176,25 @@ class ColonySlidersManager extends EffectableEntity {
     value = Math.min(2, Math.max(0, value));
     this.mechanicalAssistance = value;
 
+    const allColonies = ['t1_colony','t2_colony','t3_colony','t4_colony','t5_colony','t6_colony','t7_colony'];
+    allColonies.forEach(colonyId => {
+      const effect = {
+        target: 'colony',
+        targetId: colonyId,
+        type: 'addResourceConsumption',
+        resourceCategory: 'colony',
+        resourceId: 'components',
+        amount: value,
+        effectId: 'mechanicalAssistanceComponents',
+        sourceId: 'mechanicalAssistance'
+      };
+      if (value > 0) {
+        addEffect(effect);
+      } else {
+        removeEffect(effect);
+      }
+    });
+
     if (typeof document !== 'undefined') {
       const input = document.getElementById('mechanical-assistance-slider');
       if (input) input.value = value.toString();

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -18,6 +18,7 @@ const sixResearchColonies = researchColonies.slice(0,6);
 describe('colony sliders', () => {
   beforeEach(() => {
     global.addEffect = jest.fn();
+    global.removeEffect = jest.fn();
     resetColonySliders();
   });
 
@@ -114,15 +115,44 @@ describe('colony sliders', () => {
     }));
   });
 
-  test('setMechanicalAssistance stores value and clamps', () => {
+  test('setMechanicalAssistance adds component consumption and clamps', () => {
     addEffect.mockClear();
+    removeEffect.mockClear();
     setMechanicalAssistance(1.2);
     expect(colonySliderSettings.mechanicalAssistance).toBeCloseTo(1.2);
+    researchColonies.forEach(colonyId => {
+      expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
+        target: 'colony',
+        targetId: colonyId,
+        type: 'addResourceConsumption',
+        resourceCategory: 'colony',
+        resourceId: 'components',
+        amount: 1.2
+      }));
+    });
+
+    addEffect.mockClear();
+    removeEffect.mockClear();
     setMechanicalAssistance(-1);
     expect(colonySliderSettings.mechanicalAssistance).toBe(0);
+    researchColonies.forEach(colonyId => {
+      expect(removeEffect).toHaveBeenCalledWith(expect.objectContaining({
+        target: 'colony',
+        targetId: colonyId,
+        effectId: 'mechanicalAssistanceComponents'
+      }));
+    });
+
+    addEffect.mockClear();
     setMechanicalAssistance(5);
     expect(colonySliderSettings.mechanicalAssistance).toBe(2);
-    expect(addEffect).not.toHaveBeenCalled();
+    researchColonies.forEach(colonyId => {
+      expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
+        target: 'colony',
+        targetId: colonyId,
+        amount: 2
+      }));
+    });
   });
 
   test('resetColonySliders resets to default', () => {


### PR DESCRIPTION
## Summary
- make Mechanical Assistance slider consume components across all colonies
- test Mechanical Assistance component consumption

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb885963408327b80f805a7d6a1e65