### PR TITLE
Remove rapid sublimation from water cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,3 +478,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Atmospheric chemistry module now handles methane–oxygen combustion and calcite aerosol decay.
 - Added `buildAtmosphereContext` helper centralizing atmospheric pressure calculations for reuse in `Terraforming.updateResources`.
 - Atmospheric chemistry now assigns resource rates internally, removing rate handling from `Terraforming.updateResources`.
+- Removed rapid sublimation logic from WaterCycle, simplifying phase change calculations.

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -316,19 +316,10 @@ class WaterCycle extends ResourceCycleClass {
     changes.atmosphere.water += sublimationAmount;
     changes.water.ice -= sublimationAmount;
 
-    // --- Rapid Sublimation ---
-    const remainingIce = Math.max(0, availableIce + changes.water.ice);
-    const rapidRate = this.rapidSublimationRate(zoneTemperature, remainingIce);
-    const rapidAmount = Math.min(rapidRate * durationSeconds, remainingIce);
-    if (rapidAmount > 0) {
-      changes.water.ice -= rapidAmount;
-      changes.atmosphere.water += rapidAmount;
-    }
-
     return {
       ...changes,
       evaporationAmount,
-      sublimationAmount: sublimationAmount + rapidAmount,
+      sublimationAmount,
       meltAmount,
       freezeAmount,
     };


### PR DESCRIPTION
## Summary
- remove rapid sublimation logic from WaterCycle process zones
- document removal in AGENTS notes

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bcde6b30508327aaaae4e4459b5e0b