### PR TITLE
Adjust mechanical assistance scaling to tier-3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,7 +443,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
 - Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders and unlocking a "Mechanical Assistance" slider ranging from 0 to 2 in 0.2 steps.
 - Mechanical Assistance slider increases components consumption for all colonies by the slider's value.
-- Mechanical Assistance component costs now scale with colony tier using a 10^(tier-2) multiplier.
+- Mechanical Assistance component costs now scale with colony tier using a 10^(tier-3) multiplier.
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.
 - Colony sliders UI now provides `updateColonySlidersUI` to toggle the Mechanical Assistance slider when its flag is unlocked.

--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -180,7 +180,7 @@ class ColonySlidersManager extends EffectableEntity {
     allColonies.forEach(colonyId => {
       const tierMatch = colonyId.match(/^t(\d)_colony$/);
       const tier = tierMatch ? parseInt(tierMatch[1], 10) : 2;
-      const scaledAmount = value * Math.pow(10, tier - 2);
+      const scaledAmount = value * Math.pow(10, tier - 3);
       const effect = {
         target: 'colony',
         targetId: colonyId,

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -122,7 +122,7 @@ describe('colony sliders', () => {
     expect(colonySliderSettings.mechanicalAssistance).toBeCloseTo(1.2);
     researchColonies.forEach(colonyId => {
       const tier = parseInt(colonyId.match(/^t(\d)_/)[1], 10);
-      const expectedAmount = 1.2 * Math.pow(10, tier - 2);
+      const expectedAmount = 1.2 * Math.pow(10, tier - 3);
       expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
         target: 'colony',
         targetId: colonyId,
@@ -150,7 +150,7 @@ describe('colony sliders', () => {
     expect(colonySliderSettings.mechanicalAssistance).toBe(2);
     researchColonies.forEach(colonyId => {
       const tier = parseInt(colonyId.match(/^t(\d)_/)[1], 10);
-      const expectedAmount = 2 * Math.pow(10, tier - 2);
+      const expectedAmount = 2 * Math.pow(10, tier - 3);
       expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
         target: 'colony',
         targetId: colonyId,


### PR DESCRIPTION
## Summary
- Scale mechanical assistance components consumption by 10^(tier-3)
- Update tests for tier-3 scaling
- Note new scaling in changelog

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bb8b1595d483278782cb46050304c3