### PR TITLE
feat: extract atmospheric context builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,3 +476,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resource cycles now update atmospheric/surface rates and terraforming total fields via `updateResourceRates`; `Terraforming.updateResources` simply delegates to each cycle.
 - Cycle instances now carry atmospheric keys and process metadata and Terraforming loops over a `cycles` array to run them.
 - Atmospheric chemistry module now handles methane–oxygen combustion and calcite aerosol decay.
+- Added `buildAtmosphereContext` helper centralizing atmospheric pressure calculations for reuse in `Terraforming.updateResources`.

--- a/tests/buildAtmosphereContext.test.js
+++ b/tests/buildAtmosphereContext.test.js
@@ -1,0 +1,23 @@
+global.EffectableEntity = class {};
+const physics = require('../src/js/physics.js');
+const { buildAtmosphereContext } = require('../src/js/terraforming/terraforming.js');
+
+describe('buildAtmosphereContext', () => {
+  test('returns total and keyed pressures with availability', () => {
+    const resources = {
+      atmosphericWater: { value: 1 },
+      carbonDioxide: { value: 2 },
+      atmosphericMethane: { value: 3 },
+    };
+    const gravity = 10;
+    const radius = 1;
+    const context = buildAtmosphereContext(resources, gravity, radius);
+    const waterP = physics.calculateAtmosphericPressure(1, gravity, radius);
+    const co2P = physics.calculateAtmosphericPressure(2, gravity, radius);
+    const methaneP = physics.calculateAtmosphericPressure(3, gravity, radius);
+    expect(context.totalPressure).toBeCloseTo(waterP + co2P + methaneP);
+    expect(context.pressureByKey.atmosphericWater).toBeCloseTo(waterP);
+    expect(context.pressureByKey.carbonDioxide).toBeCloseTo(co2P);
+    expect(context.availableByKey.atmosphericMethane).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add `buildAtmosphereContext` helper to compute total and per-gas atmospheric pressure
- simplify `Terraforming.updateResources` by using the new helper
- cover helper with unit tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bcd7cb3600832796ef19fa96100384