### PR TITLE
Align planetary thrusters tests with updated calculations

### DIFF
--- a/tests/photonThrustersProject.test.js
+++ b/tests/photonThrustersProject.test.js
@@ -30,7 +30,8 @@ describe('Planetary Thrusters project', () => {
 
     ctx.resources = { colony: { energy: { value: 1000, decrease(v){ this.value -= v; }, updateStorageCap(){ } } } };
     global.resources = ctx.resources;
-    ctx.terraforming = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
 
     const config = ctx.projectParameters.planetaryThruster;
     const project = new ctx.PlanetaryThrustersProject(config, 'planetaryThruster');
@@ -56,7 +57,8 @@ describe('Planetary Thrusters project', () => {
 
     ctx.resources = { colony: { energy: { value: 0, decrease(v){ this.value -= v; }, updateStorageCap(){ } } } };
     global.resources = ctx.resources;
-    ctx.terraforming = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
 
     const config = ctx.projectParameters.planetaryThruster;
     const project = new ctx.PlanetaryThrustersProject(config, 'planetaryThruster');
@@ -84,7 +86,8 @@ describe('Planetary Thrusters project', () => {
 
     ctx.resources = { colony: { energy: { modifyRate: jest.fn(), value: 100, decrease(){}, updateStorageCap(){} } } };
     global.resources = ctx.resources;
-    ctx.terraforming = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
 
     const config = ctx.projectParameters.planetaryThruster;
     const project = new ctx.PlanetaryThrustersProject(config, 'pt');
@@ -109,7 +112,8 @@ describe('Planetary Thrusters project', () => {
 
     ctx.resources = { colony: { energy: { modifyRate: jest.fn(), value: 100, decrease(){}, updateStorageCap(){} } } };
     global.resources = ctx.resources;
-    ctx.terraforming = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1, radius: 1, rotationPeriod: 10 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
 
     const config = ctx.projectParameters.planetaryThruster;
     const project = new ctx.PlanetaryThrustersProject(config, 'pt');
@@ -117,6 +121,7 @@ describe('Planetary Thrusters project', () => {
     project.power = 20;
     project.spinInvest = true;
     project.prepareJob();
+    project.autoStart = false;
     project.update(1000);
     project.updateUI = () => {};
     project.applyCostAndGain(1000, null, 1);

--- a/tests/planetaryThrustersDayNightCycle.test.js
+++ b/tests/planetaryThrustersDayNightCycle.test.js
@@ -25,7 +25,8 @@ describe('Planetary Thrusters day-night cycle', () => {
     ctx.dayNightCycle.elapsedTime = ctx.dayNightCycle.dayDuration * 5.25;
     ctx.dayNightCycle.update(0);
     const initialProgress = ctx.dayNightCycle.getDayProgress();
-    ctx.terraforming = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 20, distanceFromSun: 1 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 20, distanceFromSun: 1 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 1e40, decrease(v){ this.value -= v; }, updateStorageCap(){} } } };
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
@@ -48,7 +49,7 @@ describe('Planetary Thrusters day-night cycle', () => {
     const initialDuration = ctx.dayNightCycle.dayDuration;
     project.update(10000000);
     project.applyCostAndGain(10000000, null, 1);
-    const newPeriod = ctx.terraforming.celestialParameters.rotationPeriod;
+    const newPeriod = ctx.currentPlanetParameters.celestialParameters.rotationPeriod;
 
     expect(newPeriod).not.toBe(20);
     expect(ctx.dayNightCycle.dayDuration).not.toBe(initialDuration);

--- a/tests/planetaryThrustersNoOvershoot.test.js
+++ b/tests/planetaryThrustersNoOvershoot.test.js
@@ -18,7 +18,8 @@ describe('Planetary Thrusters target clamping', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 24, distanceFromSun: 1 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 1e40, decrease(v){ this.value -= v; }, updateStorageCap(){} } } };
 
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
@@ -40,7 +41,7 @@ describe('Planetary Thrusters target clamping', () => {
     project.prepareJob(true, true);
     project.activeMode = 'spin';
 
-    const p = ctx.terraforming.celestialParameters;
+    const p = ctx.currentPlanetParameters.celestialParameters;
     const requiredPower = project.dVreq * p.mass / (project.getThrustPowerRatio() * 86400);
     project.power = requiredPower * 2; // overshoot in one tick
     project.update(1000);

--- a/tests/planetaryThrustersOrientation.test.js
+++ b/tests/planetaryThrustersOrientation.test.js
@@ -18,7 +18,8 @@ describe('Planetary Thrusters orientation', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 24, distanceFromSun: 1 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 1e40, decrease(v){ this.value -= v; }, updateStorageCap(){} } } };
 
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
@@ -30,7 +31,7 @@ describe('Planetary Thrusters orientation', () => {
     const container = dom.window.document.getElementById('container');
     project.renderUI(container);
     project.complete();
-    const p = ctx.terraforming.celestialParameters;
+    const p = ctx.currentPlanetParameters.celestialParameters;
 
     // spin orientation
     project.el.rotTarget.value = 0.5; // 12 hour day

--- a/tests/planetaryThrustersStarMass.test.js
+++ b/tests/planetaryThrustersStarMass.test.js
@@ -26,9 +26,10 @@ describe('Planetary Thrusters star mass', () => {
     const G = 6.67430e-11;
     const AU_IN_METERS = 1.496e11;
     const starMass = 2 * 1.989e30;
-    ctx.terraforming = {
+    ctx.currentPlanetParameters = {
       celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 10, distanceFromSun: 1, starMass }
     };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 1e40, decrease(v){ this.value -= v; }, updateStorageCap(){} } } };
 
     const config = ctx.projectParameters.planetaryThruster;

--- a/tests/planetaryThrustersUIDefault.test.js
+++ b/tests/planetaryThrustersUIDefault.test.js
@@ -18,7 +18,8 @@ describe('Planetary Thrusters UI', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 24, distanceFromSun: 1 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
 
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
@@ -49,7 +50,8 @@ describe('Planetary Thrusters UI', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 30, distanceFromSun: 1.5 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 30, distanceFromSun: 1.5 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
 
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
@@ -78,7 +80,8 @@ describe('Planetary Thrusters UI', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 24, distanceFromSun: 1 } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 6e24, radius: 6000, rotationPeriod: 24, distanceFromSun: 1 } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
 
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
@@ -115,7 +118,8 @@ describe('Planetary Thrusters UI', () => {
     ctx.console = console;
     ctx.formatNumber = numbers.formatNumber;
     ctx.projectElements = {};
-    ctx.terraforming = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 10, parentBody: { name: 'Planet', mass: 5e24, orbitRadius: 50000, distanceFromSun: 1 } } };
+    ctx.currentPlanetParameters = { celestialParameters: { mass: 1e22, radius: 1000, rotationPeriod: 10, parentBody: { name: 'Planet', mass: 5e24, orbitRadius: 50000, distanceFromSun: 1 } } };
+    global.currentPlanetParameters = ctx.currentPlanetParameters;
     ctx.resources = { colony: { energy: { value: 0, decrease(){}, updateStorageCap(){} } } };
 
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);


### PR DESCRIPTION
## Summary
- update planetary thruster tests to reference `currentPlanetParameters`
- cover energy rate changes when auto-start is disabled

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c314f230fc8327bd59d003d2625229