### PR TITLE
Add per-column step controls to space mirror oversight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,6 +431,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage strategic reserve input includes a tooltip noting that mega projects respect the reserve while transfers do not, and explaining scientific notation support.
 - Space mirror facility's unassigned slider matches the width of other sliders and locks when finer controls are enabled.
 - Water melt target input in space mirror facility advanced oversight is wider and includes k/M/B scaling dropdown.
+- Space mirror oversight finer controls now provide /10 xN x10 buttons for each column, showing lantern controls only when lanterns are available.
 - Added `reinitializeDisplayElements` to Resource for resetting default display names and margins after travel.
 - Resource `reinitializeDisplayElements` now pulls display defaults from `defaultPlanetParameters` instead of storing them on each resource.
 - Life growth rate tooltip now reflects ecumenopolis land coverage and shows land reduction percentage.

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -117,7 +117,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
     distribution: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0 },
     applyToLantern: false,
     useFinerControls: false,
-    assignmentStep: 1,
+    assignmentStep: { mirrors: 1, lanterns: 1 },
     advancedOversight: false,
     targets: { tropical: 0, temperate: 0, polar: 0, water: 0 },
     waterMultiplier: 1000,

--- a/tests/spaceMirrorColumnStepControls.test.js
+++ b/tests/spaceMirrorColumnStepControls.test.js
@@ -1,0 +1,63 @@
+const numbers = require('../src/js/numbers.js');
+const { JSDOM } = require('jsdom');
+
+global.Project = class {};
+global.projectElements = {};
+global.formatNumber = numbers.formatNumber;
+global.formatBuildingCount = numbers.formatBuildingCount;
+
+const {
+  SpaceMirrorFacilityProject,
+  toggleFinerControls,
+  initializeMirrorOversightUI,
+  resetMirrorOversightSettings
+} = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+
+const project = new SpaceMirrorFacilityProject({ name: 'Mirror', cost: {}, duration: 0 }, 'spaceMirrorFacility');
+const mirrorOversightSettings = project.mirrorOversightSettings;
+global.mirrorOversightSettings = mirrorOversightSettings;
+
+afterAll(() => {
+  delete global.Project;
+  delete global.projectElements;
+  delete global.formatNumber;
+  delete global.formatBuildingCount;
+});
+
+beforeEach(() => {
+  resetMirrorOversightSettings();
+});
+
+describe('Space Mirror column step controls', () => {
+  test('shows controls for mirrors and lanterns when lanterns available', () => {
+    const dom = new JSDOM('<div id="container"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const container = document.getElementById('container');
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: true } };
+    initializeMirrorOversightUI(container);
+    toggleFinerControls(true);
+    const mirrorGroup = container.querySelector('.step-controls .type-step-controls[data-type="mirrors"]');
+    const lanternGroup = container.querySelector('.step-controls .type-step-controls[data-type="lanterns"]');
+    expect(mirrorGroup.querySelector('.assignment-div10')).not.toBeNull();
+    expect(mirrorGroup.querySelector('.assignment-step-display')).not.toBeNull();
+    expect(mirrorGroup.querySelector('.assignment-mul10')).not.toBeNull();
+    expect(lanternGroup.style.display).not.toBe('none');
+    delete global.window;
+    delete global.document;
+  });
+
+  test('hides lantern step controls when lanterns locked', () => {
+    const dom = new JSDOM('<div id="container"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const container = document.getElementById('container');
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: false } };
+    initializeMirrorOversightUI(container);
+    toggleFinerControls(true);
+    const lanternGroup = container.querySelector('.step-controls .type-step-controls[data-type="lanterns"]');
+    expect(lanternGroup.style.display).toBe('none');
+    delete global.window;
+    delete global.document;
+  });
+});

--- a/tests/spaceMirrorOversightPersistence.test.js
+++ b/tests/spaceMirrorOversightPersistence.test.js
@@ -25,7 +25,8 @@ describe('SpaceMirrorFacilityProject oversight save/load', () => {
 
     ctx.mirrorOversightSettings.distribution.tropical = 0.5;
     ctx.mirrorOversightSettings.applyToLantern = true;
-    ctx.mirrorOversightSettings.assignmentStep = 5;
+    ctx.mirrorOversightSettings.assignmentStep.mirrors = 5;
+    ctx.mirrorOversightSettings.assignmentStep.lanterns = 2;
     ctx.mirrorOversightSettings.targets.tropical = 300;
     ctx.mirrorOversightSettings.tempMode.polar = 'night';
     ctx.mirrorOversightSettings.priority.focus = 3;
@@ -44,7 +45,8 @@ describe('SpaceMirrorFacilityProject oversight save/load', () => {
 
     expect(ctx.mirrorOversightSettings.distribution.tropical).toBe(0.5);
     expect(ctx.mirrorOversightSettings.applyToLantern).toBe(true);
-    expect(ctx.mirrorOversightSettings.assignmentStep).toBe(5);
+    expect(ctx.mirrorOversightSettings.assignmentStep.mirrors).toBe(5);
+    expect(ctx.mirrorOversightSettings.assignmentStep.lanterns).toBe(2);
     expect(ctx.mirrorOversightSettings.targets.tropical).toBe(300);
     expect(ctx.mirrorOversightSettings.tempMode.polar).toBe('night');
     expect(ctx.mirrorOversightSettings.priority.focus).toBe(3);


### PR DESCRIPTION
## Summary
- Split space mirror oversight assignment step into separate mirror and lantern controls
- Show or hide lantern step controls depending on lantern availability
- Test per-column step control visibility

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68be4d1cbe4883278090a4ace4cc87de