### PR TITLE
Modularize atmospheric chemistry and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,3 +475,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - ResourceCycle provides `applyZonalChanges` to update zonal surface stores and return totals, letting `runCycle` and its subclasses apply results without merge loops in `updateResources`.
 - Resource cycles now update atmospheric/surface rates and terraforming total fields via `updateResourceRates`; `Terraforming.updateResources` simply delegates to each cycle.
 - Cycle instances now carry atmospheric keys and process metadata and Terraforming loops over a `cycles` array to run them.
+- Atmospheric chemistry module now handles methane–oxygen combustion and calcite aerosol decay.

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
     <script src="src/js/terraforming/zones.js"></script>
     <script src="src/js/terraforming/terraforming-utils.js"></script>
     <script src="src/js/terraforming/radiation-utils.js"></script>
+    <script src="src/js/terraforming/atmospheric-chemistry.js"></script>
     <script src="src/js/terraforming/terraforming.js"></script>
     <script src="src/js/terraforming/terraformingUI.js"></script>
     <script src="src/js/life.js"></script>

--- a/tests/atmosphericChemistry.test.js
+++ b/tests/atmosphericChemistry.test.js
@@ -1,0 +1,45 @@
+const {
+  runAtmosphericChemistry,
+  OXYGEN_COMBUSTION_THRESHOLD,
+  METHANE_COMBUSTION_THRESHOLD,
+  CALCITE_HALF_LIFE_SECONDS,
+} = require('../src/js/terraforming/atmospheric-chemistry.js');
+
+describe('atmospheric chemistry', () => {
+  test('methane and oxygen combust into water and CO2 with correct ratios', () => {
+    const resources = { atmospheric: {} };
+    const params = {
+      globalOxygenPressurePa: OXYGEN_COMBUSTION_THRESHOLD + 1e6,
+      globalMethanePressurePa: METHANE_COMBUSTION_THRESHOLD + 1e6,
+      availableGlobalMethaneGas: 10,
+      availableGlobalOxygenGas: 100,
+      realSeconds: 1,
+      durationSeconds: 1,
+      surfaceArea: 1e16,
+    };
+    const result = runAtmosphericChemistry(resources, params);
+    const changes = result.changes;
+    expect(changes.atmosphericMethane).toBeCloseTo(-10);
+    expect(changes.oxygen).toBeCloseTo(-40);
+    expect(changes.atmosphericWater).toBeCloseTo(22.5);
+    expect(changes.carbonDioxide).toBeCloseTo(27.5);
+  });
+
+  test('calcite aerosol decays with expected half-life', () => {
+    const initial = 100;
+    const resources = { atmospheric: { calciteAerosol: { value: initial } } };
+    const params = {
+      globalOxygenPressurePa: 0,
+      globalMethanePressurePa: 0,
+      availableGlobalMethaneGas: 0,
+      availableGlobalOxygenGas: 0,
+      realSeconds: CALCITE_HALF_LIFE_SECONDS,
+      durationSeconds: CALCITE_HALF_LIFE_SECONDS,
+      surfaceArea: 1,
+    };
+    const result = runAtmosphericChemistry(resources, params);
+    expect(result.changes.calciteAerosol).toBeCloseTo(-initial / 2, 5);
+    expect(result.rates.calcite).toBeCloseTo((initial / 2) / CALCITE_HALF_LIFE_SECONDS, 5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- factor out methane combustion and calcite decay into `atmospheric-chemistry.js`
- wire atmospheric chemistry into terraforming update loop and include script in index
- add unit tests for combustion ratios and calcite aerosol half-life

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bcd4cc8c788327b747a737b76f22b0