### PR TITLE
Add precipitation redistribution hooks to resource cycles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,3 +465,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added "Very Cold" orbit preset (10–100 W/m²) to the Random World Generator.
 - Completing Vega-2 (chapter 17.5) now unlocks hot orbits in the Random World Generator.
 - Fixed the chapter 17.5 reward so the Random World Generator actually unlocks the hot orbit.
+- ResourceCycle now exposes an optional `redistributePrecipitation` hook implemented by
+  WaterCycle and MethaneCycle, and Terraforming calls the hook for each cycle.

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -4,10 +4,11 @@ const L_S_METHANE = 5.87e5; // Latent heat of sublimation for methane (J/kg)
 
 const isNodeHydrocarbon = (typeof module !== 'undefined' && module.exports);
 var psychrometricConstant = globalThis.psychrometricConstant;
+var redistributePrecipitationFn = globalThis.redistributePrecipitation;
 var ResourceCycleClass = globalThis.ResourceCycle;
 if (isNodeHydrocarbon) {
   try {
-    ({ psychrometricConstant } = require('./phase-change-utils.js'));
+    ({ psychrometricConstant, redistributePrecipitation: redistributePrecipitationFn } = require('./phase-change-utils.js'));
     ResourceCycleClass = require('./resource-cycle.js');
   } catch (e) {
     // fall back to globals if require fails
@@ -255,6 +256,12 @@ class MethaneCycle extends ResourceCycleClass {
       meltAmount,
       freezeAmount,
     };
+  }
+
+  redistributePrecipitation(terraforming, zonalChanges, zonalTemperatures) {
+    if (typeof redistributePrecipitationFn === 'function') {
+      redistributePrecipitationFn(terraforming, 'methane', zonalChanges, zonalTemperatures);
+    }
   }
 }
 

--- a/src/js/terraforming/resource-cycle.js
+++ b/src/js/terraforming/resource-cycle.js
@@ -89,6 +89,10 @@ class ResourceCycle {
     });
   }
 
