### PR TITLE
Align space mirror focus auto checkbox

### DIFF
--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -25,7 +25,7 @@ function createDefaultMirrorOversightSettings() {
       assignments: {
         mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
         lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
-        reversalMode: { tropical: false, temperate: false, polar: false, any: false }
+        reversalMode: { tropical: false, temperate: false, polar: false, focus: false, any: false }
       }
   };
 }
@@ -126,7 +126,7 @@ function resetMirrorOversightSettings() {
   mirrorOversightSettings.autoAssign = { tropical: false, temperate: false, polar: false, focus: false, any: false };
   mirrorOversightSettings.assignments.mirrors = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
   mirrorOversightSettings.assignments.lanterns = { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 };
-    mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
+  mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
   updateMirrorOversightUI();
 }
 
@@ -303,7 +303,7 @@ function updateAssignmentDisplays() {
     });
     const checkbox = document.querySelector(`.reversal-checkbox[data-zone="${zone}"]`);
     if (checkbox) {
-        if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
+        if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
       checkbox.checked = !!mirrorOversightSettings.assignments.reversalMode[zone];
     }
   });
@@ -436,7 +436,7 @@ function initializeMirrorOversightUI(container) {
     const box = sliderReverse[zone];
     if (!box) return;
       if (!mirrorOversightSettings.assignments.reversalMode) {
-        mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
+        mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
       }
     box.checked = !!mirrorOversightSettings.assignments.reversalMode[zone];
     box.addEventListener('change', () => {
@@ -716,6 +716,9 @@ function initializeMirrorOversightUI(container) {
         <button class="assign-plus" data-type="lanterns" data-zone="focus">+1</button>
         <button class="assign-max" data-type="lanterns" data-zone="focus">Max</button>
       </div>
+      <div class="grid-reversal-cell reversal-cell-with-checkbox" data-zone="focus" style="display:none;">
+        <input type="checkbox" class="reversal-checkbox" data-zone="focus" style="visibility:hidden;">
+      </div>
       <div class="grid-auto-cell" data-zone="focus" style="display:none;">
         <input type="checkbox" class="auto-assign" data-zone="focus">
       </div>
@@ -750,7 +753,7 @@ function initializeMirrorOversightUI(container) {
   finerContent.querySelectorAll('.reversal-checkbox').forEach(box => {
     box.addEventListener('change', () => {
       const zone = box.dataset.zone;
-        if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, any: false };
+        if (!mirrorOversightSettings.assignments.reversalMode) mirrorOversightSettings.assignments.reversalMode = { tropical: false, temperate: false, polar: false, focus: false, any: false };
       mirrorOversightSettings.assignments.reversalMode[zone] = box.checked;
       updateZonalFluxTable();
     });
@@ -1026,9 +1029,17 @@ function updateMirrorOversightUI() {
     distributeAutoAssignments('lanterns');
     updateAssignmentDisplays();
   }
-  if (C.focusZoneCells) C.focusZoneCells.forEach(el => { el.style.display = focusEnabled ? '' : 'none'; });
-  const focusCell = document.querySelector('.assign-cell[data-zone="focus"]');
-  if (focusCell) focusCell.style.display = focusEnabled ? 'flex' : 'none';
+  if (C.focusZoneCells) C.focusZoneCells.forEach(el => {
+    if (!focusEnabled) {
+      el.style.display = 'none';
+    } else if (el.classList.contains('grid-reversal-cell')) {
+      el.style.display = reversalAvailable ? 'flex' : 'none';
+    } else if (el.classList.contains('assign-cell')) {
+      el.style.display = 'flex';
+    } else {
+      el.style.display = '';
+    }
+  });
 
 
   if (enabled) {
@@ -1291,7 +1302,7 @@ function runAdvancedOversightAssignments(project) {
     // ---------------- Short-hands / accessors ----------------
     const assignM = mirrorOversightSettings.assignments.mirrors || (mirrorOversightSettings.assignments.mirrors = {});
     const assignL = mirrorOversightSettings.assignments.lanterns || (mirrorOversightSettings.assignments.lanterns = {});
-      const reverse = (mirrorOversightSettings.assignments.reversalMode ||= { tropical: false, temperate: false, polar: false, any: false });
+      const reverse = (mirrorOversightSettings.assignments.reversalMode ||= { tropical: false, temperate: false, polar: false, focus: false, any: false });
 
     const prio = mirrorOversightSettings.priority || { tropical: 1, temperate: 1, polar: 1, focus: 1 };
     const targets = mirrorOversightSettings.targets || { tropical: 0, temperate: 0, polar: 0, water: 0 };

--- a/tests/initializeGameStateSliders.test.js
+++ b/tests/initializeGameStateSliders.test.js
@@ -127,7 +127,7 @@ test('initializeGameState resets colony sliders to defaults', () => {
     assignments: {
       mirrors: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
       lanterns: { tropical: 0, temperate: 0, polar: 0, focus: 0, unassigned: 0, any: 0 },
-      reversalMode: { tropical: false, temperate: false, polar: false, any: false }
+      reversalMode: { tropical: false, temperate: false, polar: false, focus: false, any: false }
     }
   });
 });

--- a/tests/spaceMirrorFocusReversalHidden.test.js
+++ b/tests/spaceMirrorFocusReversalHidden.test.js
@@ -3,7 +3,7 @@ const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules',
 const { JSDOM } = require(jsdomPath);
 
 describe('space mirror focus reversal', () => {
-  test('focus zone lacks reversal controls', () => {
+  test('focus zone uses hidden reversal placeholder', () => {
     const originalDocument = global.document;
     const originalProject = global.Project;
     const originalFormat = global.formatNumber;
@@ -39,13 +39,23 @@ describe('space mirror focus reversal', () => {
     project.updateUI();
 
     expect(container.querySelector('#mirror-oversight-focus-reverse')).toBeNull();
-    expect(container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]')).toBeNull();
+    const revCell = container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]');
+    expect(revCell).not.toBeNull();
+    expect(revCell.style.display).toBe('none');
+    const hiddenBox = revCell.querySelector('input.reversal-checkbox');
+    expect(hiddenBox).not.toBeNull();
+    expect(hiddenBox.style.visibility).toBe('hidden');
 
     project.enableReversal();
     project.updateUI();
 
     expect(container.querySelector('#mirror-oversight-focus-reverse')).toBeNull();
-    expect(container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]')).toBeNull();
+    const revCell2 = container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]');
+    expect(revCell2).not.toBeNull();
+    expect(revCell2.style.display).toBe('flex');
+    const hiddenBox2 = revCell2.querySelector('input.reversal-checkbox');
+    expect(hiddenBox2).not.toBeNull();
+    expect(hiddenBox2.style.visibility).toBe('hidden');
 
     global.document = originalDocument;
     global.Project = originalProject;


### PR DESCRIPTION
## Summary
- Add hidden reversal checkbox to focus row so auto assignment aligns
- Track focus reversal state and display only when reversal is available
- Update tests for hidden focus reversal placeholder and default settings

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c4bb79fd988327880b119d7295e078