### PR TITLE
Refactor flow simulation to cycle methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,3 +468,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cycle modules now expose `getCoverage(zone, cache)` helpers so `Terraforming.updateResources` pulls zonal coverage through each cycle instead of reading `zonalCoverageCache` directly.
 - ResourceCycle now exposes an optional `redistributePrecipitation` hook implemented by
   WaterCycle and MethaneCycle, and Terraforming calls the hook for each cycle.
+- ResourceCycle adds a `simulateFlow` hook with WaterCycle and MethaneCycle handling
+  surface flow internally, and Terraforming loops through cycles to apply flow results.

--- a/src/js/terraforming/resource-cycle.js
+++ b/src/js/terraforming/resource-cycle.js
@@ -89,6 +89,12 @@ class ResourceCycle {
     });
   }
 
+  // Optional hook for subclasses to handle surface flow and melting
+  // eslint-disable-next-line no-unused-vars
+  simulateFlow(terraforming, durationSeconds, tempMap) {
+    return { totalMelt: 0, changes: {} };
+  }
+
   // Optional hook for subclasses to redistribute precipitation across zones
   // eslint-disable-next-line no-unused-vars
   redistributePrecipitation(terraforming, zonalChanges, zonalTemperatures) {}


### PR DESCRIPTION
## Summary
- Add a `simulateFlow` hook to `ResourceCycle` with default no-op.
- Delegate surface flow to `WaterCycle` and `MethaneCycle` implementations.
- Iterate over resource cycles in `updateResources` to apply flow results.

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bcaaee54788327bacd010cc14b2f1f