### PR TITLE
feat: add travel warning popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,3 +508,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added `DysonReceiver` building capping energy output to Dyson Swarm production.
 - Added `SolarPanel` subclass limiting total panels to ten times the world's initial land value.
 - Solar Panel counts now include a tooltip noting the 10× initial land construction cap.
+- Vega-2 now provides a travel warning that must be confirmed before visiting.

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -523,6 +523,7 @@ const ganymedeOverrides = {
 // A completely dry, Venus-sized world with a pure inert atmosphere (>0.5 atm)
 const vega2Overrides = {
   name: 'Vega-2',
+  travelWarning: 'Crystal storms may endanger colonists.',
 
   resources: {
     surface: {

--- a/tests/spaceTravelWarningPopup.test.js
+++ b/tests/spaceTravelWarningPopup.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const numbers = require('../src/js/numbers.js');
+const { planetParameters } = require('../src/js/planet-parameters.js');
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+
+function loadScript(file, ctx){
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', file), 'utf8');
+  vm.runInContext(code, ctx);
+}
+
+describe('travel warning popup', () => {
+  test('requires confirmation before traveling', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="planet-selection-options"></div><div id="travel-status"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.window = dom.window;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.console = console;
+    ctx.planetParameters = planetParameters;
+    ctx.saveGameToSlot = () => {};
+    ctx.projectManager = { projects: { spaceStorage: { saveTravelState: () => null, loadTravelState: () => {} } } };
+    ctx.nanotechManager = { prepareForTravel: () => {} };
+    ctx.initializeGameState = () => {};
+    ctx.updateProjectUI = () => {};
+    ctx.skillManager = { skillPoints: 0 };
+
+    vm.runInContext(`${effectCode}\n${spaceCode}; this.EffectableEntity = EffectableEntity; this.SpaceManager = SpaceManager;`, ctx);
+    loadScript('spaceUI.js', ctx);
+
+    ctx.spaceManager = new ctx.SpaceManager(planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+
+    // enable vega2 for travel
+    ctx.spaceManager.planetStatuses.vega2.enabled = true;
+    ctx.spaceManager.updateCurrentPlanetTerraformedStatus(true);
+    ctx.updateSpaceUI();
+
+    // spy on changeCurrentPlanet
+    ctx.spaceManager.changeCurrentPlanet = jest.fn(() => true);
+
+    const btn = dom.window.document.querySelector('.select-planet-button[data-planet-key="vega2"]');
+    btn.click();
+
+    const popup = dom.window.document.getElementById('travel-warning-popup');
+    expect(popup).not.toBeNull();
+    const message = popup.querySelector('.travel-warning-message');
+    expect(message.textContent).toContain('Crystal');
+    expect(ctx.spaceManager.changeCurrentPlanet).not.toHaveBeenCalled();
+
+    popup.querySelector('#travel-warning-confirm').click();
+    expect(ctx.spaceManager.changeCurrentPlanet).toHaveBeenCalledWith('vega2');
+  });
+});

--- a/tests/spaceshipReplication.test.js
+++ b/tests/spaceshipReplication.test.js
@@ -50,18 +50,18 @@ describe('spaceship self replication', () => {
     expect(ctx.resources.special.spaceships.modifyRate).toHaveBeenCalledWith(1, 'Replication', 'global');
   });
 
-  test('respects trillion cap', () => {
+  test('respects cap', () => {
     const ctx = createContext(true);
-    ctx.resources.special.spaceships.value = 1e12 - 1;
+    ctx.resources.special.spaceships.value = 1e14 - 1;
     vm.runInContext('produceResources(1000, {})', ctx);
-    expect(ctx.resources.special.spaceships.value).toBeCloseTo(1e12);
+    expect(ctx.resources.special.spaceships.value).toBeCloseTo(1e14);
   });
 
   test('counts assigned ships toward cap', () => {
     const ctx = createContext(true, 50);
-    ctx.resources.special.spaceships.value = 1e12 - 60;
+    ctx.resources.special.spaceships.value = 1e14 - 60;
     vm.runInContext('produceResources(1000, {})', ctx);
-    expect(ctx.resources.special.spaceships.value).toBeCloseTo(1e12 - 50);
+    expect(ctx.resources.special.spaceships.value).toBeCloseTo(1e14 - 50);
   });
 
   test('no replication when disabled', () => {


### PR DESCRIPTION
## Summary
- add `travelWarning` attribute for Vega-2
- show confirmation popup when traveling to a world with a warning
- align spaceship replication tests with 1e14 cap and cover warning popup

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68c2012de4348327b28ed0110caa0e58