### PR TITLE
refactor ghg factory productivity into subclass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,3 +499,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added Ship smelting advanced research doubling metal asteroid mining ship capacity.
 - Introduced an `OreMine` subclass of `Building` that registers deeper mining progress whenever new mines are constructed.
 - Dyson Swarm Receiver project now uses a `completedWhenUnlocked` flag to finish instantly when unlocked.
+- Added `GhgFactory` subclass overriding productivity with temperature control.

--- a/src/js/buildings/GhgFactory.js
+++ b/src/js/buildings/GhgFactory.js
@@ -1,0 +1,127 @@
+var ghgFactorySettingsRef = ghgFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('../ghg-automation.js').ghgFactorySettings
+    : globalThis.ghgFactorySettings);
+
+const BuildingRef = typeof require !== 'undefined'
+  ? require('../building.js').Building
+  : globalThis.Building;
+
+class GhgFactory extends BuildingRef {
+  updateProductivity(resources, deltaTime) {
+    const {
+      targetProductivity,
+      hasAtmosphericOversight,
+      computeMaxProduction,
+      solveRequired
+    } = this.computeBaseProductivity(resources, deltaTime);
+
+    if (this.active === 0) {
+      this.productivity = 0;
+      return;
+    }
+
+    if (
+      hasAtmosphericOversight &&
+      ghgFactorySettingsRef.autoDisableAboveTemp &&
+      terraforming && terraforming.temperature
+    ) {
+      const A = ghgFactorySettingsRef.disableTempThreshold;
+      let B = ghgFactorySettingsRef.reverseTempThreshold ?? A + 5;
+      if (B - A < 1) {
+        B = A + 1;
+        ghgFactorySettingsRef.reverseTempThreshold = B;
+      }
+      const currentTemp = terraforming.temperature.value;
+      let recipeKey = this.currentRecipeKey || 'ghg';
+      let resourceName = recipeKey === 'calcite' ? 'calciteAerosol' : 'greenhouseGas';
+
+      if (!this.reversalAvailable) {
+        const targetTemp = A;
+        if (currentTemp >= targetTemp) {
+          this.productivity = 0;
+          return;
+        }
+        if (
+          typeof terraforming.updateSurfaceTemperature === 'function' &&
+          resources?.atmospheric?.[resourceName]
+        ) {
+          const maxProduction = computeMaxProduction('atmospheric', resourceName);
+          if (maxProduction > 0) {
+            const res = resources.atmospheric[resourceName];
+            const originalAmount = res.value;
+            const required = solveRequired((added) => {
+              res.value = originalAmount + added;
+              terraforming.updateSurfaceTemperature();
+              const diff = terraforming.temperature.value - targetTemp;
+              res.value = originalAmount;
+              terraforming.updateSurfaceTemperature();
+              return diff;
+            }, maxProduction);
+            this.reverseEnabled = false;
+            this.productivity = Math.min(targetProductivity, required / maxProduction);
+            return;
+          }
+        }
+      } else {
+        if (currentTemp > A && currentTemp < B) {
+          this.productivity = 0;
+          return;
+        }
+        let reverse =
+          (recipeKey === 'ghg' && currentTemp >= B) ||
+          (recipeKey === 'calcite' && currentTemp <= A);
+
+        if (reverse) {
+          const resObj = resources?.atmospheric?.[resourceName];
+          const available = resObj ? resObj.value || 0 : 0;
+          if (available <= 0 && typeof this._toggleRecipe === 'function') {
+            this._toggleRecipe();
+            recipeKey = this.currentRecipeKey || 'ghg';
+            resourceName = recipeKey === 'calcite' ? 'calciteAerosol' : 'greenhouseGas';
+            reverse =
+              (recipeKey === 'ghg' && currentTemp >= B) ||
+              (recipeKey === 'calcite' && currentTemp <= A);
+          }
+        }
+
+        const targetTemp = reverse ? (recipeKey === 'ghg' ? B : A) : (recipeKey === 'ghg' ? A : B);
+        if (
+          typeof terraforming.updateSurfaceTemperature === 'function' &&
+          resources?.atmospheric?.[resourceName]
+        ) {
+          const maxProduction = computeMaxProduction('atmospheric', resourceName);
+          if (maxProduction > 0) {
+            const res = resources.atmospheric[resourceName];
+            const originalAmount = res.value;
+            const required = solveRequired((amt) => {
+              res.value = originalAmount + (reverse ? -amt : amt);
+              terraforming.updateSurfaceTemperature();
+              const diff = terraforming.temperature.value - targetTemp;
+              res.value = originalAmount;
+              terraforming.updateSurfaceTemperature();
+              return diff;
+            }, maxProduction);
+            this.reverseEnabled = reverse;
+            this.productivity = Math.min(targetProductivity, required / maxProduction);
+            return;
+          }
+        }
+      }
+    }
+
+    if (Math.abs(targetProductivity - this.productivity) < 0.001) {
+      this.productivity = targetProductivity;
+    } else {
+      const difference = Math.abs(targetProductivity - this.productivity);
+      const dampingFactor = difference < 0.01 ? 0.01 : 0.1;
+      this.productivity += dampingFactor * (targetProductivity - this.productivity);
+    }
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { GhgFactory };
+} else {
+  globalThis.GhgFactory = GhgFactory;
+}

--- a/tests/ghgFactoryReverseAutomation.test.js
+++ b/tests/ghgFactoryReverseAutomation.test.js
@@ -1,7 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 const { ghgFactorySettings } = require('../src/js/ghg-automation.js');
-const { Building } = require('../src/js/building.js');
+const { GhgFactory } = require('../src/js/buildings/GhgFactory.js');
 
 function createFactory(){
   const config = {
@@ -25,7 +25,7 @@ function createFactory(){
       calcite: { production: { atmospheric: { calciteAerosol: 10 } }, reverseTarget: { category: 'atmospheric', resource: 'calciteAerosol' } }
     }
   };
-  return new Building(config, 'ghgFactory');
+  return new GhgFactory(config, 'ghgFactory');
 }
 
 describe('GHG factory reverse automation', () => {

--- a/tests/ghgFactoryTempDisable.test.js
+++ b/tests/ghgFactoryTempDisable.test.js
@@ -1,7 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 const { ghgFactorySettings } = require('../src/js/ghg-automation.js');
-const { Building } = require('../src/js/building.js');
+const { GhgFactory } = require('../src/js/buildings/GhgFactory.js');
 
 const researchedManagerStub = {
   getResearchById: () => ({ isResearched: true })
@@ -23,7 +23,7 @@ function createFactory() {
     requiresWorker: 0,
     unlocked: true
   };
-  return new Building(config, 'ghgFactory');
+  return new GhgFactory(config, 'ghgFactory');
 }
 
 describe('GHG factory temperature disabling', () => {

--- a/tests/reverseRecipeToggle.test.js
+++ b/tests/reverseRecipeToggle.test.js
@@ -1,6 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 const { Building } = require('../src/js/building.js');
+const { GhgFactory } = require('../src/js/buildings/GhgFactory.js');
 
 function createGHGFactory(){
   const config = {
@@ -24,7 +25,7 @@ function createGHGFactory(){
       calcite: { production: { atmospheric: { calciteAerosol: 10 } }, reverseTarget: { category: 'atmospheric', resource: 'calciteAerosol' } }
     }
   };
-  return new Building(config, 'ghgFactory');
+  return new GhgFactory(config, 'ghgFactory');
 }
 
 function createDustFactory(){


### PR DESCRIPTION
## Summary
- add `GhgFactory` building subclass with temperature threshold and reversal logic
- expose `computeBaseProductivity` helper and streamline `Building.updateProductivity`
- register `ghgFactory` to use `GhgFactory`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c038333e3483279e409ec2731ad9b6