### PR TITLE
Add psychrometric constant for water sublimation

### DIFF
--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -482,6 +482,11 @@ function psychrometricConstantWater(atmPressure) {
     return psychrometricConstant(atmPressure, L_V_WATER); // Pa/K
 }
 
+// Function to calculate psychrometric constant for water sublimation
+function psychrometricConstantWaterSublimation(atmPressure) {
+    return psychrometricConstant(atmPressure, L_S_WATER); // Pa/K
+}
+
 // Estimate the boiling point of water (K) from pressure (Pa) using the
 // Antoine equation. The constants cover a wide range around standard
 // atmospheric conditions, avoiding iterative solves.
@@ -513,6 +518,7 @@ if (typeof module !== 'undefined' && module.exports) {
         derivativeSaturationVaporPressureBuck,
         slopeSaturationVaporPressureWater,
         psychrometricConstantWater,
+        psychrometricConstantWaterSublimation,
         sublimationRateWater,
         evaporationRateWater,
         boilingPointWater
@@ -525,6 +531,7 @@ if (typeof module !== 'undefined' && module.exports) {
     globalThis.derivativeSaturationVaporPressureBuck = derivativeSaturationVaporPressureBuck;
     globalThis.slopeSaturationVaporPressureWater = slopeSaturationVaporPressureWater;
     globalThis.psychrometricConstantWater = psychrometricConstantWater;
+    globalThis.psychrometricConstantWaterSublimation = psychrometricConstantWaterSublimation;
     globalThis.sublimationRateWater = sublimationRateWater;
     globalThis.evaporationRateWater = evaporationRateWater;
     globalThis.boilingPointWater = boilingPointWater;

--- a/tests/phaseChangeUtils.test.js
+++ b/tests/phaseChangeUtils.test.js
@@ -14,6 +14,13 @@ describe('phase-change utility helpers', () => {
     expect(res).toBeCloseTo(expected);
   });
 
+  test('psychrometricConstantWaterSublimation uses latent heat of sublimation', () => {
+    const atmPressure = 101325;
+    const res = water.psychrometricConstantWaterSublimation(atmPressure);
+    const expected = (1004 * atmPressure) / (0.622 * 2.83e6);
+    expect(res).toBeCloseTo(expected);
+  });
+
   test('penmanRate matches manual formula', () => {
     const params = {
       T: 300,


### PR DESCRIPTION
## Summary
- Add `psychrometricConstantWaterSublimation` for water sublimation calculations
- Export and expose the new constant alongside existing water utilities
- Test psychrometric constant helper for water sublimation

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bce2d540f083279e0d801a69726547