### PR TITLE
Fix colony slider flag test

### DIFF
--- a/tests/colonySlidersManagerFlag.test.js
+++ b/tests/colonySlidersManagerFlag.test.js
@@ -5,23 +5,13 @@ const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 
-test('updateColonySlidersUI uses manager flag when settings lack it', () => {
+test('updateColonySlidersUI shows row when mechanical assistance flag enabled', () => {
   const dom = new JSDOM('<!DOCTYPE html><div id="colony-sliders-container"></div>', { runScripts: 'outside-only' });
   const ctx = dom.getInternalVMContext();
   ctx.EffectableEntity = EffectableEntity;
 
   const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
   vm.runInContext(logicCode, ctx);
-
-  ctx.colonySlidersManager = ctx.colonySliderSettings;
-  ctx.colonySliderSettings = {
-    workerRatio: 0.5,
-    foodConsumption: 1,
-    luxuryWater: 1,
-    oreMineWorkers: 0,
-    mechanicalAssistance: 0,
-    isBooleanFlagSet: () => false
-  };
 
   const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
   vm.runInContext(uiCode, ctx);
@@ -30,7 +20,7 @@ test('updateColonySlidersUI uses manager flag when settings lack it', () => {
   let row = dom.window.document.getElementById('mechanical-assistance-row');
   expect(row.style.display).toBe('none');
 
-  ctx.colonySlidersManager.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
+  ctx.colonySliderSettings.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
   ctx.updateColonySlidersUI();
   row = dom.window.document.getElementById('mechanical-assistance-row');
   expect(row.style.display).toBe('grid');


### PR DESCRIPTION
## Summary
- Update colony slider flag test to use `colonySliderSettings` and verify mechanical assistance row visibility

## Testing
- `CI=true npm test 2>&1 | tee test.log | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68bb9488853c83278afb25350af6800b