### PR TITLE
Add Companion Satellite advanced research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,3 +510,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Solar Panel counts now include a tooltip noting the 10× initial land construction cap.
 - Vega-2 now provides a travel warning that must be confirmed before visiting.
 - Building worker costs now support high/normal/low priority via up/down triangles.
+- Added Companion Satellite advanced research that keeps one ore satellite per terraformed world and auto-unlocks ore satellite infrastructure.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -225,6 +225,16 @@ function initializeGameState(options = {}) {
       researchManager.reapplyEffects();
     }
   }
+  if (
+    projectManager?.projects?.satellite &&
+    researchManager.getResearchById('companion_satellite')?.isResearched &&
+    spaceManager?.getTerraformedPlanetCount
+  ) {
+    const count = spaceManager.getTerraformedPlanetCount();
+    const proj = projectManager.projects.satellite;
+    proj.repeatCount = Math.min(count, proj.maxRepeatCount);
+    proj.update?.(0);
+  }
   if (!preserveManagers || !skillManager) {
     skillManager = new SkillManager(skillParameters);
   }

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1291,6 +1291,20 @@ const researchParameters = {
         ]
       },
       {
+        id: 'companion_satellite',
+        name: 'Companion Satellite',
+        description: 'An autonomous scout that unlocks ore satellites and retains one per terraformed world when travelling.',
+        cost: { advancedResearch: 225000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'researchManager',
+            targetId: 'ore_scanning',
+            type: 'completeResearch'
+          }
+        ]
+      },
+      {
         id: 'hyperion_lantern',
         name: 'Hyperion Lantern',
         description: 'Research the construction of a large orbital facility that increases planetary luminosity.',

--- a/tests/companionSatelliteResearch.test.js
+++ b/tests/companionSatelliteResearch.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Companion Satellite research', () => {
+  test('exists in advanced research with correct cost and effect', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const advanced = ctx.researchParameters.advanced;
+    const research = advanced.find(r => r.id === 'companion_satellite');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(225000);
+    const effect = research.effects.find(e => e.target === 'researchManager' && e.targetId === 'ore_scanning' && e.type === 'completeResearch');
+    expect(effect).toBeDefined();
+  });
+});

--- a/tests/companionSatelliteTravel.test.js
+++ b/tests/companionSatelliteTravel.test.js
@@ -1,0 +1,111 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Companion Satellite travel retention', () => {
+  test('retains satellites equal to terraformed worlds', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      url: 'file://' + htmlPath,
+    });
+
+    function createNullElement() {
+      const handler = {
+        get: (target, prop) => {
+          if (prop === 'firstChild') return null;
+          if (prop === 'children' || prop === 'childNodes') return [];
+          if (prop === 'classList') return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+          return new Proxy(function () {}, handler);
+        },
+        apply: () => new Proxy(function () {}, handler),
+        set: () => true,
+      };
+      return new Proxy(function () {}, handler);
+    }
+    const nullElement = createNullElement();
+    const doc = dom.window.document;
+    doc.createElement = () => nullElement;
+    doc.getElementById = () => nullElement;
+    doc.querySelector = () => nullElement;
+    doc.querySelectorAll = () => [];
+    doc.getElementsByClassName = () => [];
+    doc.addEventListener = () => {};
+    doc.removeEventListener = () => {};
+
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+    const originalPhaser = global.Phaser;
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.Phaser = { AUTO: 'AUTO', Game: function (config) { this.config = config; } };
+    global.Phaser = dom.window.Phaser;
+
+    const srcRegex = /<script\s+[^>]*src=['"]([^'"]+)['"][^>]*>/gi;
+    const sources = [];
+    let match;
+    while ((match = srcRegex.exec(html)) !== null) {
+      if (!/^https?:\/\//.test(match[1])) {
+        sources.push(match[1]);
+      }
+    }
+
+    const ctx = dom.getInternalVMContext();
+    ctx.structuredClone = structuredClone;
+    const errors = [];
+    for (const src of sources) {
+      const file = path.join(__dirname, '..', src);
+      const code = fs.readFileSync(file, 'utf8');
+      try {
+        vm.runInContext(code, ctx);
+      } catch (err) {
+        errors.push({ script: src, message: err.message });
+      }
+    }
+
+    const overrides = `
+      createResourceDisplay=()=>{};
+      createBuildingButtons=()=>{};
+      createColonyButtons=()=>{};
+      initializeProjectsUI=()=>{};
+      renderProjects=()=>{};
+      initializeProjectAlerts=()=>{};
+      initializeResearchUI=()=>{};
+      initializeLifeUI=()=>{};
+      createMilestonesUI=()=>{};
+      updateDayNightDisplay=()=>{};
+      updateProjectUI=()=>{};
+      updateSpaceUI=()=>{};
+      TabManager = class {};
+      StoryManager = class { initializeStory(){} update(){} };
+    `;
+    vm.runInContext(overrides, ctx);
+    vm.runInContext('initializeGameState();', ctx);
+    vm.runInContext('resources.colony.advancedResearch.unlocked = true;', ctx);
+    vm.runInContext("researchManager.completeResearchInstant('companion_satellite');", ctx);
+    vm.runInContext('projectManager.projects.satellite.repeatCount = 5; projectManager.projects.satellite.update(0);', ctx);
+    vm.runInContext('spaceManager.updateCurrentPlanetTerraformedStatus(true);', ctx);
+
+    vm.runInContext("selectPlanet('titan');", ctx);
+
+    const repeat = vm.runInContext('projectManager.projects.satellite.repeatCount', ctx);
+    const oreResearch = vm.runInContext("researchManager.getResearchById('ore_scanning').isResearched", ctx);
+
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.Phaser = originalPhaser;
+    delete dom.window.Phaser;
+
+    if (errors.length) {
+      throw new Error('Script errors: ' + JSON.stringify(errors, null, 2));
+    }
+
+    expect(repeat).toBe(1);
+    expect(oreResearch).toBe(true);
+  });
+});

--- a/tests/spaceTravelWarningPopup.test.js
+++ b/tests/spaceTravelWarningPopup.test.js
@@ -49,7 +49,7 @@ describe('travel warning popup', () => {
     const popup = dom.window.document.getElementById('travel-warning-popup');
     expect(popup).not.toBeNull();
     const message = popup.querySelector('.travel-warning-message');
-    expect(message.textContent).toContain('Crystal');
+    expect(message.textContent).toBe(ctx.planetParameters.vega2.travelWarning);
     expect(ctx.spaceManager.changeCurrentPlanet).not.toHaveBeenCalled();
 
     popup.querySelector('#travel-warning-confirm').click();


### PR DESCRIPTION
## Summary
- add Companion Satellite advanced research that auto-completes ore scanning and keeps one ore satellite per terraformed world
- retain ore satellites on travel based on Companion Satellite completion
- fix travel warning popup test and add coverage for new research

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68c20465a484832792168cf5c6b3401c