### PR TITLE
Refactor surface flow into cycle helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,3 +471,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - ResourceCycle now provides `finalizeAtmosphere` to scale zonal atmospheric losses and apply precipitation consistently across cycles.
 - ResourceCycle now offers a `runCycle` method that processes all zones, finalizes atmospheric changes and redistributes precipitation so terraformers can access zonal and total results.
 - Cycle subclasses store default keys and parameters so `updateResources` only supplies dynamic values when running cycles.
+- Water and methane cycles now run surface flow during `runCycle` via a shared `surfaceFlow` helper, removing standalone flow simulation from `updateResources`.


### PR DESCRIPTION
## Summary
- add `surfaceFlow` helpers wrapping hydrology flow simulations for water and methane cycles
- run surface flow within each cycle's `runCycle` and track melt totals
- remove standalone flow simulation from `updateResources`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bcbf032714832796b6245c17253986