### PR TITLE
Refactor project duration multiplier calculation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,3 +457,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Mechanical Assistance slider label includes an info tooltip explaining gravity penalty mitigation.
 - Advanced oversight assignment now respects water melt targets when focusing, allocating mirrors and lanterns by priority.
 - Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration based on count.
+- ProjectManager duration multiplier is now computed on demand via `getDurationMultiplier` instead of a stored attribute.

--- a/tests/cargoRocketProject.test.js
+++ b/tests/cargoRocketProject.test.js
@@ -38,7 +38,7 @@ describe('Cargo Rocket project', () => {
         colony: { funding: { value: 1e9, decrease: jest.fn(), modifyRate: jest.fn() } },
         special: { spaceships: { value: 0, increase: jest.fn(), modifyRate: jest.fn() } }
       },
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
     };
     vm.createContext(ctx);
     global.resources = ctx.resources;
@@ -81,7 +81,7 @@ describe('Cargo Rocket project', () => {
         colony: { funding: { value: 1e9, decrease: jest.fn(), modifyRate: jest.fn() } },
         special: { spaceships: { value: 0, increase: jest.fn(), modifyRate: jest.fn() } }
       },
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
     };
     vm.createContext(ctx);
     global.resources = ctx.resources;
@@ -117,7 +117,7 @@ describe('Cargo Rocket project', () => {
         colony: { funding: { value: 1e9, decrease: jest.fn(), modifyRate: jest.fn() } },
         special: { spaceships: { value: 0, increase: jest.fn(), modifyRate: jest.fn() } }
       },
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
     };
     vm.createContext(ctx);
     global.resources = ctx.resources;
@@ -163,7 +163,7 @@ describe('Cargo Rocket project', () => {
         },
         special: { spaceships: { value: 0, increase(){}, modifyRate(){}, } }
       },
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
     };
     vm.createContext(ctx);
     global.resources = ctx.resources;

--- a/tests/spaceMiningAtmosphericMonitoring.test.js
+++ b/tests/spaceMiningAtmosphericMonitoring.test.js
@@ -15,7 +15,7 @@ describe('SpaceMiningProject atmospheric monitoring gating', () => {
       resources: {},
       buildings: {},
       colonies: {},
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
       populationModule: {},
       tabManager: {},
       fundingModule: {},

--- a/tests/spaceMiningMetalPenalty.test.js
+++ b/tests/spaceMiningMetalPenalty.test.js
@@ -13,7 +13,7 @@ describe('metal production penalty without space elevator', () => {
       resources: {},
       buildings: {},
       colonies: {},
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
       populationModule: {},
       tabManager: {},
       fundingModule: {},

--- a/tests/spaceMiningPressureDisable.test.js
+++ b/tests/spaceMiningPressureDisable.test.js
@@ -15,7 +15,7 @@ describe('SpaceMiningProject pressure disable', () => {
       resources: {},
       buildings: {},
       colonies: {},
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
       populationModule: {},
       tabManager: {},
       fundingModule: {},

--- a/tests/spaceMiningPressureLimit.test.js
+++ b/tests/spaceMiningPressureLimit.test.js
@@ -43,7 +43,7 @@ describe('SpaceMiningProject pressure limit capping', () => {
       EffectableEntity,
       shipEfficiency: 1,
       resources: {},
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
       terraforming: { celestialParameters: { gravity: 1, radius: 0.01 } },
       calculateAtmosphericPressure: physics.calculateAtmosphericPressure,
     };

--- a/tests/spaceMiningRate.test.js
+++ b/tests/spaceMiningRate.test.js
@@ -15,7 +15,7 @@ describe('space mining rate scaling', () => {
       resources: {},
       buildings: {},
       colonies: {},
-      projectManager: { projects: {}, durationMultiplier: 1 },
+      projectManager: { projects: {}, getDurationMultiplier: () => 1 },
       populationModule: {},
       tabManager: {},
       fundingModule: {},

--- a/tests/spaceProjectAutomation.test.js
+++ b/tests/spaceProjectAutomation.test.js
@@ -56,7 +56,7 @@ describe('continuous spaceship project automation', () => {
       celestialParameters: { gravity: 1, radius: 1 }
     };
     ctx.calculateAtmosphericPressure = (amount) => amount * 1000;
-    ctx.projectManager = { projects: {}, durationMultiplier: 1 };
+    ctx.projectManager = { projects: {}, getDurationMultiplier: () => 1 };
     vm.createContext(ctx);
     const projCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projCode + '; this.Project = Project;', ctx);

--- a/tests/spaceStorageAssignmentMultiplierSave.test.js
+++ b/tests/spaceStorageAssignmentMultiplierSave.test.js
@@ -18,7 +18,7 @@ describe('space storage assignment multiplier persistence', () => {
         getTerraformedPlanetCount: () => 1,
         getTerraformedPlanetCountIncludingCurrent: () => 1,
       },
-      projectManager: { durationMultiplier: 1 },
+      projectManager: { getDurationMultiplier: () => 1 },
       formatNumber: numbers.formatNumber,
     };
     vm.createContext(ctx);

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -36,7 +36,7 @@ describe('Space Storage project', () => {
         getTerraformedPlanetCount: () => 2,
         getTerraformedPlanetCountIncludingCurrent: () => 3
       },
-      projectManager: { durationMultiplier: 0.5 }
+      projectManager: { getDurationMultiplier: () => 0.5 }
     };
     vm.createContext(ctx);
     vm.runInContext('function capitalizeFirstLetter(s){ return s.charAt(0).toUpperCase() + s.slice(1); }', ctx);
@@ -148,7 +148,7 @@ describe('Space Storage project', () => {
         getTerraformedPlanetCountIncludingCurrent: () => 1,
         getTerraformedPlanetCount: () => 0
       },
-      projectManager: { durationMultiplier: 1 },
+      projectManager: { getDurationMultiplier: () => 1 },
     };
     vm.createContext(ctx);
     vm.runInContext('function capitalizeFirstLetter(s){ return s.charAt(0).toUpperCase() + s.slice(1); }', ctx);

--- a/tests/spaceStorageShipEfficiency.test.js
+++ b/tests/spaceStorageShipEfficiency.test.js
@@ -23,7 +23,7 @@ describe('Space Storage ship efficiency effect', () => {
         getTerraformedPlanetCountIncludingCurrent: () => 1,
         getTerraformedPlanetCount: () => 0
       },
-      projectManager: { durationMultiplier: 1 },
+      projectManager: { getDurationMultiplier: () => 1 },
       globalEffects: new EffectableEntity({ description: 'global' })
     };
     vm.createContext(context);


### PR DESCRIPTION
## Summary
- Compute project manager duration multipliers on demand via `getDurationMultiplier`
- Remove stored duration multiplier and update projects/effects to recalc durations
- Adjust tests for dynamic multiplier behavior

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bc5aa892a88327b68dd73171ede55d