### PR TITLE
Add Any Zone reversal checkbox to space mirror finer controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,7 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Land usage recalculates on save load, and inactive structure construction checks land without reserving it.
 - Space mirror facility now verifies slider percentages each tick, clamping out-of-range values and ensuring they total 100%.
 - Space mirror facility now supports a reversible reflect mode with Toward World/Away From World selection.
+- Any Zone in space mirror finer controls now includes a reversal checkbox.
 - Reversed space mirrors now subtract flux from their zones while lanterns continue adding, and zonal flux is floored at 6 µW/m²; the luminosity tooltip notes this limit.
 - Metal exportation project shows assigned ship count as current/maximum so players know remaining capacity.
 - Space export project's max export capacity line includes a tooltip explaining Earth's metal purchase limit.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -694,8 +694,8 @@ function initializeMirrorOversightUI(container) {
           <button class="assign-plus" data-type="lanterns" data-zone="${zone}">+1</button>
           <button class="assign-max" data-type="lanterns" data-zone="${zone}">Max</button>
         </div>
-        <div class="grid-${zone === 'any' ? 'reversal-cell' : 'reversal-cell reversal-cell-with-checkbox'}">
-          ${zone === 'any' ? '' : `<input type="checkbox" class="reversal-checkbox" data-zone="${zone}">`}
+        <div class="grid-reversal-cell reversal-cell-with-checkbox">
+          <input type="checkbox" class="reversal-checkbox" data-zone="${zone}">
         </div>
         <div class="grid-auto-cell">
           <input type="checkbox" class="auto-assign" data-zone="${zone}">

--- a/tests/spaceMirrorAnyReversalCheckbox.test.js
+++ b/tests/spaceMirrorAnyReversalCheckbox.test.js
@@ -1,0 +1,62 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('space mirror any reversal checkbox', () => {
+  test('any zone has reversal checkbox under finer controls', () => {
+    const originalDocument = global.document;
+    const originalProject = global.Project;
+    const originalFormat = global.formatNumber;
+    const originalTerraforming = global.terraforming;
+    const originalBuildings = global.buildings;
+    const originalProjectElements = global.projectElements;
+    const originalProjectManager = global.projectManager;
+
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    global.Project = class { saveState() { return {}; } loadState() {} };
+    global.formatNumber = v => v;
+    global.formatBuildingCount = v => v;
+    global.terraforming = {
+      calculateMirrorEffect: () => ({ interceptedPower: 0, powerPerUnitArea: 0 }),
+      celestialParameters: { crossSectionArea: 1, surfaceArea: 1 },
+    };
+    global.buildings = { spaceMirror: { active: 0 }, hyperionLantern: { unlocked: false } };
+    global.projectElements = {};
+
+    const { SpaceMirrorFacilityProject, toggleFinerControls } = require('../src/js/projects/SpaceMirrorFacilityProject.js');
+    const config = { name: 'Space Mirror Facility', cost: {}, duration: 0 };
+    const project = new SpaceMirrorFacilityProject(config, 'spaceMirrorFacility');
+    global.projectManager = {
+      projects: { spaceMirrorFacility: project },
+      isBooleanFlagSet: id => id === 'spaceMirrorFacilityOversight',
+    };
+
+    const container = document.getElementById('root');
+    project.renderUI(container);
+    project.enableReversal();
+    toggleFinerControls(true);
+    project.updateUI();
+
+    const checkbox = document.querySelector('.reversal-checkbox[data-zone="any"]');
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.closest('.grid-reversal-cell').style.display).not.toBe('none');
+
+    global.document = originalDocument;
+    global.Project = originalProject;
+    global.formatNumber = originalFormat;
+    global.terraforming = originalTerraforming;
+    global.buildings = originalBuildings;
+    global.projectElements = originalProjectElements || {};
+    global.projectManager = originalProjectManager;
+    delete global.setMirrorDistribution;
+    delete global.resetMirrorOversightSettings;
+    delete global.initializeMirrorOversightUI;
+    delete global.updateMirrorOversightUI;
+    delete global.updateZonalFluxTable;
+    delete global.applyFocusedMelt;
+    delete global.calculateZoneSolarFluxWithFacility;
+    delete global.toggleFinerControls;
+    delete global.updateAssignmentDisplays;
+  });
+});


### PR DESCRIPTION
## Summary
- Show a reversal checkbox for Any Zone in the space mirror facility's finer controls
- Document feature in AGENTS instructions
- Test that Any Zone reversal checkbox appears when finer controls are enabled

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68c4bd6678108327aecc0a1218190f2b