### PR TITLE
Handle rapid sublimation when liquid water is forbidden

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,3 +484,5 @@ The Random World Generator manager builds procedural planets and moons with lock
 - WaterCycle now sets distinct albedo defaults for liquid water evaporation and ice sublimation.
 - WaterCycle now uses the Murphy & Koop (2005) saturation vapor pressure formulation via `saturationVaporPressureMK` and exposes updated helpers.
 - Added liquid CO2 surface resource and zonal tracking.
+- ResourceCycle converts melting into rapid sublimation when liquid water is forbidden, recording rates for ice and atmosphere as "Rapid Sublimation".
+- Methane cycle converts melting into rapid sublimation when liquid methane is forbidden, tracking hydrocarbon ice and atmospheric methane as "Rapid Sublimation".

--- a/src/js/terraforming/hydrocarbon-cycle.js
+++ b/src/js/terraforming/hydrocarbon-cycle.js
@@ -97,7 +97,7 @@ class MethaneCycle extends ResourceCycleClass {
   constructor({
     key = 'methane',
     atmKey = 'atmosphericMethane',
-    totalKeys = ['evaporation', 'sublimation', 'melt', 'freeze'],
+    totalKeys = ['evaporation', 'sublimation', 'rapidSublimation', 'melt', 'freeze'],
     processTotalKeys = { rain: 'methaneRain', snow: 'methaneSnow' },
     transitionRange = 2,
     maxDiff = 10,
@@ -144,6 +144,10 @@ class MethaneCycle extends ResourceCycleClass {
       sublimation: [
         { path: 'atmospheric.atmosphericMethane', label: 'Sublimation', sign: +1 },
         { path: 'surface.hydrocarbonIce', label: 'Methane Sublimation', sign: -1 },
+      ],
+      rapidSublimation: [
+        { path: 'atmospheric.atmosphericMethane', label: 'Rapid Sublimation', sign: +1 },
+        { path: 'surface.hydrocarbonIce', label: 'Rapid Sublimation', sign: -1 },
       ],
       // Prefer methane-specific precipitation keys collected from zonal changes
       methaneRain: [
@@ -205,6 +209,7 @@ class MethaneCycle extends ResourceCycleClass {
       sublimationAlbedo: SUBLIMATION_ALBEDO_HC_ICE,
       tripleTemperature: METHANE_T_TRIPLE,
       triplePressure: METHANE_P_TRIPLE,
+      disallowLiquidBelowTriple: true,
       coverageKeys,
       precipitationKeys,
       surfaceFlowFn,
@@ -249,6 +254,12 @@ class MethaneCycle extends ResourceCycleClass {
     if (typeof redistributePrecipitationFn === 'function') {
       redistributePrecipitationFn(terraforming, 'methane', zonalChanges, zonalTemperatures);
     }
+  }
+
+  updateResourceRates(terraforming, totals = {}, durationSeconds = 1) {
+    super.updateResourceRates(terraforming, totals, durationSeconds);
+    const rapid = terraforming.totalMethaneRapidSublimationRate || 0;
+    terraforming.totalMethaneSublimationRate = (terraforming.totalMethaneSublimationRate || 0) + rapid;
   }
 
 }

--- a/src/js/terraforming/water-cycle.js
+++ b/src/js/terraforming/water-cycle.js
@@ -69,7 +69,7 @@ class WaterCycle extends ResourceCycleClass {
   constructor({
     key = 'water',
     atmKey = 'atmosphericWater',
-    totalKeys = ['evaporation', 'sublimation', 'melt', 'freeze'],
+    totalKeys = ['evaporation', 'sublimation', 'rapidSublimation', 'melt', 'freeze'],
     processTotalKeys = { rain: 'rain', snow: 'snow' },
     transitionRange = 2,
     maxDiff = 10,
@@ -116,6 +116,10 @@ class WaterCycle extends ResourceCycleClass {
       sublimation: [
         { path: 'atmospheric.atmosphericWater', label: 'Sublimation', sign: +1 },
         { path: 'surface.ice', label: 'Sublimation', sign: -1 },
+      ],
+      rapidSublimation: [
+        { path: 'atmospheric.atmosphericWater', label: 'Rapid Sublimation', sign: +1 },
+        { path: 'surface.ice', label: 'Rapid Sublimation', sign: -1 },
       ],
       // Totals often arrive as 'rain'/'snow' from zonal precipitation
       rain: [
@@ -243,7 +247,9 @@ class WaterCycle extends ResourceCycleClass {
     }
 
     // Alias expected fields
-    terraforming.totalWaterSublimationRate = terraforming.totalSublimationRate || 0;
+    const rapid = terraforming.totalRapidSublimationRate || 0;
+    terraforming.totalSublimationRate = (terraforming.totalSublimationRate || 0) + rapid;
+    terraforming.totalWaterSublimationRate = terraforming.totalSublimationRate;
     // UI expects rainfall/snowfall names, but totals keys are often rain/snow
     const rainRate = durationSeconds > 0 ? (totals.rain || 0) / durationSeconds * 86400 : 0;
     const snowRate = durationSeconds > 0 ? (totals.snow || 0) / durationSeconds * 86400 : 0;

--- a/tests/methaneRapidSublimation.test.js
+++ b/tests/methaneRapidSublimation.test.js
@@ -1,0 +1,52 @@
+jest.mock('../src/js/terraforming/hydrology.js', () => ({
+  simulateSurfaceHydrocarbonFlow: jest.fn(),
+}));
+
+global.C_P_AIR = 1004;
+global.EPSILON = 0.622;
+
+const { MethaneCycle } = require('../src/js/terraforming/hydrocarbon-cycle.js');
+
+test('methane processZone converts forbidden melt to rapid sublimation', () => {
+  const mc = new MethaneCycle();
+  mc.evaporationRate = () => 0;
+  mc.sublimationRate = () => 0;
+  mc.condensationRateFactor = () => ({ liquidRate: 0, iceRate: 0 });
+  mc.meltingFreezingRates = () => ({ meltingRate: 2, freezingRate: 0 });
+  const result = mc.processZone({
+    zoneArea: 1,
+    hydrocarbonIceCoverage: 1,
+    liquidMethaneCoverage: 0,
+    zoneTemperature: 95,
+    atmPressure: 50000,
+    vaporPressure: 0,
+    availableIce: 5,
+    availableBuriedIce: 0,
+    availableLiquid: 0,
+    durationSeconds: 1,
+  });
+  expect(result.rapidSublimationAmount).toBeCloseTo(2);
+  expect(result.atmosphere.methane).toBeCloseTo(2);
+  expect(result.methane.ice).toBeCloseTo(-2);
+});
+
+test('methane updateResourceRates handles rapid sublimation mapping', () => {
+  const mc = new MethaneCycle();
+  const resources = {
+    atmospheric: { atmosphericMethane: { modifyRate: jest.fn() } },
+    surface: { hydrocarbonIce: { modifyRate: jest.fn() } },
+  };
+  const tf = { resources };
+  mc.updateResourceRates(tf, { rapidSublimation: 1 }, 1);
+  expect(resources.atmospheric.atmosphericMethane.modifyRate).toHaveBeenCalledWith(
+    86400,
+    'Rapid Sublimation',
+    'terraforming'
+  );
+  expect(resources.surface.hydrocarbonIce.modifyRate).toHaveBeenCalledWith(
+    -86400,
+    'Rapid Sublimation',
+    'terraforming'
+  );
+  expect(tf.totalMethaneRapidSublimationRate).toBeCloseTo(86400);
+});


### PR DESCRIPTION
## Summary
- Convert melting to rapid sublimation when liquid water isn't allowed
- Track rapid sublimation totals and label ice/atmosphere rate changes
- Test rapid sublimation handling and rate mapping
- Add rapid sublimation support for methane
- Test methane rapid sublimation processing and rates

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bd7ffe29b083279bca59d62195145f