### PR TITLE
Refactor water cycle condensation handling

### DIFF
--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -380,15 +380,15 @@
     }
 
     if (potentialPrecipitationRateFactor > 1e-12) {
-      this.equilibriumPrecipitationMultiplier =
+      this.equilibriumWaterCondensationParameter =
         initialTotalWaterEvapSublRate / potentialPrecipitationRateFactor;
     } else if (initialTotalWaterEvapSublRate < 1e-12) {
-      this.equilibriumPrecipitationMultiplier = 0.0001;
+      this.equilibriumWaterCondensationParameter = 0.0001;
     } else {
       console.warn(
         'Initial state has upward water flux but no potential precipitation. Using default multiplier.'
       );
-      this.equilibriumPrecipitationMultiplier = 0.0001;
+      this.equilibriumWaterCondensationParameter = 0.0001;
     }
 
     const defaultCondensationParameter = 1.7699e-7;
@@ -420,7 +420,7 @@
     }
 
     console.log(
-      `Calculated Equilibrium Precipitation Multiplier (Rate-Based): ${this.equilibriumPrecipitationMultiplier}`
+      `Calculated Equilibrium Water Condensation Parameter (Rate-Based): ${this.equilibriumWaterCondensationParameter}`
     );
     console.log(
       `Calculated Equilibrium Condensation Parameter (Rate-Based): ${this.equilibriumCondensationParameter}`

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -151,7 +151,7 @@ class Terraforming extends EffectableEntity{
     this.zonalCoverageCache = {};
 
     this.initialValuesCalculated = false;
-    this.equilibriumPrecipitationMultiplier = EQUILIBRIUM_WATER_PARAMETER; // Default, will be calculated
+    this.equilibriumWaterCondensationParameter = EQUILIBRIUM_WATER_PARAMETER; // Default, will be calculated
     this.equilibriumCondensationParameter = globalThis.EQUILIBRIUM_CO2_PARAMETER || EQUILIBRIUM_CO2_PARAMETER; // Default, will be calculated
     this.equilibriumMethaneCondensationParameter = EQUILIBRIUM_METHANE_PARAMETER; // Default, will be calculated
 
@@ -802,7 +802,7 @@ class Terraforming extends EffectableEntity{
     }
 
     resetDefaultConstants(){
-        this.equilibriumPrecipitationMultiplier = EQUILIBRIUM_WATER_PARAMETER;
+        this.equilibriumWaterCondensationParameter = EQUILIBRIUM_WATER_PARAMETER;
         this.equilibriumCondensationParameter = globalThis.EQUILIBRIUM_CO2_PARAMETER;
         this.equilibriumMethaneCondensationParameter = EQUILIBRIUM_METHANE_PARAMETER; // Default value
     }

--- a/tests/cycleDefaults.test.js
+++ b/tests/cycleDefaults.test.js
@@ -4,7 +4,7 @@ const { CO2Cycle } = require('../src/js/terraforming/dry-ice-cycle.js');
 
 describe('cycle default parameters', () => {
   test('water cycle uses constructor defaults', () => {
-    const wc = new WaterCycle({ gravity: 9, precipitationMultiplier: 2 });
+    const wc = new WaterCycle({ gravity: 9, condensationParameter: 2 });
     wc.redistributePrecipitation = () => {};
     const tf = {
       temperature: { zones: { tropical: {} } },
@@ -23,7 +23,7 @@ describe('cycle default parameters', () => {
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({
       availableLiquid: 5,
       gravity: 9,
-      precipitationMultiplier: 2,
+      condensationParameter: 2,
     }));
     expect(result.totalAtmosphericChange).toBe(0);
   });


### PR DESCRIPTION
## Summary
- Expand `WaterCycle` constructor with transition and boiling options, swap to `condensationParameter`, and default to `boilingPointWater`
- Reorder water cycle processing to evaporation→condensation→melting/freezing→sublimation, scaling condensation by `condensationParameter`
- Rename equilibrium precipitation multiplier to `equilibriumWaterCondensationParameter` throughout and update tests

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bcdbeea52483278b80ff9b9538d325