### PR TITLE
Move GHG factory UI into building class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Resources with `marginTop` or `marginBottom` now show a thin separator line centered within that margin that only appears when the resource is visible.
 - GHG factory temperature disable controls now accept decimal values.
 - GHG factory temperature inputs no longer overwrite user edits while focused, enabling decimal adjustments.
+- GHG factory temperature control UI now resides within `GhgFactory.js` via `initUI` and `updateUI` methods.
 - Solis shop displays "Purchased" instead of a count when an upgrade reaches its maximum purchases.
 - Cargo rocket project resource selection now uses 0/-1/+1,/10,x10 controls for consistency.
 - Space storage ship assignment multiplier persists through save and load.

--- a/tests/ghgFactoryTemperatureInput.test.js
+++ b/tests/ghgFactoryTemperatureInput.test.js
@@ -31,8 +31,12 @@ function setup() {
   const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
   vm.runInContext(factorySettings, ctx);
 
-  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
-  vm.runInContext(code, ctx);
+  const structuresCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(structuresCode, ctx);
+
+  ctx.Building = class {};
+  const ghgFactoryCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildings', 'GhgFactory.js'), 'utf8');
+  vm.runInContext(ghgFactoryCode, ctx);
 
   const structure = {
     name: 'ghgFactory',
@@ -66,6 +70,8 @@ function setup() {
     updateResourceStorage: () => {},
     reversalAvailable: false,
     isBooleanFlagSet: flag => flag === 'terraformingBureauFeature',
+    initUI: ctx.GhgFactory.prototype.initUI,
+    updateUI: ctx.GhgFactory.prototype.updateUI,
   };
 
   const row = ctx.createStructureRow(structure, () => {}, () => {}, false);


### PR DESCRIPTION
## Summary
- add `initUI` and `updateUI` to `GhgFactory` to build and refresh temperature controls
- delegate GHG factory UI creation and updates from `structuresUI` to building methods
- adjust tests and documentation for relocated GHG factory UI

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c06847a9d88327bd93f63361b411e8