### PR TITLE
fix: ensure rwgManager extends EffectableEntity

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
     <script src="src/js/story/ganymede.js"></script>
     <script src="src/js/story/vega2.js"></script>
     <script src="src/js/progress-data.js"></script>
+    <script src="src/js/effectable-entity.js"></script>
     <script src="src/js/rwg.js"></script>
     <script src="src/js/rwgEquilibrate.js"></script>
     <script src="src/js/rwgEffects.js"></script>
@@ -55,7 +56,6 @@
     <!-- Core Scripts -->
     <script src="src/js/numbers.js"></script>
     <script src="src/js/buildCount.js"></script>
-    <script src="src/js/effectable-entity.js"></script>
     <script src="src/js/tab.js"></script>
     <script src="src/js/ui-utils.js"></script>
     <script src="src/js/subtab-manager.js"></script>

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -633,6 +633,9 @@ function addEffect(effect) {
 function removeEffect(effect) {
   addOrRemoveEffect(effect, 'removeEffect');
 }
+if (typeof globalThis !== "undefined") {
+  globalThis.EffectableEntity = EffectableEntity;
+}
 if (typeof module !== "undefined" && module.exports) {
   module.exports = EffectableEntity;
 }


### PR DESCRIPTION
## Summary
- Expose `EffectableEntity` on `globalThis`
- Load `effectable-entity.js` before Random World Generator scripts so `rwgManager` inherits from it

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bc952f76248327ba10a480f7766ded