### PR TITLE
Add tooltip explaining Mechanical Assistance gravity mitigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,3 +450,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.
 - Colony sliders UI now provides `updateColonySlidersUI` to toggle the Mechanical Assistance slider when its flag is unlocked.
 - `updateColonySlidersUI` now reads the `mechanicalAssistance` flag from `ColonySlidersManager` rather than the settings object.
+- Mechanical Assistance slider label includes an info tooltip explaining gravity penalty mitigation.

--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -309,7 +309,12 @@ function initializeColonySlidersUI() {
   mechanicalAssistanceRow.id = 'mechanical-assistance-row';
   const mechLabel = document.createElement('label');
   mechLabel.htmlFor = 'mechanical-assistance-slider';
-  mechLabel.textContent = 'Mechanical Assistance';
+  mechLabel.textContent = 'Mechanical Assistance ';
+  const mechInfo = document.createElement('span');
+  mechInfo.classList.add('info-tooltip-icon');
+  mechInfo.title = 'Reduces gravity penalty for colony growth; mitigation scales with slider level and Components need fill.';
+  mechInfo.innerHTML = '&#9432;';
+  mechLabel.appendChild(mechInfo);
   mechanicalAssistanceRow.appendChild(mechLabel);
 
   const mechValue = document.createElement('span');

--- a/tests/mechanicalAssistanceTooltip.test.js
+++ b/tests/mechanicalAssistanceTooltip.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Mechanical Assistance tooltip', () => {
+  test('mechanical assistance slider label includes gravity penalty tooltip', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="colony-sliders-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.EffectableEntity = EffectableEntity;
+    const logic = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
+    vm.runInContext(logic, ctx);
+    const ui = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
+    vm.runInContext(ui, ctx);
+
+    ctx.initializeColonySlidersUI();
+
+    const label = dom.window.document.querySelector('#mechanical-assistance-row label');
+    const icon = label.querySelector('.info-tooltip-icon');
+    expect(icon).not.toBeNull();
+    expect(icon.title).toMatch(/gravity penalty/i);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add info icon tooltip to Mechanical Assistance slider explaining how it mitigates gravity penalty
- document slider tooltip in AGENTS.md
- test Mechanical Assistance slider tooltip for gravity penalty explanation

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb96153ab4832790bf9bc402f2c487