### PR TITLE
Scale mechanical assistance components by colony tier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,5 +443,6 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
 - Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders and unlocking a "Mechanical Assistance" slider ranging from 0 to 2 in 0.2 steps.
 - Mechanical Assistance slider increases components consumption for all colonies by the slider's value.
+- Mechanical Assistance component costs now scale with colony tier using a 10^(tier-2) multiplier.
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.

--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -178,13 +178,16 @@ class ColonySlidersManager extends EffectableEntity {
 
     const allColonies = ['t1_colony','t2_colony','t3_colony','t4_colony','t5_colony','t6_colony','t7_colony'];
     allColonies.forEach(colonyId => {
+      const tierMatch = colonyId.match(/^t(\d)_colony$/);
+      const tier = tierMatch ? parseInt(tierMatch[1], 10) : 2;
+      const scaledAmount = value * Math.pow(10, tier - 2);
       const effect = {
         target: 'colony',
         targetId: colonyId,
         type: 'addResourceConsumption',
         resourceCategory: 'colony',
         resourceId: 'components',
-        amount: value,
+        amount: scaledAmount,
         effectId: 'mechanicalAssistanceComponents',
         sourceId: 'mechanicalAssistance'
       };

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -121,13 +121,15 @@ describe('colony sliders', () => {
     setMechanicalAssistance(1.2);
     expect(colonySliderSettings.mechanicalAssistance).toBeCloseTo(1.2);
     researchColonies.forEach(colonyId => {
+      const tier = parseInt(colonyId.match(/^t(\d)_/)[1], 10);
+      const expectedAmount = 1.2 * Math.pow(10, tier - 2);
       expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
         target: 'colony',
         targetId: colonyId,
         type: 'addResourceConsumption',
         resourceCategory: 'colony',
         resourceId: 'components',
-        amount: 1.2
+        amount: expectedAmount
       }));
     });
 
@@ -147,10 +149,12 @@ describe('colony sliders', () => {
     setMechanicalAssistance(5);
     expect(colonySliderSettings.mechanicalAssistance).toBe(2);
     researchColonies.forEach(colonyId => {
+      const tier = parseInt(colonyId.match(/^t(\d)_/)[1], 10);
+      const expectedAmount = 2 * Math.pow(10, tier - 2);
       expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
         target: 'colony',
         targetId: colonyId,
-        amount: 2
+        amount: expectedAmount
       }));
     });
   });


### PR DESCRIPTION
## Summary
- Scale mechanical assistance components consumption by colony tier using 10^(tier-2)
- Document mechanical assistance tier scaling in AGENTS.md
- Test mechanical assistance component scaling

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bb8a109bd0832784838e69daab67e9