### PR TITLE
Switch to Murphy & Koop saturation vapor pressure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,3 +482,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Removed rapid sublimation logic from WaterCycle, simplifying phase change calculations.
 - Removed rapid sublimation mechanics from the methane hydrocarbon cycle.
 - WaterCycle now sets distinct albedo defaults for liquid water evaporation and ice sublimation.
+- WaterCycle now uses the Murphy & Koop (2005) saturation vapor pressure formulation via `saturationVaporPressureMK` and exposes updated helpers.

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -259,7 +259,7 @@ const waterCycle = new WaterCycle();
 // Function to calculate the slope of the saturation vapor pressure curve (Delta_s)
 function slopeSaturationVaporPressureWater(T) {
     // T: Temperature in Kelvin (K)
-    return derivativeSaturationVaporPressureBuck(T); // Pa/K
+    return derivativeSaturationVaporPressureMK(T); // Pa/K
 }
   
 // Function to calculate psychrometric constant (gamma_s) for water evaporation
@@ -371,8 +371,8 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         WaterCycle,
         waterCycle,
-        saturationVaporPressureBuck,
-        derivativeSaturationVaporPressureBuck,
+        saturationVaporPressureMK,
+        derivativeSaturationVaporPressureMK,
         slopeSaturationVaporPressureWater,
         psychrometricConstantWater,
         psychrometricConstantWaterSublimation,
@@ -386,8 +386,8 @@ if (typeof module !== 'undefined' && module.exports) {
     // Expose functions globally for browser usage
     globalThis.WaterCycle = WaterCycle;
     globalThis.waterCycle = waterCycle;
-    globalThis.saturationVaporPressureBuck = saturationVaporPressureBuck;
-    globalThis.derivativeSaturationVaporPressureBuck = derivativeSaturationVaporPressureBuck;
+    globalThis.saturationVaporPressureMK = saturationVaporPressureMK;
+    globalThis.derivativeSaturationVaporPressureMK = derivativeSaturationVaporPressureMK;
     globalThis.slopeSaturationVaporPressureWater = slopeSaturationVaporPressureWater;
     globalThis.psychrometricConstantWater = psychrometricConstantWater;
     globalThis.psychrometricConstantWaterSublimation = psychrometricConstantWaterSublimation;

--- a/tests/condensationUtils.test.js
+++ b/tests/condensationUtils.test.js
@@ -17,11 +17,11 @@ describe('condensationRateFactor generic helper', () => {
       gravity: 9.81,
       dayTemp: 276,
       nightTemp: 275,
-      saturationFn: water.saturationVaporPressureBuck,
+      saturationFn: water.saturationVaporPressureMK,
       freezePoint: 273.15
     });
-    expect(res.liquidRate).toBeCloseTo(0.0871865839926258);
-    expect(res.iceRate).toBeCloseTo(0.002247384412881595);
+    expect(res.liquidRate).toBeCloseTo(0.0871088754676007);
+    expect(res.iceRate).toBeCloseTo(0.002246246821741467);
   });
 
   test('computes expected methane condensation factors', () => {
@@ -55,7 +55,7 @@ describe('cycle wrappers match helper output', () => {
       gravity: params.gravity,
       dayTemp: params.dayTemperature,
       nightTemp: params.nightTemperature,
-      saturationFn: water.saturationVaporPressureBuck,
+      saturationFn: water.saturationVaporPressureMK,
       freezePoint: 273.15,
       boilingPoint: water.boilingPointWater(params.atmPressure),
       boilTransitionRange: 5

--- a/tests/equilibriumConstants.test.js
+++ b/tests/equilibriumConstants.test.js
@@ -29,7 +29,7 @@ global.condensationRateFactor = require('../src/js/condensation-utils.js').conde
 const fs = require('fs');
 global.ResourceCycle = require('../src/js/terraforming/resource-cycle.js');
 eval(fs.readFileSync(require.resolve('../src/js/terraforming/water-cycle.js'), 'utf8'));
-global.saturationVaporPressureBuck = saturationVaporPressureBuck;
+global.saturationVaporPressureMK = saturationVaporPressureMK;
 eval(fs.readFileSync(require.resolve('../src/js/terraforming/dry-ice-cycle.js'), 'utf8'));
 global.evaporationRateWater = evaporationRateWater;
 global.sublimationRateWater = sublimationRateWater;

--- a/tests/phaseChangeUtils.test.js
+++ b/tests/phaseChangeUtils.test.js
@@ -31,7 +31,7 @@ describe('phase-change utility helpers', () => {
       albedo: 0.3,
       r_a: 100,
       Delta_s: water.slopeSaturationVaporPressureWater(300),
-      e_s: water.saturationVaporPressureBuck(300)
+      e_s: water.saturationVaporPressureMK(300)
     };
     const gamma_s = utils.psychrometricConstant(params.atmPressure, params.latentHeat);
     const rho_a_val = physics.airDensity(params.atmPressure, params.T);
@@ -89,7 +89,7 @@ describe('cycle modules via utils', () => {
       albedo: 0.3,
       r_a: 100,
       Delta_s: water.slopeSaturationVaporPressureWater(T),
-      e_s: water.saturationVaporPressureBuck(T)
+      e_s: water.saturationVaporPressureMK(T)
     });
     const res = water.evaporationRateWater(T, solarFlux, atmPressure, e_a, 100);
     expect(res).toBeCloseTo(expected);


### PR DESCRIPTION
## Summary
- expose new `saturationVaporPressureMK` and derivative helpers and remove obsolete Buck variants
- update slope helper and tests to use the new vapor pressure formulation
- document saturation vapor pressure change in AGENTS.md

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bcfbd0d0e88327aebe0de750e2d419