### PR TITLE
Reset flow melt tracking in resource cycles

### DIFF
--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -360,6 +360,7 @@ class MethaneCycle extends ResourceCycleClass {
     terraforming.flowMethaneMeltAmount = flow.totalMelt;
     terraforming.flowMethaneMeltRate = flow.totalMelt / durationSeconds * 86400;
     data.totals.melt = (data.totals.melt || 0) + flow.totalMelt;
+    data.totals.flowMelt = flow.totalMelt;
     for (const zone of zones) {
       const zoneChange = flow.changes[zone];
       if (!zoneChange) continue;
@@ -370,6 +371,8 @@ class MethaneCycle extends ResourceCycleClass {
       if (zoneChange.buriedIce) dest.methane.buriedIce = (dest.methane.buriedIce || 0) + zoneChange.buriedIce;
     }
     this.applyZonalChanges(terraforming, data.zonalChanges, options.zonalKey, options.surfaceBucket);
+    terraforming.flowMethaneMeltAmount = 0;
+    terraforming.flowMethaneMeltRate = 0;
     return data.totals;
   }
 
@@ -383,6 +386,7 @@ class MethaneCycle extends ResourceCycleClass {
       freeze = 0,
       methaneRain = 0,
       methaneSnow = 0,
+      flowMelt = 0,
     } = totals;
 
     const evaporationRate = durationSeconds > 0 ? evaporation / durationSeconds * 86400 : 0;
@@ -410,7 +414,7 @@ class MethaneCycle extends ResourceCycleClass {
       rateType
     );
 
-    const flowRate = terraforming.flowMethaneMeltRate || 0;
+    const flowRate = durationSeconds > 0 ? flowMelt / durationSeconds * 86400 : 0;
 
     resources.surface.liquidMethane?.modifyRate(-evaporationRate, 'Methane Evaporation', rateType);
     resources.surface.liquidMethane?.modifyRate(rainRate, 'Methane Rain', rateType);

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -579,12 +579,8 @@ class Terraforming extends EffectableEntity{
             rateType
         );
 
-        // reset stored melt from flow for next tick
-        this.flowMeltAmount = 0;
-        this.flowMethaneMeltAmount = 0;
-
-      this.synchronizeGlobalResources();
-    }
+        this.synchronizeGlobalResources();
+      }
 
     // Function to update luminosity properties
     updateLuminosity() {

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -370,6 +370,7 @@ class WaterCycle extends ResourceCycleClass {
     terraforming.flowMeltAmount = flow.totalMelt;
     terraforming.flowMeltRate = flow.totalMelt / durationSeconds * 86400;
     data.totals.melt = (data.totals.melt || 0) + flow.totalMelt;
+    data.totals.flowMelt = flow.totalMelt;
     for (const zone of zones) {
       const zoneChange = flow.changes[zone];
       if (!zoneChange) continue;
@@ -380,6 +381,8 @@ class WaterCycle extends ResourceCycleClass {
       if (zoneChange.buriedIce) dest.water.buriedIce = (dest.water.buriedIce || 0) + zoneChange.buriedIce;
     }
     this.applyZonalChanges(terraforming, data.zonalChanges, options.zonalKey, options.surfaceBucket);
+    terraforming.flowMeltAmount = 0;
+    terraforming.flowMeltRate = 0;
     return data.totals;
   }
 
@@ -393,6 +396,7 @@ class WaterCycle extends ResourceCycleClass {
       freeze = 0,
       rain = 0,
       snow = 0,
+      flowMelt = 0,
     } = totals;
 
     const focusMeltAmount = typeof globalThis.applyFocusedMelt === 'function'
@@ -428,7 +432,7 @@ class WaterCycle extends ResourceCycleClass {
     );
 
     const focusRate = terraforming.focusMeltRate || 0;
-    const flowRate = terraforming.flowMeltRate || 0;
+    const flowRate = durationSeconds > 0 ? flowMelt / durationSeconds * 86400 : 0;
 
     resources.surface.liquidWater?.modifyRate(-evaporationRate, 'Evaporation', rateType);
     resources.surface.liquidWater?.modifyRate(rainRate, 'Rain', rateType);


### PR DESCRIPTION
## Summary
- reset water and methane flow melt amounts within each cycle's runCycle
- compute flow melt rates from runCycle totals
- remove redundant flow melt resets from Terraforming.updateResources

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bcd7e4ee38832798c60d38c6bb5e5f