### PR TITLE
Track partial autobuild via structure state

### DIFF
--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -60,6 +60,17 @@ const autobuildCostTracker = {
     }
 };
 
+function resetAutoBuildPartialFlags(structures) {
+    if (!structures) return;
+    for (const name in structures) {
+        if (!Object.prototype.hasOwnProperty.call(structures, name)) continue;
+        const structure = structures[name];
+        if (structure) {
+            structure.autoBuildPartial = false;
+        }
+    }
+}
+
 // Construction Office state and UI
 const constructionOfficeState = {
     autobuilderActive: true,
@@ -235,6 +246,7 @@ function restoreAutoBuildSettings(structures) {
 }
 
 function autoBuild(buildings, delta = 0) {
+    resetAutoBuildPartialFlags(buildings);
     if (typeof constructionOfficeState !== 'undefined' && !constructionOfficeState.autobuilderActive) {
         return;
     }
@@ -280,6 +292,9 @@ function autoBuild(buildings, delta = 0) {
         let buildCount = 0;
         const reserve = constructionOfficeState.strategicReserve;
         const canBuildFull = building.canAfford(requiredAmount, reserve);
+        if (!canBuildFull) {
+            building.autoBuildPartial = true;
+        }
         if (canBuildFull) {
             buildCount = requiredAmount;
         } else {

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -21,6 +21,7 @@ class Building extends EffectableEntity {
     this.autoBuildBasis = 'population';
     this.workerPriority = 0; // -1 low, 0 normal, 1 high
     this.autoActiveEnabled = false;
+    this.autoBuildPartial = false;
 
     this.maintenanceCost = this.calculateMaintenanceCost();
     this.currentProduction = {};

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -939,7 +939,16 @@ function updateDecreaseButtonText(button, buildCount) {
         const base = structure.autoBuildBasis === 'workers' ? workerCap : pop;
         const targetCount = Math.ceil((structure.autoBuildPercent * base || 0) / 100);
         const targetEl = els.autoBuildTarget || document.getElementById(`${structure.name}-auto-build-target`);
-        if (targetEl) targetEl.textContent = `Target : ${formatBigInteger(targetCount)}`;
+        if (targetEl) {
+          const targetText = `Target : ${formatBigInteger(targetCount)}`;
+          if (targetEl.textContent !== targetText) {
+            targetEl.textContent = targetText;
+          }
+          const targetColor = structure.autoBuildPartial ? 'orange' : '';
+          if (targetEl.style.color !== targetColor) {
+            targetEl.style.color = targetColor;
+          }
+        }
 
         if (els.autoBuildBasisSelect) {
           els.autoBuildBasisSelect.value = structure.autoBuildBasis || 'population';

--- a/tests/autobuildLandPartial.test.js
+++ b/tests/autobuildLandPartial.test.js
@@ -24,5 +24,6 @@ describe('autoBuild limited by land', () => {
     autoBuild({ c: building });
 
     expect(building.build).toHaveBeenCalledWith(5, false);
+    expect(building.autoBuildPartial).toBe(true);
   });
 });

--- a/tests/autobuildTargetColor.test.js
+++ b/tests/autobuildTargetColor.test.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+function setup() {
+  const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+
+  ctx.formatNumber = n => n;
+  ctx.formatBigInteger = n => String(n);
+  ctx.formatBuildingCount = n => String(n);
+  ctx.multiplyByTen = n => n * 10;
+  ctx.divideByTen = n => Math.max(1, Math.floor(n / 10));
+  ctx.resources = {
+    colony: {
+      colonists: { value: 50 },
+      workers: { value: 0, cap: 20 }
+    }
+  };
+  ctx.globalEffects = { isBooleanFlagSet: () => false };
+  ctx.dayNightCycle = { isNight: () => false, isDay: () => true };
+  ctx.toDisplayTemperature = () => 0;
+  ctx.getTemperatureUnit = () => 'K';
+  ctx.formatResourceDetails = () => '';
+  ctx.formatStorageDetails = () => '';
+  ctx.updateColonyDetailsDisplay = () => {};
+  ctx.updateUnhideButtons = () => {};
+  ctx.ghgFactorySettings = {
+    autoDisableAboveTemp: false,
+    disableTempThreshold: 0,
+    reverseTempThreshold: 0
+  };
+  ctx.oxygenFactorySettings = {
+    autoDisableAbovePressure: false,
+    disablePressureThreshold: 15
+  };
+  ctx.enforceGhgFactoryTempGap = () => {};
+  ctx.Colony = function Colony() {};
+  ctx.updateEmptyBuildingMessages = () => {};
+  ctx.updateBuildingDisplay = () => {};
+  ctx.gameSettings = {};
+  ctx.terraforming = null;
+
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+
+  const structure = {
+    name: 'testStruct',
+    displayName: 'Test',
+    canBeToggled: true,
+    count: 0,
+    active: 0,
+    unlocked: true,
+    isHidden: false,
+    obsolete: false,
+    requiresProductivity: false,
+    autoBuildEnabled: true,
+    autoBuildPercent: 10,
+    autoBuildPriority: false,
+    autoActiveEnabled: false,
+    autoBuildBasis: 'population',
+    autoBuildPartial: false,
+    getTotalWorkerNeed: () => 0,
+    getEffectiveWorkerMultiplier: () => 1,
+    getEffectiveCost: () => ({}),
+    canAfford: () => true,
+    canAffordLand: () => true,
+    requiresLand: 0,
+    landAffordCount: () => 10,
+    getModifiedStorage: () => ({}),
+    powerPerBuilding: null,
+    activeEffects: [],
+    getEffectiveProductionMultiplier: () => 1,
+    getModifiedProduction: () => ({}),
+    getModifiedConsumption: () => ({}),
+    requiresMaintenance: false,
+    maintenanceCost: {},
+    updateResourceStorage: () => {},
+    updateUI: () => {}
+  };
+
+  const row = ctx.createStructureRow(structure, () => {}, () => {}, false);
+  dom.window.document.body.appendChild(row);
+
+  return { dom, ctx, structure };
+}
+
+describe('auto-build target styling', () => {
+  test('target text turns orange when partial flag is set', () => {
+    const { dom, ctx, structure } = setup();
+    const structures = { [structure.name]: structure };
+    ctx.updateStructureDisplay(structures);
+    const target = dom.window.document.getElementById(`${structure.name}-auto-build-target`);
+    expect(target.style.color).toBe('');
+
+    structure.autoBuildPartial = true;
+    ctx.updateStructureDisplay(structures);
+    expect(target.style.color).toBe('orange');
+
+    structure.autoBuildPartial = false;
+    ctx.updateStructureDisplay(structures);
+    expect(target.style.color).toBe('');
+  });
+});

--- a/tests/autobuilderPause.test.js
+++ b/tests/autobuilderPause.test.js
@@ -18,8 +18,10 @@ describe('autobuilder global pause', () => {
 
     building.build.mockClear();
     constructionOfficeState.autobuilderActive = false;
+    building.autoBuildPartial = true;
     autoBuild({ A: building });
     expect(building.build).not.toHaveBeenCalled();
+    expect(building.autoBuildPartial).toBe(false);
 
     constructionOfficeState.autobuilderActive = true; // reset
   });


### PR DESCRIPTION
## Summary
- mark structures with an `autoBuildPartial` flag each tick so autobuild no longer touches the DOM directly
- let `updateStructureDisplay` color auto-build targets from that flag and initialize buildings with the new state
- cover the flag and styling behavior with updated and new tests

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c86d06617483278649a6da2d4e7cdc