### PR TITLE
feat: centralize resource cycle execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,3 +469,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - ResourceCycle now exposes an optional `redistributePrecipitation` hook implemented by
   WaterCycle and MethaneCycle, and Terraforming calls the hook for each cycle.
 - ResourceCycle now provides `finalizeAtmosphere` to scale zonal atmospheric losses and apply precipitation consistently across cycles.
+- ResourceCycle now offers a `runCycle` method that processes all zones, finalizes atmospheric changes and redistributes precipitation so terraformers can access zonal and total results.

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -251,6 +251,26 @@ class CO2Cycle extends ResourceCycleClass {
       ],
     });
   }
+
+  runCycle(terraforming, zones, {
+    atmPressure = 0,
+    vaporPressure = 0,
+    available = 0,
+    durationSeconds = 1,
+    condensationParameter = 1,
+  } = {}) {
+    return super.runCycle(terraforming, zones, {
+      zonalKey: 'zonalSurface',
+      surfaceBucket: 'water',
+      atmosphereKey: 'co2',
+      vaporPressure,
+      available,
+      atmPressure,
+      durationSeconds,
+      availableKeys: ['dryIce'],
+      extraParams: { condensationParameter },
+    });
+  }
 }
 
 const co2Cycle = new CO2Cycle();

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -300,6 +300,27 @@ class MethaneCycle extends ResourceCycleClass {
       redistributePrecipitationFn(terraforming, 'methane', zonalChanges, zonalTemperatures);
     }
   }
+
+  runCycle(terraforming, zones, {
+    atmPressure = 0,
+    vaporPressure = 0,
+    available = 0,
+    durationSeconds = 1,
+    gravity = 1,
+    condensationParameter = 1,
+  } = {}) {
+    return super.runCycle(terraforming, zones, {
+      zonalKey: 'zonalHydrocarbons',
+      surfaceBucket: 'methane',
+      atmosphereKey: 'methane',
+      vaporPressure,
+      available,
+      atmPressure,
+      durationSeconds,
+      availableKeys: ['liquid', 'ice', 'buriedIce'],
+      extraParams: { gravity, condensationParameter },
+    });
+  }
 }
 
 const methaneCycle = new MethaneCycle();

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -309,6 +309,27 @@ class WaterCycle extends ResourceCycleClass {
       redistributePrecipitationFn(terraforming, 'water', zonalChanges, zonalTemperatures);
     }
   }
+
+  runCycle(terraforming, zones, {
+    atmPressure = 0,
+    vaporPressure = 0,
+    available = 0,
+    durationSeconds = 1,
+    gravity = 1,
+    precipitationMultiplier = 1,
+  } = {}) {
+    return super.runCycle(terraforming, zones, {
+      zonalKey: 'zonalWater',
+      surfaceBucket: 'water',
+      atmosphereKey: 'water',
+      vaporPressure,
+      available,
+      atmPressure,
+      durationSeconds,
+      availableKeys: ['liquid', 'ice', 'buriedIce'],
+      extraParams: { gravity, precipitationMultiplier },
+    });
+  }
 }
 
 const waterCycle = new WaterCycle();

--- a/tests/calciteDecay.test.js
+++ b/tests/calciteDecay.test.js
@@ -19,45 +19,42 @@ jest.mock('../src/js/terraforming-utils.js', () => ({
 
 jest.mock('../src/js/terraforming/water-cycle.js', () => ({
   waterCycle: {
-    processZone: jest.fn(() => ({
-      atmosphere: { water: 0 },
-      water: { liquid: 0, ice: 0, buriedIce: 0 },
-      precipitation: { potentialRain: 0, potentialSnow: 0 },
-      evaporationAmount: 0,
-      sublimationAmount: 0,
-      meltAmount: 0,
-      freezeAmount: 0,
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        temperate: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        polar: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+      },
+      totals: {},
     })),
-    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointWater: jest.fn(() => 373.15)
 }));
 
 jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
   methaneCycle: {
-    processZone: jest.fn(() => ({
-      atmosphere: { methane: 0 },
-      methane: { liquid: 0, ice: 0, buriedIce: 0 },
-      precipitation: { potentialMethaneRain: 0, potentialMethaneSnow: 0 },
-      evaporationAmount: 0,
-      sublimationAmount: 0,
-      meltAmount: 0,
-      freezeAmount: 0,
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, methane: {}, water: {}, precipitation: {} },
+        temperate: { atmosphere: {}, methane: {}, water: {}, precipitation: {} },
+        polar: { atmosphere: {}, methane: {}, water: {}, precipitation: {} },
+      },
+      totals: {},
     })),
-    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointMethane: jest.fn(() => 112)
 }));
 
 jest.mock('../src/js/dry-ice-cycle.js', () => ({
   co2Cycle: {
-    processZone: jest.fn(() => ({
-      atmosphere: { co2: 0 },
-      water: { dryIce: 0 },
-      potentialCO2Condensation: 0,
-      sublimationAmount: 0,
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        temperate: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        polar: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+      },
+      totals: {},
     })),
-    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
 }));
 

--- a/tests/oxygenMethaneCombustion.test.js
+++ b/tests/oxygenMethaneCombustion.test.js
@@ -19,45 +19,42 @@ jest.mock('../src/js/terraforming-utils.js', () => ({
 
 jest.mock('../src/js/terraforming/water-cycle.js', () => ({
   waterCycle: {
-    processZone: jest.fn(() => ({
-      atmosphere: { water: 0 },
-      water: { liquid: 0, ice: 0, buriedIce: 0 },
-      precipitation: { potentialRain: 0, potentialSnow: 0 },
-      evaporationAmount: 0,
-      sublimationAmount: 0,
-      meltAmount: 0,
-      freezeAmount: 0,
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        temperate: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        polar: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+      },
+      totals: {},
     })),
-    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointWater: jest.fn(() => 373.15)
 }));
 
 jest.mock('../src/js/hydrocarbon-cycle.js', () => ({
   methaneCycle: {
-    processZone: jest.fn(() => ({
-      atmosphere: { methane: 0 },
-      methane: { liquid: 0, ice: 0, buriedIce: 0 },
-      precipitation: { potentialMethaneRain: 0, potentialMethaneSnow: 0 },
-      evaporationAmount: 0,
-      sublimationAmount: 0,
-      meltAmount: 0,
-      freezeAmount: 0,
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, methane: {}, water: {}, precipitation: {} },
+        temperate: { atmosphere: {}, methane: {}, water: {}, precipitation: {} },
+        polar: { atmosphere: {}, methane: {}, water: {}, precipitation: {} },
+      },
+      totals: {},
     })),
-    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
   boilingPointMethane: jest.fn(() => 112)
 }));
 
 jest.mock('../src/js/dry-ice-cycle.js', () => ({
   co2Cycle: {
-    processZone: jest.fn(() => ({
-      atmosphere: { co2: 0 },
-      water: { dryIce: 0 },
-      potentialCO2Condensation: 0,
-      sublimationAmount: 0,
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        temperate: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        polar: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+      },
+      totals: {},
     })),
-    finalizeAtmosphere: jest.fn(() => ({ totalAtmosphericChange: 0, totalsByProcess: {} })),
   },
 }));
 


### PR DESCRIPTION
## Summary
- add `runCycle` to ResourceCycle to process zones, finalize atmosphere, and redistribute precipitation
- expose `runCycle` hooks in water, methane, and CO₂ cycle modules
- streamline `Terraforming.updateResources` to use each cycle's `runCycle`

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bcb24d419c832798124a681be2be01