### PR TITLE
Fix advanced oversight assignments tests

### DIFF
--- a/tests/runAdvancedOversightAssignments.test.js
+++ b/tests/runAdvancedOversightAssignments.test.js
@@ -73,28 +73,34 @@ describe('runAdvancedOversightAssignments', () => {
   });
 
   test('uses selected temperature mode', () => {
+    project.reversalAvailable = true;
     mirrorOversightSettings.targets = { tropical: 195, temperate: 0, polar: 0, water: 0 };
     mirrorOversightSettings.tempMode = { tropical: 'night', temperate: 'average', polar: 'average' };
-    runAdvancedOversightAssignments();
+    runAdvancedOversightAssignments(project);
     expect(mirrorOversightSettings.assignments.reversalMode.tropical).toBe(false);
     mirrorOversightSettings.tempMode.tropical = 'day';
-    runAdvancedOversightAssignments();
+    runAdvancedOversightAssignments(project);
     expect(mirrorOversightSettings.assignments.reversalMode.tropical).toBe(true);
+    project.reversalAvailable = false;
   });
 
   test('prioritizes water focusing and uses lanterns when needed', () => {
+    global.projectManager = {
+      isBooleanFlagSet: (flag) => flag === 'spaceMirrorFocusing'
+    };
     mirrorOversightSettings.priority = { tropical: 2, temperate: 3, polar: 4, focus: 1 };
     mirrorOversightSettings.targets = { tropical: 230, temperate: 0, polar: 0, water: 0.001 };
     mirrorOversightSettings.applyToLantern = true;
     buildings.spaceMirror.active = 1;
     buildings.hyperionLantern.active = 5;
 
-    runAdvancedOversightAssignments();
+    runAdvancedOversightAssignments(project);
 
     expect(mirrorOversightSettings.assignments.mirrors.focus).toBe(1);
-    expect(mirrorOversightSettings.assignments.lanterns.focus).toBe(0);
+    expect(mirrorOversightSettings.assignments.lanterns.focus).toBe(1);
     // Remaining mirrors go to tropical but are insufficient to reach target fully
     expect(mirrorOversightSettings.assignments.mirrors.tropical).toBe(0);
+    delete global.projectManager;
   });
   afterAll(() => {
     delete global.Project;


### PR DESCRIPTION
## Summary
- ensure runAdvancedOversightAssignments tests supply project data so reversal mode can be triggered
- mock space mirror focusing flag and update lantern expectations for water focus assignments

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68be4aa42adc8327b4fc81c3b93cece9