### PR TITLE
Add Ship smelting advanced research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,3 +496,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - slopeSVPCO2 now returns the critical temperature slope for T ≥ Tc.
 - Ore and geothermal satellites now scale their build count with worker cap (one satellite per 5,000 cap) instead of population.
 - Android resource displays an exclamation mark when capped while unused land remains below 99% of capacity.
+- Added Ship smelting advanced research doubling metal asteroid mining ship capacity.

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -194,6 +194,9 @@ class EffectableEntity {
         case 'shipEfficiency':
           this.applyShipEfficiency(effect);
           break;
+        case 'shipCapacityMultiplier':
+          this.applyShipCapacityMultiplier(effect);
+          break;
         case 'projectDurationReduction':
           this.applyProjectDurationReduction(effect);
           break;
@@ -417,6 +420,12 @@ class EffectableEntity {
     applyShipEfficiency(effect) {
       if (typeof shipEfficiency !== 'undefined') {
         shipEfficiency = 1 + effect.value;
+      }
+    }
+
+    applyShipCapacityMultiplier(effect) {
+      if (typeof this.shipCapacityMultiplier === 'number') {
+        this.shipCapacityMultiplier *= effect.value;
       }
     }
 

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -9,6 +9,7 @@ class SpaceshipProject extends Project {
     this.assignmentMultiplier = 1;
     this.lastActiveTime = 0;
     this.pendingGain = null;
+    this.shipCapacityMultiplier = 1;
   }
 
   isContinuous() {
@@ -76,7 +77,7 @@ class SpaceshipProject extends Project {
 
   getShipCapacity(baseAmount = this.attributes.disposalAmount || 0) {
     const efficiency = typeof shipEfficiency !== 'undefined' ? shipEfficiency : 1;
-    return baseAmount * efficiency;
+    return baseAmount * efficiency * this.shipCapacityMultiplier;
   }
 
   updateCostAndGains(elements) {

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1483,6 +1483,21 @@ const researchParameters = {
         ]
       },
       {
+        id: 'ship_smelting',
+        name: 'Ship smelting',
+        description: 'Ships can now smelt asteroids directly, allowing them to carry more metal.',
+        cost: { advancedResearch: 200000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'project',
+            targetId: 'oreSpaceMining',
+            type: 'shipCapacityMultiplier',
+            value: 2
+          }
+        ]
+      },
+      {
         id: 'self_replicating_ships_concept',
         name: 'Self Replicating Ships',
         description: 'Opens research into autonomous self-building spacecraft.',

--- a/tests/shipCapacityMultiplierEffect.test.js
+++ b/tests/shipCapacityMultiplierEffect.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('shipCapacityMultiplier effect', () => {
+  test('doubles resource gain per ship when applied', () => {
+    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+    const miningCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceMiningProject.js'), 'utf8');
+    vm.runInContext(miningCode + '; this.SpaceMiningProject = SpaceMiningProject;', ctx);
+
+    const config = {
+      name: 'Test',
+      category: 'resources',
+      cost: {},
+      duration: 100,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceMining: true,
+        costPerShip: { colony: { metal: 1 } },
+        resourceGainPerShip: { colony: { metal: 10 } }
+      }
+    };
+
+    const project = new ctx.SpaceMiningProject(config, 'oreSpaceMining');
+    project.assignedSpaceships = 1;
+    let gain = project.calculateSpaceshipTotalResourceGain();
+    expect(gain.colony.metal).toBeCloseTo(10);
+    project.addAndReplace({ type: 'shipCapacityMultiplier', value: 2, effectId: 'test', sourceId: 'test' });
+    gain = project.calculateSpaceshipTotalResourceGain();
+    expect(gain.colony.metal).toBeCloseTo(20);
+  });
+});

--- a/tests/shipSmeltingResearch.test.js
+++ b/tests/shipSmeltingResearch.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Ship smelting advanced research', () => {
+  test('exists in advanced research with correct cost and effect', () => {
+    const ctx = {};
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research-parameters.js'), 'utf8');
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const adv = ctx.researchParameters.advanced;
+    const research = adv.find(r => r.id === 'ship_smelting');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(200000);
+    const effect = research.effects.find(e => e.type === 'shipCapacityMultiplier' && e.target === 'project' && e.targetId === 'oreSpaceMining' && e.value === 2);
+    expect(effect).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add Ship smelting advanced research doubling metal asteroid mining ship capacity
- support per-project ship capacity multiplier
- cover new research and effect with tests

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68bf69d1a61c83279b2c03d7ebce0670