### PR TITLE
feat: apply water and ice albedo constants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,3 +480,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Atmospheric chemistry now assigns resource rates internally, removing rate handling from `Terraforming.updateResources`.
 - Removed rapid sublimation logic from WaterCycle, simplifying phase change calculations.
 - Removed rapid sublimation mechanics from the methane hydrocarbon cycle.
+- WaterCycle now sets distinct albedo defaults for liquid water evaporation and ice sublimation.

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -1,5 +1,7 @@
 const L_S_WATER = 2.83e6; // Latent heat of sublimation for water (J/kg)
 const L_V_WATER = 2.45e6; // Latent heat of vaporization for water (J/kg)
+const EVAP_ALBEDO_WATER = 0.06; // Representative albedo for liquid water
+const SUBLIMATION_ALBEDO_ICE = 0.6; // Representative albedo for ice
 
 const isNodeWaterCycle = (typeof module !== 'undefined' && module.exports);
 var psychrometricConstant = globalThis.psychrometricConstant;
@@ -146,6 +148,8 @@ class WaterCycle extends ResourceCycleClass {
       slopeSaturationVaporPressureFn: derivativeSaturationVaporPressureBuck,
       freezePoint: 273.15,
       sublimationPoint: 273.15,
+      evaporationAlbedo: EVAP_ALBEDO_WATER,
+      sublimationAlbedo: SUBLIMATION_ALBEDO_ICE,
     });
     this.key = key;
     this.atmKey = atmKey;

--- a/tests/waterCycleAlbedo.test.js
+++ b/tests/waterCycleAlbedo.test.js
@@ -1,0 +1,42 @@
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+const { WaterCycle } = require('../src/js/terraforming/water-cycle.js');
+const { penmanRate } = require('../src/js/terraforming/phase-change-utils.js');
+
+describe('WaterCycle albedo defaults', () => {
+  test('evaporationRate uses configured evaporation albedo', () => {
+    const wc = new WaterCycle();
+    const args = { T: 300, solarFlux: 500, atmPressure: 100000, vaporPressure: 1000 };
+    const expected = penmanRate({
+      T: args.T,
+      solarFlux: args.solarFlux,
+      atmPressure: args.atmPressure,
+      e_a: args.vaporPressure,
+      latentHeat: wc.latentHeatVaporization,
+      albedo: wc.evaporationAlbedo,
+      r_a: 100,
+      Delta_s: wc.slopeSaturationVaporPressureFn(args.T),
+      e_s: wc.saturationVaporPressureFn(args.T),
+    });
+    expect(wc.evaporationRate(args)).toBeCloseTo(expected);
+    expect(wc.evaporationAlbedo).toBeCloseTo(0.06);
+  });
+
+  test('sublimationRate uses configured sublimation albedo', () => {
+    const wc = new WaterCycle();
+    const args = { T: 250, solarFlux: 400, atmPressure: 100000, vaporPressure: 1000 };
+    const expected = penmanRate({
+      T: args.T,
+      solarFlux: args.solarFlux,
+      atmPressure: args.atmPressure,
+      e_a: args.vaporPressure,
+      latentHeat: wc.latentHeatSublimation,
+      albedo: wc.sublimationAlbedo,
+      r_a: 100,
+      Delta_s: wc.slopeSaturationVaporPressureFn(args.T),
+      e_s: wc.saturationVaporPressureFn(args.T),
+    });
+    expect(wc.sublimationRate(args)).toBeCloseTo(expected);
+    expect(wc.sublimationAlbedo).toBeCloseTo(0.6);
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit albedo constants for liquid water and ice
- pass albedo constants through WaterCycle constructor
- verify water cycle albedo defaults with unit tests

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bce058fb94832785c38cdb483096a8