### PR TITLE
Add Mars-like population bonus to RWG effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,6 +456,6 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Mechanical Assistance slider hides when no gravity penalty exists, only appearing on worlds with gravity above 10 m/s².
 - Mechanical Assistance slider label includes an info tooltip explaining gravity penalty mitigation.
 - Advanced oversight assignment now respects water melt targets when focusing, allocating mirrors and lanterns by priority.
-- Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration, Carbon planets speed Carbon Asteroid Mining, and icy moons accelerate Ice and Water importation.
+- Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration, Carbon planets speed Carbon Asteroid Mining, icy moons accelerate Ice and Water importation, and Mars-like worlds boost global population growth by 1% each.
 - Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration based on count.
 - ProjectManager duration multiplier is now computed on demand via `getDurationMultiplier` instead of a stored attribute.

--- a/src/js/rwgEffects.js
+++ b/src/js/rwgEffects.js
@@ -41,6 +41,18 @@ const RWG_EFFECTS = {
       },
     },
   ],
+  "mars-like": [
+    {
+      effectId: "rwg-mars-pop",
+      target: "population",
+      type: "globalPopulationGrowth",
+      factor: 0.01,
+      computeValue(count, def) {
+        const f = typeof def.factor === "number" ? def.factor : 0.01;
+        return f * count;
+      },
+    },
+  ],
 };
 
 function applyRWGEffects() {


### PR DESCRIPTION
## Summary
- Add Mars-like RWG effect granting +1% global population growth per terraformed Mars-like world
- Test RWG Mars-like population bonus and handle classification objects in tests
- Document new RWG bonus in AGENTS notes

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bc5c9c7e1c832794f2a798df5c9c4c