### PR TITLE
Persist cargo ship cost penalty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,6 +443,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket project resource selection now uses 0/-1/+1,/10,x10 controls for consistency.
 - Space storage ship assignment multiplier persists through save and load.
 - Cargo rocket x10 and /10 buttons adjust the ± buttons' increment instead of changing the current value.
+- Cargo rocket ship price increase now persists through save/load and planetary travel.
 - Added Mechanical Assistance advanced research adding a `mechanicalAssistance` boolean flag to colony sliders and unlocking a "Mechanical Assistance" slider ranging from 0 to 2 in 0.2 steps.
 - Mechanical Assistance slider increases components consumption for all colonies by the slider's value.
 - Mechanical Assistance slider displays a mitigation percentage and reduces gravity penalty for colony growth accordingly.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -515,6 +515,7 @@ class CargoRocketProject extends Project {
     if (this.autoStart) {
       state.selectedResources = this.selectedResources;
     }
+    state.spaceshipPriceIncrease = this.spaceshipPriceIncrease;
     return state;
   }
 
@@ -523,6 +524,15 @@ class CargoRocketProject extends Project {
     this.selectedResources = this.autoStart && state.selectedResources
       ? state.selectedResources
       : [];
+    this.spaceshipPriceIncrease = state.spaceshipPriceIncrease || 0;
+  }
+
+  saveTravelState() {
+    return { spaceshipPriceIncrease: this.spaceshipPriceIncrease };
+  }
+
+  loadTravelState(state = {}) {
+    this.spaceshipPriceIncrease = state.spaceshipPriceIncrease || 0;
   }
 
   applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {


### PR DESCRIPTION
## Summary
- persist cargo rocket ship price penalty when saving/loading and traveling
- test ship price penalty serialization
- document cargo rocket ship price persistence

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bc550089588327b709cff30ecc9359