### PR TITLE
Return critical slope for CO₂ saturation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,3 +493,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Random World Effects card can now be collapsed to hide its table.
 - Disabling space mirror advanced oversight now auto-enables finer controls and retains current assignments.
 - penmanRate now prevents negative humidity deficits above the critical temperature.
+- slopeSVPCO2 now returns the critical temperature slope for T ≥ Tc.

--- a/src/js/terraforming/dry-ice-cycle.js
+++ b/src/js/terraforming/dry-ice-cycle.js
@@ -78,9 +78,19 @@ function calculateSaturationPressureCO2(T) {
   if (T < CO2_T_TRIPLE) return psatCO2Solid(T); // solid branch
   return psatCO2Liquid(T);                      // liquid branch
 }
+
+// Precompute saturation vapor pressure slope at the critical point (Pa/K)
+const CRITICAL_SVP_SLOPE_CO2 = (() => {
+  const h = 0.01;
+  const p1 = psatCO2Liquid(CO2_T_CRIT - h);
+  const p2 = psatCO2Liquid(CO2_T_CRIT);
+  const slope = (p2 - p1) / h;
+  return Number.isFinite(slope) ? Math.max(slope, 0) : 0;
+})();
 // Numerical slope dPsat/dT (Pa/K)
 function slopeSVPCO2(T) {
   const h = 0.01;
+  if (T >= CO2_T_CRIT) return CRITICAL_SVP_SLOPE_CO2;
   const T1 = Math.max(1, T - h);
   const T2 = T + h;
   const p1 = calculateSaturationPressureCO2(T1);

--- a/tests/slopeSVPCO2Critical.test.js
+++ b/tests/slopeSVPCO2Critical.test.js
@@ -1,0 +1,10 @@
+const { slopeSVPCO2, CO2_T_CRIT } = require('../src/js/dry-ice-cycle.js');
+
+describe('slopeSVPCO2 critical behavior', () => {
+  test('returns slope at critical temperature when above Tc', () => {
+    const slopeAtCritical = slopeSVPCO2(CO2_T_CRIT);
+    const slopeAbove = slopeSVPCO2(CO2_T_CRIT + 10);
+    expect(slopeAbove).toBeCloseTo(slopeAtCritical);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure `slopeSVPCO2` uses the critical temperature derivative above `CO2_T_CRIT`
- document new behavior in AGENTS instructions
- test that `slopeSVPCO2` holds slope constant beyond the critical point

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68bee2f2bcac832790403ae34cc22f08