### PR TITLE
feat: toggle mechanical assistance slider with update UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,3 +444,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders and unlocking a "Mechanical Assistance" slider ranging from 0 to 2 in 0.2 steps.
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.
+- Colony sliders UI now provides `updateColonySlidersUI` to toggle the Mechanical Assistance slider when its flag is unlocked.

--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -190,13 +190,6 @@ class ColonySlidersManager extends EffectableEntity {
 
   applyBooleanFlag(effect) {
     super.applyBooleanFlag(effect);
-    if (effect.flagId === 'mechanicalAssistance' && typeof document !== 'undefined') {
-      const row = document.getElementById('mechanical-assistance-row');
-      if (row) {
-        // Use 'hidden' to fully remove the slider from layout when locked
-        row.classList.toggle('hidden', !effect.value);
-      }
-    }
   }
 
   reset() {

--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -1,5 +1,7 @@
 // Colony sliders management
 
+let mechanicalAssistanceRow;
+
 function initializeColonySlidersUI() {
   const container = document.getElementById('colony-sliders-container');
   if (!container) return;
@@ -302,18 +304,18 @@ function initializeColonySlidersUI() {
   body.appendChild(oreRow);
 
   // Mechanical assistance slider
-  const mechRow = document.createElement('div');
-  mechRow.classList.add('colony-slider');
-  mechRow.id = 'mechanical-assistance-row';
+  mechanicalAssistanceRow = document.createElement('div');
+  mechanicalAssistanceRow.classList.add('colony-slider');
+  mechanicalAssistanceRow.id = 'mechanical-assistance-row';
   const mechLabel = document.createElement('label');
   mechLabel.htmlFor = 'mechanical-assistance-slider';
   mechLabel.textContent = 'Mechanical Assistance';
-  mechRow.appendChild(mechLabel);
+  mechanicalAssistanceRow.appendChild(mechLabel);
 
   const mechValue = document.createElement('span');
   mechValue.id = 'mechanical-assistance-slider-value';
   mechValue.classList.add('slider-value');
-  mechRow.appendChild(mechValue);
+  mechanicalAssistanceRow.appendChild(mechValue);
 
   const mechInput = document.createElement('input');
   mechInput.type = 'range';
@@ -336,12 +338,12 @@ function initializeColonySlidersUI() {
     mechTickMarks.appendChild(tick);
   }
   mechSliderContainer.appendChild(mechTickMarks);
-  mechRow.appendChild(mechSliderContainer);
+  mechanicalAssistanceRow.appendChild(mechSliderContainer);
 
   const mechEffect = document.createElement('span');
   mechEffect.id = 'mechanical-assistance-slider-effect';
   mechEffect.classList.add('slider-effect');
-  mechRow.appendChild(mechEffect);
+  mechanicalAssistanceRow.appendChild(mechEffect);
 
   const mechList = document.createElement('datalist');
   mechList.id = 'mechanical-assistance-slider-ticks';
@@ -353,9 +355,9 @@ function initializeColonySlidersUI() {
   container.appendChild(mechList);
   if (!colonySliderSettings.isBooleanFlagSet('mechanicalAssistance')) {
     // Hide the slider entirely until mechanical assistance is unlocked
-    mechRow.classList.add('hidden');
+    mechanicalAssistanceRow.classList.add('hidden');
   }
-  body.appendChild(mechRow);
+  body.appendChild(mechanicalAssistanceRow);
 
   card.appendChild(body);
   container.appendChild(card);
@@ -412,7 +414,16 @@ function initializeColonySlidersUI() {
   });
 }
 
+function updateColonySlidersUI() {
+  if (!mechanicalAssistanceRow) {
+    mechanicalAssistanceRow = document.getElementById('mechanical-assistance-row');
+  }
+  if (!mechanicalAssistanceRow) return;
+  const unlocked = colonySliderSettings.isBooleanFlagSet('mechanicalAssistance');
+  mechanicalAssistanceRow.classList.toggle('hidden', !unlocked);
+}
+
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { initializeColonySlidersUI };
+  module.exports = { initializeColonySlidersUI, updateColonySlidersUI };
 }
 

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -10,7 +10,7 @@ const {
   colonySliderSettings,
   ColonySlidersManager
 } = require('../src/js/colonySliders.js');
-const { initializeColonySlidersUI } = require('../src/js/colonySlidersUI.js');
+const { initializeColonySlidersUI, updateColonySlidersUI } = require('../src/js/colonySlidersUI.js');
 
 const researchColonies = ['t1_colony','t2_colony','t3_colony','t4_colony','t5_colony','t6_colony','t7_colony'];
 const sixResearchColonies = researchColonies.slice(0,6);
@@ -317,6 +317,7 @@ describe('colony sliders', () => {
 
     ctx.colonySliderSettings.sortAllResearches = () => {};
     ctx.colonySliderSettings.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
+    ctx.updateColonySlidersUI();
     row = dom.window.document.getElementById('mechanical-assistance-row');
     expect(row.classList.contains('hidden')).toBe(false);
   });


### PR DESCRIPTION
## Summary
- add updateColonySlidersUI to show or hide the Mechanical Assistance slider based on its unlock flag
- remove DOM tweaks from colony slider logic
- test slider visibility toggling through new update function

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bb89739b388327834faa65e62e2171