### PR TITLE
Fix Random World Generator heading colors in light mode

### DIFF
--- a/src/css/rwg.css
+++ b/src/css/rwg.css
@@ -147,7 +147,7 @@
   background: transparent;
   border-bottom: 1px solid var(--rwg-border);
 }
-.rwg-card h3, .rwg-card h4 { margin: 0; }
+.rwg-card h3, .rwg-card h4 { margin: 0; color: var(--rwg-fg); }
 .collapse-arrow { margin-right: 6px; cursor: pointer; }
 .rwg-card.collapsed .card-body { display: none; }
 

--- a/src/css/space.css
+++ b/src/css/space.css
@@ -106,7 +106,7 @@ body:not(.dark-mode) .planet-stats p > strong {
 .rwg-grid > div { background:#1c1c1c; border:1px solid #3a3a3a; padding:8px; border-radius:4px; text-align:center; }
 .rwg-planets { display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
 .rwg-planet-card { border:1px solid #555; background:#262626; padding:10px; border-radius:6px; }
-.rwg-planet-title { font-weight:600; margin-bottom:8px; text-align:center; }
+.rwg-planet-title { font-weight:600; margin-bottom:8px; text-align:center; color: var(--rwg-fg); }
 .rwg-columns { display:grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 8px; }
 
 /* RWG visited worlds history */

--- a/tests/rwgNameColorLightMode.test.js
+++ b/tests/rwgNameColorLightMode.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Random World Generator name colors', () => {
+  test('star and planet name styles specify light text', () => {
+    const rwgCss = fs.readFileSync(path.join(__dirname, '../src/css/rwg.css'), 'utf8');
+    const spaceCss = fs.readFileSync(path.join(__dirname, '../src/css/space.css'), 'utf8');
+    expect(rwgCss).toMatch(/\.rwg-card h3,\s*\.rwg-card h4\s*\{[^}]*color:\s*var\(--rwg-fg\);/);
+    expect(spaceCss).toMatch(/\.rwg-planet-title\s*\{[^}]*color:\s*var\(--rwg-fg\);/);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep star and planet names white in the Random World Generator light theme
- Test that RWG heading styles define light text

## Testing
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68c302332c388327a9b9b3f01d2663d7