### PR TITLE
Remove methane rapid sublimation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,3 +478,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Atmospheric chemistry module now handles methane–oxygen combustion and calcite aerosol decay.
 - Added `buildAtmosphereContext` helper centralizing atmospheric pressure calculations for reuse in `Terraforming.updateResources`.
 - Atmospheric chemistry now assigns resource rates internally, removing rate handling from `Terraforming.updateResources`.
+- Removed rapid sublimation mechanics from the methane hydrocarbon cycle.

--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -6,7 +6,6 @@
       methaneCycleInstance,
       calculateMethaneEvaporationRate,
       calculateMethaneSublimationRate,
-      rapidSublimationRateMethane,
       getZonePercentage,
       getZoneRatio,
       estimateCoverage,
@@ -26,7 +25,6 @@
     methaneCycleInstance = hydrocarbonMod.methaneCycle;
     calculateMethaneEvaporationRate = hydrocarbonMod.calculateMethaneEvaporationRate;
     calculateMethaneSublimationRate = hydrocarbonMod.calculateMethaneSublimationRate;
-    rapidSublimationRateMethane = hydrocarbonMod.rapidSublimationRateMethane;
     boilingPointMethane = hydrocarbonMod.boilingPointMethane;
 
     const physics = require('./terraforming/physics.js');
@@ -46,7 +44,6 @@
     methaneCycleInstance = globalThis.methaneCycle;
     calculateMethaneEvaporationRate = globalThis.calculateMethaneEvaporationRate;
     calculateMethaneSublimationRate = globalThis.calculateMethaneSublimationRate;
-    rapidSublimationRateMethane = globalThis.rapidSublimationRateMethane;
     boilingPointWater = globalThis.boilingPointWater;
     boilingPointMethane = globalThis.boilingPointMethane;
     getZonePercentage = globalThis.getZonePercentage;
@@ -359,10 +356,6 @@
         zonalSolarFlux
       });
       initialTotalMethaneEvapRate += methaneSublimationRateValue;
-
-      const availableMethaneIce = this.zonalHydrocarbons[zone]?.ice || 0;
-      const rapidMethaneRate = rapidSublimationRateMethane(dayTemp, availableMethaneIce);
-      initialTotalMethaneEvapRate += rapidMethaneRate;
 
       const methaneBoil = boilingPointMethane(initialTotalPressurePa);
       const { liquidRate: ch4Liquid, iceRate: ch4Ice } = methaneCycleInstance.condensationRateFactor({

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -121,7 +121,6 @@ class MethaneCycle extends ResourceCycleClass {
       slopeSaturationVaporPressureFn: slopeSVPMethane,
       freezePoint: 90.7,
       sublimationPoint: 90.7,
-      rapidSublimationMultiplier: 0.000001,
       evaporationAlbedo: 0.1,
       sublimationAlbedo: 0.6,
     });
@@ -290,19 +289,10 @@ class MethaneCycle extends ResourceCycleClass {
     changes.atmosphere.methane += sublimationAmount;
     changes.methane.ice -= sublimationAmount;
 
-    // --- Rapid Sublimation ---
-    const remainingIce = Math.max(0, availableIce + changes.methane.ice);
-    const rapidRate = this.rapidSublimationRate(zoneTemperature, remainingIce);
-    const rapidAmount = Math.min(rapidRate * durationSeconds, remainingIce);
-    if (rapidAmount > 0) {
-      changes.methane.ice -= rapidAmount;
-      changes.atmosphere.methane += rapidAmount;
-    }
-
     return {
       ...changes,
       evaporationAmount,
-      sublimationAmount: sublimationAmount + rapidAmount,
+      sublimationAmount,
       meltAmount,
       freezeAmount,
     };
@@ -466,10 +456,6 @@ function sublimationRateMethane(T, solarFlux, atmPressure, e_a, r_a = 100) {
     return methaneCycle.sublimationRate({ T, solarFlux, atmPressure, vaporPressure: e_a, r_a });
 }
 
-function rapidSublimationRateMethane(temperature, availableMethaneIce) {
-    return methaneCycle.rapidSublimationRate(temperature, availableMethaneIce);
-}
-
 function calculateMethaneEvaporationRate({
     zoneArea,
     liquidMethaneCoverage,
@@ -544,7 +530,6 @@ if (typeof module !== 'undefined' && module.exports) {
         evaporationRateMethane,
         calculateMethaneEvaporationRate,
         sublimationRateMethane,
-        rapidSublimationRateMethane,
         calculateMethaneSublimationRate,
         boilingPointMethane
     };
@@ -558,7 +543,6 @@ if (typeof module !== 'undefined' && module.exports) {
     globalThis.evaporationRateMethane = evaporationRateMethane;
     globalThis.calculateMethaneEvaporationRate = calculateMethaneEvaporationRate;
     globalThis.sublimationRateMethane = sublimationRateMethane;
-    globalThis.rapidSublimationRateMethane = rapidSublimationRateMethane;
     globalThis.calculateMethaneSublimationRate = calculateMethaneSublimationRate;
     globalThis.boilingPointMethane = boilingPointMethane;
 }


### PR DESCRIPTION
## Summary
- drop methane rapid sublimation logic and exports
- clean up debug tools to remove unused methane rapid sublimation hooks
- note removal in AGENTS instructions

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bcde346a148327aaa03a76726bb0a3