### PR TITLE
Scale satellite build count with worker cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,3 +494,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Disabling space mirror advanced oversight now auto-enables finer controls and retains current assignments.
 - penmanRate now prevents negative humidity deficits above the critical temperature.
 - slopeSVPCO2 now returns the critical temperature slope for T ≥ Tc.
+- Ore and geothermal satellites now scale their build count with worker cap (one satellite per 5,000 cap) instead of population.

--- a/src/js/projects/AGENTS.md
+++ b/src/js/projects/AGENTS.md
@@ -8,7 +8,7 @@ This folder contains classes for repeatable projects. Any new module here should
 - **DysonSwarmReceiverProject** – builds the Dyson Swarm Receiver and deploys solar collectors that persist across planets.
 - **OrbitalRingProject** – constructs repeatable orbital rings that count as terraformed worlds and may draw from space storage.
 - **PlanetaryThrustersProject** – consumes energy continuously to change planetary rotation or orbit via spin and motion targets.
-- **ScannerProject** – produces orbital scanners that slowly reveal underground deposits; build count scales with population.
+- **ScannerProject** – produces orbital scanners that slowly reveal underground deposits; build count scales with worker cap.
 - **SpaceExportBaseProject** – shared spaceship logic for exporting or jettisoning resources, including optional capacity waiting and temperature automation.
 - **SpaceExportProject** – sells selected resources for funding; export capacity scales with terraformed worlds.
 - **SpaceDisposalProject** – jettisons selected resources and can remove greenhouse gases to cool the planet.

