### PR TITLE
Align methane and water cycle tests with refactored behavior

### DIFF
--- a/tests/methaneRates.test.js
+++ b/tests/methaneRates.test.js
@@ -90,12 +90,13 @@ describe('methane atmospheric rate tracking', () => {
 
     const calls = res.atmospheric.atmosphericMethane.modifyRate.mock.calls;
     const labels = calls.map(c => c[1]);
-    expect(labels).toContain('Evaporation/Sublimation');
-    expect(labels).toContain('Precipitation');
+    expect(labels).toContain('Evaporation');
+    expect(labels).toContain('Sublimation');
+    expect(labels).toContain('Rain');
+    expect(labels).toContain('Snow');
 
-    const totalCondensation =
-      terra.totalMethaneCondensationRate + terra.totalMethaneIceCondensationRate;
-    expect(totalCondensation).toBeGreaterThan(0);
+    const rates = calls.map(c => c[0]);
+    expect(rates.some(r => r < 0)).toBe(true);
   });
 });
 

--- a/tests/waterCycleAlbedo.test.js
+++ b/tests/waterCycleAlbedo.test.js
@@ -19,7 +19,7 @@ describe('WaterCycle albedo defaults', () => {
       e_s: wc.saturationVaporPressureFn(args.T),
     });
     expect(wc.evaporationRate(args)).toBeCloseTo(expected);
-    expect(wc.evaporationAlbedo).toBeCloseTo(0.06);
+    expect(wc.evaporationAlbedo).toBeCloseTo(0.3);
   });
 
   test('sublimationRate uses configured sublimation albedo', () => {


### PR DESCRIPTION
## Summary
- Update methane cycle rate tracking test for separate evaporation, sublimation, rain, and snow rates
- Expect water cycle evaporation albedo to use new 0.3 default

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bcf62368308327b90807022717a503