### PR TITLE
Add hidden reversal placeholder to space mirror focusing slider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,6 +433,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space storage strategic reserve and nanobot energy limit inputs now accept scientific notation (e.g., 1e3 for 1000).
 - Space storage strategic reserve input includes a tooltip noting that mega projects respect the reserve while transfers do not, and explaining scientific notation support.
 - Space mirror facility's unassigned slider matches the width of other sliders and locks when finer controls are enabled.
+- Space mirror facility's focusing slider includes a hidden reversal checkbox to maintain consistent slider width.
 - Water melt target input in space mirror facility advanced oversight is wider and includes k/M/B scaling dropdown.
 - Space mirror oversight finer controls now provide /10 xN x10 buttons for each column, showing lantern controls only when lanterns are available.
 - Added `reinitializeDisplayElements` to Resource for resetting default display names and margins after travel.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -384,6 +384,8 @@ function initializeMirrorOversightUI(container) {
         <label for="mirror-oversight-focus">Focusing:<span class="info-tooltip-icon" title="Concentrate mirror and lantern energy on a single point to melt surface ice into liquid water. Only surface ice melts and the warmest zone with ice is targeted first. Uses the heat required to warm the ice to 0°C plus the energy of fusion/melting.">&#9432;</span></label>
         <input type="range" id="mirror-oversight-focus" min="0" max="100" step="1" value="0">
         <span id="mirror-oversight-focus-value" class="slider-value">0%</span>
+        <input type="checkbox" id="mirror-oversight-focus-reverse" class="slider-reversal-checkbox" data-zone="focus" style="display:none; visibility:hidden;">
+        <label for="mirror-oversight-focus-reverse" class="slider-reverse-label" style="display:none; visibility:hidden;">Reverse</label>
       </div>
       <div class="control-group">
         <label for="mirror-oversight-any">Any Zone:</label>

--- a/tests/spaceMirrorFocusReversalHidden.test.js
+++ b/tests/spaceMirrorFocusReversalHidden.test.js
@@ -38,7 +38,14 @@ describe('space mirror focus reversal', () => {
     project.renderUI(container);
     project.updateUI();
 
-    expect(container.querySelector('#mirror-oversight-focus-reverse')).toBeNull();
+    const sliderBox = container.querySelector('#mirror-oversight-focus-reverse');
+    const sliderLabel = container.querySelector('label[for="mirror-oversight-focus-reverse"]');
+    expect(sliderBox).not.toBeNull();
+    expect(sliderLabel).not.toBeNull();
+    expect(sliderBox.style.display).toBe('none');
+    expect(sliderLabel.style.display).toBe('none');
+    expect(sliderBox.style.visibility).toBe('hidden');
+    expect(sliderLabel.style.visibility).toBe('hidden');
     const revCell = container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]');
     expect(revCell).not.toBeNull();
     expect(revCell.style.display).toBe('none');
@@ -49,7 +56,14 @@ describe('space mirror focus reversal', () => {
     project.enableReversal();
     project.updateUI();
 
-    expect(container.querySelector('#mirror-oversight-focus-reverse')).toBeNull();
+    const sliderBox2 = container.querySelector('#mirror-oversight-focus-reverse');
+    const sliderLabel2 = container.querySelector('label[for="mirror-oversight-focus-reverse"]');
+    expect(sliderBox2).not.toBeNull();
+    expect(sliderLabel2).not.toBeNull();
+    expect(sliderBox2.style.display).toBe('');
+    expect(sliderLabel2.style.display).toBe('');
+    expect(sliderBox2.style.visibility).toBe('hidden');
+    expect(sliderLabel2.style.visibility).toBe('hidden');
     const revCell2 = container.querySelector('#assignment-grid .grid-reversal-cell[data-zone="focus"]');
     expect(revCell2).not.toBeNull();
     expect(revCell2.style.display).toBe('flex');


### PR DESCRIPTION
## Summary
- Add invisible reversal checkbox and label after focusing slider so mirror oversight sliders remain aligned
- Document focusing slider update in AGENTS
- Adjust focus reversal test for new placeholder

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68c4bd4c7bb88327b45fc98deb18088d