### PR TITLE
Add per-column step controls for space mirror oversight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,6 +430,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage strategic reserve and nanobot energy limit inputs now accept scientific notation (e.g., 1e3 for 1000).
 - Space storage strategic reserve input includes a tooltip noting that mega projects respect the reserve while transfers do not, and explaining scientific notation support.
 - Space mirror facility's unassigned slider matches the width of other sliders and locks when finer controls are enabled.
+- Space mirror finer controls provide column-specific /10 xN x10 buttons for mirror and lantern assignments.
 - Water melt target input in space mirror facility advanced oversight is wider and includes k/M/B scaling dropdown.
 - Added `reinitializeDisplayElements` to Resource for resetting default display names and margins after travel.
 - Resource `reinitializeDisplayElements` now pulls display defaults from `defaultPlanetParameters` instead of storing them on each resource.

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -117,7 +117,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
     distribution: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0 },
     applyToLantern: false,
     useFinerControls: false,
-    assignmentStep: 1,
+    assignmentStep: { mirrors: 1, lanterns: 1 },
     advancedOversight: false,
     targets: { tropical: 0, temperate: 0, polar: 0, water: 0 },
     waterMultiplier: 1000,

--- a/tests/spaceMirrorFinerControls.test.js
+++ b/tests/spaceMirrorFinerControls.test.js
@@ -134,6 +134,8 @@ describe('Space Mirror finer controls', () => {
     updateMirrorOversightUI();
     const cell = container.querySelector('#assignment-grid .assign-cell[data-type="lanterns"]');
     expect(cell.style.display).toBe('none');
+    const step = container.querySelector('.step-controls[data-type="lanterns"]');
+    expect(step.style.display).toBe('none');
     delete global.window;
     delete global.document;
   });
@@ -194,6 +196,30 @@ describe('Space Mirror finer controls', () => {
     expect(mirrorOversightSettings.assignments.mirrors.any).toBe(9);
     plusBtn.click();
     expect(mirrorOversightSettings.assignments.mirrors.any).toBe(10);
+    delete global.window;
+    delete global.document;
+  });
+
+  test('each column has independent step controls', () => {
+    resetMirrorOversightSettings();
+    const dom = new JSDOM('<div id="container"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const container = document.getElementById('container');
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: true } };
+    global.projectManager = { isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight' };
+    initializeMirrorOversightUI(container);
+    toggleFinerControls(true);
+    const mirrorMul = container.querySelector('.assignment-mul10[data-type="mirrors"]');
+    const lanternMul = container.querySelector('.assignment-mul10[data-type="lanterns"]');
+    mirrorMul.click();
+    expect(mirrorOversightSettings.assignmentStep.mirrors).toBe(10);
+    expect(mirrorOversightSettings.assignmentStep.lanterns).toBe(1);
+    lanternMul.click();
+    expect(mirrorOversightSettings.assignmentStep.lanterns).toBe(10);
+    const mirrorDiv = container.querySelector('.assignment-div10[data-type="mirrors"]');
+    mirrorDiv.click();
+    expect(mirrorOversightSettings.assignmentStep.mirrors).toBe(1);
     delete global.window;
     delete global.document;
   });

--- a/tests/spaceMirrorOversightPersistence.test.js
+++ b/tests/spaceMirrorOversightPersistence.test.js
@@ -25,7 +25,8 @@ describe('SpaceMirrorFacilityProject oversight save/load', () => {
 
     ctx.mirrorOversightSettings.distribution.tropical = 0.5;
     ctx.mirrorOversightSettings.applyToLantern = true;
-    ctx.mirrorOversightSettings.assignmentStep = 5;
+    ctx.mirrorOversightSettings.assignmentStep.mirrors = 5;
+    ctx.mirrorOversightSettings.assignmentStep.lanterns = 5;
     ctx.mirrorOversightSettings.targets.tropical = 300;
     ctx.mirrorOversightSettings.tempMode.polar = 'night';
     ctx.mirrorOversightSettings.priority.focus = 3;
@@ -44,7 +45,8 @@ describe('SpaceMirrorFacilityProject oversight save/load', () => {
 
     expect(ctx.mirrorOversightSettings.distribution.tropical).toBe(0.5);
     expect(ctx.mirrorOversightSettings.applyToLantern).toBe(true);
-    expect(ctx.mirrorOversightSettings.assignmentStep).toBe(5);
+    expect(ctx.mirrorOversightSettings.assignmentStep.mirrors).toBe(5);
+    expect(ctx.mirrorOversightSettings.assignmentStep.lanterns).toBe(5);
     expect(ctx.mirrorOversightSettings.targets.tropical).toBe(300);
     expect(ctx.mirrorOversightSettings.tempMode.polar).toBe('night');
     expect(ctx.mirrorOversightSettings.priority.focus).toBe(3);


### PR DESCRIPTION
## Summary
- Split mirror oversight assignment steps into separate values for mirrors and lanterns
- Add /10 xN x10 controls to each mirror/lantern column when finer controls are enabled
- Document new controls and cover with tests

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68be1da116a88327a5b740073abd4734