### PR TITLE
Add desert RWG production bonuses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,3 +459,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration, Carbon planets speed Carbon Asteroid Mining, and icy moons accelerate Ice and Water importation.
 - Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration based on count.
 - ProjectManager duration multiplier is now computed on demand via `getDurationMultiplier` instead of a stored attribute.
+- Desert worlds grant +10% Ore Mine production per desert world terraformed, and desiccated deserts grant +10% Sand Quarry production per desiccated desert terraformed.

--- a/src/js/rwgEffects.js
+++ b/src/js/rwgEffects.js
@@ -41,6 +41,32 @@ const RWG_EFFECTS = {
       },
     },
   ],
+  "cold-desert": [
+    {
+      effectId: "rwg-desert-ore",
+      target: "building",
+      targetId: "oreMine",
+      type: "productionMultiplier",
+      factor: 0.1,
+      computeValue(count, def) {
+        const f = typeof def.factor === "number" ? def.factor : 0.1;
+        return 1 + f * count;
+      },
+    },
+  ],
+  "desiccated-desert": [
+    {
+      effectId: "rwg-desiccated-sand",
+      target: "building",
+      targetId: "sandQuarry",
+      type: "productionMultiplier",
+      factor: 0.1,
+      computeValue(count, def) {
+        const f = typeof def.factor === "number" ? def.factor : 0.1;
+        return 1 + f * count;
+      },
+    },
+  ],
 };
 
 function applyRWGEffects() {
@@ -50,7 +76,8 @@ function applyRWGEffects() {
   const statuses = spaceManager.randomWorldStatuses || {};
   for (const seed in statuses) {
     const st = statuses[seed];
-    const type = st?.original?.override?.classification.archetype;
+    const cls = st?.original?.override?.classification;
+    const type = typeof cls === "string" ? cls : cls?.archetype;
     if (st?.terraformed && type) {
       counts[type] = (counts[type] || 0) + 1;
     }

--- a/tests/rwgEffectsDesert.test.js
+++ b/tests/rwgEffectsDesert.test.js
@@ -1,0 +1,31 @@
+const { applyRWGEffects } = require('../src/js/rwgEffects.js');
+
+test('desert and desiccated-desert worlds boost ore and sand production', () => {
+  const effects = [];
+  global.addEffect = (eff) => effects.push(eff);
+  global.spaceManager = {
+    randomWorldStatuses: {
+      a: { terraformed: true, original: { override: { classification: { archetype: 'cold-desert' } } } },
+      b: { terraformed: true, original: { override: { classification: { archetype: 'cold-desert' } } } },
+      c: { terraformed: true, original: { override: { classification: { archetype: 'desiccated-desert' } } } },
+      d: { terraformed: false, original: { override: { classification: { archetype: 'desiccated-desert' } } } },
+    },
+  };
+
+  applyRWGEffects();
+
+  const desert = effects.find(e => e.effectId === 'rwg-desert-ore');
+  expect(desert).toBeDefined();
+  expect(desert.target).toBe('building');
+  expect(desert.targetId).toBe('oreMine');
+  expect(desert.value).toBeCloseTo(1.2);
+
+  const desiccated = effects.find(e => e.effectId === 'rwg-desiccated-sand');
+  expect(desiccated).toBeDefined();
+  expect(desiccated.target).toBe('building');
+  expect(desiccated.targetId).toBe('sandQuarry');
+  expect(desiccated.value).toBeCloseTo(1.1);
+
+  delete global.addEffect;
+  delete global.spaceManager;
+});


### PR DESCRIPTION
## Summary
- Boost Ore Mine production for each terraformed desert world
- Boost Sand Quarry output for desiccated deserts
- Support string or object classifications when applying RWG effects

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bc5cc6858483278a857d5740d1f495