### PR TITLE
feat: add oxygen factory subclass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,3 +500,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Introduced an `OreMine` subclass of `Building` that registers deeper mining progress whenever new mines are constructed.
 - Dyson Swarm Receiver project now uses a `completedWhenUnlocked` flag to finish instantly when unlocked.
 - Added `GhgFactory` subclass overriding productivity with temperature control.
+- Added `OxygenFactory` subclass auto-disabling productivity above pressure thresholds.

--- a/src/js/buildings/OxygenFactory.js
+++ b/src/js/buildings/OxygenFactory.js
@@ -1,0 +1,79 @@
+var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
+  (typeof require !== 'undefined'
+    ? require('../ghg-automation.js').oxygenFactorySettings
+    : globalThis.oxygenFactorySettings);
+
+const BuildingRef = typeof require !== 'undefined'
+  ? require('../building.js').Building
+  : globalThis.Building;
+
+class OxygenFactory extends BuildingRef {
+  updateProductivity(resources, deltaTime) {
+    const {
+      targetProductivity: baseTarget,
+      hasAtmosphericOversight,
+      computeMaxProduction,
+      solveRequired
+    } = this.computeBaseProductivity(resources, deltaTime);
+
+    if (this.active === 0) {
+      this.productivity = 0;
+      return;
+    }
+
+    let targetProductivity = baseTarget;
+
+    if (
+      hasAtmosphericOversight &&
+      oxygenFactorySettingsRef.autoDisableAbovePressure &&
+      terraforming &&
+      resources.atmospheric?.oxygen &&
+      typeof calculateAtmosphericPressure === 'function'
+    ) {
+      const oxygen = resources.atmospheric.oxygen;
+      const targetPa = oxygenFactorySettingsRef.disablePressureThreshold * 1000;
+      const currentPa = calculateAtmosphericPressure(
+        oxygen.value,
+        terraforming.celestialParameters.gravity,
+        terraforming.celestialParameters.radius
+      );
+      if (currentPa >= targetPa) {
+        this.productivity = 0;
+        return;
+      }
+      const maxProduction = computeMaxProduction('atmospheric', 'oxygen');
+      if (maxProduction > 0) {
+        const originalAmount = oxygen.value;
+        const required = solveRequired((added) => {
+          return (
+            calculateAtmosphericPressure(
+              originalAmount + added,
+              terraforming.celestialParameters.gravity,
+              terraforming.celestialParameters.radius
+            ) - targetPa
+          );
+        }, maxProduction);
+        this.productivity = Math.min(
+          targetProductivity,
+          required / maxProduction
+        );
+        return;
+      }
+    }
+
+    if (Math.abs(targetProductivity - this.productivity) < 0.001) {
+      this.productivity = targetProductivity;
+    } else {
+      const difference = Math.abs(targetProductivity - this.productivity);
+      const dampingFactor = difference < 0.01 ? 0.01 : 0.1;
+      this.productivity +=
+        dampingFactor * (targetProductivity - this.productivity);
+    }
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { OxygenFactory };
+} else {
+  globalThis.OxygenFactory = OxygenFactory;
+}

--- a/tests/oxygenFactoryDerivative.test.js
+++ b/tests/oxygenFactoryDerivative.test.js
@@ -1,7 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 const { oxygenFactorySettings } = require('../src/js/ghg-automation.js');
-const { Building } = require('../src/js/building.js');
+const { OxygenFactory } = require('../src/js/buildings/OxygenFactory.js');
 
 describe('Oxygen factory pressure derivative', () => {
   beforeEach(() => {
@@ -44,7 +44,7 @@ describe('Oxygen factory pressure derivative', () => {
       unlocked: true,
     };
 
-    const building = new Building(config, 'oxygenFactory');
+    const building = new OxygenFactory(config, 'oxygenFactory');
     building.active = 1;
     building.addEffect({ type: 'booleanFlag', flagId: 'terraformingBureauFeature', value: true });
 

--- a/tests/oxygenFactoryPressureDisable.test.js
+++ b/tests/oxygenFactoryPressureDisable.test.js
@@ -1,7 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 const { oxygenFactorySettings } = require('../src/js/ghg-automation.js');
-const { Building } = require('../src/js/building.js');
+const { OxygenFactory } = require('../src/js/buildings/OxygenFactory.js');
 global.calculateAtmosphericPressure = (amount) => amount * 1000; // 1 unit => 1 kPa
 
 const researchedManagerStub = {
@@ -24,7 +24,7 @@ function createFactory() {
     requiresWorker: 0,
     unlocked: true
   };
-  return new Building(config, 'oxygenFactory');
+  return new OxygenFactory(config, 'oxygenFactory');
 }
 
 describe('Oxygen factory pressure disabling', () => {


### PR DESCRIPTION
## Summary
- create `OxygenFactory` building subclass with pressure-based auto-disable
- strip oxygen factory logic from base `Building` and register new subclass
- adjust tests for dedicated `OxygenFactory`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c039d07e748327952986fe176136cb