### PR TITLE
Show colony mechanical assistance slider via display style

### DIFF
--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -353,10 +353,7 @@ function initializeColonySlidersUI() {
     mechList.appendChild(option);
   }
   container.appendChild(mechList);
-  if (!colonySliderSettings.isBooleanFlagSet('mechanicalAssistance')) {
-    // Hide the slider entirely until mechanical assistance is unlocked
-    mechanicalAssistanceRow.classList.add('hidden');
-  }
+  mechanicalAssistanceRow.style.display = colonySliderSettings.isBooleanFlagSet('mechanicalAssistance') ? 'grid' : 'none';
   body.appendChild(mechanicalAssistanceRow);
 
   card.appendChild(body);
@@ -419,9 +416,9 @@ function updateColonySlidersUI() {
     mechanicalAssistanceRow = document.getElementById('mechanical-assistance-row');
   }
   if (!mechanicalAssistanceRow) return;
-  const manager = colonySliderSettings;
+  const manager = typeof colonySlidersManager !== 'undefined' ? colonySlidersManager : colonySliderSettings;
   const unlocked = manager.isBooleanFlagSet('mechanicalAssistance');
-  mechanicalAssistanceRow.classList.toggle('hidden', !unlocked);
+  mechanicalAssistanceRow.style.display = unlocked ? 'grid' : 'none';
 }
 
 if (typeof module !== "undefined" && module.exports) {

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -378,12 +378,12 @@ describe('colony sliders', () => {
 
     ctx.initializeColonySlidersUI();
     let row = dom.window.document.getElementById('mechanical-assistance-row');
-    expect(row.classList.contains('hidden')).toBe(true);
+    expect(row.style.display).toBe('none');
 
     ctx.colonySliderSettings.sortAllResearches = () => {};
     ctx.colonySliderSettings.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
     ctx.updateColonySlidersUI();
     row = dom.window.document.getElementById('mechanical-assistance-row');
-    expect(row.classList.contains('hidden')).toBe(false);
+    expect(row.style.display).toBe('grid');
   });
 });

--- a/tests/colonySlidersManagerFlag.test.js
+++ b/tests/colonySlidersManagerFlag.test.js
@@ -28,10 +28,10 @@ test('updateColonySlidersUI uses manager flag when settings lack it', () => {
 
   ctx.initializeColonySlidersUI();
   let row = dom.window.document.getElementById('mechanical-assistance-row');
-  expect(row.classList.contains('hidden')).toBe(true);
+  expect(row.style.display).toBe('none');
 
   ctx.colonySlidersManager.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
   ctx.updateColonySlidersUI();
   row = dom.window.document.getElementById('mechanical-assistance-row');
-  expect(row.classList.contains('hidden')).toBe(false);
+  expect(row.style.display).toBe('grid');
 });


### PR DESCRIPTION
## Summary
- Show and hide the mechanical assistance slider by setting `style.display` instead of toggling a `.hidden` class
- Update tests to expect `display: none`/`grid`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb906454e083278d616df8b94f09a0