### PR TITLE
Refactor resource cycles into configurable loop

### DIFF
--- a/tests/terraformingCycleLoop.test.js
+++ b/tests/terraformingCycleLoop.test.js
@@ -1,0 +1,141 @@
+const { getPlanetParameters } = require('../src/js/planet-parameters.js');
+const { getZoneRatio, getZonePercentage } = require('../src/js/zones.js');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+const lifeParameters = require('../src/js/life-parameters.js');
+const physics = require('../src/js/physics.js');
+
+jest.mock('../src/js/hydrology.js', () => ({
+  simulateSurfaceWaterFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
+  simulateSurfaceHydrocarbonFlow: jest.fn(() => ({ totalMelt: 0, changes: { tropical: {}, temperate: {}, polar: {} } })),
+  calculateMethaneMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 })),
+  calculateMeltingFreezingRates: jest.fn(() => ({ meltingRate: 0, freezingRate: 0 }))
+}));
+
+jest.mock('../src/js/terraforming-utils.js', () => ({
+  calculateAverageCoverage: jest.fn(() => 0),
+  calculateSurfaceFractions: jest.fn(() => ({})),
+  calculateZonalSurfaceFractions: jest.fn(() => ({}))
+}));
+
+jest.mock('../src/js/terraforming/water-cycle.js', () => ({
+  waterCycle: {
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: { water: 5 }, water: { liquid: 2 }, methane: {}, precipitation: { rain: 1 } },
+        temperate: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        polar: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+      },
+      totals: {
+        evaporation: 2,
+        sublimation: 0,
+        melt: 0,
+        freeze: 0,
+        totalAtmosphericChange: 5,
+        rain: 1,
+        snow: 0,
+      },
+    })),
+  },
+  boilingPointWater: jest.fn(() => 373.15),
+}));
+
+jest.mock('../src/js/terraforming/hydrocarbon-cycle.js', () => ({
+  methaneCycle: {
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        temperate: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        polar: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+      },
+      totals: {
+        evaporation: 0,
+        sublimation: 0,
+        melt: 0,
+        freeze: 0,
+        totalAtmosphericChange: 0,
+        methaneRain: 0,
+        methaneSnow: 0,
+      },
+    })),
+  },
+  boilingPointMethane: jest.fn(() => 112),
+}));
+
+jest.mock('../src/js/terraforming/dry-ice-cycle.js', () => ({
+  co2Cycle: {
+    runCycle: jest.fn(() => ({
+      zonalChanges: {
+        tropical: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        temperate: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+        polar: { atmosphere: {}, water: {}, methane: {}, precipitation: {} },
+      },
+      totals: {
+        sublimation: 0,
+        totalAtmosphericChange: 0,
+        condensation: 0,
+      },
+    })),
+  },
+}));
+
+jest.mock('../src/js/radiation-utils.js', () => ({
+  estimateSurfaceDoseByColumn: jest.fn(() => 0),
+  radiationPenalty: jest.fn(() => 0),
+}));
+
+global.getZoneRatio = getZoneRatio;
+global.getZonePercentage = getZonePercentage;
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = lifeParameters;
+global.projectManager = { projects: { spaceMirrorFacility: { isBooleanFlagSet: () => false } }, isBooleanFlagSet: () => false };
+global.mirrorOversightSettings = {};
+global.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+global.calculateEmissivity = physics.calculateEmissivity;
+global.dayNightTemperaturesModel = physics.dayNightTemperaturesModel;
+global.effectiveTemp = physics.effectiveTemp;
+global.surfaceAlbedoMix = physics.surfaceAlbedoMix;
+global.cloudFraction = physics.cloudFraction;
+global.calculateActualAlbedoPhysics = physics.calculateActualAlbedoPhysics;
+global.airDensity = physics.airDensity;
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+global.R_AIR = 287;
+
+const Terraforming = require('../src/js/terraforming.js');
+
+delete global.calculateZoneSolarFluxWithFacility;
+
+function createResources() {
+  return {
+    atmospheric: {
+      oxygen: { value: 0, modifyRate: jest.fn() },
+      atmosphericMethane: { value: 0, modifyRate: jest.fn() },
+      atmosphericWater: { value: 0, modifyRate: jest.fn() },
+      carbonDioxide: { value: 0, modifyRate: jest.fn() },
+    },
+    surface: {
+      liquidWater: { value: 0, modifyRate: jest.fn() },
+      ice: { value: 0, modifyRate: jest.fn() },
+      dryIce: { value: 0, modifyRate: jest.fn() },
+      liquidMethane: { value: 0, modifyRate: jest.fn() },
+      hydrocarbonIce: { value: 0, modifyRate: jest.fn() },
+    },
+    colony: { colonists: { value: 0 }, workers: { value: 0, cap: 0 } },
+    special: { albedoUpgrades: { value: 0 } },
+  };
+}
+
+test('water cycle updates via loop', () => {
+  const params = getPlanetParameters('mars');
+  global.currentPlanetParameters = params;
+  const res = createResources();
+  global.resources = res;
+  const terra = new Terraforming(res, params.celestialParameters);
+  terra.calculateInitialValues(params);
+
+  terra.updateResources(1);
+  expect(require('../src/js/terraforming/water-cycle.js').waterCycle.runCycle).toHaveBeenCalledTimes(1);
+  expect(require('../src/js/terraforming/hydrocarbon-cycle.js').methaneCycle.runCycle).toHaveBeenCalledTimes(1);
+  expect(require('../src/js/terraforming/dry-ice-cycle.js').co2Cycle.runCycle).toHaveBeenCalledTimes(1);
+  expect(terra.zonalWater.tropical.liquid).toBe(2);
+});


### PR DESCRIPTION
## Summary
- Build cycle configuration array and loop through water, methane, and CO₂ cycles
- Replace explicit runCycle calls with loop and consolidate total handling
- Add unit test ensuring looped execution invokes each cycle and applies zonal water changes

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bcb741359c8327bc6adc117445a6cc