### PR TITLE
Handle legacy random world seeds from 'auto' keys

### DIFF
--- a/src/js/space.js
+++ b/src/js/space.js
@@ -15,6 +15,11 @@ if (typeof module !== 'undefined' && module.exports) {
     ({ getEcumenopolisLandFraction } = require('./advanced-research/ecumenopolis.js'));
 }
 
+var generateRandomPlanet = globalThis.generateRandomPlanet;
+if (typeof module !== 'undefined' && module.exports) {
+    ({ generateRandomPlanet } = require('./rwg.js'));
+}
+
 class SpaceManager extends EffectableEntity {
     constructor(planetsData) { // Keep planetsData for validation
         super({ description: 'Manages planetary travel' });
@@ -595,6 +600,20 @@ class SpaceManager extends EffectableEntity {
 
         if (savedData.randomWorldStatuses) {
             this.randomWorldStatuses = savedData.randomWorldStatuses;
+            if (typeof generateRandomPlanet === 'function') {
+                const seeds = Object.keys(this.randomWorldStatuses);
+                seeds.forEach(seed => {
+                    if (String(seed).toLowerCase().includes('auto')) {
+                        try {
+                            const { seedString } = generateRandomPlanet(seed);
+                            if (seedString && seedString !== seed) {
+                                this.randomWorldStatuses[seedString] = this.randomWorldStatuses[seed];
+                                delete this.randomWorldStatuses[seed];
+                            }
+                        } catch (_) { }
+                    }
+                });
+            }
         }
 
         if (typeof savedData.randomTabEnabled === 'boolean') {

--- a/tests/randomWorldAutoSeedMigration.test.js
+++ b/tests/randomWorldAutoSeedMigration.test.js
@@ -1,0 +1,20 @@
+const { generateRandomPlanet } = require('../src/js/rwg.js');
+
+global.EffectableEntity = class {};
+const SpaceManager = require('../src/js/space.js');
+
+describe('SpaceManager auto seed migration', () => {
+  test('replaces auto seeds with canonical seed', () => {
+    const canonical = generateRandomPlanet('auto').seedString;
+    const original = { name: 'AutoWorld', visited: true };
+    const saved = { randomWorldStatuses: { auto: { ...original } } };
+    const sm = new SpaceManager({ mars: { name: 'Mars' } });
+    sm.loadState(saved);
+    expect(sm.randomWorldStatuses[canonical]).toEqual(original);
+    expect(sm.randomWorldStatuses.auto).toBeUndefined();
+  });
+});
+
+afterAll(() => {
+  delete global.EffectableEntity;
+});


### PR DESCRIPTION
## Summary
- detect random world status keys containing 'auto' during load and replace them with canonical seeds
- expose `generateRandomPlanet` in `SpaceManager` to derive canonical seed
- cover auto-seed migration with a regression test

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bc385532f08327936819878992cba1