### PR TITLE
Count super-earths as extra terraformed worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,4 +458,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Advanced oversight assignment now respects water melt targets when focusing, allocating mirrors and lanterns by priority.
 - Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration, Carbon planets speed Carbon Asteroid Mining, and icy moons accelerate Ice and Water importation.
 - Random World Generator terraformed-type effects now grant bonuses; Titan-like worlds shorten Nitrogen harvesting project duration based on count.
+- Random World Generator Super-Earths count as an additional terraformed world through a new effect.
 - ProjectManager duration multiplier is now computed on demand via `getDurationMultiplier` instead of a stored attribute.

--- a/src/js/rwgEffects.js
+++ b/src/js/rwgEffects.js
@@ -41,6 +41,16 @@ const RWG_EFFECTS = {
       },
     },
   ],
+  "super-earth": [
+    {
+      effectId: "rwg-super-earth-bonus",
+      target: "spaceManager",
+      type: "extraTerraformedWorlds",
+      computeValue(count) {
+        return count;
+      },
+    },
+  ],
 };
 
 function applyRWGEffects() {
@@ -50,7 +60,8 @@ function applyRWGEffects() {
   const statuses = spaceManager.randomWorldStatuses || {};
   for (const seed in statuses) {
     const st = statuses[seed];
-    const type = st?.original?.override?.classification.archetype;
+    const cls = st?.original?.override?.classification;
+    const type = typeof cls === 'string' ? cls : cls?.archetype;
     if (st?.terraformed && type) {
       counts[type] = (counts[type] || 0) + 1;
     }

--- a/tests/spaceManagerTerraformedCount.test.js
+++ b/tests/spaceManagerTerraformedCount.test.js
@@ -37,6 +37,35 @@ describe('SpaceManager terraformed planet counting', () => {
     expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(1);
     expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(0);
   });
+
+  test('super-earth adds extra terraformed world', () => {
+    const sm = new SpaceManager({ mars: {}, titan: {} });
+    sm.randomWorldStatuses['111'] = {
+      terraformed: true,
+      visited: true,
+      colonists: 0,
+      name: 'Seed 111',
+      original: { override: { classification: { archetype: 'super-earth' } } },
+    };
+
+    global.spaceManager = sm;
+    global.addEffect = (eff) => {
+      if (eff.target === 'spaceManager') sm.addAndReplace(eff);
+    };
+    const { applyRWGEffects } = require('../src/js/rwgEffects.js');
+    applyRWGEffects();
+
+    expect(sm.getTerraformedPlanetCount()).toBe(2);
+    expect(sm.getTerraformedPlanetCountIncludingCurrent()).toBe(3);
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(2);
+
+    sm.currentRandomSeed = '111';
+    sm.currentPlanetKey = '111';
+    expect(sm.getTerraformedPlanetCountExcludingCurrent()).toBe(0);
+
+    delete global.spaceManager;
+    delete global.addEffect;
+  });
 });
 
 delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- Add RWG effect so terraformed Super-Earths count as an extra world
- Track and apply extra terraformed worlds in SpaceManager, updating count methods
- Cover Super-Earth bonus with new test

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bc5d5215888327a1c9fdc5a920c273