### PR TITLE
Remove focus reversal checkbox from space mirror facility

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -22,11 +22,11 @@ function createDefaultMirrorOversightSettings() {
     tempMode: { tropical: 'average', temperate: 'average', polar: 'average' },
     priority: { tropical: 1, temperate: 1, polar: 1, focus: 1 },
     autoAssign: { tropical: false, temperate: false, polar: false, focus: false, any: false },
-    assignments: {
-      mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
-      lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
-      reversalMode: { tropical: false, temperate: false, polar: false, focus: false, any: false }
-    }
+      assignments: {
+        mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
+        lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
+        reversalMode: { tropical: false, temperate: false, polar: false, any: false }
+      }
   };
 }
 
@@ -126,7 +126,7 @@ function resetMirrorOversightSettings() {
   mirrorOversightSettings.autoAssign = { tropical: false, temperate: false, polar: false, focus: false, any: false };
   mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
   mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
-  mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
+    mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
   updateMirrorOversightUI();
 }
 
@@ -303,7 +303,7 @@ function updateAssignmentDisplays() {
     });
     const checkbox = document.querySelector(`.reversal-checkbox[data-zone="${zone}"]`);
     if (checkbox) {
-      if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
+        if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
       checkbox.checked = !!mirrorOversightSettings.assignments.reversalMode[zone];
     }
   });
