### PR TITLE
Refactor terraforming cycle handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,3 +474,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Water and methane cycles now run surface flow during `runCycle` via a shared `surfaceFlow` helper, removing standalone flow simulation from `updateResources`.
 - ResourceCycle provides `applyZonalChanges` to update zonal surface stores and return totals, letting `runCycle` and its subclasses apply results without merge loops in `updateResources`.
 - Resource cycles now expose `updateResourceRates` and Terraforming loops call each cycle to update atmospheric and surface resource rates.
+- Cycle instances now carry atmospheric keys and process metadata and Terraforming loops over a `cycles` array to run them.

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -94,6 +94,10 @@ function slopeSVPCO2(temperature) {
 
 class CO2Cycle extends ResourceCycleClass {
   constructor({
+    key = 'co2',
+    atmKey = 'carbonDioxide',
+    totalKeys = ['sublimation'],
+    processTotalKeys = { condensation: 'condensation' },
     zonalKey = 'zonalSurface',
     surfaceBucket = 'water',
     atmosphereKey = 'co2',
@@ -111,11 +115,21 @@ class CO2Cycle extends ResourceCycleClass {
       evaporationAlbedo: 0.6,
       sublimationAlbedo: 0.6,
     });
+    this.key = key;
+    this.atmKey = atmKey;
+    this.totalKeys = totalKeys;
+    this.processTotalKeys = processTotalKeys;
     this.zonalKey = zonalKey;
     this.surfaceBucket = surfaceBucket;
     this.atmosphereKey = atmosphereKey;
     this.availableKeys = availableKeys;
     this.defaultExtraParams = { condensationParameter };
+  }
+
+  getExtraParams(terraforming) {
+    return {
+      condensationParameter: terraforming.equilibriumCondensationParameter,
+    };
   }
 
   /**

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -99,6 +99,10 @@ function slopeSVPMethane(temperature) {
 
 class MethaneCycle extends ResourceCycleClass {
   constructor({
+    key = 'methane',
+    atmKey = 'atmosphericMethane',
+    totalKeys = ['evaporation', 'sublimation', 'melt', 'freeze'],
+    processTotalKeys = { rain: 'methaneRain', snow: 'methaneSnow' },
     transitionRange = 2,
     maxDiff = 10,
     boilingPointFn = boilingPointMethane,
@@ -121,6 +125,10 @@ class MethaneCycle extends ResourceCycleClass {
       evaporationAlbedo: 0.1,
       sublimationAlbedo: 0.6,
     });
+    this.key = key;
+    this.atmKey = atmKey;
+    this.totalKeys = totalKeys;
+    this.processTotalKeys = processTotalKeys;
     this.transitionRange = transitionRange;
     this.maxDiff = maxDiff;
     this.boilingPointFn = boilingPointFn;
@@ -130,6 +138,13 @@ class MethaneCycle extends ResourceCycleClass {
     this.atmosphereKey = atmosphereKey;
     this.availableKeys = availableKeys;
     this.defaultExtraParams = { gravity, condensationParameter };
+  }
+
+  getExtraParams(terraforming) {
+    return {
+      gravity: terraforming.celestialParameters.gravity,
+      condensationParameter: terraforming.equilibriumMethaneCondensationParameter,
+    };
   }
 
   /**

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -124,6 +124,10 @@ function derivativeSaturationVaporPressureBuck(T) {
 
 class WaterCycle extends ResourceCycleClass {
   constructor({
+    key = 'water',
+    atmKey = 'atmosphericWater',
+    totalKeys = ['evaporation', 'sublimation', 'melt', 'freeze'],
+    processTotalKeys = { rain: 'rain', snow: 'snow' },
     zonalKey = 'zonalWater',
     surfaceBucket = 'water',
     atmosphereKey = 'water',
@@ -139,11 +143,22 @@ class WaterCycle extends ResourceCycleClass {
       freezePoint: 273.15,
       sublimationPoint: 273.15,
     });
+    this.key = key;
+    this.atmKey = atmKey;
+    this.totalKeys = totalKeys;
+    this.processTotalKeys = processTotalKeys;
     this.zonalKey = zonalKey;
     this.surfaceBucket = surfaceBucket;
     this.atmosphereKey = atmosphereKey;
     this.availableKeys = availableKeys;
     this.defaultExtraParams = { gravity, precipitationMultiplier };
+  }
+
+  getExtraParams(terraforming) {
+    return {
+      gravity: terraforming.celestialParameters.gravity,
+      precipitationMultiplier: terraforming.equilibriumPrecipitationMultiplier,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Attach atmospheric keys and process metadata to water, methane, and CO₂ cycle modules
- Drive terraforming resource updates by iterating over a cycles array instead of hard-coded configs
- Remove per-tick default parameter wiring from `updateResources`

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bccccf2a848327af7cc439740b2ef2