### PR TITLE
Fix Vega-2 reward unlocking hot orbit in RWG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,3 +464,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Random world types now include display names used for the type dropdown and effects list.
 - Added "Very Cold" orbit preset (10–100 W/m²) to the Random World Generator.
 - Completing Vega-2 (chapter 17.5) now unlocks hot orbits in the Random World Generator.
+- Fixed the chapter 17.5 reward so the Random World Generator actually unlocks the hot orbit.

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -652,7 +652,12 @@ class RwgManager extends EffectableEntity {
   }
 
   applyEffect(effect) {
-    if(effect.type == 'enable' && effect.type2 == 'orbit'){
+    if (effect.type === 'unlockOrbit') {
+      this.unlockOrbit(effect.targetId);
+    } else if (effect.type === 'lockOrbit') {
+      this.lockOrbit(effect.targetId);
+    } else if (effect.type === 'enable' && effect.type2 === 'orbit') {
+      // Backward compatibility for older save effects
       this.unlockOrbit(effect.targetId);
     }
   }

--- a/src/js/story/vega2.js
+++ b/src/js/story/vega2.js
@@ -523,7 +523,7 @@ progressVega2.chapters.push(
     objectives: [{ type: 'terraforming', terraformingParameter: 'complete' }],
     reward: [
       { target: 'spaceManager', type: 'setRwgLock', targetId: 'vega2', value: true },
-      { target: 'rwgManager', type: 'enable', type2: 'orbit', targetId: 'hot' },
+      { target: 'rwgManager', type: 'unlockOrbit', targetId: 'hot' },
     ]
   }
 );


### PR DESCRIPTION
## Summary
- Allow RwgManager to handle `unlockOrbit` effects and retain backwards compatibility
- Use explicit `unlockOrbit` reward for Vega-2 chapter 17.5 so hot orbit becomes available
- Document fix in AGENTS instructions

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bc92cacae483278ff6d35a0e75f5fd