### PR TITLE
Unlock hot RWG orbits after Vega-2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,3 +462,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - ProjectManager duration multiplier is now computed on demand via `getDurationMultiplier` instead of a stored attribute.
 - Desert worlds grant +10% Ore Mine production per desert world terraformed, and desiccated deserts grant +10% Sand Quarry production per desiccated desert terraformed.
 - Random world types now include display names used for the type dropdown and effects list.
+- Completing Vega-2 (chapter 17.5) now unlocks hot orbits in the Random World Generator.

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -593,6 +593,7 @@ function addOrRemoveEffect(effect, action) {
     'solisManager' : solisManager,
     'spaceManager' : spaceManager,
     'warpGateCommand' : warpGateCommand,
+    'rwgManager': typeof rwgManager !== 'undefined' ? rwgManager : undefined,
     'nanotechManager': typeof nanotechManager !== 'undefined' ? nanotechManager : undefined,
     'colonySliders': typeof colonySliderSettings !== 'undefined' ? colonySliderSettings : undefined
   };

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -650,6 +650,14 @@ class RwgManager extends EffectableEntity {
     return base.filter((t) => !this.lockedTypes.has(t));
   }
 
+  applyEffect(effect) {
+    if (effect.type === 'unlockOrbit') {
+      this.unlockOrbit(effect.targetId);
+    } else {
+      super.applyEffect(effect);
+    }
+  }
+
   generateRandomPlanet(seed, opts = {}) {
     const P = resolveParams(this.params, opts.params);
     const { seedInt: S, baseSeed, ann: seedAnn } = parseSeedSpec(seed);

--- a/src/js/story/vega2.js
+++ b/src/js/story/vega2.js
@@ -521,7 +521,10 @@ progressVega2.chapters.push(
     ),
     prerequisites: ['chapter17.4'],
     objectives: [{ type: 'terraforming', terraformingParameter: 'complete' }],
-    reward: [{ target: 'spaceManager', type: 'setRwgLock', targetId: 'vega2', value: true },]
+    reward: [
+      { target: 'spaceManager', type: 'setRwgLock', targetId: 'vega2', value: true },
+      { target: 'rwgManager', type: 'unlockOrbit', targetId: 'hot' },
+    ]
   }
 );
 

--- a/tests/rwgHotOrbitUnlockReward.test.js
+++ b/tests/rwgHotOrbitUnlockReward.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Chapter17.5 reward unlocks hot orbit', () => {
+  test('addEffect reward unlocks hot orbit', () => {
+    const ctx = {
+      console,
+      fundingModule: {},
+      populationModule: {},
+      projectManager: {},
+      tabManager: {},
+      globalEffects: {},
+      terraforming: {},
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {},
+      researchManager: {},
+      solisManager: {},
+      spaceManager: {},
+      warpGateCommand: {}
+    };
+    vm.createContext(ctx);
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const rwgCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwg.js'), 'utf8');
+    vm.runInContext(`${effectCode}\n${rwgCode}`, ctx);
+    expect(vm.runInContext('rwgManager.isOrbitLocked("hot");', ctx)).toBe(true);
+    vm.runInContext('addEffect({ target: "rwgManager", type: "unlockOrbit", targetId: "hot" });', ctx);
+    expect(vm.runInContext('rwgManager.isOrbitLocked("hot");', ctx)).toBe(false);
+  });
+
+  test('story chapter17.5 includes unlockOrbit reward', () => {
+    const progressVega2 = require('../src/js/story/vega2.js');
+    const chapter = progressVega2.chapters.find(ch => ch.id === 'chapter17.5');
+    const hasReward = chapter.reward.some(r => r.target === 'rwgManager' && r.type === 'unlockOrbit' && r.targetId === 'hot');
+    expect(hasReward).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Unlock hot orbits in the Random World Generator once Vega-2 is terraformed
- Route story rewards to `rwgManager` and handle an `unlockOrbit` effect
- Test that Chapter 17.5 rewards enable hot orbits

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bc8ec302888327b1942a86964b81ec