### PR TITLE
Add save/load for ColonySlidersManager

### DIFF
--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -210,6 +210,27 @@ class ColonySlidersManager extends EffectableEntity {
     }
   }
 
+  saveState() {
+    return {
+      workerRatio: this.workerRatio,
+      foodConsumption: this.foodConsumption,
+      luxuryWater: this.luxuryWater,
+      oreMineWorkers: this.oreMineWorkers,
+      mechanicalAssistance: this.mechanicalAssistance,
+      booleanFlags: Array.from(this.booleanFlags)
+    };
+  }
+
+  loadState(state) {
+    if (!state) return;
+    this.booleanFlags = new Set(state.booleanFlags || state.flags || []);
+    this.setWorkforceRatio(state.workerRatio ?? 0.5);
+    this.setFoodConsumptionMultiplier(state.foodConsumption ?? 1);
+    this.setLuxuryWaterMultiplier(state.luxuryWater ?? 1);
+    this.setOreMineWorkerAssist(state.oreMineWorkers ?? 0);
+    this.setMechanicalAssistance(state.mechanicalAssistance ?? 0);
+  }
+
   applyBooleanFlag(effect) {
     super.applyBooleanFlag(effect);
   }

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -54,7 +54,7 @@ function getGameState() {
     spaceManager: (typeof spaceManager !== 'undefined' && typeof spaceManager.saveState === 'function') ? spaceManager.saveState() : undefined,
     selectedBuildCounts: typeof selectedBuildCounts !== 'undefined' ? selectedBuildCounts : undefined,
     settings: typeof gameSettings !== 'undefined' ? gameSettings : undefined,
-    colonySliderSettings: typeof colonySliderSettings !== 'undefined' ? colonySliderSettings : undefined,
+    colonySliderSettings: (typeof colonySliderSettings !== 'undefined' && typeof colonySliderSettings.saveState === 'function') ? colonySliderSettings.saveState() : undefined,
     ghgFactorySettings: typeof ghgFactorySettingsRef !== 'undefined' ? ghgFactorySettingsRef : undefined,
     oxygenFactorySettings: typeof oxygenFactorySettingsRef !== 'undefined' ? oxygenFactorySettingsRef : undefined,
     constructionOffice: typeof saveConstructionOfficeState === 'function' ? saveConstructionOfficeState() : undefined,
@@ -372,12 +372,11 @@ function loadGame(slotOrCustomString) {
     }
 
     if(gameState.colonySliderSettings){
-      Object.assign(colonySliderSettings, gameState.colonySliderSettings);
-      setWorkforceRatio(colonySliderSettings.workerRatio);
-      setFoodConsumptionMultiplier(colonySliderSettings.foodConsumption);
-      setLuxuryWaterMultiplier(colonySliderSettings.luxuryWater);
-      setOreMineWorkerAssist(colonySliderSettings.oreMineWorkers);
-      setMechanicalAssistance(colonySliderSettings.mechanicalAssistance);
+      if (typeof colonySliderSettings.loadState === 'function') {
+        colonySliderSettings.loadState(gameState.colonySliderSettings);
+      } else {
+        Object.assign(colonySliderSettings, gameState.colonySliderSettings);
+      }
     }
 
     if(gameState.ghgFactorySettings){

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -173,6 +173,37 @@ describe('colony sliders', () => {
     expect(colonySliderSettings.mechanicalAssistance).toBe(0);
   });
 
+  test('saveState and loadState round trip', () => {
+    colonySliderSettings.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
+    setWorkforceRatio(0.7);
+    setFoodConsumptionMultiplier(2);
+    setLuxuryWaterMultiplier(3);
+    setOreMineWorkerAssist(4);
+    setMechanicalAssistance(1.5);
+
+    const saved = colonySliderSettings.saveState();
+    resetColonySliders();
+    colonySliderSettings.loadState(saved);
+
+    expect(colonySliderSettings.workerRatio).toBe(0.7);
+    expect(colonySliderSettings.foodConsumption).toBe(2);
+    expect(colonySliderSettings.luxuryWater).toBe(3);
+    expect(colonySliderSettings.oreMineWorkers).toBe(4);
+    expect(colonySliderSettings.mechanicalAssistance).toBeCloseTo(1.5);
+    expect(colonySliderSettings.isBooleanFlagSet('mechanicalAssistance')).toBe(true);
+  });
+
+  test('loadState handles legacy plain object', () => {
+    resetColonySliders();
+    const legacy = { workerRatio: 0.6, foodConsumption: 2, luxuryWater: 4, oreMineWorkers: 3, mechanicalAssistance: 1 };
+    colonySliderSettings.loadState(legacy);
+    expect(colonySliderSettings.workerRatio).toBe(0.6);
+    expect(colonySliderSettings.foodConsumption).toBe(2);
+    expect(colonySliderSettings.luxuryWater).toBe(4);
+    expect(colonySliderSettings.oreMineWorkers).toBe(3);
+    expect(colonySliderSettings.mechanicalAssistance).toBe(1);
+  });
+
   test('initializeColonySlidersUI sets default text values', () => {
     const fs = require('fs');
     const path = require('path');


### PR DESCRIPTION
## Summary
- implement `saveState` and `loadState` for colony sliders to serialize settings and flags
- hook colony slider manager into game save/load routines
- cover slider manager serialization with unit tests

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bb8e0b142083279640469f50849a2c