+  // Optional hook for subclasses to redistribute precipitation across zones
+  // eslint-disable-next-line no-unused-vars
+  redistributePrecipitation(terraforming, zonalChanges, zonalTemperatures) {}
+
   rapidSublimationRate(temperature, availableIce) {
     if (temperature > this.sublimationPoint && availableIce > 0) {
       const diff = temperature - this.sublimationPoint;

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -37,7 +37,6 @@ if (typeof module !== 'undefined' && module.exports) {
     var calculateAverageCoverage = terraformUtils.calculateAverageCoverage;
     var calculateSurfaceFractions = terraformUtils.calculateSurfaceFractions;
     var calculateZonalSurfaceFractions = terraformUtils.calculateZonalSurfaceFractions;
-    var redistributePrecipitation = require('./phase-change-utils.js').redistributePrecipitation;
 
       const radiation = require('./radiation-utils.js');
       var estimateSurfaceDoseByColumn = radiation.estimateSurfaceDoseByColumn;
@@ -97,10 +96,6 @@ if (typeof module !== 'undefined' && module.exports) {
     }
 }
 
-// Fraction of precipitation redistributed across zones
-const PRECIPITATION_REDISTRIBUTION_FRACTION = 0.3;
-// Weights for redistribution: small effect from winds, larger from water coverage
-const WIND_WEIGHT = 0.2;
 
 const terraformingGasTargets = {
   carbonDioxide : {min : 0, max : 100},
@@ -772,9 +767,13 @@ class Terraforming extends EffectableEntity{
             }
         });
 
-        // --- 3. Redistribute Precipitation ---
-        redistributePrecipitation(this, 'water', zonalChanges, this.temperature.zones);
-        redistributePrecipitation(this, 'methane', zonalChanges, this.temperature.zones);
+        // --- 3. Redistribute Precipitation via cycle hooks ---
+        const cycles = [waterCycleInstance, methaneCycleInstance, co2CycleInstance];
+        for (const cycle of cycles) {
+            if (cycle && typeof cycle.redistributePrecipitation === 'function') {
+                cycle.redistributePrecipitation(this, zonalChanges, this.temperature.zones);
+            }
+        }
 
 
         // --- 4. Recalculate precipitation totals after redistribution for accurate UI reporting ---

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -3,10 +3,11 @@ const L_V_WATER = 2.45e6; // Latent heat of vaporization for water (J/kg)
 
 const isNodeWaterCycle = (typeof module !== 'undefined' && module.exports);
 var psychrometricConstant = globalThis.psychrometricConstant;
+var redistributePrecipitationFn = globalThis.redistributePrecipitation;
 var ResourceCycleClass = globalThis.ResourceCycle;
 if (isNodeWaterCycle) {
   try {
-    ({ psychrometricConstant } = require('./phase-change-utils.js'));
+    ({ psychrometricConstant, redistributePrecipitation: redistributePrecipitationFn } = require('./phase-change-utils.js'));
     ResourceCycleClass = require('./resource-cycle.js');
   } catch (e) {
     // fall back to globals if require fails
@@ -264,6 +265,12 @@ class WaterCycle extends ResourceCycleClass {
       meltAmount,
       freezeAmount,
     };
+  }
+
+  redistributePrecipitation(terraforming, zonalChanges, zonalTemperatures) {
+    if (typeof redistributePrecipitationFn === 'function') {
+      redistributePrecipitationFn(terraforming, 'water', zonalChanges, zonalTemperatures);
+    }
   }
 }
 

--- a/tests/redistributePrecipitationHook.test.js
+++ b/tests/redistributePrecipitationHook.test.js
@@ -1,0 +1,83 @@
+const { getPlanetParameters } = require('../src/js/planet-parameters.js');
+const { getZoneRatio, getZonePercentage } = require('../src/js/zones.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const lifeParameters = require('../src/js/life-parameters.js');
+const physics = require('../src/js/physics.js');
+const dryIce = require('../src/js/terraforming/dry-ice-cycle.js');
+const hydrocarbon = require('../src/js/terraforming/hydrocarbon-cycle.js');
+const water = require('../src/js/terraforming/water-cycle.js');
+
+jest.mock('../src/js/hydrology.js', () => ({
+  simulateSurfaceWaterFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
+  simulateSurfaceHydrocarbonFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
+  calculateMethaneMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 })),
+  calculateMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 })),
+}));
+
+const hydrology = require('../src/js/hydrology.js');
+
+// Required globals for terraforming.js
+global.getZoneRatio = getZoneRatio;
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+global.projectManager = { projects: { spaceMirrorFacility: { isBooleanFlagSet: () => false } }, isBooleanFlagSet: () => false };
+global.mirrorOversightSettings = {};
+global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+global.calculateEmissivity = physics.calculateEmissivity;
+global.dayNightTemperaturesModel = physics.dayNightTemperaturesModel;
+global.effectiveTemp = physics.effectiveTemp;
+global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
+global.cloudFraction = physics.cloudFraction;
+global.calculateActualAlbedoPhysics = physics.calculateActualAlbedoPhysics;
+global.airDensity = physics.airDensity;
+
+global.sublimationRateCO2 = dryIce.sublimationRateCO2;
+global.co2Cycle = dryIce.co2Cycle;
+
+global.evaporationRateMethane = hydrocarbon.evaporationRateMethane;
+global.methaneCycle = hydrocarbon.methaneCycle;
+global.boilingPointMethane = hydrocarbon.boilingPointMethane;
+global.waterCycle = water.waterCycle;
+
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+global.R_AIR = 287;
+
+const Terraforming = require('../src/js/terraforming.js');
+
+function createResources() {
+  return {
+    atmospheric: {
+      atmosphericWater: { value: 0, modifyRate: jest.fn() },
+      carbonDioxide: { value: 0, modifyRate: jest.fn() },
+      atmosphericMethane: { value: 0, modifyRate: jest.fn() },
+    },
+    surface: {
+      liquidWater: { value: 0, modifyRate: jest.fn() },
+      ice: { value: 0, modifyRate: jest.fn() },
+      dryIce: { value: 0, modifyRate: jest.fn() },
+      liquidMethane: { value: 0, modifyRate: jest.fn() },
+      hydrocarbonIce: { value: 0, modifyRate: jest.fn() },
+    },
+    colony: {},
+    special: { albedoUpgrades: { value: 0 } },
+  };
+}
+
+test('updateResources calls cycle precipitation redistribution hooks', () => {
+  const params = getPlanetParameters('titan');
+  global.currentPlanetParameters = params;
+  const res = createResources();
+  global.resources = res;
+  const terra = new Terraforming(res, params.celestialParameters);
+  terra.calculateInitialValues(params);
+
+  const waterSpy = jest.spyOn(water.waterCycle, 'redistributePrecipitation');
+  const methaneSpy = jest.spyOn(hydrocarbon.methaneCycle, 'redistributePrecipitation');
+
+  terra.updateResources(1000);
+
+  expect(waterSpy).toHaveBeenCalled();
+  expect(methaneSpy).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add optional `redistributePrecipitation` hook to `ResourceCycle`
- implement precipitation redistribution in `WaterCycle` and `MethaneCycle`
- invoke cycle `redistributePrecipitation` hooks in `Terraforming.updateResources`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bca64cb0ac83278300db793820bdcc