### PR TITLE
Delegate atmospheric chemistry rate handling to its module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,3 +477,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cycle instances now carry atmospheric keys and process metadata and Terraforming loops over a `cycles` array to run them.
 - Atmospheric chemistry module now handles methane–oxygen combustion and calcite aerosol decay.
 - Added `buildAtmosphereContext` helper centralizing atmospheric pressure calculations for reuse in `Terraforming.updateResources`.
+- Atmospheric chemistry now assigns resource rates internally, removing rate handling from `Terraforming.updateResources`.

--- a/src/js/terraforming/atmospheric-chemistry.js
+++ b/src/js/terraforming/atmospheric-chemistry.js
@@ -49,6 +49,39 @@ function runAtmosphericChemistry(resources, params = {}) {
       currentCalcite * (1 - Math.exp(-CALCITE_DECAY_CONSTANT * realSeconds));
   }
 
+  const methaneRate = durationSeconds > 0 ? (combustionMethaneAmount / durationSeconds) * 86400 : 0;
+  const oxygenRate = durationSeconds > 0 ? (combustionOxygenAmount / durationSeconds) * 86400 : 0;
+  const waterRate = durationSeconds > 0 ? (combustionWaterAmount / durationSeconds) * 86400 : 0;
+  const co2Rate = durationSeconds > 0 ? (combustionCO2Amount / durationSeconds) * 86400 : 0;
+  const calciteRate = realSeconds > 0 ? calciteDecayAmount / realSeconds : 0;
+
+  const rateType = 'terraforming';
+  resources?.atmospheric?.atmosphericWater?.modifyRate?.(
+    waterRate,
+    'Methane Combustion',
+    rateType
+  );
+  resources?.atmospheric?.carbonDioxide?.modifyRate?.(
+    co2Rate,
+    'Methane Combustion',
+    rateType
+  );
+  resources?.atmospheric?.atmosphericMethane?.modifyRate?.(
+    -methaneRate,
+    'Methane Combustion',
+    rateType
+  );
+  resources?.atmospheric?.oxygen?.modifyRate?.(
+    -oxygenRate,
+    'Methane Combustion',
+    rateType
+  );
+  resources?.atmospheric?.calciteAerosol?.modifyRate?.(
+    -calciteRate,
+    'Calcite Decay',
+    rateType
+  );
+
   return {
     changes: {
       atmosphericMethane: -combustionMethaneAmount,
@@ -58,11 +91,11 @@ function runAtmosphericChemistry(resources, params = {}) {
       calciteAerosol: -calciteDecayAmount,
     },
     rates: {
-      methane: durationSeconds > 0 ? (combustionMethaneAmount / durationSeconds) * 86400 : 0,
-      oxygen: durationSeconds > 0 ? (combustionOxygenAmount / durationSeconds) * 86400 : 0,
-      water: durationSeconds > 0 ? (combustionWaterAmount / durationSeconds) * 86400 : 0,
-      co2: durationSeconds > 0 ? (combustionCO2Amount / durationSeconds) * 86400 : 0,
-      calcite: realSeconds > 0 ? calciteDecayAmount / realSeconds : 0,
+      methane: methaneRate,
+      oxygen: oxygenRate,
+      water: waterRate,
+      co2: co2Rate,
+      calcite: calciteRate,
     },
   };
 }

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -179,11 +179,6 @@ class Terraforming extends EffectableEntity{
     this.totalMethaneFreezeRate = 0;
     this.flowMethaneMeltAmount = 0;
     this.flowMethaneMeltRate = 0;
-    this.totalMethaneCombustionRate = 0;
-    this.totalOxygenCombustionRate = 0;
-    this.totalCombustionWaterRate = 0;
-    this.totalCombustionCo2Rate = 0;
-    this.totalCalciteDecayRate = 0;
 
     // Zonal Water Data - Replaces global this.water
     this.zonalWater = {};
@@ -542,39 +537,6 @@ class Terraforming extends EffectableEntity{
                 res.value = Math.max(0, res.value + delta);
             }
         }
