### PR TITLE
feat: centralize atmospheric loss scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,3 +468,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cycle modules now expose `getCoverage(zone, cache)` helpers so `Terraforming.updateResources` pulls zonal coverage through each cycle instead of reading `zonalCoverageCache` directly.
 - ResourceCycle now exposes an optional `redistributePrecipitation` hook implemented by
   WaterCycle and MethaneCycle, and Terraforming calls the hook for each cycle.
+- ResourceCycle now provides `finalizeAtmosphere` to scale zonal atmospheric losses and apply precipitation consistently across cycles.

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -234,6 +234,23 @@ class CO2Cycle extends ResourceCycleClass {
       sublimationAmount: sublimationAmount + rapidAmount,
     };
   }
+
+  finalizeAtmosphere({ available, zonalChanges }) {
+    return super.finalizeAtmosphere({
+      available,
+      zonalChanges,
+      atmosphereKey: 'co2',
+      processes: [
+        {
+          container: 'root',
+          potentialKey: 'potentialCO2Condensation',
+          surfaceBucket: 'water',
+          surfaceKey: 'dryIce',
+          totalKey: 'condensation',
+        },
+      ],
+    });
+  }
 }
 
 const co2Cycle = new CO2Cycle();

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -269,6 +269,32 @@ class MethaneCycle extends ResourceCycleClass {
     };
   }
 
+  finalizeAtmosphere({ available, zonalChanges }) {
+    return super.finalizeAtmosphere({
+      available,
+      zonalChanges,
+      atmosphereKey: 'methane',
+      processes: [
+        {
+          container: 'precipitation',
+          potentialKey: 'potentialMethaneRain',
+          precipitationKey: 'methaneRain',
+          surfaceBucket: 'methane',
+          surfaceKey: 'liquid',
+          totalKey: 'rain',
+        },
+        {
+          container: 'precipitation',
+          potentialKey: 'potentialMethaneSnow',
+          precipitationKey: 'methaneSnow',
+          surfaceBucket: 'methane',
+          surfaceKey: 'ice',
+          totalKey: 'snow',
+        },
+      ],
+    });
+  }
+
   redistributePrecipitation(terraforming, zonalChanges, zonalTemperatures) {
     if (typeof redistributePrecipitationFn === 'function') {
       redistributePrecipitationFn(terraforming, 'methane', zonalChanges, zonalTemperatures);

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -278,6 +278,32 @@ class WaterCycle extends ResourceCycleClass {
     };
   }
 
+  finalizeAtmosphere({ available, zonalChanges }) {
+    return super.finalizeAtmosphere({
+      available,
+      zonalChanges,
+      atmosphereKey: 'water',
+      processes: [
+        {
+          container: 'precipitation',
+          potentialKey: 'potentialRain',
+          precipitationKey: 'rain',
+          surfaceBucket: 'water',
+          surfaceKey: 'liquid',
+          totalKey: 'rain',
+        },
+        {
+          container: 'precipitation',
+          potentialKey: 'potentialSnow',
+          precipitationKey: 'snow',
+          surfaceBucket: 'water',
+          surfaceKey: 'ice',
+          totalKey: 'snow',
+        },
+      ],
+    });
+  }
+
   redistributePrecipitation(terraforming, zonalChanges, zonalTemperatures) {
     if (typeof redistributePrecipitationFn === 'function') {
       redistributePrecipitationFn(terraforming, 'water', zonalChanges, zonalTemperatures);

--- a/tests/calciteDecay.test.js
+++ b/tests/calciteDecay.test.js
@@ -28,6 +28,7 @@ jest.mock('../src/js/terraforming/water-cycle.js', () => ({
       meltAmount: 0,
       freezeAmount: 0,
     })),
+    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointWater: jest.fn(() => 373.15)
 }));
@@ -43,6 +44,7 @@ jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
       meltAmount: 0,
       freezeAmount: 0,
     })),
+    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointMethane: jest.fn(() => 112)
 }));
@@ -55,6 +57,7 @@ jest.mock('../src/js/dry-ice-cycle.js', () => ({
       potentialCO2Condensation: 0,
       sublimationAmount: 0,
     })),
+    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
 }));
 

--- a/tests/oxygenMethaneCombustion.test.js
+++ b/tests/oxygenMethaneCombustion.test.js
@@ -28,6 +28,7 @@ jest.mock('../src/js/terraforming/water-cycle.js', () => ({
       meltAmount: 0,
       freezeAmount: 0,
     })),
+    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointWater: jest.fn(() => 373.15)
 }));
@@ -43,6 +44,7 @@ jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
       meltAmount: 0,
       freezeAmount: 0,
     })),
+    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointMethane: jest.fn(() => 112)
 }));
@@ -55,6 +57,7 @@ jest.mock('../src/js/dry-ice-cycle.js', () => ({
       potentialCO2Condensation: 0,
       sublimationAmount: 0,
     })),
+    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
 }));
 

--- a/tests/resourceCycle.test.js
+++ b/tests/resourceCycle.test.js
@@ -80,4 +80,42 @@ describe('ResourceCycle base class', () => {
     expect(rate).toBeCloseTo(50 * 0.1 * 5);
     expect(rc.rapidSublimationRate(190, 50)).toBe(0);
   });
+
+  test('finalizeAtmosphere scales losses and precipitation', () => {
+    const zones = {
+      A: {
+        atmosphere: { foo: -5 },
+        precipitation: { potentialRain: 3 },
+        foo: { liquid: 0 },
+      },
+      B: {
+        atmosphere: { foo: 1 },
+        precipitation: { potentialRain: 2 },
+        foo: { liquid: 0 },
+      },
+    };
+
+    const result = rc.finalizeAtmosphere({
+      available: 2,
+      zonalChanges: zones,
+      atmosphereKey: 'foo',
+      processes: [
+        {
+          container: 'precipitation',
+          potentialKey: 'potentialRain',
+          precipitationKey: 'rain',
+          surfaceBucket: 'foo',
+          surfaceKey: 'liquid',
+          totalKey: 'rain',
+        },
+      ],
+    });
+
+    expect(zones.A.atmosphere.foo).toBeCloseTo(-2);
+    expect(zones.A.precipitation.rain).toBeCloseTo(1.2);
+    expect(zones.A.foo.liquid).toBeCloseTo(1.2);
+    expect(zones.B.precipitation.rain).toBeCloseTo(2);
+    expect(result.totalAtmosphericChange).toBeCloseTo(-1);
+    expect(result.totalsByProcess.rain).toBeCloseTo(3.2);
+  });
 });


### PR DESCRIPTION
## Summary
- add reusable finalizeAtmosphere helper to ResourceCycle
- implement finalizeAtmosphere for water, methane and CO₂ cycles
- refactor terraforming updateResources to use cycle finalizers

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bcaae93cc8832799cac63e434d255c