### PR TITLE
feat: auto-complete Dyson Swarm Receiver on unlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,3 +497,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Ore and geothermal satellites now scale their build count with worker cap (one satellite per 5,000 cap) instead of population.
 - Android resource displays an exclamation mark when capped while unused land remains below 99% of capacity.
 - Added Ship smelting advanced research doubling metal asteroid mining ship capacity.
+- Dyson Swarm Receiver project now uses a `completedWhenUnlocked` flag to finish instantly when unlocked.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -402,7 +402,7 @@ const projectParameters = {
     repeatable: false,
     unlocked: false,
     treatAsBuilding: true,
-    attributes: { canUseSpaceStorage: true }
+    attributes: { canUseSpaceStorage: true, completedWhenUnlocked: true }
   },
   orbitalRing: {
     type: 'OrbitalRingProject',

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -453,6 +453,9 @@ class Project extends EffectableEntity {
         registerProjectUnlockAlert(`${cat}-projects`);
       }
     }
+    if (this.attributes?.completedWhenUnlocked && !this.isCompleted) {
+      this.complete();
+    }
   }
 
   usesSpaceStorageForResource(category, resource, amount) {

--- a/tests/dysonSwarmProject.test.js
+++ b/tests/dysonSwarmProject.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('Dyson Swarm Receiver project', () => {
   test('defined in parameters', () => {
@@ -15,5 +16,37 @@ describe('Dyson Swarm Receiver project', () => {
     expect(project.cost.colony.metal).toBe(10000000);
     expect(project.duration).toBe(300000);
     expect(project.treatAsBuilding).toBe(true);
+    expect(project.attributes.completedWhenUnlocked).toBe(true);
+  });
+
+  test('auto completes when enabled', () => {
+    const ctx = {
+      console,
+      EffectableEntity,
+      resources: {},
+      projectElements: {},
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false,
+      spaceManager: { getCurrentPlanetKey: () => 'mars' },
+    };
+    vm.createContext(ctx);
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.ProjectManager = ProjectManager; this.Project = Project;', ctx);
+    const baseCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'TerraformingDurationProject.js'), 'utf8');
+    vm.runInContext(baseCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
+    const dysonCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'dysonswarm.js'), 'utf8');
+    vm.runInContext(dysonCode + '; this.DysonSwarmReceiverProject = DysonSwarmReceiverProject;', ctx);
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    ctx.projectManager = new ctx.ProjectManager();
+    ctx.projectManager.initializeProjects(ctx.projectParameters);
+
+    const before = vm.runInContext('projectManager.projects.dysonSwarmReceiver.isCompleted', ctx);
+    expect(before).toBe(false);
+
+    vm.runInContext('projectManager.projects.dysonSwarmReceiver.enable();', ctx);
+    const after = vm.runInContext('projectManager.projects.dysonSwarmReceiver.isCompleted', ctx);
+    expect(after).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- allow projects with `completedWhenUnlocked` to instantly complete when enabled
- mark Dyson Swarm Receiver with `completedWhenUnlocked`
- document feature and add coverage

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c03473db788327a4b72ed5f3631b81