### PR TITLE
Add Dyson Receiver building with productivity cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,3 +503,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added `GhgFactory` subclass overriding productivity with temperature control.
 - Added `OxygenFactory` subclass auto-disabling productivity above pressure thresholds.
 - Added `Biodome` subclass disabling productivity when life can't survive anywhere.
+- Added `DysonReceiver` building capping energy output to Dyson Swarm production.

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
     <script src="src/js/buildings/GhgFactory.js"></script>
     <script src="src/js/buildings/OxygenFactory.js"></script>
     <script src="src/js/buildings/Biodome.js"></script>
+    <script src="src/js/buildings/dysonReceiver.js"></script>
     <script src="src/js/buildingUI.js"></script>
     <script src="src/js/colony.js"></script>
     <script src="src/js/colonyUI.js"></script>

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -751,7 +751,8 @@ const constructors = {
   oreMine: 'OreMine',
   ghgFactory: 'GhgFactory',
   oxygenFactory: 'OxygenFactory',
-  biodome: 'Biodome'
+  biodome: 'Biodome',
+  dysonReceiver: 'dysonReceiver'
 };
 
 function loadConstructor(name) {

--- a/src/js/buildings/dysonReceiver.js
+++ b/src/js/buildings/dysonReceiver.js
@@ -1,0 +1,25 @@
+class DysonReceiver extends Building {
+  updateProductivity(resources, deltaTime) {
+    const { targetProductivity } = this.computeBaseProductivity(resources, deltaTime);
+    if (this.active === 0) {
+      this.productivity = 0;
+      return;
+    }
+    const project = projectManager?.projects?.dysonSwarmReceiver;
+    const perBuilding = this.production?.colony?.energy || 0;
+    if (!project || !project.isCompleted || project.collectors <= 0 || perBuilding <= 0) {
+      this.productivity = 0;
+      return;
+    }
+    const totalEnergy = project.collectors * project.energyPerCollector;
+    const maxProductivity = totalEnergy / (perBuilding * this.active);
+    this.productivity = Math.min(targetProductivity, maxProductivity);
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { DysonReceiver, dysonReceiver: DysonReceiver };
+} else {
+  globalThis.DysonReceiver = DysonReceiver;
+  globalThis.dysonReceiver = DysonReceiver;
+}

--- a/tests/dysonReceiverProductivityCap.test.js
+++ b/tests/dysonReceiverProductivityCap.test.js
@@ -1,0 +1,63 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+const { dysonReceiver: DysonReceiver } = require('../src/js/buildings/dysonReceiver.js');
+
+function createReceiver() {
+  const config = {
+    name: 'Dyson Receiver',
+    category: 'energy',
+    cost: {},
+    consumption: {},
+    production: { colony: { energy: 100 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new DysonReceiver(config, 'dysonReceiver');
+}
+
+describe('Dyson Receiver productivity cap', () => {
+  beforeEach(() => {
+    global.resources = { colony: { energy: { value: 0, modifyRate: () => {} } } };
+    global.populationModule = { getWorkerAvailabilityRatio: () => 1 };
+  });
+
+  test('caps productivity to available swarm energy', () => {
+    const building = createReceiver();
+    building.active = 1;
+    global.projectManager = {
+      projects: {
+        dysonSwarmReceiver: {
+          isCompleted: true,
+          collectors: 1,
+          energyPerCollector: 50
+        }
+      }
+    };
+    building.updateProductivity(global.resources, 1000);
+    expect(building.productivity).toBeCloseTo(0.5);
+  });
+
+  test('no swarm energy disables productivity', () => {
+    const building = createReceiver();
+    building.active = 1;
+    global.projectManager = {
+      projects: {
+        dysonSwarmReceiver: {
+          isCompleted: false,
+          collectors: 0,
+          energyPerCollector: 50
+        }
+      }
+    };
+    building.updateProductivity(global.resources, 1000);
+    expect(building.productivity).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Dyson Receiver building capped by Dyson Swarm energy
- register Dyson Receiver and load script in index.html
- test productivity cap

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68c0446894bc83278529ce40493be3fd