### PR TITLE
Store cycle defaults for streamlined resource updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,3 +470,4 @@ The Random World Generator manager builds procedural planets and moons with lock
   WaterCycle and MethaneCycle, and Terraforming calls the hook for each cycle.
 - ResourceCycle now provides `finalizeAtmosphere` to scale zonal atmospheric losses and apply precipitation consistently across cycles.
 - ResourceCycle now offers a `runCycle` method that processes all zones, finalizes atmospheric changes and redistributes precipitation so terraformers can access zonal and total results.
+- Cycle subclasses store default keys and parameters so `updateResources` only supplies dynamic values when running cycles.

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -93,7 +93,13 @@ function slopeSVPCO2(temperature) {
 }
 
 class CO2Cycle extends ResourceCycleClass {
-  constructor() {
+  constructor({
+    zonalKey = 'zonalSurface',
+    surfaceBucket = 'water',
+    atmosphereKey = 'co2',
+    availableKeys = ['dryIce'],
+    condensationParameter = 1,
+  } = {}) {
     super({
       latentHeatVaporization: L_S_CO2,
       latentHeatSublimation: L_S_CO2,
@@ -105,6 +111,11 @@ class CO2Cycle extends ResourceCycleClass {
       evaporationAlbedo: 0.6,
       sublimationAlbedo: 0.6,
     });
+    this.zonalKey = zonalKey;
+    this.surfaceBucket = surfaceBucket;
+    this.atmosphereKey = atmosphereKey;
+    this.availableKeys = availableKeys;
+    this.defaultExtraParams = { condensationParameter };
   }
 
   /**
@@ -249,26 +260,6 @@ class CO2Cycle extends ResourceCycleClass {
           totalKey: 'condensation',
         },
       ],
-    });
-  }
-
-  runCycle(terraforming, zones, {
-    atmPressure = 0,
-    vaporPressure = 0,
-    available = 0,
-    durationSeconds = 1,
-    condensationParameter = 1,
-  } = {}) {
-    return super.runCycle(terraforming, zones, {
-      zonalKey: 'zonalSurface',
-      surfaceBucket: 'water',
-      atmosphereKey: 'co2',
-      vaporPressure,
-      available,
-      atmPressure,
-      durationSeconds,
-      availableKeys: ['dryIce'],
-      extraParams: { condensationParameter },
     });
   }
 }

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -90,6 +90,12 @@ class MethaneCycle extends ResourceCycleClass {
     maxDiff = 10,
     boilingPointFn = boilingPointMethane,
     boilTransitionRange = 5,
+    zonalKey = 'zonalHydrocarbons',
+    surfaceBucket = 'methane',
+    atmosphereKey = 'methane',
+    availableKeys = ['liquid', 'ice', 'buriedIce'],
+    gravity = 1,
+    condensationParameter = 1,
   } = {}) {
     super({
       latentHeatVaporization: L_V_METHANE,
@@ -106,6 +112,11 @@ class MethaneCycle extends ResourceCycleClass {
     this.maxDiff = maxDiff;
     this.boilingPointFn = boilingPointFn;
     this.boilTransitionRange = boilTransitionRange;
+    this.zonalKey = zonalKey;
+    this.surfaceBucket = surfaceBucket;
+    this.atmosphereKey = atmosphereKey;
+    this.availableKeys = availableKeys;
+    this.defaultExtraParams = { gravity, condensationParameter };
   }
 
   /**
@@ -299,27 +310,6 @@ class MethaneCycle extends ResourceCycleClass {
     if (typeof redistributePrecipitationFn === 'function') {
       redistributePrecipitationFn(terraforming, 'methane', zonalChanges, zonalTemperatures);
     }
-  }
-
-  runCycle(terraforming, zones, {
-    atmPressure = 0,
-    vaporPressure = 0,
-    available = 0,
-    durationSeconds = 1,
-    gravity = 1,
-    condensationParameter = 1,
-  } = {}) {
-    return super.runCycle(terraforming, zones, {
-      zonalKey: 'zonalHydrocarbons',
-      surfaceBucket: 'methane',
-      atmosphereKey: 'methane',
-      vaporPressure,
-      available,
-      atmPressure,
-      durationSeconds,
-      availableKeys: ['liquid', 'ice', 'buriedIce'],
-      extraParams: { gravity, condensationParameter },
-    });
   }
 }
 

--- a/src/js/terraforming/resource-cycle.js
+++ b/src/js/terraforming/resource-cycle.js
@@ -149,18 +149,19 @@ class ResourceCycle {
   }
 
   runCycle(terraforming, zones, {
-    zonalKey,
-    surfaceBucket,
-    atmosphereKey,
+    zonalKey = this.zonalKey,
+    surfaceBucket = this.surfaceBucket,
+    atmosphereKey = this.atmosphereKey,
     vaporPressure = 0,
     available = 0,
     atmPressure = 0,
     durationSeconds = 1,
-    availableKeys = [],
+    availableKeys = this.availableKeys || [],
     extraParams = {},
   } = {}) {
     const zonalChanges = {};
     const cycleTotals = { evaporation: 0, sublimation: 0, melt: 0, freeze: 0 };
+    const mergedExtra = { ...(this.defaultExtraParams || {}), ...extraParams };
 
     for (const zone of zones) {
       const temps = terraforming.temperature.zones[zone] || {};
@@ -180,7 +181,7 @@ class ResourceCycle {
         zonalSolarFlux: terraforming.calculateZoneSolarFlux(zone, true),
         durationSeconds,
         ...coverage,
-        ...extraParams,
+        ...mergedExtra,
       };
       for (const key of availableKeys) {
         const paramKey = 'available' + key.charAt(0).toUpperCase() + key.slice(1);
@@ -216,6 +217,7 @@ class ResourceCycle {
     const finalizeResult = this.finalizeAtmosphere({
       available,
       zonalChanges,
+      atmosphereKey,
     });
 
     if (typeof this.redistributePrecipitation === 'function') {

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -593,13 +593,14 @@ class Terraforming extends EffectableEntity{
             }
         };
 
+        if (!waterCycleInstance.defaultExtraParams) waterCycleInstance.defaultExtraParams = {};
+        waterCycleInstance.defaultExtraParams.gravity = gravity;
+        waterCycleInstance.defaultExtraParams.precipitationMultiplier = precipitationMultiplier;
         const waterData = waterCycleInstance.runCycle(this, zones, {
             atmPressure: globalTotalPressurePa,
             vaporPressure: globalWaterPressurePa,
             available: availableGlobalWaterVapor,
             durationSeconds,
-            gravity,
-            precipitationMultiplier,
         });
         mergeZonalChanges(waterData.zonalChanges);
         cycleTotals.water.evaporation = waterData.totals.evaporation || 0;
@@ -610,13 +611,14 @@ class Terraforming extends EffectableEntity{
         totalRainfallAmount = waterData.totals.rain || 0;
         totalSnowfallAmount = waterData.totals.snow || 0;
 
+        if (!methaneCycleInstance.defaultExtraParams) methaneCycleInstance.defaultExtraParams = {};
+        methaneCycleInstance.defaultExtraParams.gravity = gravity;
+        methaneCycleInstance.defaultExtraParams.condensationParameter = methaneCondensationParameter;
         const methaneData = methaneCycleInstance.runCycle(this, zones, {
             atmPressure: globalTotalPressurePa,
             vaporPressure: globalMethanePressurePa,
             available: availableGlobalMethaneGas,
             durationSeconds,
-            gravity,
-            condensationParameter: methaneCondensationParameter,
         });
         mergeZonalChanges(methaneData.zonalChanges);
         cycleTotals.methane.evaporation = methaneData.totals.evaporation || 0;
@@ -627,12 +629,13 @@ class Terraforming extends EffectableEntity{
         totalMethaneCondensationAmount = methaneData.totals.methaneRain || methaneData.totals.rain || 0;
         totalMethaneIceCondensationAmount = methaneData.totals.methaneSnow || methaneData.totals.snow || 0;
 
+        if (!co2CycleInstance.defaultExtraParams) co2CycleInstance.defaultExtraParams = {};
+        co2CycleInstance.defaultExtraParams.condensationParameter = condensationParameter;
         const co2Data = co2CycleInstance.runCycle(this, zones, {
             atmPressure: globalTotalPressurePa,
             vaporPressure: globalCo2PressurePa,
             available: availableGlobalCo2Gas,
             durationSeconds,
-            condensationParameter,
         });
         mergeZonalChanges(co2Data.zonalChanges);
         cycleTotals.co2.sublimation = co2Data.totals.sublimation || 0;

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -110,7 +110,14 @@ function derivativeSaturationVaporPressureBuck(T) {
 }
 
 class WaterCycle extends ResourceCycleClass {
-  constructor() {
+  constructor({
+    zonalKey = 'zonalWater',
+    surfaceBucket = 'water',
+    atmosphereKey = 'water',
+    availableKeys = ['liquid', 'ice', 'buriedIce'],
+    gravity = 1,
+    precipitationMultiplier = 1,
+  } = {}) {
     super({
       latentHeatVaporization: L_V_WATER,
       latentHeatSublimation: L_S_WATER,
@@ -119,6 +126,11 @@ class WaterCycle extends ResourceCycleClass {
       freezePoint: 273.15,
       sublimationPoint: 273.15,
     });
+    this.zonalKey = zonalKey;
+    this.surfaceBucket = surfaceBucket;
+    this.atmosphereKey = atmosphereKey;
+    this.availableKeys = availableKeys;
+    this.defaultExtraParams = { gravity, precipitationMultiplier };
   }
 
   /**
@@ -308,27 +320,6 @@ class WaterCycle extends ResourceCycleClass {
     if (typeof redistributePrecipitationFn === 'function') {
       redistributePrecipitationFn(terraforming, 'water', zonalChanges, zonalTemperatures);
     }
-  }
-
-  runCycle(terraforming, zones, {
-    atmPressure = 0,
-    vaporPressure = 0,
-    available = 0,
-    durationSeconds = 1,
-    gravity = 1,
-    precipitationMultiplier = 1,
-  } = {}) {
-    return super.runCycle(terraforming, zones, {
-      zonalKey: 'zonalWater',
-      surfaceBucket: 'water',
-      atmosphereKey: 'water',
-      vaporPressure,
-      available,
-      atmPressure,
-      durationSeconds,
-      availableKeys: ['liquid', 'ice', 'buriedIce'],
-      extraParams: { gravity, precipitationMultiplier },
-    });
   }
 }
 

--- a/tests/cycleDefaults.test.js
+++ b/tests/cycleDefaults.test.js
@@ -1,0 +1,82 @@
+const { WaterCycle } = require('../src/js/terraforming/water-cycle.js');
+const { MethaneCycle } = require('../src/js/terraforming/hydrocarbon-cycle.js');
+const { CO2Cycle } = require('../src/js/terraforming/dry-ice-cycle.js');
+
+describe('cycle default parameters', () => {
+  test('water cycle uses constructor defaults', () => {
+    const wc = new WaterCycle({ gravity: 9, precipitationMultiplier: 2 });
+    wc.redistributePrecipitation = () => {};
+    const tf = {
+      temperature: { zones: { tropical: {} } },
+      zonalCoverageCache: { tropical: { zoneArea: 1 } },
+      calculateZoneSolarFlux: () => 0,
+      zonalWater: { tropical: { liquid: 5 } },
+      celestialParameters: { surfaceArea: 1 },
+    };
+    const spy = jest.spyOn(wc, 'processZone').mockReturnValue({ atmosphere: { water: 0 }, water: {} });
+    const result = wc.runCycle(tf, ['tropical'], {
+      atmPressure: 0,
+      vaporPressure: 0,
+      available: 0,
+      durationSeconds: 1,
+    });
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({
+      availableLiquid: 5,
+      gravity: 9,
+      precipitationMultiplier: 2,
+    }));
+    expect(result.zonalChanges.tropical.atmosphere.water).toBe(0);
+    expect(result.zonalChanges.tropical.water).toBeDefined();
+  });
+
+  test('methane cycle uses constructor defaults', () => {
+    const mc = new MethaneCycle({ gravity: 1.6, condensationParameter: 3 });
+    mc.redistributePrecipitation = () => {};
+    const tf = {
+      temperature: { zones: { polar: {} } },
+      zonalCoverageCache: { polar: { zoneArea: 1 } },
+      calculateZoneSolarFlux: () => 0,
+      zonalHydrocarbons: { polar: { liquid: 7 } },
+      celestialParameters: { surfaceArea: 1 },
+    };
+    const spy = jest.spyOn(mc, 'processZone').mockReturnValue({ atmosphere: { methane: 0 }, methane: {} });
+    const result = mc.runCycle(tf, ['polar'], {
+      atmPressure: 0,
+      vaporPressure: 0,
+      available: 0,
+      durationSeconds: 1,
+    });
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({
+      availableLiquid: 7,
+      gravity: 1.6,
+      condensationParameter: 3,
+    }));
+    expect(result.zonalChanges.polar.atmosphere.methane).toBe(0);
+    expect(result.zonalChanges.polar.methane).toBeDefined();
+  });
+
+  test('co2 cycle uses constructor defaults', () => {
+    const cc = new CO2Cycle({ condensationParameter: 4 });
+    cc.redistributePrecipitation = () => {};
+    const tf = {
+      temperature: { zones: { temperate: {} } },
+      zonalCoverageCache: { temperate: { zoneArea: 1 } },
+      calculateZoneSolarFlux: () => 0,
+      zonalSurface: { temperate: { dryIce: 2 } },
+      celestialParameters: { surfaceArea: 1 },
+    };
+    const spy = jest.spyOn(cc, 'processZone').mockReturnValue({ atmosphere: { co2: 0 }, water: { dryIce: 0 }, potentialCO2Condensation: 0 });
+    const result = cc.runCycle(tf, ['temperate'], {
+      atmPressure: 0,
+      vaporPressure: 0,
+      available: 0,
+      durationSeconds: 1,
+    });
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({
+      availableDryIce: 2,
+      condensationParameter: 4,
+    }));
+    expect(result.zonalChanges.temperate.atmosphere.co2).toBe(0);
+    expect(result.zonalChanges.temperate.water).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Allow cycle constructors to configure default keys and constants, including gravity, precipitation multipliers, and condensation parameters
- Let `ResourceCycle.runCycle` fall back on stored defaults and merge constant params
- Update `Terraforming.updateResources` to supply only dynamic values when executing cycles
- Verify default behavior with new cycle default tests

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bcb555fb388327b61b55abd5f58d88