### PR TITLE
Reveal regular research after space tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,3 +520,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Added Aerostat Colony, a slider-affected colony type immune to temperature and pressure penalties.
 - Space mirror facility now provides quick build buttons for mirrors and lanterns beneath their status cards.
 - Mirror and lantern quick build controls only appear once the Space Mirror Facility project is complete.
+- Regular researches remain fully visible after unlocking the space tab via a `stopHidingRegular` flag on the ResearchManager.

--- a/src/js/research.js
+++ b/src/js/research.js
@@ -144,6 +144,9 @@ class Research {
     // completed researches stay visible along with the cheapest `limit`
     // incomplete ones that are displayable on the current planet.
     getVisibleResearchIdsByCategory(category, limit = 3) {
+      if (this.isBooleanFlagSet('stopHidingRegular') && category !== 'advanced') {
+        limit = Infinity;
+      }
       const researches = this.getResearchesByCategory(category);
       const visible = new Set();
       const unresearched = researches.filter(r => !r.isResearched && this.isResearchDisplayable(r));

--- a/src/js/story/mars.js
+++ b/src/js/story/mars.js
@@ -713,17 +713,25 @@ var progressMars = {
         narrative: "Receiving transmission...\n  'H.O.P.E.? This is Mary. Martin's daughter. I'm on Mars. Something's happened to Earth. There was a light... and then nothing. All our communications are down. Your systems are showing critical errors. Please, stand by.'",
         prerequisites: ["chapter4.1"],
         objectives: [],
-        reward: [          {
-              target: 'tab',          // Target the TabManager
-              targetId: 'space-tab',  // The ID of the tab button in index.html
-              type: 'enable'          // Calls the 'enable' method in TabManager
+        reward: [
+          {
+            target: 'tab',          // Target the TabManager
+            targetId: 'space-tab',  // The ID of the tab button in index.html
+            type: 'enable'          // Calls the 'enable' method in TabManager
           },
           {
             target: 'tab',
             targetId: 'space',
             type: 'activateTab',
             onLoad : false
-          }]
+          },
+          {
+            target: 'researchManager',
+            type: 'booleanFlag',
+            flagId: 'stopHidingRegular',
+            value: true
+          }
+        ]
       },
       {
         id: "chapter4.3",

--- a/tests/researchStopHidingRegular.test.js
+++ b/tests/researchStopHidingRegular.test.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research.js'), 'utf8');
+const researchUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'researchUI.js'), 'utf8');
+
+describe('stopHidingRegular flag shows all researches', () => {
+  test('disables regular research visibility limit', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="energy-research-buttons"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.canAffordResearch = () => true;
+    ctx.formatNumber = () => '';
+    ctx.resources = { colony: { research: { value: 1000 }, advancedResearch: { value: 0 } } };
+    ctx.globalGameIsLoadingFromSave = false;
+    vm.createContext(ctx);
+    vm.runInContext(effectCode + researchCode + researchUICode + '; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.loadResearchCategory = loadResearchCategory; this.updateResearchUI = updateResearchUI;', ctx);
+
+    const params = {
+      energy: [
+        { id: 'a', name: 'A', description: 'A desc', cost: { research: 100 }, prerequisites: [], effects: [] },
+        { id: 'b', name: 'B', description: 'B desc', cost: { research: 200 }, prerequisites: [], effects: [] },
+        { id: 'c', name: 'C', description: 'C desc', cost: { research: 300 }, prerequisites: [], effects: [] },
+        { id: 'd', name: 'D', description: 'D desc', cost: { research: 400 }, prerequisites: [], effects: [] }
+      ],
+      industry: [],
+      colonization: [],
+      terraforming: [],
+      advanced: []
+    };
+
+    ctx.researchManager = new ctx.ResearchManager(params);
+    ctx.loadResearchCategory('energy');
+
+    let buttons = dom.window.document.querySelectorAll('.research-button');
+    let costs = dom.window.document.querySelectorAll('.research-cost');
+    let descs = dom.window.document.querySelectorAll('.research-description');
+
+    expect(buttons[3].textContent).toBe('???');
+    expect(costs[3].textContent).toBe('Cost: ???');
+    expect(descs[3].textContent).toBe('???');
+
+    ctx.researchManager.addAndReplace({ type: 'booleanFlag', flagId: 'stopHidingRegular', value: true });
+    ctx.updateResearchUI();
+
+    buttons = dom.window.document.querySelectorAll('.research-button');
+    costs = dom.window.document.querySelectorAll('.research-cost');
+    descs = dom.window.document.querySelectorAll('.research-description');
+
+    expect(buttons[3].textContent).toBe('D');
+    expect(costs[3].textContent).toBe('Cost:  Research Points');
+    expect(descs[3].textContent).toBe('D desc');
+  });
+});

--- a/tests/stopHidingRegularChapter.test.js
+++ b/tests/stopHidingRegularChapter.test.js
@@ -1,0 +1,13 @@
+const loadProgress = require('./loadProgress');
+
+describe('stop hiding regular research chapter', () => {
+  test('chapter4.2 sets stopHidingRegular flag', () => {
+    const ctx = {};
+    loadProgress(ctx);
+    const chapters = ctx.progressData.chapters;
+    const ch = chapters.find(c => c.id === 'chapter4.2');
+    expect(ch.reward).toBeDefined();
+    const flagEffect = ch.reward.find(r => r.target === 'researchManager' && r.type === 'booleanFlag' && r.flagId === 'stopHidingRegular' && r.value === true);
+    expect(flagEffect).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Show all non-advanced research once the space tab unlocks via new `stopHidingRegular` flag
- Mars chapter 4.2 sets this flag so regular research lines become visible
- Documented the behaviour and added regression tests

## Testing
- `npm ci`
- `CI=true npm test 2>&1 | tee test.log`

------
https://chatgpt.com/codex/tasks/task_b_68c6b51835308327a45727870e1b45af