### PR TITLE
Prioritize terraformed world warning over equilibrate in RWG UI

### DIFF
--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -221,14 +221,14 @@ function updateRandomWorldUI() {
         ? sm.isSeedTerraformed(canonicalSeed)
         : (seedUsed && typeof sm.isSeedTerraformed === 'function' ? sm.isSeedTerraformed(seedUsed) : false);
       const lockedByStory = typeof sm.isRandomTravelLocked === 'function' ? sm.isRandomTravelLocked() : false;
-      const travelDisabled = lockedByStory || !eqDone || !!alreadyTerraformed;
+      const travelDisabled = lockedByStory || !!alreadyTerraformed || !eqDone;
       travelBtn.disabled = travelDisabled;
 
       const warningMsg = lockedByStory
         ? 'You must complete the story for the current world first'
-        : (!eqDone
-          ? 'Press Equilibrate at least once before traveling.'
-          : (alreadyTerraformed ? 'This world has already been terraformed.' : ''));
+        : (alreadyTerraformed
+          ? 'This world has already been terraformed.'
+          : (!eqDone ? 'Press Equilibrate at least once before traveling.' : ''));
       let warnEl = document.getElementById('rwg-travel-warning');
       if (warningMsg) {
         if (!warnEl) {
@@ -521,7 +521,7 @@ function renderWorldDetail(res, seedUsed, forcedType) {
     ? sm.isSeedTerraformed(res.seedString)
     : (seedUsed && sm?.isSeedTerraformed ? sm.isSeedTerraformed(seedUsed) : false);
   const lockedByStory = sm?.isRandomTravelLocked ? sm.isRandomTravelLocked() : false;
-  const travelDisabled = lockedByStory || !eqDone || alreadyTerraformed;
+  const travelDisabled = lockedByStory || alreadyTerraformed || !eqDone;
   const showTemps = !seedUsed || eqDone;
   const meanTVal = (showTemps && temps)
     ? `${fmt(Math.round(toDisplayTemp(temps.mean)))} ${tempUnit}`
@@ -534,9 +534,9 @@ function renderWorldDetail(res, seedUsed, forcedType) {
     : '—';
   const warningMsg = lockedByStory
     ? 'You must complete the story for the current world first'
-    : (!eqDone
-      ? 'Press Equilibrate at least once before traveling.'
-      : (alreadyTerraformed ? 'This world has already been terraformed.' : ''));
+    : (alreadyTerraformed
+      ? 'This world has already been terraformed.'
+      : (!eqDone ? 'Press Equilibrate at least once before traveling.' : ''));
   const gPenalty = c.gravity > 10 ? Math.min((c.gravity - 10) * 5, 100) : 0;
   const gWarn = gPenalty > 0
     ? `<span class="info-tooltip-icon" title="Humans and their bodies are very sensitive to high gravity.  Every value of gravity above 10 reduces happiness by 5% of its value, for a maximum of a 100% reduction. This world imposes a ${fmt(gPenalty)}% happiness penalty">⚠</span>`

--- a/tests/rwgTerraformedWarningPriority.test.js
+++ b/tests/rwgTerraformedWarningPriority.test.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('RWG terraformed warning priority', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<div id="rwg-result"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.formatNumber = n => n;
+    global.calculateAtmosphericPressure = () => 0;
+    global.dayNightTemperaturesModel = () => ({ mean:0, day:0, night:0 });
+    global.getGameSpeed = () => 1;
+    global.setGameSpeed = () => {};
+    global.runEquilibration = jest.fn(async o => ({ override:o }));
+    global.deepMerge = (a,b) => ({ ...a, ...b });
+    global.defaultPlanetParameters = {};
+    global.spaceManager = new SpaceManager({ mars: {} });
+    global.spaceManager.setRwgLock('mars', true);
+  });
+
+  test('shows terraformed warning even before equilibration', () => {
+    spaceManager.randomWorldStatuses['canonical'] = { name:'World', terraformed:true };
+    const { renderWorldDetail, attachEquilibrateHandler, attachTravelHandler } = require('../src/js/rwgUI.js');
+    const res = {
+      seedString: 'canonical',
+      star: { name:'Sun', spectralType:'G', luminositySolar:1, massSolar:1, temperatureK:5800, habitableZone:{ inner:0.5, outer:1.5 } },
+      merged: {
+        celestialParameters:{ distanceFromSun:1, radius:6000, gravity:9.8, albedo:0.3, rotationPeriod:24 },
+        resources:{ atmospheric:{ carbonDioxide:{ initialValue:1 }, inertGas:{ initialValue:1 } }, surface:{} },
+        classification:{ archetype:'mars-like' }
+      },
+      override:{ resources:{ atmospheric:{} } }
+    };
+    const box = document.getElementById('rwg-result');
+    box.innerHTML = renderWorldDetail(res, '123', 'mars-like');
+    attachEquilibrateHandler(res, '123', 'mars-like', box);
+    attachTravelHandler(res, '123');
+    const warning = document.getElementById('rwg-travel-warning').textContent;
+    expect(warning).toMatch(/already been terraformed/);
+  });
+});
+
+delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- Prioritize terraformed-world warning over equilibrate requirement in Random World Generator UI
- Add test ensuring terraformed warning shows even before equilibration

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bc37aa913c8327a2c7955b2bd6db24