### PR TITLE
Add mechanical assistance gravity mitigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,5 +443,6 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
 - Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders and unlocking a "Mechanical Assistance" slider ranging from 0 to 2 in 0.2 steps.
 - Mechanical Assistance slider increases components consumption for all colonies by the slider's value.
+- Mechanical Assistance slider displays a mitigation percentage and reduces gravity penalty for colony growth accordingly.
 - Cargo rocket x10 and /10 buttons are now global controls in the resource selection header.
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -191,7 +191,10 @@ class Colony extends Building {
 
     // Apply gravity penalty: every m/s² above 10 reduces happiness by 5%, capped at 100%
     const gravity = terraforming?.celestialParameters?.gravity || 0;
-    const gravityPenalty = gravity > 10 ? Math.min((gravity - 10) * 0.05, 1) : 0;
+    let gravityPenalty = gravity > 10 ? Math.min((gravity - 10) * 0.05, 1) : 0;
+    const mechAssist = colonySliderSettings?.mechanicalAssistance || 0;
+    const mitigationFactor = 1 - mechAssist * 0.25;
+    gravityPenalty *= mitigationFactor;
 
     // Calculate the target happiness after gravity penalty
     const targetHappiness = (nonLuxuryHappiness + comfortHappiness + totalLuxuryHappiness + milestoneHappiness) * (1 - gravityPenalty);

--- a/src/js/colonySliders.js
+++ b/src/js/colonySliders.js
@@ -202,7 +202,8 @@ class ColonySlidersManager extends EffectableEntity {
       const effectSpan = document.getElementById('mechanical-assistance-slider-effect');
       if (valueSpan && effectSpan) {
         valueSpan.textContent = `${value.toFixed(1)}x`;
-        effectSpan.textContent = '';
+        const mitigation = Math.round(value * 25);
+        effectSpan.textContent = `Mitigation: -${mitigation}%`;
       }
     }
   }

--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -390,7 +390,8 @@ function initializeColonySlidersUI() {
   const updateMechanicalValue = (val) => {
     if (mechValue && mechEffect) {
       mechValue.textContent = `${val.toFixed(1)}x`;
-      mechEffect.textContent = '';
+      const mitigation = Math.round(val * 25);
+      mechEffect.textContent = `Mitigation: -${mitigation}%`;
     }
   };
 

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -208,7 +208,38 @@ describe('colony sliders', () => {
     expect(oreWorkers).toBe('0');
     expect(oreBoost).toBe('Boost: 0%');
     expect(mechVal).toBe('0.0x');
-    expect(mechEffect).toBe('');
+    expect(mechEffect).toBe('Mitigation: -0%');
+  });
+
+  test('setMechanicalAssistance updates mitigation text', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+    const { JSDOM } = require(jsdomPath);
+    const vm = require('vm');
+
+    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>` , { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.colonySliderSettings = {
+      workerRatio: 0.5,
+      foodConsumption: 1,
+      luxuryWater: 1,
+      oreMineWorkers: 0,
+      mechanicalAssistance: 0,
+      isBooleanFlagSet: () => true
+    };
+    ctx.addEffect = () => {};
+    ctx.removeEffect = () => {};
+    const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
+    vm.runInContext(logicCode, ctx);
+    const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
+    vm.runInContext(uiCode, ctx);
+
+    ctx.initializeColonySlidersUI();
+    ctx.setMechanicalAssistance(0.4);
+    const effect = dom.window.document.getElementById('mechanical-assistance-slider-effect').textContent;
+    expect(effect).toBe('Mitigation: -10%');
   });
 
   test('initializeColonySlidersUI keeps container hidden', () => {
@@ -323,7 +354,7 @@ describe('colony sliders', () => {
     expect(oreWorkers).toBe('40');
     expect(oreBoost).toBe('Boost: 400%');
     expect(mechVal).toBe('1.2x');
-    expect(mechEffect).toBe('');
+    expect(mechEffect).toBe('Mitigation: -30%');
   });
 
   test('mechanical assistance slider visibility toggles with flag', () => {

--- a/tests/gravityHappinessPenalty.test.js
+++ b/tests/gravityHappinessPenalty.test.js
@@ -5,6 +5,7 @@ const vm = require('vm');
 function setup(gravity) {
   const ctx = { console };
   ctx.milestonesManager = { getHappinessBonus: () => 0 };
+  ctx.colonySliderSettings = { mechanicalAssistance: 0 };
   ctx.resources = { colony: { metal: { updateStorageCap: () => {}, maintenanceMultiplier: 1 } } };
   ctx.buildings = {};
   ctx.terraforming = { celestialParameters: { gravity } };

--- a/tests/mechanicalAssistanceMitigation.test.js
+++ b/tests/mechanicalAssistanceMitigation.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Mechanical Assistance mitigation', () => {
+  test('reduces gravity penalty multiplicatively', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colony.js'), 'utf8');
+    const ctx = {
+      EffectableEntity: class {},
+      Building: class {
+        constructor(config) {
+          this.consumption = config.consumption || {};
+          this.storage = { colony: { colonists: 100 } };
+          this.active = 1;
+          this.baseComfort = config.baseComfort || 0;
+          this.happiness = 0;
+        }
+        initializeFromConfig() {}
+        getConsumptionResource(cat, res) { return { amount: this.consumption?.[cat]?.[res] || 0 }; }
+        getEffectiveConsumptionMultiplier() { return 1; }
+        getEffectiveResourceConsumptionMultiplier() { return 1; }
+      },
+      colonies: {},
+      resources: { colony: { colonists: { value: 100, cap: 100 } } },
+      terraforming: { celestialParameters: { gravity: 18 } },
+      milestonesManager: { getHappinessBonus: () => 0 },
+      colonySliderSettings: { mechanicalAssistance: 0 }
+    };
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.Colony = Colony;', ctx);
+    const colony = new ctx.Colony({ consumption: { colony: { food: 1, energy: 1 } }, baseComfort: 0 }, 'test');
+    colony.updateNeedsRatio = function() { this.filledNeeds.food = 1; this.filledNeeds.energy = 1; };
+    colony.happiness = 0;
+    ctx.colonies.test = colony;
+    colony.updateHappiness(1000);
+    const noMit = colony.happiness;
+
+    ctx.colonySliderSettings.mechanicalAssistance = 0.4;
+    colony.happiness = 0;
+    colony.updateHappiness(1000);
+    const withMit = colony.happiness;
+
+    expect(noMit).toBeCloseTo(0.3);
+    expect(withMit).toBeCloseTo(0.32);
+  });
+});


### PR DESCRIPTION
## Summary
- Show mechanical assistance mitigation percent beside colony slider
- Mitigate gravity-based happiness penalty using mechanical assistance
- Test mechanical assistance mitigation and UI text

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb8a8de05c8327b6f0600fb5cd82d4