### PR TITLE
Display gravity happiness penalty in RWG tooltips

### DIFF
--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -442,8 +442,9 @@ function renderPlanetCard(p, index) {
   const fmt = typeof formatNumber === 'function' ? formatNumber : (n => n);
   const c = p.merged?.celestialParameters || {};
   const cls = p.classification || p.merged?.classification;
-  const gWarn = c.gravity > 10
-    ? '<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 5%, for a maximum of a 100% reduction">⚠</span>'
+  const gPenalty = c.gravity > 10 ? Math.min((c.gravity - 10) * 5, 100) : 0;
+  const gWarn = gPenalty > 0
+    ? `<span class="info-tooltip-icon" title="Every value of gravity above 10 reduces happiness by 5%, for a maximum of a 100% reduction. This world imposes a ${fmt(gPenalty)}% happiness penalty">⚠</span>`
     : '';
   return `
     <div class="rwg-planet-card">
@@ -516,8 +517,9 @@ function renderWorldDetail(res, seedUsed, forcedType) {
     : (!eqDone
       ? 'Press Equilibrate at least once before traveling.'
       : (alreadyTerraformed ? 'This world has already been terraformed.' : ''));
-  const gWarn = c.gravity > 10
-    ? '<span class="info-tooltip-icon" title="Humans and their bodies are very sensitive to high gravity.  Every value of gravity above 10 reduces happiness by 5% of its value, for a maximum of a 100% reduction">⚠</span>'
+  const gPenalty = c.gravity > 10 ? Math.min((c.gravity - 10) * 5, 100) : 0;
+  const gWarn = gPenalty > 0
+    ? `<span class="info-tooltip-icon" title="Humans and their bodies are very sensitive to high gravity.  Every value of gravity above 10 reduces happiness by 5% of its value, for a maximum of a 100% reduction. This world imposes a ${fmt(gPenalty)}% happiness penalty">⚠</span>`
     : '';
   const worldPanel = `
     <div class="rwg-card">

--- a/tests/rwgGravityWarning.test.js
+++ b/tests/rwgGravityWarning.test.js
@@ -35,7 +35,8 @@ describe('RWG gravity warning icon', () => {
     let icon = chip.querySelector('.info-tooltip-icon');
     expect(icon).not.toBeNull();
     expect(icon.textContent).toBe('⚠');
-    expect(icon.getAttribute('title')).toContain('5%');
+    const penalty = Math.min((12 - 10) * 5, 100);
+    expect(icon.getAttribute('title')).toContain(`${ctx.formatNumber(penalty)}%`);
 
     baseRes.merged.celestialParameters.gravity = 9;
     html = ctx.renderWorldDetail(baseRes, 'seed');
@@ -52,7 +53,8 @@ describe('RWG gravity warning icon', () => {
     let icon = dom.window.document.querySelector('.info-tooltip-icon');
     expect(icon).not.toBeNull();
     expect(icon.textContent).toBe('⚠');
-    expect(icon.getAttribute('title')).toContain('5%');
+    const penalty = Math.min((12 - 10) * 5, 100);
+    expect(icon.getAttribute('title')).toContain(`${ctx.formatNumber(penalty)}%`);
 
     const safeHtml = ctx.renderPlanetCard({ merged: { celestialParameters: { gravity: 9, radius: 1, albedo: 0 }, name: 'B' } }, 0);
     dom = new JSDOM(safeHtml);


### PR DESCRIPTION
## Summary
- Show exact happiness penalty for high-gravity worlds in Random World Generator planet cards and detail view
- Update gravity warning tests to validate displayed penalty

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bb8cba92f8832794cdcf674d7d1d73