### PR TITLE
Make Random World Effects menu collapsible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,3 +489,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Cargo rocket x10 and /10 increment count now persists through save and load.
 - Added a sulfuric acid atmospheric resource integrated with physics.js and albedo cloud calculations.
 - Zonal dry ice storage moved from `zonalSurface` to `zonalCO2.ice` and all interactions updated accordingly.
+- Random World Effects card can now be collapsed to hide its table.

--- a/src/css/rwg.css
+++ b/src/css/rwg.css
@@ -139,7 +139,15 @@
   padding: 14px;
 }
 
-.rwg-card h3, .rwg-card h4 { margin: 0 0 10px; color: var(--rwg-fg); }
+.rwg-card .card-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+  color: var(--rwg-fg);
+}
+.rwg-card h3, .rwg-card h4 { margin: 0; }
+.collapse-arrow { margin-right: 6px; cursor: pointer; }
+.rwg-card.collapsed .card-body { display: none; }
 
 .rwg-grid {
   display: grid;

--- a/src/js/rwgEffectsUI.js
+++ b/src/js/rwgEffectsUI.js
@@ -34,9 +34,12 @@ function _ensureRWGEffectsUI() {
   card.className = 'rwg-card';
   card.id = 'rwg-effects-card';
   card.innerHTML = `
-    <h3>Random World Effects <span class="info-tooltip-icon" title="Bonuses from terraforming random worlds of each type">&#9432;</span></h3>
-    <div id="rwg-effects-list" class="rwg-effects-list"></div>
+    <div class="card-header">
+      <h3 class="card-title">Random World Effects <span class="info-tooltip-icon" title="Bonuses from terraforming random worlds of each type">&#9432;</span></h3>
+    </div>
+    <div id="rwg-effects-list" class="card-body rwg-effects-list"></div>
   `;
+  if (typeof makeCollapsibleCard === 'function') makeCollapsibleCard(card);
   const historyEl = document.getElementById('rwg-history');
   if (historyEl && historyEl.parentElement === container) {
     container.insertBefore(card, historyEl);

--- a/tests/rwgEffectsCollapse.test.js
+++ b/tests/rwgEffectsCollapse.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Random World Effects card collapse', () => {
+  test('arrow toggles collapsed class and icon', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="space-random"><div id="rwg-history"></div></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+
+    const uiUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ui-utils.js'), 'utf8');
+    const rwgEffectsUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgEffectsUI.js'), 'utf8');
+    vm.runInContext(`${uiUtilsCode}\n${rwgEffectsUICode}`, ctx);
+    vm.runInContext('_ensureRWGEffectsUI();', ctx);
+
+    const card = dom.window.document.getElementById('rwg-effects-card');
+    const arrow = card.querySelector('.collapse-arrow');
+    expect(card.classList.contains('collapsed')).toBe(false);
+    expect(arrow.innerHTML).toBe('▼');
+
+    arrow.dispatchEvent(new dom.window.Event('click'));
+
+    expect(card.classList.contains('collapsed')).toBe(true);
+    expect(arrow.innerHTML).toBe('▶');
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap Random World Effects content in a card header/body and use `makeCollapsibleCard` for toggling
- Style the Random World Effects card to hide its table when collapsed
- Cover collapse behavior with a dedicated unit test

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68be4cab14c08327b8207b498d8bd2b1