### PR TITLE
Fix mechanical assistance flag lookup in colony sliders UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,3 +447,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.
 - Colony sliders UI now provides `updateColonySlidersUI` to toggle the Mechanical Assistance slider when its flag is unlocked.
+- `updateColonySlidersUI` now reads the `mechanicalAssistance` flag from `ColonySlidersManager` rather than the settings object.

--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -419,7 +419,12 @@ function updateColonySlidersUI() {
     mechanicalAssistanceRow = document.getElementById('mechanical-assistance-row');
   }
   if (!mechanicalAssistanceRow) return;
-  const unlocked = colonySliderSettings.isBooleanFlagSet('mechanicalAssistance');
+  const manager = typeof colonySlidersManager !== 'undefined'
+    ? colonySlidersManager
+    : colonySliderSettings;
+  const unlocked = manager && typeof manager.isBooleanFlagSet === 'function'
+    ? manager.isBooleanFlagSet('mechanicalAssistance')
+    : false;
   mechanicalAssistanceRow.classList.toggle('hidden', !unlocked);
 }
 

--- a/tests/colonySlidersManagerFlag.test.js
+++ b/tests/colonySlidersManagerFlag.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+test('updateColonySlidersUI uses manager flag when settings lack it', () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="colony-sliders-container"></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.EffectableEntity = EffectableEntity;
+
+  const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
+  vm.runInContext(logicCode, ctx);
+
+  ctx.colonySlidersManager = ctx.colonySliderSettings;
+  ctx.colonySliderSettings = {
+    workerRatio: 0.5,
+    foodConsumption: 1,
+    luxuryWater: 1,
+    oreMineWorkers: 0,
+    mechanicalAssistance: 0,
+    isBooleanFlagSet: () => false
+  };
+
+  const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
+  vm.runInContext(uiCode, ctx);
+
+  ctx.initializeColonySlidersUI();
+  let row = dom.window.document.getElementById('mechanical-assistance-row');
+  expect(row.classList.contains('hidden')).toBe(true);
+
+  ctx.colonySlidersManager.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
+  ctx.updateColonySlidersUI();
+  row = dom.window.document.getElementById('mechanical-assistance-row');
+  expect(row.classList.contains('hidden')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Ensure `updateColonySlidersUI` checks `ColonySlidersManager` for the `mechanicalAssistance` flag
- Add regression test covering manager flag handling when settings object lacks effectable entity methods
- Document lookup fix in `AGENTS.md`

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bb8bd41c18832784f6eecbc8266564