### PR TITLE
Refactor oxygen factory pressure controls into subclass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - GHG factory temperature disable controls now accept decimal values.
 - GHG factory temperature inputs no longer overwrite user edits while focused, enabling decimal adjustments.
 - GHG factory temperature control UI now resides within `GhgFactory.js` via `initUI` and `updateUI` methods.
+- Oxygen factory pressure control UI now resides within `OxygenFactory.js` via `initUI` and `updateUI` methods.
 - Solis shop displays "Purchased" instead of a count when an upgrade reaches its maximum purchases.
 - Cargo rocket project resource selection now uses 0/-1/+1,/10,x10 controls for consistency.
 - Space storage ship assignment multiplier persists through save and load.

--- a/src/js/buildings/OxygenFactory.js
+++ b/src/js/buildings/OxygenFactory.js
@@ -66,6 +66,78 @@ class OxygenFactory extends Building {
         dampingFactor * (targetProductivity - this.productivity);
     }
   }
+
+  initUI(autoBuildContainer, cache) {
+    if (!autoBuildContainer || !cache) return;
+
+    const pressureControl = document.createElement('div');
+    pressureControl.classList.add('o2-pressure-control');
+    pressureControl.style.display = this.isBooleanFlagSet('terraformingBureauFeature')
+      ? 'flex'
+      : 'none';
+
+    const pressureCheckbox = document.createElement('input');
+    pressureCheckbox.type = 'checkbox';
+    pressureCheckbox.classList.add('o2-pressure-checkbox');
+    pressureCheckbox.checked = oxygenFactorySettingsRef.autoDisableAbovePressure;
+    pressureCheckbox.addEventListener('change', () => {
+      oxygenFactorySettingsRef.autoDisableAbovePressure = pressureCheckbox.checked;
+    });
+    pressureControl.appendChild(pressureCheckbox);
+
+    const pressureLabel = document.createElement('span');
+    pressureLabel.textContent = 'Disable if O2 P > ';
+    pressureControl.appendChild(pressureLabel);
+
+    const pressureInput = document.createElement('input');
+    pressureInput.type = 'number';
+    pressureInput.step = 1;
+    pressureInput.classList.add('o2-pressure-input');
+    pressureControl.appendChild(pressureInput);
+
+    const unitSpan = document.createElement('span');
+    unitSpan.classList.add('o2-pressure-unit');
+    unitSpan.textContent = 'kPa';
+    pressureControl.appendChild(unitSpan);
+
+    const update = () => {
+      if (document.activeElement !== pressureInput) {
+        pressureInput.value = oxygenFactorySettingsRef.disablePressureThreshold;
+      }
+    };
+    update();
+
+    pressureInput.addEventListener('input', () => {
+      const val = parseFloat(pressureInput.value);
+      oxygenFactorySettingsRef.disablePressureThreshold = val;
+    });
+
+    autoBuildContainer.appendChild(pressureControl);
+
+    cache.o2 = {
+      container: pressureControl,
+      checkbox: pressureCheckbox,
+      input: pressureInput,
+      unitSpan: unitSpan
+    };
+  }
+
+  updateUI(elements) {
+    const o2Els = elements?.o2;
+    if (!o2Els || !o2Els.container) return;
+
+    const enabled = this.isBooleanFlagSet('terraformingBureauFeature');
+    o2Els.container.style.display = enabled ? 'flex' : 'none';
+    if (o2Els.checkbox) {
+      o2Els.checkbox.checked = oxygenFactorySettingsRef.autoDisableAbovePressure;
+    }
+    if (o2Els.input && document.activeElement !== o2Els.input) {
+      o2Els.input.value = oxygenFactorySettingsRef.disablePressureThreshold;
+    }
+    if (o2Els.unitSpan) {
+      o2Els.unitSpan.textContent = 'kPa';
+    }
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -1,8 +1,3 @@
-var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
-  (typeof require !== 'undefined'
-    ? require('./ghg-automation.js').oxygenFactorySettings
-    : globalThis.oxygenFactorySettings);
-
 // structures-ui.js
 
 // Create an object to store the selected build count for each structure
@@ -515,51 +510,6 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
 
   structure.initUI?.(autoBuildContainer, cached);
 
-  if(structure.name === 'oxygenFactory') {
-    const pressureControl = document.createElement('div');
-    pressureControl.id = `${structure.name}-pressure-control`;
-    pressureControl.classList.add('o2-pressure-control');
-    pressureControl.style.display = structure.isBooleanFlagSet('terraformingBureauFeature') ? 'flex' : 'none';
-
-    const pressureCheckbox = document.createElement('input');
-    pressureCheckbox.type = 'checkbox';
-    pressureCheckbox.classList.add('o2-pressure-checkbox');
-    pressureCheckbox.checked = oxygenFactorySettingsRef.autoDisableAbovePressure;
-    pressureCheckbox.addEventListener('change', () => {
-      oxygenFactorySettingsRef.autoDisableAbovePressure = pressureCheckbox.checked;
-    });
-    pressureControl.appendChild(pressureCheckbox);
-
-    const pressureLabel = document.createElement('span');
-    pressureLabel.textContent = 'Disable if O2 P > ';
-    pressureControl.appendChild(pressureLabel);
-
-    const pressureInput = document.createElement('input');
-    pressureInput.type = 'number';
-    pressureInput.step = 1;
-    pressureInput.classList.add('o2-pressure-input');
-    pressureInput.value = oxygenFactorySettingsRef.disablePressureThreshold;
-    pressureInput.addEventListener('input', () => {
-      const val = parseFloat(pressureInput.value);
-      oxygenFactorySettingsRef.disablePressureThreshold = val;
-    });
-    pressureControl.appendChild(pressureInput);
-
-    const unitSpan = document.createElement('span');
-    unitSpan.classList.add('o2-pressure-unit');
-    unitSpan.textContent = 'kPa';
-    pressureControl.appendChild(unitSpan);
-
-    autoBuildContainer.appendChild(pressureControl);
-    // Cache O2 control elements
-    structureUIElements[structure.name] = structureUIElements[structure.name] || {};
-    structureUIElements[structure.name].o2 = {
-      container: pressureControl,
-      checkbox: pressureCheckbox,
-      input: pressureInput
-    };
-  }
-
   combinedStructureRow.append(autoBuildContainer);
 
   collapseArrow.addEventListener('click', () => {
@@ -984,14 +934,6 @@ function updateDecreaseButtonText(button, buildCount) {
         }
 
         structure.updateUI?.(els);
-
-        const o2Els = els.o2;
-        if (o2Els && o2Els.container) {
-          const enabled = structure.isBooleanFlagSet('terraformingBureauFeature');
-          o2Els.container.style.display = enabled ? 'flex' : 'none';
-          if (o2Els.checkbox) o2Els.checkbox.checked = oxygenFactorySettingsRef.autoDisableAbovePressure;
-          if (o2Els.input) o2Els.input.value = oxygenFactorySettingsRef.disablePressureThreshold;
-        }
       }
   
       const productivityElement = document.getElementById(`${structureName}-productivity`);


### PR DESCRIPTION
## Summary
- Move oxygen factory pressure checkbox and threshold input into `OxygenFactory` via `initUI` and `updateUI` methods
- Remove oxygen-factory-specific DOM handling from `structuresUI` and rely on subclass hooks
- Document the UI migration in `AGENTS.md`

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c069fa1b188327a44b0c5f20263905