### PR TITLE
Refactor ore mine into dedicated subclass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,3 +497,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Ore and geothermal satellites now scale their build count with worker cap (one satellite per 5,000 cap) instead of population.
 - Android resource displays an exclamation mark when capped while unused land remains below 99% of capacity.
 - Added Ship smelting advanced research doubling metal asteroid mining ship capacity.
+- Introduced an `OreMine` subclass of `Building` that registers deeper mining progress whenever new mines are constructed.

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
     <script src="src/js/resource.js"></script>
     <script src="src/js/resourceUI.js"></script>
     <script src="src/js/building.js"></script>
+    <script src="src/js/buildings/OreMine.js"></script>
     <script src="src/js/buildingUI.js"></script>
     <script src="src/js/colony.js"></script>
     <script src="src/js/colonyUI.js"></script>

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -464,12 +464,6 @@ class Building extends EffectableEntity {
       if (activate) {
         this.active += buildCount;
       }
-      if (this.name === 'oreMine' && typeof projectManager !== 'undefined') {
-        const dm = projectManager.projects?.deeperMining;
-        if (dm && typeof dm.registerMine === 'function') {
-          dm.registerMine();
-        }
-      }
       if(this.active > 0){
         this.productivity = oldProductivity * (oldActive / this.active);
       } else {
@@ -899,8 +893,18 @@ function initializeBuildings(buildingsParameters) {
     const buildingConfig = {
       ...buildingData
     };
-
-    buildings[buildingName] = new Building(buildingConfig, buildingName);
+    if (buildingName === 'oreMine') {
+      let OreMineCtor;
+      if (typeof require !== 'undefined') {
+        try {
+          OreMineCtor = require('./buildings/OreMine.js').OreMine;
+        } catch (e) {}
+      }
+      OreMineCtor = OreMineCtor || globalThis.OreMine || Building;
+      buildings[buildingName] = new OreMineCtor(buildingConfig, buildingName);
+    } else {
+      buildings[buildingName] = new Building(buildingConfig, buildingName);
+    }
   }
   initializeBuildingTabs();
   return buildings;
@@ -908,4 +912,7 @@ function initializeBuildings(buildingsParameters) {
 
 if (typeof module !== "undefined" && module.exports) {
   module.exports = { Building, initializeBuildings };
+} else if (typeof globalThis !== 'undefined') {
+  globalThis.Building = Building;
+  globalThis.initializeBuildings = initializeBuildings;
 }

--- a/src/js/buildings/OreMine.js
+++ b/src/js/buildings/OreMine.js
@@ -1,0 +1,19 @@
+const BuildingRef = typeof require !== 'undefined'
+  ? require('../building.js').Building
+  : globalThis.Building;
+
+class OreMine extends BuildingRef {
+  build(buildCount = 1, activate = true) {
+    const built = super.build(buildCount, activate);
+    if (built) {
+      projectManager?.projects?.deeperMining?.registerMine?.();
+    }
+    return built;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { OreMine };
+} else {
+  globalThis.OreMine = OreMine;
+}

--- a/tests/oreMineBuildRegistersMine.test.js
+++ b/tests/oreMineBuildRegistersMine.test.js
@@ -1,0 +1,41 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { OreMine } = require('../src/js/buildings/OreMine.js');
+
+describe('OreMine.build', () => {
+  let config;
+  beforeEach(() => {
+    config = {
+      name: 'Ore Mine',
+      category: 'resource',
+      cost: {},
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: false,
+      requiresMaintenance: false,
+      requiresDeposit: false,
+      requiresWorker: 0,
+      unlocked: true
+    };
+    global.resources = { colony: {}, surface: {}, underground: {} };
+  });
+
+  test('registers mine with deeper mining project', () => {
+    const registerMine = jest.fn();
+    global.projectManager = { projects: { deeperMining: { registerMine } } };
+    const oreMine = new OreMine(config, 'oreMine');
+    const result = oreMine.build(1);
+    expect(result).toBe(true);
+    expect(registerMine).toHaveBeenCalled();
+    expect(oreMine.count).toBe(1);
+  });
+
+  test('does not throw without deeper mining project', () => {
+    global.projectManager = { projects: {} };
+    const oreMine = new OreMine(config, 'oreMine');
+    expect(() => oreMine.build(1)).not.toThrow();
+    expect(oreMine.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `OreMine` class extending `Building` and registering deeper mining on build
- Instantiate `OreMine` in `initializeBuildings` and load it in `index.html`
- Remove special-case ore mine logic from `Building.build`
- Test `OreMine.build` registration behavior

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68c035d82b908327ba1be3fe8a7535f3