### PR TITLE
Add atmospheric pressure cost penalty for colonies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added Next-Generation Fusion research doubling Superalloy Fusion Reactor energy production.
 - Temperature penalty for colonies now affects Ecumenopolis Districts.
 - Colony energy penalty from temperature is continuous, scaling with distance below 15 °C or above 20 °C.
+- High atmospheric pressure increases colony metal and glass costs, scaling with the square root of total pressure in atmospheres and shown in the atmosphere box when active.
 - High temperatures now increase colony maintenance costs by 1% per kelvin above 373.15 K, shown in the temperature box when active.
 - WGC logs now format artifact gains with two decimal places.
 - WGC team cards cache DOM nodes for buttons, inputs, selects, progress bars, logs and HP bars, rebuilding these caches when cards redraw or team counts change for faster updates.

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -1073,6 +1073,13 @@ class Terraforming extends EffectableEntity{
       return Math.sqrt(pressureAtm);
     }
 
+    calculateColonyPressureCostPenalty() {
+      const pressureKPa = this.calculateTotalPressure();
+      const pressureAtm = pressureKPa / KPA_PER_ATM;
+      const multiplier = Math.sqrt(pressureAtm);
+      return Math.max(1, multiplier);
+    }
+
     calculateColonyEnergyPenalty() {
       const zones = this.temperature.zones;
 
@@ -1147,6 +1154,7 @@ class Terraforming extends EffectableEntity{
 
 
       const colonyEnergyPenalty = this.calculateColonyEnergyPenalty();
+      const colonyCostPenalty = this.calculateColonyPressureCostPenalty();
       const maintenancePenalty = this.calculateMaintenancePenalty();
 
       for (let i = 1; i <= 7; i++) {
@@ -1161,6 +1169,29 @@ class Terraforming extends EffectableEntity{
         };
 
         addEffect(energyPenaltyEffect);
+
+        const metalCostPenaltyEffect = {
+            effectId: 'pressureCostPenalty-metal',
+            target: 'colony',
+            targetId: `t${i}_colony`,
+            type: 'resourceCostMultiplier',
+            resourceCategory: 'colony',
+            resourceId: 'metal',
+            value: colonyCostPenalty
+        };
+
+        const glassCostPenaltyEffect = {
+            effectId: 'pressureCostPenalty-glass',
+            target: 'colony',
+            targetId: `t${i}_colony`,
+            type: 'resourceCostMultiplier',
+            resourceCategory: 'colony',
+            resourceId: 'glass',
+            value: colonyCostPenalty
+        };
+
+        addEffect(metalCostPenaltyEffect);
+        addEffect(glassCostPenaltyEffect);
       }
 
       if (typeof buildings !== 'undefined') {

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -329,6 +329,11 @@ function createTemperatureBox(row) {
       atmosphereHeading.appendChild(atmInfo);
     }
 
+    const pressurePenaltySpan = document.createElement('p');
+    pressurePenaltySpan.id = 'pressure-cost-penalty';
+    pressurePenaltySpan.style.display = 'none';
+    atmosphereBox.appendChild(pressurePenaltySpan);
+
     row.appendChild(atmosphereBox);
     const gasElements = {};
     for (const gas in resources.atmospheric) {
@@ -347,6 +352,7 @@ function createTemperatureBox(row) {
       opticalDepthInfo: atmosphereBox.querySelector('#optical-depth-info'),
       opticalDepthTooltip: atmosphereBox.querySelector('#optical-depth-tooltip'),
       windMultiplier: atmosphereBox.querySelector('#wind-turbine-multiplier'),
+      pressurePenalty: atmosphereBox.querySelector('#pressure-cost-penalty'),
       gases: gasElements
     };
     const els = terraformingUICache.atmosphere;
@@ -390,6 +396,16 @@ function createTemperatureBox(row) {
 
     if (els.windMultiplier) {
       els.windMultiplier.textContent = `${(terraforming.calculateWindTurbineMultiplier()*100).toFixed(2)}`;
+    }
+
+    if (els.pressurePenalty && typeof terraforming.calculateColonyPressureCostPenalty === 'function') {
+      const penalty = terraforming.calculateColonyPressureCostPenalty();
+      if (penalty > 1) {
+        els.pressurePenalty.style.display = '';
+        els.pressurePenalty.textContent = `Colony cost multiplier from pressure : ${penalty.toFixed(2)}`;
+      } else {
+        els.pressurePenalty.style.display = 'none';
+      }
     }
 
     for (const gas in resources.atmospheric) {

--- a/tests/atmosphereGasStatus.test.js
+++ b/tests/atmosphereGasStatus.test.js
@@ -33,6 +33,7 @@ describe('atmosphere gas status icons', () => {
       calculateSolarPanelMultiplier: () => 1,
       calculateWindTurbineMultiplier: () => 1,
       calculateTotalPressure: () => 0,
+      calculateColonyPressureCostPenalty: () => 1,
       getAtmosphereStatus: () => true,
       getLuminosityStatus: () => true,
       getMagnetosphereStatus: () => true,

--- a/tests/atmosphereOpticalDepthUI.test.js
+++ b/tests/atmosphereOpticalDepthUI.test.js
@@ -46,6 +46,8 @@ describe('atmosphere UI optical depth', () => {
       calculateSolarPanelMultiplier: () => 1,
       calculateWindTurbineMultiplier: () => 1,
       calculateTotalPressure: () => 1,
+      calculateColonyPressureCostPenalty: () => 1,
+      calculateColonyPressureCostPenalty: () => 1,
       getAtmosphereStatus: () => true,
       getLuminosityStatus: () => true,
       getMagnetosphereStatus: () => true,
@@ -62,7 +64,7 @@ describe('atmosphere UI optical depth', () => {
 
     const box = dom.window.document.getElementById('atmosphere-box');
     const pEls = box.querySelectorAll('p');
-    expect(pEls.length).toBe(3);
+    expect(pEls.length).toBe(4);
     expect(pEls[0].querySelector('#atmosphere-current')).not.toBeNull();
     expect(pEls[1].querySelector('#optical-depth')).not.toBeNull();
     const info = pEls[1].querySelector('#optical-depth-info');

--- a/tests/colonyPressureCostPenalty.test.js
+++ b/tests/colonyPressureCostPenalty.test.js
@@ -1,0 +1,61 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+// Minimal globals
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = {};
+
+const Terraforming = require('../src/js/terraforming.js');
+Terraforming.prototype.updateLuminosity = function(){};
+Terraforming.prototype.updateSurfaceTemperature = function(){};
+Terraforming.prototype.updateSurfaceRadiation = function(){};
+
+describe('calculateColonyPressureCostPenalty', () => {
+  test('returns 1 at or below 1 atm and scales with pressure', () => {
+    const tfLow = { calculateTotalPressure: () => 50 };
+    const lowPenalty = Terraforming.prototype.calculateColonyPressureCostPenalty.call(tfLow);
+    expect(lowPenalty).toBe(1);
+
+    const tfHigh = { calculateTotalPressure: () => 405.3 };
+    const highPenalty = Terraforming.prototype.calculateColonyPressureCostPenalty.call(tfHigh);
+    expect(highPenalty).toBeCloseTo(2);
+  });
+
+  test('applies to colony metal and glass costs', () => {
+    global.resources = { atmospheric:{}, special:{ albedoUpgrades:{ value:0 } }, surface:{}, colony:{} };
+    global.buildings = {};
+    global.colonies = {};
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, { distanceFromSun:1, radius:1, gravity:1, albedo:0 });
+    tf.calculateTotalPressure = () => 405.3; // 4 atm
+    tf.calculateColonyEnergyPenalty = () => 1;
+    tf.calculateMaintenancePenalty = () => 1;
+    tf.calculateSolarPanelMultiplier = () => 1;
+    tf.calculateWindTurbineMultiplier = () => 1;
+
+    const originalAdd = global.addEffect;
+    const mockAdd = jest.fn();
+    global.addEffect = mockAdd;
+
+    tf.applyTerraformingEffects();
+
+    const calls = mockAdd.mock.calls.map(c => c[0]);
+    expect(calls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ target: 'colony', targetId: 't1_colony', resourceId: 'metal', type: 'resourceCostMultiplier', value: 2 }),
+      expect.objectContaining({ target: 'colony', targetId: 't1_colony', resourceId: 'glass', type: 'resourceCostMultiplier', value: 2 }),
+      expect.objectContaining({ target: 'colony', targetId: 't7_colony', resourceId: 'metal', type: 'resourceCostMultiplier', value: 2 }),
+      expect.objectContaining({ target: 'colony', targetId: 't7_colony', resourceId: 'glass', type: 'resourceCostMultiplier', value: 2 })
+    ]));
+    expect(calls).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ resourceId: 'water' })
+    ]));
+
+    global.addEffect = originalAdd;
+  });
+});
+

--- a/tests/pressureCostPenaltyDisplay.test.js
+++ b/tests/pressureCostPenaltyDisplay.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('pressure cost penalty display', () => {
+  test('shows only when penalty is greater than 1', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="summary-terraforming"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    const numbers = require('../src/js/numbers.js');
+    const physics = require('../src/js/physics.js');
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.getZonePercentage = require('../src/js/zones.js').getZonePercentage;
+    ctx.DEFAULT_SURFACE_ALBEDO = physics.DEFAULT_SURFACE_ALBEDO;
+    ctx.calculateAtmosphericPressure = physics.calculateAtmosphericPressure;
+
+    ctx.resources = { atmospheric: { o2: { displayName: 'O2', value: 0 } } };
+    ctx.currentPlanetParameters = { resources: { atmospheric: { o2: { initialValue: 0 } } } };
+    ctx.terraformingGasTargets = { o2: { min: 0, max: 100 } };
+    ctx.projectManager = { isBooleanFlagSet: () => false };
+
+    ctx.terraforming = {
+      temperature: { name: 'Temp', value: 300, emissivity: 1, opticalDepth: 0, effectiveTempNoAtmosphere: 0,
+        zones: { tropical: { value: 0, day: 0, night: 0, initial: 0 },
+                 temperate: { value: 0, day: 0, night: 0, initial: 0 },
+                 polar: { value: 0, day: 0, night: 0, initial: 0 } } },
+      atmosphere: { name: 'Atm' },
+      water: {},
+      luminosity: { name: 'Lum', albedo: 0, cloudHazePenalty: 0, solarFlux: 0, modifiedSolarFlux: 0 },
+      life: { name: 'Life', target: 0.5 },
+      magnetosphere: { name: 'Mag' },
+      celestialParameters: { albedo: 0, gravity: 1, radius: 1, surfaceArea: 1 },
+      calculateSolarPanelMultiplier: () => 1,
+      calculateWindTurbineMultiplier: () => 1,
+      getAtmosphereStatus: () => true,
+      getLuminosityStatus: () => true,
+      getMagnetosphereStatus: () => true,
+      calculateColonyEnergyPenalty: () => 1,
+      calculateMaintenancePenalty: () => 1,
+      calculateTotalPressure: () => 101.325,
+      calculateColonyPressureCostPenalty: () => 1,
+      waterTarget: 0.2,
+      totalEvaporationRate: 0,
+      totalWaterSublimationRate: 0,
+      totalRainfallRate: 0,
+      totalSnowfallRate: 0,
+      totalMeltRate: 0,
+      totalFreezeRate: 0,
+      zonalSurface: { tropical: { biomass: 0 }, temperate: { biomass: 0 }, polar: { biomass: 0 } },
+      zonalWater: { tropical: {}, temperate: {}, polar: {} }
+    };
+
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraforming', 'terraformingUI.js'), 'utf8');
+    vm.runInContext(code, ctx);
+
+    ctx.createTerraformingSummaryUI();
+    let el = dom.window.document.querySelector('#pressure-cost-penalty');
+    expect(el.style.display).toBe('none');
+
+    ctx.terraforming.calculateColonyPressureCostPenalty = () => 2;
+    ctx.updateAtmosphereBox();
+    el = dom.window.document.querySelector('#pressure-cost-penalty');
+    expect(el.style.display).toBe('');
+    expect(el.textContent).toContain('2.00');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Scale colony metal and glass construction costs by the square root of atmospheric pressure
- Show pressure-based cost multiplier in the atmosphere panel when greater than 1
- Cover new pressure penalty with unit and integration tests

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3476d7a148327af05c0f1bad27f3e