### PR TITLE
Add Biodome building subclass with survivability gating

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,3 +502,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Dyson Swarm Receiver project now uses a `completedWhenUnlocked` flag to finish instantly when unlocked.
 - Added `GhgFactory` subclass overriding productivity with temperature control.
 - Added `OxygenFactory` subclass auto-disabling productivity above pressure thresholds.
+- Added `Biodome` subclass disabling productivity when life can't survive anywhere.

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
     <script src="src/js/buildings/OreMine.js"></script>
     <script src="src/js/buildings/GhgFactory.js"></script>
     <script src="src/js/buildings/OxygenFactory.js"></script>
+    <script src="src/js/buildings/Biodome.js"></script>
     <script src="src/js/buildingUI.js"></script>
     <script src="src/js/colony.js"></script>
     <script src="src/js/colonyUI.js"></script>

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -566,17 +566,6 @@ class Building extends EffectableEntity {
 
     let targetProductivity = baseTarget;
 
-    // Disable Biodome when designed life cannot survive anywhere
-    if (
-      this.name === 'biodome' &&
-      typeof lifeDesigner !== 'undefined' &&
-      lifeDesigner.currentDesign &&
-      typeof lifeDesigner.currentDesign.canSurviveAnywhere === 'function' &&
-      !lifeDesigner.currentDesign.canSurviveAnywhere()
-    ) {
-      targetProductivity = 0;
-    }
-
     if (Math.abs(targetProductivity - this.productivity) < 0.001) {
       this.productivity = targetProductivity;
     } else {
@@ -794,6 +783,15 @@ function initializeBuildings(buildingsParameters) {
       }
       OxygenFactoryCtor = OxygenFactoryCtor || globalThis.OxygenFactory || Building;
       buildings[buildingName] = new OxygenFactoryCtor(buildingConfig, buildingName);
+    } else if (buildingName === 'biodome') {
+      let BiodomeCtor;
+      if (typeof require !== 'undefined') {
+        try {
+          BiodomeCtor = require('./buildings/Biodome.js').Biodome;
+        } catch (e) {}
+      }
+      BiodomeCtor = BiodomeCtor || globalThis.Biodome || Building;
+      buildings[buildingName] = new BiodomeCtor(buildingConfig, buildingName);
     } else {
       buildings[buildingName] = new Building(buildingConfig, buildingName);
     }

--- a/src/js/buildings/Biodome.js
+++ b/src/js/buildings/Biodome.js
@@ -1,0 +1,20 @@
+class Biodome extends Building {
+  updateProductivity(resources, deltaTime) {
+    if (
+      typeof lifeDesigner !== 'undefined' &&
+      lifeDesigner.currentDesign &&
+      typeof lifeDesigner.currentDesign.canSurviveAnywhere === 'function' &&
+      !lifeDesigner.currentDesign.canSurviveAnywhere()
+    ) {
+      this.productivity = 0;
+      return;
+    }
+    super.updateProductivity(resources, deltaTime);
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { Biodome };
+} else {
+  globalThis.Biodome = Biodome;
+}

--- a/tests/biodomeSurvival.test.js
+++ b/tests/biodomeSurvival.test.js
@@ -2,6 +2,8 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 // expose globally before requiring Building
 global.EffectableEntity = EffectableEntity;
 const { Building } = require('../src/js/building.js');
+global.Building = Building;
+const { Biodome } = require('../src/js/buildings/Biodome.js');
 
 function createBiodome(){
   const config = {
@@ -19,7 +21,7 @@ function createBiodome(){
     requiresWorker: 0,
     unlocked: true
   };
-  return new Building(config, 'biodome');
+  return new Biodome(config, 'biodome');
 }
 
 describe('biodome productivity requires survivable environment', () => {

--- a/tests/initializeBiodome.test.js
+++ b/tests/initializeBiodome.test.js
@@ -1,0 +1,30 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { initializeBuildings, Building } = require('../src/js/building.js');
+global.Building = Building;
+const { Biodome } = require('../src/js/buildings/Biodome.js');
+global.initializeBuildingTabs = () => {};
+
+describe('initializeBuildings biodome mapping', () => {
+  test('returns Biodome instance for biodome', () => {
+    const params = {
+      biodome: {
+        name: 'Biodome',
+        category: 'terraforming',
+        cost: {},
+        consumption: {},
+        production: {},
+        storage: {},
+        dayNightActivity: false,
+        canBeToggled: true,
+        requiresMaintenance: false,
+        maintenanceFactor: 1,
+        requiresDeposit: null,
+        requiresWorker: 0,
+        unlocked: true
+      }
+    };
+    const buildings = initializeBuildings(params);
+    expect(buildings.biodome).toBeInstanceOf(Biodome);
+  });
+});


### PR DESCRIPTION
## Summary
- add Biodome building subclass that shuts down when life can't survive anywhere
- load Biodome script and map type in initializeBuildings
- document addition in AGENTS

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c03dce7adc83278ba47669dc8b290f