--- a/src/js/projects/ScannerProject.js
+++ b/src/js/projects/ScannerProject.js
@@ -164,7 +164,7 @@ class ScannerProject extends Project {
   update(deltaTime) {
     super.update(deltaTime);
     if (this.autoMax) {
-      const limit = this.getColonistLimit();
+      const limit = this.getWorkerCapLimit();
       if (this.buildCount < limit) {
         this.buildCount = limit;
         if (typeof updateProjectUI === 'function') {
@@ -233,12 +233,12 @@ class ScannerProject extends Project {
     return scanData ? scanData.D_current : null;
   }
 
-  getColonistLimit() {
-    const colonistCap = Math.ceil((resources?.colony?.colonists?.value || 0) / 10000);
+  getWorkerCapLimit() {
+    const workerCap = Math.ceil((resources?.colony?.workers?.cap || 0) / 5000);
     if (this.maxRepeatCount === Infinity) {
-      return colonistCap;
+      return workerCap;
     }
-    return Math.max(Math.min(colonistCap, this.maxRepeatCount),1);
+    return Math.max(Math.min(workerCap, this.maxRepeatCount), 1);
   }
 
   getEffectiveBuildCount(count = this.buildCount) {
@@ -248,7 +248,12 @@ class ScannerProject extends Project {
 
   getScaledCost() {
     const base = super.getScaledCost();
-    const count = this.isActive ? (this.activeBuildCount || 1) : this.getEffectiveBuildCount(Math.min(this.buildCount, this.getColonistLimit()));
+    const count =
+      this.isActive
+        ? (this.activeBuildCount || 1)
+        : this.getEffectiveBuildCount(
+            Math.min(this.buildCount, this.getWorkerCapLimit())
+          );
     const scaled = {};
     for (const cat in base) {
       scaled[cat] = {};
@@ -260,21 +265,23 @@ class ScannerProject extends Project {
   }
 
   adjustBuildCount(delta) {
-    const limit = this.getColonistLimit();
+    const limit = this.getWorkerCapLimit();
     this.buildCount = Math.max(0, Math.min(this.buildCount + delta, limit));
   }
 
   setBuildCount(val) {
-    const limit = this.getColonistLimit();
+    const limit = this.getWorkerCapLimit();
     this.buildCount = Math.max(0, Math.min(val, limit));
   }
 
   setMaxBuildCount() {
-    this.setBuildCount(this.getColonistLimit());
+    this.setBuildCount(this.getWorkerCapLimit());
   }
 
   start(resources) {
-    this.activeBuildCount = this.getEffectiveBuildCount(Math.min(this.buildCount, this.getColonistLimit()));
+    this.activeBuildCount = this.getEffectiveBuildCount(
+      Math.min(this.buildCount, this.getWorkerCapLimit())
+    );
     return super.start(resources);
   }
 
@@ -345,7 +352,7 @@ class ScannerProject extends Project {
     max.id = `${this.name}-max`;
     const info = document.createElement('span');
     info.className = 'info-tooltip-icon';
-    info.title = 'Colonists let us build scanners in parallel. One satellite can be produced per 10,000 colonists.';
+    info.title = 'Worker capacity lets us build scanners in parallel. One satellite can be produced per 5,000 worker cap.';
     info.innerHTML = '&#9432;';
     amountDisplay.append(val, slash, max, info);
 
@@ -440,7 +447,7 @@ class ScannerProject extends Project {
       this.el.val.textContent = formatNumber(this.buildCount, true);
     }
     if (this.el.max) {
-      this.el.max.textContent = formatNumber(this.getColonistLimit(), true);
+      this.el.max.textContent = formatNumber(this.getWorkerCapLimit(), true);
     }
     if (this.el.bPlus) {
       this.el.bPlus.textContent = `+${formatNumber(this.step, true)}`;

--- a/tests/scannerProject.test.js
+++ b/tests/scannerProject.test.js
@@ -18,7 +18,7 @@ describe('ScannerProject scanning effect', () => {
     const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
     const ctx = { console, EffectableEntity };
     ctx.oreScanner = { adjustScanningStrength: jest.fn(), startScan: jest.fn() };
-    ctx.resources = { colony: { colonists: { value: 20000 } } };
+    ctx.resources = { colony: { workers: { cap: 20000 } } };
     vm.createContext(ctx);
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
     vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);

--- a/tests/scannerProjectAutoMax.test.js
+++ b/tests/scannerProjectAutoMax.test.js
@@ -14,7 +14,7 @@ describe('ScannerProject auto max', () => {
         metal: { value: 0, decrease(){}, updateStorageCap(){} },
         electronics: { value: 0, decrease(){}, updateStorageCap(){} },
         energy: { value: 0, decrease(){}, updateStorageCap(){} },
-        colonists: { value: 10000 }
+        workers: { cap: 10000 }
       }
     };
     vm.createContext(ctx);
@@ -24,7 +24,7 @@ describe('ScannerProject auto max', () => {
     return ctx;
   }
 
-  test('build count follows colonist cap when auto max enabled', () => {
+  test('build count follows worker cap when auto max enabled', () => {
     const ctx = createContext();
     const config = {
       name: 'scan',
@@ -39,14 +39,14 @@ describe('ScannerProject auto max', () => {
     };
     const project = new ctx.ScannerProject(config, 'scan');
     project.update(0);
-    expect(project.buildCount).toBe(1);
-    ctx.resources.colony.colonists.value = 20000;
-    project.update(0);
     expect(project.buildCount).toBe(2);
+    ctx.resources.colony.workers.cap = 20000;
+    project.update(0);
+    expect(project.buildCount).toBe(4);
     project.autoMax = false;
-    ctx.resources.colony.colonists.value = 30000;
+    ctx.resources.colony.workers.cap = 30000;
     project.update(0);
-    expect(project.buildCount).toBe(2);
+    expect(project.buildCount).toBe(4);
   });
 });
 

--- a/tests/scannerProjectBuildCount.test.js
+++ b/tests/scannerProjectBuildCount.test.js
@@ -14,7 +14,7 @@ describe('ScannerProject build count', () => {
         metal: { value: 1000, decrease(v){ this.value -= v; }, updateStorageCap(){} },
         electronics: { value: 1000, decrease(){}, updateStorageCap(){} },
         energy: { value: 1000000, decrease(){}, updateStorageCap(){} },
-        colonists: { value: 100000 }
+        workers: { cap: 100000 }
       }
     };
     vm.createContext(ctx);
@@ -50,9 +50,9 @@ describe('ScannerProject build count', () => {
     expect(project.scanData.ore.currentScanningStrength).toBeCloseTo(0.5);
   });
 
-  test('build count cropped by colonists and remaining repeats', () => {
+  test('build count cropped by worker cap and remaining repeats', () => {
     const ctx = createContext();
-    ctx.resources.colony.colonists.value = 5000; // limit 1
+    ctx.resources.colony.workers.cap = 5000; // limit 1
     const config = {
       name: 'scan',
       category: 'infra',
@@ -73,13 +73,13 @@ describe('ScannerProject build count', () => {
     project.complete();
     project.update(0);
     expect(project.repeatCount).toBe(3);
-    // Strength scales with repeat count regardless of colonists
+    // Strength scales with repeat count regardless of worker cap
     expect(project.scanData.ore.currentScanningStrength).toBeCloseTo(0.3);
   });
 
-  test('colonist limit capped by max repeat count', () => {
+  test('worker cap limit capped by max repeat count', () => {
     const ctx = createContext();
-    ctx.resources.colony.colonists.value = 20000000; // would allow 2000
+    ctx.resources.colony.workers.cap = 20000000; // would allow 4000
     const config = {
       name: 'scan',
       category: 'infra',
@@ -92,6 +92,6 @@ describe('ScannerProject build count', () => {
       attributes: { scanner: { canSearchForDeposits: true, searchValue: 0.1, depositType: 'ore' } }
     };
     const project = new ctx.ScannerProject(config, 'scan');
-    expect(project.getColonistLimit()).toBe(1000);
+    expect(project.getWorkerCapLimit()).toBe(1000);
   });
 });

--- a/tests/scannerProjectRate.test.js
+++ b/tests/scannerProjectRate.test.js
@@ -19,7 +19,7 @@ describe('ScannerProject auto-start cost rate', () => {
         metal: { value: 1000, modifyRate: jest.fn(), decrease(){}, updateStorageCap(){} },
         electronics: { value: 1000, modifyRate: jest.fn(), decrease(){}, updateStorageCap(){} },
         energy: { value: 3000000, modifyRate: jest.fn(), decrease(){}, updateStorageCap(){} },
-        colonists: { value: 100000 }
+        workers: { cap: 100000 }
       }
     };
     global.resources = ctx.resources;

--- a/tests/scannerProjectUIUpdate.test.js
+++ b/tests/scannerProjectUIUpdate.test.js
@@ -20,7 +20,7 @@ describe('ScannerProject UI update', () => {
     ctx.projectElements = {};
     ctx.resources = {
       colony: {
-        colonists: { value: 15000, displayName: 'Colonists' },
+        workers: { cap: 15000, displayName: 'Workers' },
         metal:{value:0,decrease(){},updateStorageCap(){}},
         electronics:{value:0,decrease(){},updateStorageCap(){}},
         energy:{value:0,decrease(){},updateStorageCap(){}}
@@ -42,7 +42,7 @@ describe('ScannerProject UI update', () => {
     project.updateUI();
 
     expect(project.el.val.textContent).toBe('1');
-    expect(project.el.max.textContent).toBe('2');
+    expect(project.el.max.textContent).toBe('3');
     expect(project.el.dVal.textContent).toBe('0');
     expect(project.el.dMax.textContent).toBe('10');
     expect(project.el.bPlus.textContent).toBe('+1');


### PR DESCRIPTION
## Summary
- Base ScannerProject satellite limit on worker capacity (1 per 5k cap) instead of population
- Update tooltip and documentation for worker-cap scaling
- Adjust tests to cover new worker-cap behavior

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bf27655c0c83279e1e6b53b25c21dd