### PR TITLE
Hide Mechanical Assistance slider without gravity penalty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,3 +450,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Buildings and colonies can gain new consumption resources via an `addResourceConsumption` effect.
 - Colony sliders UI now provides `updateColonySlidersUI` to toggle the Mechanical Assistance slider when its flag is unlocked.
 - `updateColonySlidersUI` now reads the `mechanicalAssistance` flag from `ColonySlidersManager` rather than the settings object.
+- Mechanical Assistance slider hides when no gravity penalty exists, only appearing on worlds with gravity above 10 m/s².

--- a/src/js/colonySlidersUI.js
+++ b/src/js/colonySlidersUI.js
@@ -419,7 +419,9 @@ function updateColonySlidersUI() {
   if (!mechanicalAssistanceRow) return;
   const manager = colonySliderSettings;
   const unlocked = manager.isBooleanFlagSet('mechanicalAssistance');
-  mechanicalAssistanceRow.style.display = unlocked ? 'grid' : 'none';
+  const gravity = terraforming.celestialParameters.gravity;
+  const hasPenalty = gravity > 10;
+  mechanicalAssistanceRow.style.display = unlocked && hasPenalty ? 'grid' : 'none';
 }
 
 if (typeof module !== "undefined" && module.exports) {

--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -402,6 +402,7 @@ describe('colony sliders', () => {
     const dom = new JSDOM(`<!DOCTYPE html><div id="colony-sliders-container"></div>` , { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.EffectableEntity = EffectableEntity;
+    ctx.terraforming = { celestialParameters: { gravity: 15 } };
     const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
     vm.runInContext(logicCode, ctx);
     const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');

--- a/tests/colonySlidersManagerFlag.test.js
+++ b/tests/colonySlidersManagerFlag.test.js
@@ -9,6 +9,7 @@ test('updateColonySlidersUI shows row when mechanical assistance flag enabled', 
   const dom = new JSDOM('<!DOCTYPE html><div id="colony-sliders-container"></div>', { runScripts: 'outside-only' });
   const ctx = dom.getInternalVMContext();
   ctx.EffectableEntity = EffectableEntity;
+  ctx.terraforming = { celestialParameters: { gravity: 15 } };
 
   const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
   vm.runInContext(logicCode, ctx);
@@ -24,4 +25,23 @@ test('updateColonySlidersUI shows row when mechanical assistance flag enabled', 
   ctx.updateColonySlidersUI();
   row = dom.window.document.getElementById('mechanical-assistance-row');
   expect(row.style.display).toBe('grid');
+});
+
+test('updateColonySlidersUI hides row without gravity penalty', () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="colony-sliders-container"></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.EffectableEntity = EffectableEntity;
+  ctx.terraforming = { celestialParameters: { gravity: 5 } };
+
+  const logicCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySliders.js'), 'utf8');
+  vm.runInContext(logicCode, ctx);
+
+  const uiCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'colonySlidersUI.js'), 'utf8');
+  vm.runInContext(uiCode, ctx);
+
+  ctx.initializeColonySlidersUI();
+  ctx.colonySliderSettings.applyBooleanFlag({ flagId: 'mechanicalAssistance', value: true });
+  ctx.updateColonySlidersUI();
+  const row = dom.window.document.getElementById('mechanical-assistance-row');
+  expect(row.style.display).toBe('none');
 });


### PR DESCRIPTION
## Summary
- Only show Mechanical Assistance slider when current gravity exceeds 10 m/s²
- Cover slider visibility with new tests for both high and low gravity scenarios

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bb963550c88327b1a78cd921ad428d