### PR TITLE
Add solar panel build cap tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -507,3 +507,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added `Biodome` subclass disabling productivity when life can't survive anywhere.
 - Added `DysonReceiver` building capping energy output to Dyson Swarm production.
 - Added `SolarPanel` subclass limiting total panels to ten times the world's initial land value.
+- Solar Panel counts now include a tooltip noting the 10× initial land construction cap.

--- a/src/js/buildings/solarPanel.js
+++ b/src/js/buildings/solarPanel.js
@@ -9,6 +9,22 @@ class SolarPanel extends Building {
     const allowed = Math.min(buildCount, remaining);
     return super.build(allowed, activate);
   }
+
+  initUI(_, cache) {
+    const row = cache?.row;
+    if (!row || cache.countTooltip) return;
+    const countEl =
+      row.querySelector(`#${this.name}-count-active`) ||
+      row.querySelector(`#${this.name}-count`);
+    if (!countEl) return;
+    const tooltip = document.createElement('span');
+    tooltip.classList.add('info-tooltip-icon');
+    tooltip.title =
+      'Solar panels are limited to 10× the initial land amount.';
+    tooltip.innerHTML = '&#9432;';
+    countEl.parentElement.insertBefore(tooltip, countEl.nextSibling);
+    cache.countTooltip = tooltip;
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/tests/solarPanelTooltip.test.js
+++ b/tests/solarPanelTooltip.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+const { SolarPanel } = require('../src/js/buildings/solarPanel.js');
+
+describe('Solar panel tooltip', () => {
+  test('solar panel count includes build cap tooltip', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    const ctx = dom.getInternalVMContext();
+
+    ctx.EffectableEntity = EffectableEntity;
+    ctx.Building = Building;
+    ctx.formatNumber = n => n;
+    ctx.formatBigInteger = n => String(n);
+    ctx.formatBuildingCount = n => String(n);
+    ctx.formatResourceDetails = () => '';
+    ctx.formatStorageDetails = () => '';
+    ctx.multiplyByTen = n => n * 10;
+    ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
+    ctx.resources = { colony: { colonists: { value: 0 }, workers: { value: 0 } } };
+    ctx.globalEffects = { isBooleanFlagSet: () => true };
+    ctx.dayNightCycle = { isNight: () => false, isDay: () => true };
+    ctx.toDisplayTemperature = () => 0;
+    ctx.getTemperatureUnit = () => 'K';
+    ctx.capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+    ctx.updateColonyDetailsDisplay = () => {};
+    ctx.updateEmptyBuildingMessages = () => {};
+    ctx.updateBuildingDisplay = () => {};
+    ctx.terraforming = { celestialParameters: {} };
+
+    const factorySettings = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ghg-automation.js'), 'utf8');
+    vm.runInContext(factorySettings, ctx);
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    const config = {
+      name: 'Solar Panel Array',
+      category: 'energy',
+      description: 'desc',
+      cost: {},
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: true,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      requiresDeposit: false,
+      requiresWorker: 0,
+      unlocked: true
+    };
+
+    const panel = new SolarPanel(config, 'solarPanel');
+
+    const row = ctx.createStructureRow(panel, () => {}, () => {}, false);
+    dom.window.document.body.appendChild(row);
+
+    const tooltip = dom.window.document.querySelector('#solarPanel-count-active + .info-tooltip-icon, #solarPanel-count + .info-tooltip-icon');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.getAttribute('title')).toMatch(/10\s*×\s*the initial land/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add tooltip next to solar panel counts explaining 10× initial land limit
- cover new tooltip with a unit test

## Testing
- `npm ci`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c06b3de4208327ad4b88e84eb196c4