### PR TITLE
Hide Space Mirror quick builds until project completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,3 +519,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added atmospheric utility functions to compute mean molecular weight and specific lift.
 - Added Aerostat Colony, a slider-affected colony type immune to temperature and pressure penalties.
 - Space mirror facility now provides quick build buttons for mirrors and lanterns beneath their status cards.
+- Mirror and lantern quick build controls only appear once the Space Mirror Facility project is complete.

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -1871,6 +1871,7 @@ class SpaceMirrorFacilityProject extends Project {
 
     const mirrorQuick = document.createElement('div');
     mirrorQuick.classList.add('quick-build-row');
+    mirrorQuick.style.display = 'none';
     const mirrorQuickLabel = document.createElement('span');
     mirrorQuickLabel.classList.add('quick-build-label');
     mirrorQuickLabel.textContent = 'Quick Build:';
@@ -2043,25 +2044,29 @@ class SpaceMirrorFacilityProject extends Project {
 
     if (elements.quickBuild && elements.quickBuild.mirror) {
       const qb = elements.quickBuild.mirror;
-      const building = buildings.spaceMirror;
-      qb.button.textContent = `Build ${formatNumber(qb.count, true)} ${building.displayName}`;
-      const canAfford = typeof building.canAfford === 'function' ? building.canAfford(qb.count) : true;
-      if (qb.button.classList) {
-        if (!canAfford) qb.button.classList.add('cant-afford');
-        else qb.button.classList.remove('cant-afford');
-      } else {
-        qb.button.style.color = canAfford ? '' : 'red';
+      qb.container.style.display = this.isCompleted ? 'grid' : 'none';
+      if (this.isCompleted) {
+        const building = buildings.spaceMirror;
+        qb.button.textContent = `Build ${formatNumber(qb.count, true)} ${building.displayName}`;
+        const canAfford = typeof building.canAfford === 'function' ? building.canAfford(qb.count) : true;
+        if (qb.button.classList) {
+          if (!canAfford) qb.button.classList.add('cant-afford');
+          else qb.button.classList.remove('cant-afford');
+        } else {
+          qb.button.style.color = canAfford ? '' : 'red';
+        }
       }
     }
 
     if (elements.lanternDetails) {
       const lantern = buildings.hyperionLantern;
       const unlocked = lantern && lantern.unlocked;
-      elements.lanternDetails.container.style.display = unlocked ? 'block' : 'none';
+      const showLantern = this.isCompleted && unlocked;
+      elements.lanternDetails.container.style.display = showLantern ? 'block' : 'none';
       if (elements.quickBuild && elements.quickBuild.lantern) {
-        elements.quickBuild.lantern.container.style.display = unlocked ? 'grid' : 'none';
+        elements.quickBuild.lantern.container.style.display = showLantern ? 'grid' : 'none';
       }
-      if (unlocked) {
+      if (showLantern) {
         const area = terraforming.celestialParameters.crossSectionArea || terraforming.celestialParameters.surfaceArea;
         const productivity = typeof lantern.productivity === 'number' ? lantern.productivity : 1;
         const numLanterns = lantern.active || 0;

--- a/tests/spaceMirrorFacilityProject.test.js
+++ b/tests/spaceMirrorFacilityProject.test.js
@@ -101,6 +101,10 @@ describe('SpaceMirrorFacilityProject', () => {
     const lanternCard = ctx.projectElements.spaceMirrorFacility.lanternDetails.container;
     expect(lanternCard.style.display).toBe('none');
 
+    project.isCompleted = true;
+    project.updateUI();
+    expect(lanternCard.style.display).toBe('none');
+
     ctx.buildings.hyperionLantern.unlocked = true;
     project.updateUI();
     expect(lanternCard.style.display).toBe('block');

--- a/tests/spaceMirrorQuickBuildButtons.test.js
+++ b/tests/spaceMirrorQuickBuildButtons.test.js
@@ -58,12 +58,18 @@ describe('SpaceMirrorFacility quick build buttons', () => {
     ctx.projectElements = vm.runInContext('projectElements', ctx);
 
     project.updateUI();
+    const qbContainer = ctx.projectElements.spaceMirrorFacility.quickBuild.mirror.container;
+    expect(qbContainer.style.display).toBe('none');
+
+    project.isCompleted = true;
+    project.updateUI();
     const mirrorBtn = ctx.projectElements.spaceMirrorFacility.quickBuild.mirror.button;
-    expect(mirrorBtn.style.color).toBe('red');
+    expect(qbContainer.style.display).toBe('grid');
+    expect(mirrorBtn.classList.contains('cant-afford')).toBe(true);
 
     ctx.resources.colony.metal.value = 1000;
     project.updateUI();
-    expect(mirrorBtn.style.color).toBe('');
+    expect(mirrorBtn.classList.contains('cant-afford')).toBe(false);
 
     mirrorBtn.dispatchEvent(new dom.window.Event('click'));
     expect(ctx.resources.colony.metal.value).toBe(990);
@@ -117,8 +123,12 @@ describe('SpaceMirrorFacility quick build buttons', () => {
     const qbContainer = ctx.projectElements.spaceMirrorFacility.quickBuild.lantern.container;
     expect(qbContainer.style.display).toBe('none');
 
+    project.isCompleted = true;
+    project.updateUI();
+    expect(qbContainer.style.display).toBe('none');
+
     ctx.buildings.hyperionLantern.unlocked = true;
     project.updateUI();
-    expect(qbContainer.style.display).toBe('block');
+    expect(qbContainer.style.display).toBe('grid');
   });
 });


### PR DESCRIPTION
## Summary
- hide Space Mirror Facility quick build controls until the project finishes
- update tests for mirror and lantern quick build visibility

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c54b32cce48327b73bc5ca2cf37d92