### PR TITLE
Add RWG terraformed effects with titan nitrogen bonus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,3 +455,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Mechanical Assistance slider hides when no gravity penalty exists, only appearing on worlds with gravity above 10 m/s².
 - Mechanical Assistance slider label includes an info tooltip explaining gravity penalty mitigation.
 - Advanced oversight assignment now respects water melt targets when focusing, allocating mirrors and lanterns by priority.
+- Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration based on count.

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     <script src="src/js/progress-data.js"></script>
     <script src="src/js/rwg.js"></script>
     <script src="src/js/rwgEquilibrate.js"></script>
+    <script src="src/js/rwgEffects.js"></script>
 
     <!-- Core Scripts -->
     <script src="src/js/numbers.js"></script>

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -197,6 +197,11 @@ class EffectableEntity {
         case 'projectDurationReduction':
           this.applyProjectDurationReduction(effect);
           break;
+        case 'projectDurationMultiplier':
+          if (typeof this.applyProjectDurationMultiplier === 'function') {
+            this.applyProjectDurationMultiplier(effect);
+          }
+          break;
         case 'researchCostMultiplier':
           this.applyResearchCostMultiplier(effect);
           break;

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -355,6 +355,10 @@ function updateLogic(delta) {
   // apply rewards, and check for/activate newly available events.
   storyManager.update(); // <--- NEW CENTRAL UPDATE CALL
 
+  if (typeof applyRWGEffects === 'function') {
+    applyRWGEffects();
+  }
+
   recalculateTotalRates();
 
 }

--- a/src/js/rwgEffects.js
+++ b/src/js/rwgEffects.js
@@ -1,0 +1,55 @@
+"use strict";
+
+// Random World Generator Effects
+const RWG_EFFECTS = {
+  "titan-like": [
+    {
+      effectId: "rwg-titan-nitrogen",
+      target: "project",
+      targetId: "nitrogenSpaceMining",
+      type: "projectDurationMultiplier",
+      factor: 0.1,
+      computeValue(count, def) {
+        const f = typeof def.factor === "number" ? def.factor : 0.1;
+        return 1 / (1 + f * count);
+      },
+    },
+  ],
+};
+
+function applyRWGEffects() {
+  if (typeof spaceManager === "undefined" || typeof addEffect !== "function") return;
+
+  const counts = {};
+  const statuses = spaceManager.randomWorldStatuses || {};
+  for (const seed in statuses) {
+    const st = statuses[seed];
+    const type = st?.original?.override?.classification;
+    if (st?.terraformed && type) {
+      counts[type] = (counts[type] || 0) + 1;
+    }
+  }
+
+  for (const [type, effects] of Object.entries(RWG_EFFECTS)) {
+    const count = counts[type] || 0;
+    for (const eff of effects) {
+      const value = typeof eff.computeValue === "function" ? eff.computeValue(count, eff) : eff.value;
+      addEffect({
+        effectId: eff.effectId,
+        sourceId: `rwg-${type}`,
+        type: eff.type,
+        target: eff.target,
+        targetId: eff.targetId,
+        value,
+      });
+    }
+  }
+}
+
+if (typeof globalThis !== "undefined") {
+  globalThis.applyRWGEffects = applyRWGEffects;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { applyRWGEffects, RWG_EFFECTS };
+}

--- a/tests/rwgEffects.test.js
+++ b/tests/rwgEffects.test.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('rwgEffects titan-like nitrogen bonus', () => {
+  let context;
+  beforeEach(() => {
+    context = { console };
+    vm.createContext(context);
+
+    context.globalEffects = {};
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity; this.addEffect = addEffect;', context);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', context);
+
+    const rwgEffectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgEffects.js'), 'utf8');
+    vm.runInContext(rwgEffectsCode + '; this.applyRWGEffects = applyRWGEffects;', context);
+
+    context.resources = { colony: {}, special: {} };
+    context.buildings = {};
+    context.colonies = {};
+    context.populationModule = {};
+    context.tabManager = {};
+    context.fundingModule = {};
+    context.terraforming = {};
+    context.lifeDesigner = {};
+    context.lifeManager = {};
+    context.oreScanner = {};
+    context.researchManager = {};
+    context.solisManager = {};
+    context.warpGateCommand = {};
+    context.nanotechManager = {};
+    context.colonySliderSettings = {};
+
+    context.projectManager = new context.ProjectManager();
+    context.projectManager.initializeProjects({
+      nitrogenSpaceMining: {
+        name: 'Nitrogen harvesting',
+        duration: 100,
+        description: '',
+        cost: {},
+        category: 'resources',
+        unlocked: true,
+      },
+    });
+
+    context.spaceManager = {
+      randomWorldStatuses: {
+        a: { terraformed: true, original: { override: { classification: 'titan-like' } } },
+        b: { terraformed: true, original: { override: { classification: 'titan-like' } } },
+        c: { terraformed: true, original: { override: { classification: 'rocky' } } },
+      },
+    };
+  });
+
+  test('applies duration multiplier based on titan-like count', () => {
+    const project = context.projectManager.projects.nitrogenSpaceMining;
+    expect(project.getEffectiveDuration()).toBeCloseTo(100);
+    context.applyRWGEffects();
+    expect(project.getEffectiveDuration()).toBeCloseTo(100 / (1 + 0.1 * 2));
+  });
+});


### PR DESCRIPTION
## Summary
- Apply Random World Generator effects each tick with new rwgEffects module
- Titan-like worlds now shorten Nitrogen harvesting project duration based on terraformed count
- Compute project duration multipliers from active effects without storing a local multiplier

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bc5637ef048327806eb8046a526a4f