-
-        this.totalMethaneCombustionRate = chemTotals.rates.methane;
-        this.totalOxygenCombustionRate = chemTotals.rates.oxygen;
-        this.totalCombustionWaterRate = chemTotals.rates.water;
-        this.totalCombustionCo2Rate = chemTotals.rates.co2;
-        this.totalCalciteDecayRate = chemTotals.rates.calcite;
-
-        const rateType = 'terraforming';
-        this.resources.atmospheric.atmosphericWater?.modifyRate(
-            this.totalCombustionWaterRate,
-            'Methane Combustion',
-            rateType
-        );
-        this.resources.atmospheric.carbonDioxide?.modifyRate(
-            this.totalCombustionCo2Rate,
-            'Methane Combustion',
-            rateType
-        );
-        this.resources.atmospheric.atmosphericMethane?.modifyRate(
-            -this.totalMethaneCombustionRate,
-            'Methane Combustion',
-            rateType
-        );
-        this.resources.atmospheric.oxygen?.modifyRate(
-            -this.totalOxygenCombustionRate,
-            'Methane Combustion',
-            rateType
-        );
-        this.resources.atmospheric.calciteAerosol?.modifyRate(
-            -this.totalCalciteDecayRate,
-            'Calcite Decay',
-            rateType
-        );
 
         this.synchronizeGlobalResources();
       }

--- a/tests/atmosphericChemistry.test.js
+++ b/tests/atmosphericChemistry.test.js
@@ -41,5 +41,53 @@ describe('atmospheric chemistry', () => {
     expect(result.changes.calciteAerosol).toBeCloseTo(-initial / 2, 5);
     expect(result.rates.calcite).toBeCloseTo((initial / 2) / CALCITE_HALF_LIFE_SECONDS, 5);
   });
+
+  test('assigns combustion and decay rates to resources', () => {
+    const createRes = () => ({ value: 0, modifyRate: jest.fn() });
+    const resources = {
+      atmospheric: {
+        atmosphericWater: createRes(),
+        carbonDioxide: createRes(),
+        atmosphericMethane: createRes(),
+        oxygen: createRes(),
+        calciteAerosol: createRes(),
+      },
+    };
+    const params = {
+      globalOxygenPressurePa: OXYGEN_COMBUSTION_THRESHOLD + 1e6,
+      globalMethanePressurePa: METHANE_COMBUSTION_THRESHOLD + 1e6,
+      availableGlobalMethaneGas: 10,
+      availableGlobalOxygenGas: 100,
+      realSeconds: 1,
+      durationSeconds: 1,
+      surfaceArea: 1e16,
+    };
+    const result = runAtmosphericChemistry(resources, params);
+    expect(resources.atmospheric.atmosphericWater.modifyRate).toHaveBeenCalledWith(
+      result.rates.water,
+      'Methane Combustion',
+      'terraforming'
+    );
+    expect(resources.atmospheric.carbonDioxide.modifyRate).toHaveBeenCalledWith(
+      result.rates.co2,
+      'Methane Combustion',
+      'terraforming'
+    );
+    expect(resources.atmospheric.atmosphericMethane.modifyRate).toHaveBeenCalledWith(
+      -result.rates.methane,
+      'Methane Combustion',
+      'terraforming'
+    );
+    expect(resources.atmospheric.oxygen.modifyRate).toHaveBeenCalledWith(
+      -result.rates.oxygen,
+      'Methane Combustion',
+      'terraforming'
+    );
+    expect(resources.atmospheric.calciteAerosol.modifyRate).toHaveBeenCalledWith(
+      -result.rates.calcite,
+      'Calcite Decay',
+      'terraforming'
+    );
+  });
 });
 


### PR DESCRIPTION
## Summary
- Let atmospheric chemistry modify resource rates directly
- Simplify `Terraforming.updateResources` by removing rate assignments
- Verify rate assignment logic with new atmospheric chemistry test

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bcd97f84ec8327b2408c025dceafa3