### PR TITLE
Use archetype for RWG effects

### DIFF
--- a/src/js/rwgEffects.js
+++ b/src/js/rwgEffects.js
@@ -97,8 +97,7 @@ function applyRWGEffects() {
   const statuses = spaceManager.randomWorldStatuses || {};
   for (const seed in statuses) {
     const st = statuses[seed];
-    const cls = st?.original?.override?.classification;
-    const type = typeof cls === "string" ? cls : cls?.archetype;
+    const type = st?.original?.archetype || st?.original?.override?.classification?.archetype;
     if (st?.terraformed && type) {
       counts[type] = (counts[type] || 0) + 1;
     }

--- a/tests/rwgEffects.test.js
+++ b/tests/rwgEffects.test.js
@@ -61,18 +61,18 @@ function initContext(projectKey, classification) {
   };
   context.projectManager.initializeProjects({ [projectKey]: projectDefs[projectKey] });
 
-  const classObj =
+  const archetype =
     typeof classification === 'string'
-      ? { archetype: classification }
-      : classification;
+      ? classification
+      : classification.archetype;
 
   context.spaceManager = {
     randomWorldStatuses: {
-      a: { terraformed: true, original: { override: { classification: classObj } } },
-      b: { terraformed: true, original: { override: { classification: classObj } } },
+      a: { terraformed: true, original: { archetype, override: { classification: { archetype } } } },
+      b: { terraformed: true, original: { archetype, override: { classification: { archetype } } } },
       c: {
         terraformed: true,
-        original: { override: { classification: { archetype: 'rocky' } } },
+        original: { archetype: 'rocky', override: { classification: { archetype: 'rocky' } } },
       },
     },
   };

--- a/tests/rwgEffectsDesert.test.js
+++ b/tests/rwgEffectsDesert.test.js
@@ -5,10 +5,10 @@ test('desert and desiccated-desert worlds boost ore and sand production', () => 
   global.addEffect = (eff) => effects.push(eff);
   global.spaceManager = {
     randomWorldStatuses: {
-      a: { terraformed: true, original: { override: { classification: { archetype: 'cold-desert' } } } },
-      b: { terraformed: true, original: { override: { classification: { archetype: 'cold-desert' } } } },
-      c: { terraformed: true, original: { override: { classification: { archetype: 'desiccated-desert' } } } },
-      d: { terraformed: false, original: { override: { classification: { archetype: 'desiccated-desert' } } } },
+      a: { terraformed: true, original: { archetype: 'cold-desert', override: { classification: { archetype: 'cold-desert' } } } },
+      b: { terraformed: true, original: { archetype: 'cold-desert', override: { classification: { archetype: 'cold-desert' } } } },
+      c: { terraformed: true, original: { archetype: 'desiccated-desert', override: { classification: { archetype: 'desiccated-desert' } } } },
+      d: { terraformed: false, original: { archetype: 'desiccated-desert', override: { classification: { archetype: 'desiccated-desert' } } } },
     },
   };
 

--- a/tests/spaceManagerTerraformedCount.test.js
+++ b/tests/spaceManagerTerraformedCount.test.js
@@ -45,7 +45,7 @@ describe('SpaceManager terraformed planet counting', () => {
       visited: true,
       colonists: 0,
       name: 'Seed 111',
-      original: { override: { classification: { archetype: 'super-earth' } } },
+      original: { archetype: 'super-earth', override: { classification: { archetype: 'super-earth' } } },
     };
 
     global.spaceManager = sm;


### PR DESCRIPTION
## Summary
- count terraformed worlds for RWG bonuses using each world's archetype
- adjust RWG effect tests to build statuses using archetypes

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bc5f990f508327a55472a8ddc6619c