### PR TITLE
feat: add android capacity warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,3 +495,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - penmanRate now prevents negative humidity deficits above the critical temperature.
 - slopeSVPCO2 now returns the critical temperature slope for T ≥ Tc.
 - Ore and geothermal satellites now scale their build count with worker cap (one satellite per 5,000 cap) instead of population.
+- Android resource displays an exclamation mark when capped while unused land remains below 99% of capacity.

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -545,7 +545,7 @@ function createResourceElement(category, resourceObj, resourceName) {
     // Special display for population (colonists) as an integer
     resourceElement.innerHTML = `
       <div class="resource-row ${!resourceObj.hasCap ? 'no-cap' : ''}">
-        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong>${resourceName === 'biomass' ? ' <span class="resource-warning" id="biomass-warning"></span>' : ''}</div>
+        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong>${['biomass', 'androids'].includes(resourceName) ? ` <span class="resource-warning" id="${resourceName}-warning"></span>` : ''}</div>
         <div class="resource-value" id="${resourceName}-resources-container">${Math.floor(resourceObj.value)}</div>
         ${resourceObj.hasCap ? `
           <div class="resource-slash">/</div>
@@ -589,7 +589,7 @@ function createResourceElement(category, resourceObj, resourceName) {
   } else {
     resourceElement.innerHTML = `
       <div class="resource-row ${!resourceObj.hasCap ? 'no-cap' : ''}">
-        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong>${resourceName === 'biomass' ? ' <span class="resource-warning" id="biomass-warning"></span>' : ''}</div>
+        <div class="resource-name"><strong id="${resourceName}-name">${resourceObj.displayName}</strong>${['biomass', 'androids'].includes(resourceName) ? ` <span class="resource-warning" id="${resourceName}-warning"></span>` : ''}</div>
         <div class="resource-value" id="${resourceName}-resources-container">${resourceObj.value.toFixed(2)}</div>
         ${resourceObj.hasCap ? `
           <div class="resource-slash">/</div>
@@ -697,6 +697,18 @@ function updateResourceDisplay(resources) {
         const zones = terraforming?.biomassDyingZones || {};
         const count = ['tropical', 'temperate', 'polar'].reduce((n, z) => n + (zones[z] ? 1 : 0), 0);
         const text = '!'.repeat(count);
+        if (entry.warningEl.textContent !== text) entry.warningEl.textContent = text;
+      }
+
+      if (resourceName === 'androids' && entry.warningEl) {
+        const land = resources.surface?.land;
+        const warn =
+          resourceObj.cap &&
+          resourceObj.value >= resourceObj.cap &&
+          land &&
+          land.value > 0 &&
+          land.reserved / land.value < 0.99;
+        const text = warn ? '!' : '';
         if (entry.warningEl.textContent !== text) entry.warningEl.textContent = text;
       }
 

--- a/tests/androidWarningDisplay.test.js
+++ b/tests/androidWarningDisplay.test.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+const vm = require('vm');
+const numbers = require('../src/js/numbers.js');
+
+describe('android warning display', () => {
+  function setup({ androidsValue, androidsCap, landValue, landReserved }) {
+    const dom = new JSDOM('<!DOCTYPE html><div id="resources-container"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.formatDuration = numbers.formatDuration;
+    ctx.oreScanner = { scanData: {} };
+    ctx.terraforming = {};
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resourceUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const res = {
+      colony: {
+        androids: {
+          name: 'androids',
+          displayName: 'Androids',
+          category: 'colony',
+          value: androidsValue,
+          cap: androidsCap,
+          hasCap: true,
+          reserved: 0,
+          unlocked: true,
+          hideWhenSmall: false,
+          productionRate: 0,
+          consumptionRate: 0,
+          productionRateBySource: {},
+          consumptionRateBySource: {},
+          isBooleanFlagSet: () => false
+        }
+      },
+      surface: {
+        land: {
+          name: 'land',
+          displayName: 'Land',
+          category: 'surface',
+          value: landValue,
+          cap: landValue,
+          hasCap: true,
+          reserved: landReserved,
+          unlocked: true,
+          hideWhenSmall: false,
+          productionRate: 0,
+          consumptionRate: 0,
+          productionRateBySource: {},
+          consumptionRateBySource: {},
+          isBooleanFlagSet: () => false
+        }
+      }
+    };
+
+    ctx.createResourceDisplay(res);
+    ctx.updateResourceDisplay(res);
+    return { dom };
+  }
+
+  test('shows exclamation mark when androids maxed but land available', () => {
+    const { dom } = setup({ androidsValue: 10, androidsCap: 10, landValue: 100, landReserved: 50 });
+    const warn = dom.window.document.getElementById('androids-warning');
+    expect(warn.textContent).toBe('!');
+  });
+
+  test('no exclamation mark when land nearly full', () => {
+    const { dom } = setup({ androidsValue: 10, androidsCap: 10, landValue: 100, landReserved: 99 });
+    const warn = dom.window.document.getElementById('androids-warning');
+    expect(warn.textContent).toBe('');
+  });
+
+  test('no exclamation mark when androids below cap', () => {
+    const { dom } = setup({ androidsValue: 9, androidsCap: 10, landValue: 100, landReserved: 50 });
+    const warn = dom.window.document.getElementById('androids-warning');
+    expect(warn.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- show warning when androids are at cap but land remains
- test android warning display conditions

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bf2bf792e88327b5b85a5f02172773