### PR TITLE
Ensure Building class is available in tests

### DIFF
--- a/tests/ghgFactoryReverseAutomation.test.js
+++ b/tests/ghgFactoryReverseAutomation.test.js
@@ -1,5 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
 const { ghgFactorySettings } = require('../src/js/ghg-automation.js');
 const { GhgFactory } = require('../src/js/buildings/GhgFactory.js');
 

--- a/tests/ghgFactoryTempDisable.test.js
+++ b/tests/ghgFactoryTempDisable.test.js
@@ -1,5 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
 const { ghgFactorySettings } = require('../src/js/ghg-automation.js');
 const { GhgFactory } = require('../src/js/buildings/GhgFactory.js');
 

--- a/tests/oreMineBuildRegistersMine.test.js
+++ b/tests/oreMineBuildRegistersMine.test.js
@@ -1,5 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
 const { OreMine } = require('../src/js/buildings/OreMine.js');
 
 describe('OreMine.build', () => {

--- a/tests/oxygenFactoryDerivative.test.js
+++ b/tests/oxygenFactoryDerivative.test.js
@@ -1,5 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
 const { oxygenFactorySettings } = require('../src/js/ghg-automation.js');
 const { OxygenFactory } = require('../src/js/buildings/OxygenFactory.js');
 

--- a/tests/oxygenFactoryPressureDisable.test.js
+++ b/tests/oxygenFactoryPressureDisable.test.js
@@ -1,5 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
 const { oxygenFactorySettings } = require('../src/js/ghg-automation.js');
 const { OxygenFactory } = require('../src/js/buildings/OxygenFactory.js');
 global.calculateAtmosphericPressure = (amount) => amount * 1000; // 1 unit => 1 kPa

--- a/tests/reverseRecipeToggle.test.js
+++ b/tests/reverseRecipeToggle.test.js
@@ -1,6 +1,7 @@
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 const { Building } = require('../src/js/building.js');
+global.Building = Building;
 const { GhgFactory } = require('../src/js/buildings/GhgFactory.js');
 
 function createGHGFactory(){


### PR DESCRIPTION
## Summary
- Load the Building base class in greenhouse gas, oxygen factory, and ore mine tests to prevent reference errors

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c03ca25dac8327896c696be422a4c3