### PR TITLE
refactor: use cycle helpers for coverage lookups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,3 +465,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added "Very Cold" orbit preset (10–100 W/m²) to the Random World Generator.
 - Completing Vega-2 (chapter 17.5) now unlocks hot orbits in the Random World Generator.
 - Fixed the chapter 17.5 reward so the Random World Generator actually unlocks the hot orbit.
+- Cycle modules now expose `getCoverage(zone, cache)` helpers so `Terraforming.updateResources` pulls zonal coverage through each cycle instead of reading `zonalCoverageCache` directly.

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -107,6 +107,16 @@ class CO2Cycle extends ResourceCycleClass {
     });
   }
 
+  /**
+   * Extract dry ice coverage values for a zone from a cache object.
+   */
+  getCoverage(zone, cache = {}) {
+    const data = cache[zone] || {};
+    return {
+      dryIceCoverage: data.dryIce ?? 0,
+    };
+  }
+
   // Preserve original condensation calculation behavior
   condensationRateFactor({ zoneArea, co2VaporPressure, dayTemperature, nightTemperature }) {
     const condensationTemperatureCO2 = 195; // K

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -108,6 +108,17 @@ class MethaneCycle extends ResourceCycleClass {
   }
 
   /**
+   * Extract methane-related coverage values for a zone from a cache object.
+   */
+  getCoverage(zone, cache = {}) {
+    const data = cache[zone] || {};
+    return {
+      liquidMethaneCoverage: data.liquidMethane ?? 0,
+      hydrocarbonIceCoverage: data.hydrocarbonIce ?? 0,
+    };
+  }
+
+  /**
    * Compute methane-cycle changes for a zone over a time step.
    * Returns an object compatible with terraforming.updateResources zonal changes.
    */

--- a/src/js/terraforming/terraforming-utils.js
+++ b/src/js/terraforming/terraforming-utils.js
@@ -1,21 +1,41 @@
 // Utility functions for terraforming calculations
 
 const isNode = (typeof module !== 'undefined' && module.exports);
-let ZONES_LIST, getZonePercentageFn;
+let ZONES_LIST, getZonePercentageFn, terraformUtilsWaterCycle, terraformUtilsMethaneCycle, terraformUtilsCo2Cycle;
 
 if (isNode) {
   const zonesMod = require('./zones.js');
   ZONES_LIST = zonesMod.ZONES;
   getZonePercentageFn = zonesMod.getZonePercentage;
+  ({ waterCycle: terraformUtilsWaterCycle } = require('./water-cycle.js'));
+  ({ methaneCycle: terraformUtilsMethaneCycle } = require('./hydrocarbon-cycle.js'));
+  ({ co2Cycle: terraformUtilsCo2Cycle } = require('./dry-ice-cycle.js'));
 } else {
   ZONES_LIST = globalThis.ZONES;
   getZonePercentageFn = globalThis.getZonePercentage;
+  terraformUtilsWaterCycle = globalThis.waterCycle;
+  terraformUtilsMethaneCycle = globalThis.methaneCycle;
+  terraformUtilsCo2Cycle = globalThis.co2Cycle;
 }
 
 function calculateAverageCoverage(terraforming, resourceType) {
+  const coverageMap = {
+    liquidWater: { cycle: terraformUtilsWaterCycle, key: 'liquidWaterCoverage' },
+    ice: { cycle: terraformUtilsWaterCycle, key: 'iceCoverage' },
+    liquidMethane: { cycle: terraformUtilsMethaneCycle, key: 'liquidMethaneCoverage' },
+    hydrocarbonIce: { cycle: terraformUtilsMethaneCycle, key: 'hydrocarbonIceCoverage' },
+    dryIce: { cycle: terraformUtilsCo2Cycle, key: 'dryIceCoverage' },
+    biomass: { key: 'biomass' },
+  };
+  const mapping = coverageMap[resourceType];
   let weightedAverageCoverage = 0;
   for (const zone of ZONES_LIST) {
-    const cov = terraforming.zonalCoverageCache[zone]?.[resourceType] ?? 0;
+    let cov = 0;
+    if (mapping?.cycle && typeof mapping.cycle.getCoverage === 'function') {
+      cov = mapping.cycle.getCoverage(zone, terraforming.zonalCoverageCache)[mapping.key] ?? 0;
+    } else if (mapping) {
+      cov = terraforming.zonalCoverageCache[zone]?.[mapping.key] ?? 0;
+    }
     const zonePct = getZonePercentageFn(zone);
     weightedAverageCoverage += cov * zonePct;
   }
@@ -57,12 +77,10 @@ function calculateSurfaceFractions(waterCoverage, iceCoverage, biomassCoverage,
 
 function calculateZonalSurfaceFractions(terraforming, zone) {
   const cache = terraforming.zonalCoverageCache[zone] || {};
-  const water = cache.liquidWater ?? 0;
-  const ice = cache.ice ?? 0;
+  const { liquidWaterCoverage: water, iceCoverage: ice } = terraformUtilsWaterCycle.getCoverage(zone, terraforming.zonalCoverageCache);
+  const { liquidMethaneCoverage: hydro, hydrocarbonIceCoverage: hydroIce } = terraformUtilsMethaneCycle.getCoverage(zone, terraforming.zonalCoverageCache);
+  const { dryIceCoverage: dryIce } = terraformUtilsCo2Cycle.getCoverage(zone, terraforming.zonalCoverageCache);
   const bio = cache.biomass ?? 0;
-  const hydro = cache.liquidMethane ?? 0;
-  const hydroIce = cache.hydrocarbonIce ?? 0;
-  const dryIce = cache.dryIce ?? 0;
   return calculateSurfaceFractions(water, ice, bio, hydro, hydroIce, dryIce);
 }
 

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -574,9 +574,15 @@ class Terraforming extends EffectableEntity{
             const availableDryIce = this.zonalSurface[zone].dryIce || 0;
             const zonalSolarFlux = this.calculateZoneSolarFlux(zone, true);
             const zoneArea = this.zonalCoverageCache[zone]?.zoneArea ?? this.celestialParameters.surfaceArea * getZonePercentage(zone);
-            const liquidWaterCoverage = this.zonalCoverageCache[zone]?.liquidWater ?? 0;
-            const iceCoverage = this.zonalCoverageCache[zone]?.ice ?? 0;
-            const dryIceCoverage = this.zonalCoverageCache[zone]?.dryIce ?? 0;
+            const { liquidWaterCoverage, iceCoverage } = (typeof waterCycleInstance.getCoverage === 'function')
+                ? waterCycleInstance.getCoverage(zone, this.zonalCoverageCache)
+                : {
+                    liquidWaterCoverage: this.zonalCoverageCache[zone]?.liquidWater ?? 0,
+                    iceCoverage: this.zonalCoverageCache[zone]?.ice ?? 0,
+                };
+            const { dryIceCoverage } = (typeof co2CycleInstance.getCoverage === 'function')
+                ? co2CycleInstance.getCoverage(zone, this.zonalCoverageCache)
+                : { dryIceCoverage: this.zonalCoverageCache[zone]?.dryIce ?? 0 };
 
             // --- Water Cycle ---
             const waterResult = waterCycleInstance.processZone({
@@ -632,8 +638,12 @@ class Terraforming extends EffectableEntity{
             const availableLiquidMethane = this.zonalHydrocarbons[zone].liquid || 0;
             const availableHydrocarbonIce = this.zonalHydrocarbons[zone].ice || 0;
             const availableBuriedHydrocarbonIce = this.zonalHydrocarbons[zone].buriedIce || 0;
-            const liquidMethaneCoverage = this.zonalCoverageCache[zone]?.liquidMethane ?? 0;
-            const hydrocarbonIceCoverage = this.zonalCoverageCache[zone]?.hydrocarbonIce ?? 0;
+            const { liquidMethaneCoverage, hydrocarbonIceCoverage } = (typeof methaneCycleInstance.getCoverage === 'function')
+                ? methaneCycleInstance.getCoverage(zone, this.zonalCoverageCache)
+                : {
+                    liquidMethaneCoverage: this.zonalCoverageCache[zone]?.liquidMethane ?? 0,
+                    hydrocarbonIceCoverage: this.zonalCoverageCache[zone]?.hydrocarbonIce ?? 0,
+                };
 
             const methaneResult = methaneCycleInstance.processZone({
                 zoneArea,
@@ -1165,7 +1175,9 @@ class Terraforming extends EffectableEntity{
 
     calculateZonalSurfaceAlbedo(zone) {
         const groundAlbedo = this.calculateGroundAlbedo();
-        const fractions = calculateZonalSurfaceFractions(this, zone);
+        const fractions = (typeof calculateZonalSurfaceFractions === 'function')
+            ? calculateZonalSurfaceFractions(this, zone)
+            : { ocean: 0, ice: 0, hydrocarbon: 0, hydrocarbonIce: 0, co2_ice: 0, biomass: 0 };
         return surfaceAlbedoMix(groundAlbedo, fractions);
     }
 

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -121,6 +121,17 @@ class WaterCycle extends ResourceCycleClass {
   }
 
   /**
+   * Extract water-related coverage values for a zone from a cache object.
+   */
+  getCoverage(zone, cache = {}) {
+    const data = cache[zone] || {};
+    return {
+      liquidWaterCoverage: data.liquidWater ?? 0,
+      iceCoverage: data.ice ?? 0,
+    };
+  }
+
+  /**
    * Calculate zonal resource changes for water using base phase-change helpers.
    * Returns an object shaped like the entries in terraforming.updateResources's
    * `zonalChanges` map so results can be merged directly.

--- a/tests/cycleCoverage.test.js
+++ b/tests/cycleCoverage.test.js
@@ -1,0 +1,23 @@
+const { waterCycle } = require('../src/js/terraforming/water-cycle.js');
+const { methaneCycle } = require('../src/js/terraforming/hydrocarbon-cycle.js');
+const { co2Cycle } = require('../src/js/terraforming/dry-ice-cycle.js');
+
+describe('cycle getCoverage helpers', () => {
+  test('water cycle coverage extraction', () => {
+    const cache = { polar: { liquidWater: 0.2, ice: 0.5 } };
+    expect(waterCycle.getCoverage('polar', cache)).toEqual({ liquidWaterCoverage: 0.2, iceCoverage: 0.5 });
+    expect(waterCycle.getCoverage('temperate', cache)).toEqual({ liquidWaterCoverage: 0, iceCoverage: 0 });
+  });
+
+  test('methane cycle coverage extraction', () => {
+    const cache = { polar: { liquidMethane: 0.3, hydrocarbonIce: 0.1 } };
+    expect(methaneCycle.getCoverage('polar', cache)).toEqual({ liquidMethaneCoverage: 0.3, hydrocarbonIceCoverage: 0.1 });
+    expect(methaneCycle.getCoverage('temperate', cache)).toEqual({ liquidMethaneCoverage: 0, hydrocarbonIceCoverage: 0 });
+  });
+
+  test('CO2 cycle coverage extraction', () => {
+    const cache = { polar: { dryIce: 0.4 } };
+    expect(co2Cycle.getCoverage('polar', cache)).toEqual({ dryIceCoverage: 0.4 });
+    expect(co2Cycle.getCoverage('temperate', cache)).toEqual({ dryIceCoverage: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- add `getCoverage(zone, cache)` to water, methane, and CO₂ cycles
- route `Terraforming.updateResources` through cycle coverage helpers
- support cycle-driven coverage queries in `terraforming-utils`
- test coverage helper behavior

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bca6882da483279694dafbe2bc2da6