### PR TITLE
feat(rwg): add display names for world types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,3 +461,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Random World Generator Super-Earths count as an additional terraformed world through a new effect.
 - ProjectManager duration multiplier is now computed on demand via `getDurationMultiplier` instead of a stored attribute.
 - Desert worlds grant +10% Ore Mine production per desert world terraformed, and desiccated deserts grant +10% Sand Quarry production per desiccated desert terraformed.
+- Random world types now include display names used for the type dropdown and effects list.

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -71,6 +71,20 @@ try {
   calcAtmPressure = calcAtmPressure || physics.calculateAtmosphericPressure;
 } catch (_) {}
 
+// World type metadata
+const RWG_WORLD_TYPES = {
+  "mars-like": { displayName: "Mars-like" },
+  "cold-desert": { displayName: "Cold Desert" },
+  "icy-moon": { displayName: "Icy" },
+  "titan-like": { displayName: "Titan-like" },
+  "carbon-planet": { displayName: "Carbon" },
+  "desiccated-desert": { displayName: "Desiccated Desert" },
+  "super-earth": { displayName: "Super-Earth" },
+  "venus-like": { displayName: "Venus-like" },
+  rocky: { displayName: "Rocky" },
+  "hot-rocky": { displayName: "Hot Rocky" },
+};
+
 // ===================== Parameter Pack (edit here) =====================
 const DEFAULT_PARAMS = {
   naming: {
@@ -717,7 +731,22 @@ function generateRandomPlanet(seed, opts) { return rwgManager.generateRandomPlan
 function generateSystem(seed, planetCount, opts) { return rwgManager.generateSystem(seed, planetCount, opts); }
 
 // Expose globals (browser)
-if (typeof globalThis !== "undefined") { globalThis.rwgManager = rwgManager; globalThis.generateRandomPlanet = generateRandomPlanet; globalThis.generateSystem = generateSystem; globalThis.DEFAULT_PARAMS = DEFAULT_PARAMS; }
+if (typeof globalThis !== "undefined") {
+  globalThis.rwgManager = rwgManager;
+  globalThis.generateRandomPlanet = generateRandomPlanet;
+  globalThis.generateSystem = generateSystem;
+  globalThis.DEFAULT_PARAMS = DEFAULT_PARAMS;
+  globalThis.RWG_WORLD_TYPES = RWG_WORLD_TYPES;
+}
 
 // CommonJS exports
-try { module.exports = { RwgManager, rwgManager, generateRandomPlanet, generateSystem, DEFAULT_PARAMS }; } catch (_) {}
+try {
+  module.exports = {
+    RwgManager,
+    rwgManager,
+    generateRandomPlanet,
+    generateSystem,
+    DEFAULT_PARAMS,
+    RWG_WORLD_TYPES,
+  };
+} catch (_) {}

--- a/src/js/rwgEffectsUI.js
+++ b/src/js/rwgEffectsUI.js
@@ -139,7 +139,8 @@ function updateRWGEffectsUI() {
   `);
   let altFlip = false; // alternate background per group (header + effects)
   for (const entry of summary) {
-    const nice = _titleCaseArchetype(entry.type);
+    const nice = (globalThis.RWG_WORLD_TYPES && globalThis.RWG_WORLD_TYPES[entry.type]?.displayName)
+      || _titleCaseArchetype(entry.type);
     // Flip once per group
     altFlip = !altFlip;
     const groupAlt = altFlip ? ' alt' : '';

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -56,17 +56,7 @@ function initializeRandomWorldUI() {
         <option value="planet">Target: Planet</option>
         <option value="moon">Target: Moon</option>
       </select>
-      <select id="rwg-type">
-        <option value="auto" selected>Type: Auto</option>
-        <option value="mars-like">Type: Mars-like</option>
-        <option value="cold-desert">Type: Cold Desert</option>
-        <option value="icy-moon">Type: Icy</option>
-        <option value="titan-like">Type: Titan-like</option>
-        <option value="carbon-planet">Type: Carbon</option>
-        <option value="desiccated-desert">Type: Desiccated-desert</option>
-        <option value="super-earth">Type: Super-Earth</option>
-        <option value="venus-like" disabled>Type: Venus-like (Locked)</option>
-      </select>
+      <select id="rwg-type"></select>
       <select id="rwg-orbit">
         <option value="auto" selected>Orbit: Auto</option>
         <option value="hz-inner">Orbit: HZ Inner</option>
@@ -86,6 +76,39 @@ function initializeRandomWorldUI() {
   rwgTargetEl = container.querySelector('#rwg-target');
   rwgTypeEl = container.querySelector('#rwg-type');
   rwgOrbitEl = container.querySelector('#rwg-orbit');
+
+  if (rwgTypeEl) {
+    const typeOrder = [
+      'mars-like',
+      'cold-desert',
+      'icy-moon',
+      'titan-like',
+      'carbon-planet',
+      'desiccated-desert',
+      'super-earth',
+      'venus-like',
+    ];
+    const frag = document.createDocumentFragment();
+    const autoOpt = document.createElement('option');
+    autoOpt.value = 'auto';
+    autoOpt.textContent = 'Type: Auto';
+    autoOpt.selected = true;
+    frag.appendChild(autoOpt);
+    typeOrder.forEach(t => {
+      const info = (globalThis.RWG_WORLD_TYPES && globalThis.RWG_WORLD_TYPES[t]) || {};
+      const opt = document.createElement('option');
+      opt.value = t;
+      const base = `Type: ${info.displayName || t}`;
+      opt.textContent = base;
+      opt.dataset.baseText = base;
+      if (typeof rwgManager !== 'undefined' && typeof rwgManager.isTypeLocked === 'function' && rwgManager.isTypeLocked(t)) {
+        opt.disabled = true;
+        opt.textContent = `${base} (Locked)`;
+      }
+      frag.appendChild(opt);
+    });
+    rwgTypeEl.appendChild(frag);
+  }
 
   const result = document.createElement('div');
   result.id = 'rwg-result';

--- a/tests/rwgEffectsUIDisplayNames.test.js
+++ b/tests/rwgEffectsUIDisplayNames.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Random World Generator effects UI display names', () => {
+  test('effects list uses custom display names', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="space-random"><div id="rwg-history"></div></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+
+    const rwgCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwg.js'), 'utf8');
+    const rwgEffectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgEffects.js'), 'utf8');
+    const rwgEffectsUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgEffectsUI.js'), 'utf8');
+
+    vm.runInContext(`
+      ${rwgCode}
+      ${rwgEffectsCode}
+      ${rwgEffectsUICode}
+    `, ctx);
+
+    ctx.spaceManager = { randomWorldStatuses: { abc: { terraformed: true, original: { override: { classification: { archetype: 'icy-moon' } } } } } };
+    vm.runInContext('updateRWGEffectsUI();', ctx);
+
+    const header = dom.window.document.querySelector('.rwg-effects-head[data-type="icy-moon"] .col-type strong');
+    expect(header.textContent).toBe('Icy');
+  });
+});
+

--- a/tests/rwgUIDisplayNames.test.js
+++ b/tests/rwgUIDisplayNames.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Random World Generator type display names', () => {
+  test('dropdown shows custom display names', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="space-random"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+
+    const spaceUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'spaceUI.js'), 'utf8');
+    const rwgCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwg.js'), 'utf8');
+    const rwgUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+
+    vm.runInContext(`
+      function isObject(o){ return o && typeof o === 'object' && !Array.isArray(o); }
+      function deepMerge(a,b){
+        if(!isObject(a) || !isObject(b)) return { ...(a||{}), ...(b||{}) };
+        const out = { ...a };
+        Object.keys(b).forEach(k => { out[k] = isObject(a[k]) && isObject(b[k]) ? deepMerge(a[k], b[k]) : b[k]; });
+        return out;
+      }
+      const defaultPlanetParameters = { name:'Default', resources:{ colony:{}, surface:{}, underground:{}, atmospheric:{}, special:{} }, buildingParameters:{}, populationParameters:{}, celestialParameters:{} };
+      ${spaceUICode}
+      ${rwgCode}
+      ${rwgUICode}
+      initializeRandomWorldUI();
+    `, ctx);
+
+    const icyOpt = dom.window.document.querySelector('#rwg-type option[value="icy-moon"]');
+    const carbonOpt = dom.window.document.querySelector('#rwg-type option[value="carbon-planet"]');
+    expect(icyOpt.textContent).toBe('Type: Icy');
+    expect(carbonOpt.textContent).toBe('Type: Carbon');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add RWG_WORLD_TYPES with display names
- render type dropdown and effects list using display names
- test that RWG UIs show display names

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bc8c8876e4832798095cacbd49f13c