### PR TITLE
Add RWG bonuses for carbon and icy worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,4 +456,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Mechanical Assistance slider hides when no gravity penalty exists, only appearing on worlds with gravity above 10 m/s².
 - Mechanical Assistance slider label includes an info tooltip explaining gravity penalty mitigation.
 - Advanced oversight assignment now respects water melt targets when focusing, allocating mirrors and lanterns by priority.
-- Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration based on count.
+- Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration, Carbon planets speed Carbon Asteroid Mining, and icy moons accelerate Ice and Water importation.

--- a/src/js/rwgEffects.js
+++ b/src/js/rwgEffects.js
@@ -15,6 +15,32 @@ const RWG_EFFECTS = {
       },
     },
   ],
+  "carbon-planet": [
+    {
+      effectId: "rwg-carbon-carbon",
+      target: "project",
+      targetId: "carbonSpaceMining",
+      type: "projectDurationMultiplier",
+      factor: 0.1,
+      computeValue(count, def) {
+        const f = typeof def.factor === "number" ? def.factor : 0.1;
+        return 1 / (1 + f * count);
+      },
+    },
+  ],
+  "icy-moon": [
+    {
+      effectId: "rwg-icy-water",
+      target: "project",
+      targetId: "waterSpaceMining",
+      type: "projectDurationMultiplier",
+      factor: 0.1,
+      computeValue(count, def) {
+        const f = typeof def.factor === "number" ? def.factor : 0.1;
+        return 1 / (1 + f * count);
+      },
+    },
+  ],
 };
 
 function applyRWGEffects() {

--- a/tests/rwgEffects.test.js
+++ b/tests/rwgEffects.test.js
@@ -2,61 +2,112 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
+function initContext(projectKey, classification) {
+  const context = { console };
+  vm.createContext(context);
+
+  context.globalEffects = {};
+  const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+  vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity; this.addEffect = addEffect;', context);
+
+  const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', context);
+
+  const rwgEffectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgEffects.js'), 'utf8');
+  vm.runInContext(rwgEffectsCode + '; this.applyRWGEffects = applyRWGEffects;', context);
+
+  context.resources = { colony: {}, special: {} };
+  context.buildings = {};
+  context.colonies = {};
+  context.populationModule = {};
+  context.tabManager = {};
+  context.fundingModule = {};
+  context.terraforming = {};
+  context.lifeDesigner = {};
+  context.lifeManager = {};
+  context.oreScanner = {};
+  context.researchManager = {};
+  context.solisManager = {};
+  context.warpGateCommand = {};
+  context.nanotechManager = {};
+  context.colonySliderSettings = {};
+
+  context.projectManager = new context.ProjectManager();
+  const projectDefs = {
+    nitrogenSpaceMining: {
+      name: 'Nitrogen harvesting',
+      duration: 100,
+      description: '',
+      cost: {},
+      category: 'resources',
+      unlocked: true,
+    },
+    carbonSpaceMining: {
+      name: 'Carbon Asteroid Mining',
+      duration: 100,
+      description: '',
+      cost: {},
+      category: 'resources',
+      unlocked: true,
+    },
+    waterSpaceMining: {
+      name: 'Ice and Water importation',
+      duration: 100,
+      description: '',
+      cost: {},
+      category: 'resources',
+      unlocked: true,
+    },
+  };
+  context.projectManager.initializeProjects({ [projectKey]: projectDefs[projectKey] });
+
+  context.spaceManager = {
+    randomWorldStatuses: {
+      a: { terraformed: true, original: { override: { classification } } },
+      b: { terraformed: true, original: { override: { classification } } },
+      c: { terraformed: true, original: { override: { classification: 'rocky' } } },
+    },
+  };
+
+  return context;
+}
+
 describe('rwgEffects titan-like nitrogen bonus', () => {
   let context;
   beforeEach(() => {
-    context = { console };
-    vm.createContext(context);
-
-    context.globalEffects = {};
-    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
-    vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity; this.addEffect = addEffect;', context);
-
-    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
-    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', context);
-
-    const rwgEffectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgEffects.js'), 'utf8');
-    vm.runInContext(rwgEffectsCode + '; this.applyRWGEffects = applyRWGEffects;', context);
-
-    context.resources = { colony: {}, special: {} };
-    context.buildings = {};
-    context.colonies = {};
-    context.populationModule = {};
-    context.tabManager = {};
-    context.fundingModule = {};
-    context.terraforming = {};
-    context.lifeDesigner = {};
-    context.lifeManager = {};
-    context.oreScanner = {};
-    context.researchManager = {};
-    context.solisManager = {};
-    context.warpGateCommand = {};
-    context.nanotechManager = {};
-    context.colonySliderSettings = {};
-
-    context.projectManager = new context.ProjectManager();
-    context.projectManager.initializeProjects({
-      nitrogenSpaceMining: {
-        name: 'Nitrogen harvesting',
-        duration: 100,
-        description: '',
-        cost: {},
-        category: 'resources',
-        unlocked: true,
-      },
-    });
-
-    context.spaceManager = {
-      randomWorldStatuses: {
-        a: { terraformed: true, original: { override: { classification: 'titan-like' } } },
-        b: { terraformed: true, original: { override: { classification: 'titan-like' } } },
-        c: { terraformed: true, original: { override: { classification: 'rocky' } } },
-      },
-    };
+    context = initContext('nitrogenSpaceMining', 'titan-like');
   });
 
   test('applies duration multiplier based on titan-like count', () => {
     const project = context.projectManager.projects.nitrogenSpaceMining;
+    expect(project.getEffectiveDuration()).toBeCloseTo(100);
+    context.applyRWGEffects();
+    expect(project.getEffectiveDuration()).toBeCloseTo(100 / (1 + 0.1 * 2));
+  });
+});
+
+describe('rwgEffects carbon-planet carbon bonus', () => {
+  let context;
+  beforeEach(() => {
+    context = initContext('carbonSpaceMining', 'carbon-planet');
+  });
+
+  test('applies duration multiplier based on carbon-planet count', () => {
+    const project = context.projectManager.projects.carbonSpaceMining;
+    expect(project.getEffectiveDuration()).toBeCloseTo(100);
+    context.applyRWGEffects();
+    expect(project.getEffectiveDuration()).toBeCloseTo(100 / (1 + 0.1 * 2));
+  });
+});
+
+describe('rwgEffects icy-moon water bonus', () => {
+  let context;
+  beforeEach(() => {
+    context = initContext('waterSpaceMining', 'icy-moon');
+  });
+
+  test('applies duration multiplier based on icy-moon count', () => {
+    const project = context.projectManager.projects.waterSpaceMining;
     expect(project.getEffectiveDuration()).toBeCloseTo(100);
     context.applyRWGEffects();
     expect(project.getEffectiveDuration()).toBeCloseTo(100 / (1 + 0.1 * 2));


### PR DESCRIPTION
## Summary
- Extend Random World Generator effects to grant carbon planets a carbon mining speed bonus and icy moons a water importation bonus.
- Document these new bonuses in AGENTS instructions.
- Add tests covering the new carbon-planet and icy-moon RWG effects.

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bc5ba26dbc832796a86c19394386ad