### PR TITLE
fix: account for water focus in mirror oversight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,3 +453,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - `updateColonySlidersUI` now reads the `mechanicalAssistance` flag from `ColonySlidersManager` rather than the settings object.
 - Mechanical Assistance slider hides when no gravity penalty exists, only appearing on worlds with gravity above 10 m/s².
 - Mechanical Assistance slider label includes an info tooltip explaining gravity penalty mitigation.
+- Advanced oversight assignment now respects water melt targets when focusing, allocating mirrors and lanterns by priority.


### PR DESCRIPTION
## Summary
- allow advanced oversight to prioritize water melting by calculating needed mirror and lantern power
- test water-focused assignments
- document advanced oversight water targeting behavior

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bc28e63af48327b82f0e3f79b69e1e