### PR TITLE
feat: cap solar panel build count based on land

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,3 +504,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added `OxygenFactory` subclass auto-disabling productivity above pressure thresholds.
 - Added `Biodome` subclass disabling productivity when life can't survive anywhere.
 - Added `DysonReceiver` building capping energy output to Dyson Swarm production.
+- Added `SolarPanel` subclass limiting total panels to ten times the world's initial land value.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -752,7 +752,8 @@ const constructors = {
   ghgFactory: 'GhgFactory',
   oxygenFactory: 'OxygenFactory',
   biodome: 'Biodome',
-  dysonReceiver: 'dysonReceiver'
+  dysonReceiver: 'dysonReceiver',
+  solarPanel: 'solarPanel'
 };
 
 function loadConstructor(name) {

--- a/src/js/buildings/solarPanel.js
+++ b/src/js/buildings/solarPanel.js
@@ -1,0 +1,19 @@
+class SolarPanel extends Building {
+  build(buildCount = 1, activate = true) {
+    const initialLand = (typeof terraforming !== 'undefined' && terraforming.initialLand) ? terraforming.initialLand : 0;
+    const cap = initialLand * 10;
+    const remaining = cap - this.count;
+    if (remaining <= 0) {
+      return false;
+    }
+    const allowed = Math.min(buildCount, remaining);
+    return super.build(allowed, activate);
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { SolarPanel, solarPanel: SolarPanel };
+} else {
+  globalThis.SolarPanel = SolarPanel;
+  globalThis.solarPanel = SolarPanel;
+}

--- a/tests/solarPanelBuildCap.test.js
+++ b/tests/solarPanelBuildCap.test.js
@@ -1,0 +1,36 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+const { SolarPanel } = require('../src/js/buildings/solarPanel.js');
+
+describe('SolarPanel build cap', () => {
+  let config;
+  beforeEach(() => {
+    config = {
+      name: 'Solar Panel Array',
+      category: 'energy',
+      cost: {},
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: true,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      requiresDeposit: false,
+      requiresWorker: 0,
+      unlocked: true
+    };
+    global.resources = { colony: {}, surface: {}, underground: {} };
+    global.terraforming = { initialLand: 2 };
+  });
+
+  test('does not exceed 10x initial land cap', () => {
+    const panel = new SolarPanel(config, 'solarPanel');
+    const result = panel.build(25);
+    expect(result).toBe(true);
+    expect(panel.count).toBe(20);
+    expect(panel.build(1)).toBe(false);
+    expect(panel.count).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
- restrict solar panel construction with a cap tied to the world's initial land
- register SolarPanel subclass and document feature
- test solar panel cap logic

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c066db3c5883279dd50bbf5ced367f