@@ -384,8 +384,6 @@ function initializeMirrorOversightUI(container) {
         <label for="mirror-oversight-focus">Focusing:<span class="info-tooltip-icon" title="Concentrate mirror and lantern energy on a single point to melt surface ice into liquid water. Only surface ice melts and the warmest zone with ice is targeted first. Uses the heat required to warm the ice to 0°C plus the energy of fusion/melting.">&#9432;</span></label>
         <input type="range" id="mirror-oversight-focus" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-focus-value" class="slider-value">0%</span>
-        <input type="checkbox" id="mirror-oversight-focus-reverse" class="slider-reversal-checkbox" data-zone="focus" style="display:none;">
-        <label for="mirror-oversight-focus-reverse" class="slider-reverse-label" style="display:none;">Reverse</label>
       </div>
       <div class="control-group">
         <label for="mirror-oversight-any">Any Zone:</label>
@@ -432,15 +430,14 @@ function initializeMirrorOversightUI(container) {
     tropical: div.querySelector('#mirror-oversight-tropical-reverse'),
     temperate: div.querySelector('#mirror-oversight-temperate-reverse'),
     polar: div.querySelector('#mirror-oversight-polar-reverse'),
-    focus: div.querySelector('#mirror-oversight-focus-reverse'),
     any: div.querySelector('#mirror-oversight-any-reverse'),
   };
   Object.keys(sliderReverse).forEach(zone => {
     const box = sliderReverse[zone];
     if (!box) return;
-    if (!mirrorOversightSettings.assignments.reversalMode) {
-      mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
-    }
+      if (!mirrorOversightSettings.assignments.reversalMode) {
+        mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
+      }
     box.checked = !!mirrorOversightSettings.assignments.reversalMode[zone];
     box.addEventListener('change', () => {
       mirrorOversightSettings.assignments.reversalMode[zone] = box.checked;
@@ -719,9 +716,6 @@ function initializeMirrorOversightUI(container) {
         <button class="assign-plus" data-type="lanterns" data-zone="focus">+1</button>
         <button class="assign-max" data-type="lanterns" data-zone="focus">Max</button>
       </div>
-      <div class="grid-reversal-cell" data-zone="focus" style="display:none;">
-        <input type="checkbox" class="reversal-checkbox" data-zone="focus">
-      </div>
       <div class="grid-auto-cell" data-zone="focus" style="display:none;">
         <input type="checkbox" class="auto-assign" data-zone="focus">
       </div>
@@ -756,7 +750,7 @@ function initializeMirrorOversightUI(container) {
   finerContent.querySelectorAll('.reversal-checkbox').forEach(box => {
     box.addEventListener('change', () => {
       const zone = box.dataset.zone;
-      if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
+        if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
       mirrorOversightSettings.assignments.reversalMode[zone] = box.checked;
       updateZonalFluxTable();
     });
@@ -1297,7 +1291,7 @@ function runAdvancedOversightAssignments(project) {
     // ---------------- Short-hands / accessors ----------------
     const assignM = mirrorOversightSettings.assignments.mirrors || (mirrorOversightSettings.assignments.mirrors = {});
     const assignL = mirrorOversightSettings.assignments.lanterns || (mirrorOversightSettings.assignments.lanterns = {});
-    const reverse = (mirrorOversightSettings.assignments.reversalMode ||= { tropical: false, temperate: false, polar: false, focus: false, any: false });
+      const reverse = (mirrorOversightSettings.assignments.reversalMode ||= { tropical: false, temperate: false, polar: false, any: false });
 
     const prio = mirrorOversightSettings.priority || { tropical: 1, temperate: 1, polar: 1, focus: 1 };
     const targets = mirrorOversightSettings.targets || { tropical: 0, temperate: 0, polar: 0, water: 0 };
@@ -1392,9 +1386,9 @@ function runAdvancedOversightAssignments(project) {
       const savedReverse = { ...reverse };
 
       // Zero assignments and turn off all reversal for baseline evaluation
-      assignM.tropical = 0; assignM.temperate = 0; assignM.polar = 0; assignM.focus = 0;
-      assignL.tropical = 0; assignL.temperate = 0; assignL.polar = 0; assignL.focus = 0;
-      reverse.tropical = false; reverse.temperate = false; reverse.polar = false; reverse.focus = false; reverse.any = false;
+        assignM.tropical = 0; assignM.temperate = 0; assignM.polar = 0; assignM.focus = 0;
+        assignL.tropical = 0; assignL.temperate = 0; assignL.polar = 0; assignL.focus = 0;
+        reverse.tropical = false; reverse.temperate = false; reverse.polar = false; reverse.any = false;
       updateTemps();
 
       // Read baseline temps with no facility effect

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -127,7 +127,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
     assignments: {
       mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
       lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
-      reversalMode: { tropical: false, temperate: false, polar: false, focus: false, any: false }
+      reversalMode: { tropical: false, temperate: false, polar: false, any: false }
     }
   });
 });

--- a/tests/spaceMirrorFocusReversalHidden.test.js
+++ b/tests/spaceMirrorFocusReversalHidden.test.js
@@ -1,0 +1,68 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('space mirror focus reversal', () => {
+  test('focus zone lacks reversal controls', () => {
+    const originalDocument = global.document;
+    const originalProject = global.Project;
+    const originalFormat = global.formatNumber;
+    const originalTerraforming = global.terraforming;
+    const originalBuildings = global.buildings;
+    const originalProjectElements = global.projectElements;
+    const originalProjectManager = global.projectManager;
+
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    global.Project = class {
+      saveState() { return {}; }
+      loadState() {}
+    };
+    global.formatNumber = v => v;
+    global.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      celestialParameters: { crossSectionArea: 1, surfaceArea: 1 },
+    };
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { unlocked: false } };
+    global.projectElements = {};
+
+    const { SpaceMirrorFacilityProject } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+    const config = { name: 'Space Mirror Facility', cost: {}, duration: 0 };
+    const project = new SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    global.projectManager = {
+      projects: { spaceMirrorFacility: project },
+      isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight' || id === 'spaceMirrorFocusing',
+    };
+
+    const container = document.getElementById('root');
+    project.renderUI(container);
+    project.updateUI();
+
+    expect(container.querySelector('#mirror-oversight-focus-reverse')).toBeNull();
+    expect(container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]')).toBeNull();
+
+    project.enableReversal();
+    project.updateUI();
+
+    expect(container.querySelector('#mirror-oversight-focus-reverse')).toBeNull();
+    expect(container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]')).toBeNull();
+
+    global.document = originalDocument;
+    global.Project = originalProject;
+    global.formatNumber = originalFormat;
+    global.terraforming = originalTerraforming;
+    global.buildings = originalBuildings;
+    global.projectElements = originalProjectElements || {};
+    global.projectManager = originalProjectManager;
+    delete global.setMirrorDistribution;
+    delete global.resetMirrorOversightSettings;
+    delete global.initializeMirrorOversightUI;
+    delete global.updateMirrorOversightUI;
+    delete global.updateZonalFluxTable;
+    delete global.applyFocusedMelt;
+    delete global.calculateZoneSolarFluxWithFacility;
+    delete global.toggleFinerControls;
+    delete global.updateAssignmentDisplays;
+  });
+});
+


### PR DESCRIPTION
## Summary
- prevent focus zone from tracking reversal mode and expose no reverse checkbox in finer controls
- add regression test ensuring focus zone never shows reversal controls

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c4b8aa14d483278be03b70bef5aa32