### PR TITLE
Preserve solar panel tooltip across UI refreshes

### DIFF
--- a/src/js/buildings/solarPanel.js
+++ b/src/js/buildings/solarPanel.js
@@ -10,20 +10,41 @@ class SolarPanel extends Building {
     return super.build(allowed, activate);
   }
 
+  _ensureTooltip(cache) {
+    if (!cache) return;
+
+    let countEl = cache.countEl;
+    if (!countEl || !countEl.isConnected) {
+      const row = cache.row;
+      if (!row) return;
+      countEl =
+        row.querySelector(`#${this.name}-count-active`) ||
+        row.querySelector(`#${this.name}-count`);
+      if (!countEl) return;
+      cache.countEl = countEl;
+    }
+
+    let tooltip = cache.countTooltip;
+    if (!tooltip) {
+      tooltip = document.createElement('span');
+      tooltip.classList.add('info-tooltip-icon');
+      tooltip.title =
+        'Solar panels are limited to 10× the initial land amount.';
+      tooltip.innerHTML = '&#9432;';
+      cache.countTooltip = tooltip;
+    }
+
+    if (!tooltip.isConnected) {
+      countEl.parentElement.insertBefore(tooltip, countEl.nextSibling);
+    }
+  }
+
   initUI(_, cache) {
-    const row = cache?.row;
-    if (!row || cache.countTooltip) return;
-    const countEl =
-      row.querySelector(`#${this.name}-count-active`) ||
-      row.querySelector(`#${this.name}-count`);
-    if (!countEl) return;
-    const tooltip = document.createElement('span');
-    tooltip.classList.add('info-tooltip-icon');
-    tooltip.title =
-      'Solar panels are limited to 10× the initial land amount.';
-    tooltip.innerHTML = '&#9432;';
-    countEl.parentElement.insertBefore(tooltip, countEl.nextSibling);
-    cache.countTooltip = tooltip;
+    this._ensureTooltip(cache);
+  }
+
+  updateUI(cache) {
+    this._ensureTooltip(cache);
   }
 }
 

--- a/tests/solarPanelTooltip.test.js
+++ b/tests/solarPanelTooltip.test.js
@@ -66,4 +66,41 @@ describe('Solar panel tooltip', () => {
     expect(tooltip).not.toBeNull();
     expect(tooltip.getAttribute('title')).toMatch(/10\s*×\s*the initial land/i);
   });
+
+  test('solar panel tooltip persists after UI update', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="row"><span id="solarPanel-count">0</span></div>');
+    global.document = dom.window.document;
+
+    const config = {
+      name: 'Solar Panel Array',
+      category: 'energy',
+      description: 'desc',
+      cost: {},
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: true,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      requiresDeposit: false,
+      requiresWorker: 0,
+      unlocked: true
+    };
+
+    const panel = new SolarPanel(config, 'solarPanel');
+    const cache = { row: dom.window.document.getElementById('row') };
+    panel.initUI(null, cache);
+
+    let tooltip = dom.window.document.querySelector('#solarPanel-count + .info-tooltip-icon');
+    expect(tooltip).not.toBeNull();
+
+    tooltip.remove();
+    expect(dom.window.document.querySelector('#solarPanel-count + .info-tooltip-icon')).toBeNull();
+
+    panel.updateUI(cache);
+
+    tooltip = dom.window.document.querySelector('#solarPanel-count + .info-tooltip-icon');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.getAttribute('title')).toMatch(/10\s*×\s*the initial land/i);
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure solar panel build count tooltip is reattached if the DOM rebuilds
- Cover tooltip persistence with a regression test

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68c06ddec7fc8327b8182cb5cba940f6