### PR TITLE
Add sulfuric acid atmospheric resource

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,3 +487,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - ResourceCycle converts melting into rapid sublimation when liquid water is forbidden, recording rates for ice and atmosphere as "Rapid Sublimation".
 - Methane cycle converts melting into rapid sublimation when liquid methane is forbidden, tracking hydrocarbon ice and atmospheric methane as "Rapid Sublimation".
 - Cargo rocket x10 and /10 increment count now persists through save and load.
+- Added a sulfuric acid atmospheric resource integrated with physics.js and albedo cloud calculations.

--- a/src/js/debug-tools.js
+++ b/src/js/debug-tools.js
@@ -68,6 +68,7 @@
       co2: resources.atmospheric.carbonDioxide?.value || 0,
       waterVapor: resources.atmospheric.atmosphericWater?.value || 0,
       atmosphericMethane: resources.atmospheric.atmosphericMethane?.value || 0,
+      sulfuricAcid: resources.atmospheric.sulfuricAcid?.value || 0,
       buriedIce: 0
     };
     const zonalVals = {};
@@ -91,7 +92,7 @@
   }
 
   function isStable(prev, cur, threshold) {
-    const keys = ['ice','buriedIce','liquidWater','dryIce','co2','waterVapor','liquidMethane','hydrocarbonIce','atmosphericMethane'];
+    const keys = ['ice','buriedIce','liquidWater','dryIce','co2','waterVapor','liquidMethane','hydrocarbonIce','atmosphericMethane','sulfuricAcid'];
     for (const k of keys) {
       if (Math.abs(cur.global[k] - prev.global[k]) > threshold) return false;
     }
@@ -114,7 +115,8 @@
     const atmospheric = {
       carbonDioxide: { initialValue: values.global.co2 },
       atmosphericWater: { initialValue: values.global.waterVapor },
-      atmosphericMethane: { initialValue: values.global.atmosphericMethane }
+      atmosphericMethane: { initialValue: values.global.atmosphericMethane },
+      sulfuricAcid: { initialValue: values.global.sulfuricAcid }
     };
     const zonalWater = {};
     const zonalSurface = {};

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -71,6 +71,7 @@ const defaultPlanetParameters = {
       atmosphericWater: { name: 'Water Vap.', initialValue:  19100402.066922974, unlocked:false , unit: 'ton' }, // Default (Mars) - Adjusted based on review
       greenhouseGas: {name: 'Safe GHG', initialValue : 0, unlocked: false, unit: 'ton', hideWhenSmall: true }, // Default (Mars)
       atmosphericMethane: { name: 'Methane', initialValue: 0, unlocked: false, unit: 'ton', hideWhenSmall: true },
+      sulfuricAcid: { name: 'Sulfuric Acid', initialValue: 0, unlocked: false, unit: 'ton', hideWhenSmall: true },
       calciteAerosol: { name: 'Calcite Aerosol', initialValue: 0, unlocked: false, unit: 'ton', hideWhenSmall: true }
     },
     special: {

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -456,7 +456,7 @@ const projectParameters = {
     attributes: {
       spaceExport : true,
       costPerShip : {colony : {metal : 100000, energy : 10000000000}},
-      disposable : {surface : ['liquidWater', 'ice', 'dryIce'], atmospheric : ['carbonDioxide', 'oxygen', 'inertGas', 'greenhouseGas', 'atmosphericMethane']},
+      disposable : {surface : ['liquidWater', 'ice', 'dryIce'], atmospheric : ['carbonDioxide', 'oxygen', 'inertGas', 'greenhouseGas', 'atmosphericMethane', 'sulfuricAcid']},
     disposalAmount : 1000000
     }
   }

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -112,7 +112,7 @@ class SpaceExportBaseProject extends SpaceshipProject {
   }
 
   isGasResource(resource) {
-    const gases = ['carbonDioxide', 'oxygen', 'inertGas', 'greenhouseGas', 'atmosphericMethane'];
+    const gases = ['carbonDioxide', 'oxygen', 'inertGas', 'greenhouseGas', 'atmosphericMethane', 'sulfuricAcid'];
     return gases.includes(resource);
   }
 

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -388,7 +388,7 @@ function buildAtmosphere(archetype, radius_km, gravity, rng, params) {
   const pressureBar = tpl ? tpl.pressureBar * randRange(rng, band[0], band[1]) : randRange(rng, 0.001, 2.0);
   const totalTons = totalAtmosphereMassTons(pressureBar, radius_km, gravity);
   const baseMix = (tpl && tpl.mix) ? tpl.mix : {};
-  const mixKeys = ["carbonDioxide","inertGas","oxygen","atmosphericWater","atmosphericMethane"];
+  const mixKeys = ["carbonDioxide","inertGas","oxygen","atmosphericWater","atmosphericMethane","sulfuricAcid"];
   const jittered = {}; let sum = 0;
   for (const k of mixKeys) { const base = baseMix[k] || 0; if (base <= 0) { jittered[k] = 0; continue; } const jitter = 1 + randRange(rng, -0.25, 0.25); const val = Math.max(0, base * jitter); jittered[k] = val; sum += val; }
   const gas = {}; if (sum <= 0) { gas.inertGas = { initialValue: totalTons, unlocked: false }; for (const k of mixKeys) if (k !== "inertGas") gas[k] = { initialValue: 0, unlocked: false }; return gas; }
@@ -507,7 +507,7 @@ function buildPlanetOverride({ seed, star, aAU, isMoon, forcedType }, params) {
   // Atmosphere composition & pressure for physics model
   let totalAtmoMass = 0; const compMass = {};
   for (const g in atmo) { const m = atmo[g]?.initialValue || 0; compMass[g] = m; totalAtmoMass += m; }
-  const composition = {}; if (totalAtmoMass > 0) { if (compMass.carbonDioxide) composition.co2 = compMass.carbonDioxide / totalAtmoMass; if (compMass.atmosphericWater) composition.h2o = compMass.atmosphericWater / totalAtmoMass; if (compMass.atmosphericMethane) composition.ch4 = compMass.atmosphericMethane / totalAtmoMass; }
+  const composition = {}; if (totalAtmoMass > 0) { if (compMass.carbonDioxide) composition.co2 = compMass.carbonDioxide / totalAtmoMass; if (compMass.atmosphericWater) composition.h2o = compMass.atmosphericWater / totalAtmoMass; if (compMass.atmosphericMethane) composition.ch4 = compMass.atmosphericMethane / totalAtmoMass; if (compMass.sulfuricAcid) composition.h2so4 = compMass.sulfuricAcid / totalAtmoMass; }
   const surfacePressureBar = calcAtmPressure ? calcAtmPressure(totalAtmoMass, bulk.gravity, bulk.radius_km) / 100000 : 0;
   const SOLAR_FLUX_1AU = 1361; const flux = (SOLAR_FLUX_1AU * (star.luminositySolar || 1)) / (aAU * aAU);
   const temps = dayNightTemperaturesModelFn ? dayNightTemperaturesModelFn({ groundAlbedo: classification.albedo, flux, rotationPeriodH: rotation, surfacePressureBar, composition, surfaceFractions, gSurface: bulk.gravity }) : { day: 0, night: 0, mean: 0, albedo };

--- a/src/js/rwgEquilibrate.js
+++ b/src/js/rwgEquilibrate.js
@@ -106,7 +106,7 @@
   function copyBackToOverrideFromSandbox(override, sandboxResources, terra) {
     const out = JSON.parse(JSON.stringify(override));
     // Write atmospheric and surface resources back into override
-    const atmoKeys = ['carbonDioxide','inertGas','oxygen','atmosphericWater','atmosphericMethane'];
+    const atmoKeys = ['carbonDioxide','inertGas','oxygen','atmosphericWater','atmosphericMethane','sulfuricAcid'];
     out.resources = out.resources || {};
     out.resources.atmospheric = out.resources.atmospheric || {};
     atmoKeys.forEach(k => {
@@ -157,7 +157,7 @@
     const surf = terra.resources.surface || {};
     function g(obj, k) { return obj[k] ? (obj[k].value || 0) : 0; }
     const metrics = [
-      g(atmo,'carbonDioxide'), g(atmo,'inertGas'), g(atmo,'oxygen'), g(atmo,'atmosphericWater'), g(atmo,'atmosphericMethane'),
+      g(atmo,'carbonDioxide'), g(atmo,'inertGas'), g(atmo,'oxygen'), g(atmo,'atmosphericWater'), g(atmo,'atmosphericMethane'), g(atmo,'sulfuricAcid'),
       g(surf,'ice'), g(surf,'liquidWater'), g(surf,'dryIce'), g(surf,'liquidMethane'), g(surf,'hydrocarbonIce')
     ];
     const zones = ['tropical', 'temperate', 'polar'];

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -659,7 +659,8 @@ function renderAtmoTable(res) {
     { label: 'Inert Gas', key: 'inertGas' },
     { label: 'O₂', key: 'oxygen' },
     { label: 'Water Vap.', key: 'atmosphericWater' },
-    { label: 'CH₄', key: 'atmosphericMethane' }
+    { label: 'CH₄', key: 'atmosphericMethane' },
+    { label: 'H₂SO₄', key: 'sulfuricAcid' }
   ];
   const fmt = typeof formatNumber === 'function' ? formatNumber : (n => n);
   const cells = rows.map(r => {

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -840,22 +840,24 @@ class Terraforming extends EffectableEntity{
     }
 
     calculateAtmosphericComposition() {
-        let co2Mass = 0, h2oMass = 0, ch4Mass = 0, safeGHGMass = 0, inertMass = 0;
+        let co2Mass = 0, h2oMass = 0, ch4Mass = 0, h2so4Mass = 0, safeGHGMass = 0, inertMass = 0;
         for (const gas in this.resources.atmospheric) {
             const amountTons = this.resources.atmospheric[gas].value || 0;
             const kg = amountTons * 1000;
             if (gas === 'carbonDioxide') co2Mass += kg;
             else if (gas === 'atmosphericWater') h2oMass += kg;
             else if (gas === 'atmosphericMethane') ch4Mass += kg;
+            else if (gas === 'sulfuricAcid') h2so4Mass += kg;
             else if (gas === 'greenhouseGas') safeGHGMass += kg;
             else inertMass += kg;
         }
-        const totalMass = co2Mass + h2oMass + ch4Mass + safeGHGMass + inertMass;
+        const totalMass = co2Mass + h2oMass + ch4Mass + h2so4Mass + safeGHGMass + inertMass;
         const composition = {};
         if (totalMass > 0) {
             if (co2Mass > 0) composition.co2 = co2Mass / totalMass;
             if (h2oMass > 0) composition.h2o = h2oMass / totalMass;
             if (ch4Mass > 0) composition.ch4 = ch4Mass / totalMass;
+            if (h2so4Mass > 0) composition.h2so4 = h2so4Mass / totalMass;
             if (safeGHGMass > 0) composition.greenhouseGas = safeGHGMass / totalMass;
         }
         return { composition, totalMass };

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -359,7 +359,8 @@ function createTemperatureBox(row) {
             co2: 'carbonDioxide',
             h2o: 'atmosphericWater',
             ch4: 'atmosphericMethane',
-            greenhousegas: 'greenhouseGas'
+            greenhousegas: 'greenhouseGas',
+            h2so4: 'sulfuricAcid'
           };
           const resourceKey = mapping[gas.toLowerCase()];
           const displayName = resourceKey && resources.atmospheric[resourceKey]

--- a/tests/physics.test.js
+++ b/tests/physics.test.js
@@ -28,4 +28,11 @@ describe('physics helpers', () => {
     expect(res.cfCloud).toBeGreaterThan(0);
     expect(res.cfHaze).toBeGreaterThan(0);
   });
+
+  test('sulfuric acid clouds brighten albedo', () => {
+    const base = calculateActualAlbedoPhysics(0.3, 5, {}, 9.81);
+    const withAcid = calculateActualAlbedoPhysics(0.3, 5, { h2so4: 0.001 }, 9.81);
+    expect(withAcid.albedo).toBeGreaterThan(base.albedo);
+    expect(withAcid.cfCloud).toBeGreaterThan(base.cfCloud);
+  });
 });


### PR DESCRIPTION
## Summary
- add sulfuric acid to atmospheric resources and composition calculations
- surface disposal and export logic recognize sulfuric acid gas
- cover sulfuric acid cloud albedo behavior with tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bda8a3a4cc83278372d77266ed8f91