### PR TITLE
Enable finer controls after disabling advanced oversight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,3 +491,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added a sulfuric acid atmospheric resource integrated with physics.js and albedo cloud calculations.
 - Zonal dry ice storage moved from `zonalSurface` to `zonalCO2.ice` and all interactions updated accordingly.
 - Random World Effects card can now be collapsed to hide its table.
+- Disabling space mirror advanced oversight now auto-enables finer controls and retains current assignments.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -312,9 +312,10 @@ function updateAssignmentDisplays() {
 
 // Toggle Advanced Oversight mode: uses assignments, hides 'any', and seeds default targets
 function toggleAdvancedOversight(enable) {
+  const wasAdvanced = !!mirrorOversightSettings.advancedOversight;
   mirrorOversightSettings.advancedOversight = !!enable;
-  mirrorOversightSettings.useFinerControls = !!enable;
   if (enable) {
+    mirrorOversightSettings.useFinerControls = true;
     mirrorOversightSettings.autoAssign.any = false;
     mirrorOversightSettings.autoAssign.tropical = false;
     mirrorOversightSettings.autoAssign.temperate = false;
@@ -338,6 +339,8 @@ function toggleAdvancedOversight(enable) {
       if (!mirrorOversightSettings.tempMode.temperate) mirrorOversightSettings.tempMode.temperate = 'average';
       if (!mirrorOversightSettings.tempMode.polar) mirrorOversightSettings.tempMode.polar = 'average';
     }
+  } else if (wasAdvanced) {
+    mirrorOversightSettings.useFinerControls = true;
   }
   if (typeof updateMirrorOversightUI === 'function') updateMirrorOversightUI();
 }

--- a/tests/spaceMirrorAdvancedOversight.test.js
+++ b/tests/spaceMirrorAdvancedOversight.test.js
@@ -2,7 +2,9 @@ global.Project = class {};
 global.projectElements = {};
 global.terraforming = { calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }) };
 const originalFormatNumber = global.formatNumber;
+const originalFormatBuildingCount = global.formatBuildingCount;
 global.formatNumber = () => '';
+global.formatBuildingCount = () => '';
 const { JSDOM } = require('jsdom');
 const dom = new JSDOM('<!doctype html><html><body></body></html>');
 global.document = dom.window.document;
@@ -14,6 +16,7 @@ const {
   toggleAdvancedOversight,
   resetMirrorOversightSettings,
   initializeMirrorOversightUI,
+  updateMirrorOversightUI,
 } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
 
 const project = new SpaceMirrorFacilityProject({ name: 'Mirror', cost: {}, duration: 0 }, 'spaceMirrorFacility');
@@ -23,7 +26,6 @@ const mirrorOversightSettings = project.mirrorOversightSettings;
 delete global.Project;
 delete global.projectElements;
 delete global.terraforming;
-if (originalFormatNumber !== undefined) global.formatNumber = originalFormatNumber; else delete global.formatNumber;
 delete global.calculateZoneSolarFluxWithFacility;
 delete global.setMirrorDistribution;
 delete global.resetMirrorOversightSettings;
@@ -45,6 +47,13 @@ describe('advanced mirror oversight', () => {
     delete global.buildings;
   });
 
+  afterAll(() => {
+    if (originalFormatNumber !== undefined) global.formatNumber = originalFormatNumber;
+    else delete global.formatNumber;
+    if (originalFormatBuildingCount !== undefined) global.formatBuildingCount = originalFormatBuildingCount;
+    else delete global.formatBuildingCount;
+  });
+
   test('any zone assignments cleared when advanced oversight enabled', () => {
     setMirrorDistribution('any', 100);
     distributeAssignmentsFromSliders('mirrors');
@@ -60,5 +69,27 @@ describe('advanced mirror oversight', () => {
     const tooltip = container.querySelector('#mirror-advanced-oversight-div .info-tooltip-icon');
     expect(tooltip).not.toBeNull();
     expect(tooltip.getAttribute('title')).toMatch(/lower numbers are assigned first/i);
+  });
+
+  test('disabling advanced oversight enables finer controls with existing assignments', () => {
+    const container = document.body;
+    container.innerHTML = '';
+    initializeMirrorOversightUI(container);
+    toggleAdvancedOversight(true);
+    mirrorOversightSettings.assignments.mirrors = {
+      tropical: 4,
+      temperate: 6,
+      polar: 0,
+      focus: 0,
+      unassigned: 0,
+      any: 0,
+    };
+    toggleAdvancedOversight(false);
+    updateMirrorOversightUI();
+    expect(mirrorOversightSettings.useFinerControls).toBe(true);
+    const finerBox = document.getElementById('mirror-use-finer');
+    expect(finerBox.checked).toBe(true);
+    expect(mirrorOversightSettings.assignments.mirrors.tropical).toBe(4);
+    expect(mirrorOversightSettings.assignments.mirrors.temperate).toBe(6);
   });
 });

--- a/tests/spaceMirrorColumnStepControls.test.js
+++ b/tests/spaceMirrorColumnStepControls.test.js
@@ -37,12 +37,11 @@ describe('Space Mirror column step controls', () => {
     global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: true } };
     initializeMirrorOversightUI(container);
     toggleFinerControls(true);
-    const mirrorGroup = container.querySelector('.step-controls .type-step-controls[data-type="mirrors"]');
-    const lanternGroup = container.querySelector('.step-controls .type-step-controls[data-type="lanterns"]');
-    expect(mirrorGroup.querySelector('.assignment-div10')).not.toBeNull();
-    expect(mirrorGroup.querySelector('.assignment-step-display')).not.toBeNull();
-    expect(mirrorGroup.querySelector('.assignment-mul10')).not.toBeNull();
-    expect(lanternGroup.style.display).not.toBe('none');
+    const mirrorCell = container.querySelector('.available-mirror-cell');
+    const lanternCell = container.querySelector('.available-lantern-cell');
+    expect(mirrorCell.querySelector('.assignment-div10')).not.toBeNull();
+    expect(mirrorCell.querySelector('.assignment-mul10')).not.toBeNull();
+    expect(lanternCell.style.display).not.toBe('none');
     delete global.window;
     delete global.document;
   });
@@ -55,8 +54,8 @@ describe('Space Mirror column step controls', () => {
     global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { active: 0, unlocked: false } };
     initializeMirrorOversightUI(container);
     toggleFinerControls(true);
-    const lanternGroup = container.querySelector('.step-controls .type-step-controls[data-type="lanterns"]');
-    expect(lanternGroup.style.display).toBe('none');
+    const lanternCell = container.querySelector('.available-lantern-cell');
+    expect(lanternCell.style.display).toBe('none');
     delete global.window;
     delete global.document;
   });


### PR DESCRIPTION
## Summary
- Auto-enable finer controls when advanced oversight is disabled, preserving current assignments
- Add regression test for finer control activation and update column step control tests
- Document advanced oversight disable behavior

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68be514b75988327b6315e018f530b17