### PR TITLE
Add terraforming world subtab and default view

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
     <div class="tab hidden" id="special-projects-tab" data-tab="special-projects">Special Projects<span id="projects-alert" class="unlock-alert">!</span></div>
     <div class="tab hidden" id="colonies-tab" data-tab="colonies">Colony</div>
     <div class="tab hidden" id="research-tab" data-tab="research">Research<span id="research-alert" class="unlock-alert">!</span></div>
-    <div class="tab hidden" id="terraforming-tab" data-tab="terraforming">Terraforming<span id="terraforming-alert" class="milestone-alert">!</span></div>
+    <div class="tab" id="terraforming-tab" data-tab="terraforming">Terraforming<span id="terraforming-alert" class="milestone-alert">!</span></div>
     <!-- *** NEW SPACE TAB BUTTON *** -->
     <div class="tab hidden" id="space-tab" data-tab="space">Space</div>
     <!-- *************************** -->
@@ -362,12 +362,14 @@
       <!-- ... existing terraforming content ... -->
        <div class="container">
         <div class="terraforming-subtabs">
-          <div class="terraforming-subtab active" data-subtab="summary-terraforming">Summary</div>
+          <div class="terraforming-subtab active" data-subtab="world-terraforming">World</div>
+          <div class="terraforming-subtab hidden" data-subtab="summary-terraforming">Summary</div>
           <div class="terraforming-subtab" data-subtab="life-terraforming">Life</div>
           <div class="terraforming-subtab" data-subtab="milestone-terraforming">Milestones<span id="milestone-subtab-alert" class="milestone-alert">!</span></div>
-      </div>
+        </div>
       <div class="terraforming-subtab-content-wrapper">
-          <div id = "summary-terraforming" class="terraforming-subtab-content active">
+          <div id="world-terraforming" class="terraforming-subtab-content active"></div>
+          <div id = "summary-terraforming" class="terraforming-subtab-content hidden">
               <div id="play-time-display">0 days</div>
                <!-- Terraforming UI goes here -->
           </div>
@@ -673,8 +675,10 @@
                 startNewGame();
             } else {
                 initializeGameState();
+                if (typeof openTerraformingWorldTab === 'function') {
+                    openTerraformingWorldTab();
+                }
             }
-            activateTab('settings');
         }
     });
 

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -110,6 +110,9 @@ function create() {
 
   if(!loadMostRecentSave()){  // Handle initial game state (building counts, etc.)
     initializeGameState();
+    if (typeof openTerraformingWorldTab === 'function') {
+      openTerraformingWorldTab();
+    }
   }
 }
 
@@ -460,5 +463,8 @@ function startNewGame() {
   currentPlanetParameters = planetParameters.mars;
   totalPlayTimeSeconds = 0;
   initializeGameState();
+  if (typeof openTerraformingWorldTab === 'function') {
+    openTerraformingWorldTab();
+  }
 }
 

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -994,6 +994,12 @@ const researchParameters = {
             onLoad : false
           },
           {
+            target: 'terraforming',
+            type: 'booleanFlag',
+            flagId: 'summaryUnlocked',
+            value: true
+          },
+          {
             target: 'resource',
             resourceType: 'surface',
             targetId : 'liquidWater',

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -462,7 +462,11 @@ function loadGame(slotOrCustomString) {
         totalPlayTimeSeconds = gameState.totalPlayTimeSeconds;
       }
 
-      tabManager.activateTab('buildings');
+      if (typeof openTerraformingWorldTab === 'function') {
+        openTerraformingWorldTab();
+      } else if (tabManager && typeof tabManager.activateTab === 'function') {
+        tabManager.activateTab('terraforming');
+      }
 
     if(typeof applyDayNightSettingEffects === 'function'){
       applyDayNightSettingEffects();

--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -28,7 +28,7 @@ const tabParameters = {
         id: "terraforming-tab",
         label: "Terraforming",
         isActive: false,
-        isHidden: true // Hidden initially
+        isHidden: false // Visible by default
       },
       {
         id: "space-tab",

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -134,6 +134,7 @@ class Terraforming extends EffectableEntity{
     super({ description: 'This module manages all terraforming compononents' });
 
     this.resources = resources;
+    this.summaryUnlocked = false;
     this.initialLand = resources.surface?.land?.value || 0;
 
     // Clone so config values remain immutable
@@ -922,7 +923,27 @@ class Terraforming extends EffectableEntity{
       this.updateSurfaceRadiation();
 
     } // <-- Correct closing brace for the 'update' method
-  
+
+    applyBooleanFlag(effect) {
+      super.applyBooleanFlag(effect);
+      if (effect.flagId === 'summaryUnlocked' && typeof setTerraformingSummaryVisibility === 'function') {
+        setTerraformingSummaryVisibility(!!effect.value);
+      }
+    }
+
+    removeEffect(effect) {
+      const result = super.removeEffect(effect);
+      if (
+        effect.type === 'booleanFlag' &&
+        effect.flagId === 'summaryUnlocked' &&
+        !this.summaryUnlocked &&
+        typeof setTerraformingSummaryVisibility === 'function'
+      ) {
+        setTerraformingSummaryVisibility(false);
+      }
+      return result;
+    }
+
     unlock(aspect) {
       if (this[aspect]) {
         this[aspect].unlocked = true;
@@ -931,6 +952,9 @@ class Terraforming extends EffectableEntity{
 
     initializeTerraforming(){
         initializeTerraformingTabs();
+        if (typeof setTerraformingSummaryVisibility === 'function') {
+          setTerraformingSummaryVisibility(this.summaryUnlocked);
+        }
         createTerraformingSummaryUI();
         if(!this.initialValuesCalculated){
           this.calculateInitialValues(currentPlanetParameters);

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -17,6 +17,52 @@ function getGasRangeString(gasName) {
 let terraformingTabsInitialized = false;
 let terraformingSummaryInitialized = false;
 
+const terraformingTabElements = {
+  subtabs: [],
+  contents: [],
+  buttonMap: {},
+  contentMap: {},
+  summaryButton: null,
+  summaryContent: null,
+  worldButton: null,
+  worldContent: null,
+};
+
+function cacheTerraformingTabElements() {
+  if (terraformingTabElements.subtabs.length > 0) {
+    return terraformingTabElements;
+  }
+
+  const subtabs = Array.from(document.getElementsByClassName('terraforming-subtab'));
+  const contents = Array.from(document.getElementsByClassName('terraforming-subtab-content'));
+
+  terraformingTabElements.subtabs = subtabs;
+  terraformingTabElements.contents = contents;
+  terraformingTabElements.buttonMap = {};
+  terraformingTabElements.contentMap = {};
+
+  subtabs.forEach((subtab) => {
+    const id = subtab?.dataset?.subtab;
+    if (id) {
+      terraformingTabElements.buttonMap[id] = subtab;
+    }
+  });
+
+  contents.forEach((content) => {
+    const id = content?.id;
+    if (id) {
+      terraformingTabElements.contentMap[id] = content;
+    }
+  });
+
+  terraformingTabElements.summaryButton = terraformingTabElements.buttonMap['summary-terraforming'] || null;
+  terraformingTabElements.summaryContent = terraformingTabElements.contentMap['summary-terraforming'] || null;
+  terraformingTabElements.worldButton = terraformingTabElements.buttonMap['world-terraforming'] || null;
+  terraformingTabElements.worldContent = terraformingTabElements.contentMap['world-terraforming'] || null;
+
+  return terraformingTabElements;
+}
+
 const terraformingUICache = {
   temperature: {},
   atmosphere: {},
@@ -28,42 +74,100 @@ const terraformingUICache = {
 
 function resetTerraformingUI() {
   terraformingSummaryInitialized = false;
+  terraformingTabsInitialized = false;
+  terraformingTabElements.subtabs = [];
+  terraformingTabElements.contents = [];
+  terraformingTabElements.buttonMap = {};
+  terraformingTabElements.contentMap = {};
+  terraformingTabElements.summaryButton = null;
+  terraformingTabElements.summaryContent = null;
+  terraformingTabElements.worldButton = null;
+  terraformingTabElements.worldContent = null;
   Object.keys(terraformingUICache).forEach(key => {
     terraformingUICache[key] = {};
   });
 }
 
 function initializeTerraformingTabs() {
+  cacheTerraformingTabElements();
+
   if (terraformingTabsInitialized) {
     return;
   }
 
   // Set up event listeners for terraforming sub-tabs
-  document.querySelectorAll('.terraforming-subtab').forEach(subtab => {
-      subtab.addEventListener('click', () => {
-          const subtabContentId = subtab.dataset.subtab;
-          activateTerraformingSubtab(subtabContentId);
-      });
+  terraformingTabElements.subtabs.forEach((subtab) => {
+    if (!subtab) {
+      return;
+    }
+    subtab.addEventListener('click', () => {
+      const subtabContentId = subtab?.dataset?.subtab;
+      if (subtabContentId) {
+        activateTerraformingSubtab(subtabContentId);
+      }
+    });
   });
 
-  // Activate the 'energy' category
-  activateTerraformingSubtab('summary-terraforming');
+  // Activate the default subtab
+  activateTerraformingSubtab('world-terraforming');
 
   terraformingTabsInitialized = true;
 }
 
 function activateTerraformingSubtab(subtabId) {
-  // Remove active class from all subtabs and subtab-contents
-  document.querySelectorAll('.terraforming-subtab').forEach((t) => t.classList.remove('active'));
-  document.querySelectorAll('.terraforming-subtab-content').forEach((t) => t.classList.remove('active'));
-  
-  // Add active class to the clicked subtab and corresponding content
-  document.querySelector(`[data-subtab="${subtabId}"]`).classList.add('active');
-  document.getElementById(subtabId).classList.add('active');
+  cacheTerraformingTabElements();
 
-  if(subtabId === 'milestone-terraforming' && typeof markMilestonesViewed === 'function') {
+  const tab = terraformingTabElements.buttonMap[subtabId] || null;
+  const content = terraformingTabElements.contentMap[subtabId] || null;
+
+  if (!tab || tab.classList.contains('hidden')) {
+    if (subtabId !== 'world-terraforming') {
+      activateTerraformingSubtab('world-terraforming');
+    }
+    return;
+  }
+
+  terraformingTabElements.subtabs.forEach((t) => t?.classList.remove('active'));
+  terraformingTabElements.contents.forEach((c) => c?.classList.remove('active'));
+
+  tab.classList.add('active');
+  if (content) {
+    content.classList.add('active');
+  }
+
+  if (subtabId === 'milestone-terraforming' && typeof markMilestonesViewed === 'function') {
     markMilestonesViewed();
   }
+}
+
+function setTerraformingSummaryVisibility(unlocked) {
+  cacheTerraformingTabElements();
+
+  const { summaryButton, summaryContent } = terraformingTabElements;
+  if (!summaryButton || !summaryContent) {
+    return;
+  }
+
+  if (unlocked) {
+    summaryButton.classList.remove('hidden');
+    summaryContent.classList.remove('hidden');
+  } else {
+    summaryButton.classList.add('hidden');
+    summaryContent.classList.add('hidden');
+    if (summaryButton.classList.contains('active') || summaryContent.classList.contains('active')) {
+      activateTerraformingSubtab('world-terraforming');
+    }
+  }
+}
+
+function openTerraformingWorldTab() {
+  initializeTerraformingTabs();
+  if (typeof tabManager !== 'undefined' && tabManager && typeof tabManager.activateTab === 'function') {
+    tabManager.activateTab('terraforming');
+  } else if (typeof activateTab === 'function') {
+    activateTab('terraforming');
+  }
+  activateTerraformingSubtab('world-terraforming');
 }
 
 function createTerraformingSummaryUI() {

--- a/tests/terraformingWorldSubtab.test.js
+++ b/tests/terraformingWorldSubtab.test.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+function loadTerraformingUI() {
+  const dom = new JSDOM(`<!DOCTYPE html>
+    <div class="terraforming-subtabs">
+      <div class="terraforming-subtab active" data-subtab="world-terraforming"></div>
+      <div class="terraforming-subtab hidden" data-subtab="summary-terraforming"></div>
+      <div class="terraforming-subtab" data-subtab="milestone-terraforming"></div>
+    </div>
+    <div class="terraforming-subtab-content-wrapper">
+      <div id="world-terraforming" class="terraforming-subtab-content active"></div>
+      <div id="summary-terraforming" class="terraforming-subtab-content hidden"></div>
+      <div id="milestone-terraforming" class="terraforming-subtab-content"></div>
+    </div>`, { runScripts: 'outside-only' });
+
+  const ctx = dom.getInternalVMContext();
+  ctx.window = dom.window;
+  ctx.document = dom.window.document;
+  ctx.markMilestonesViewed = () => {};
+
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'terraforming', 'terraformingUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+
+  return { dom, ctx };
+}
+
+describe('Terraforming world subtab', () => {
+  test('locks summary until unlocked', () => {
+    const { dom, ctx } = loadTerraformingUI();
+    ctx.initializeTerraformingTabs();
+
+    const summaryButton = dom.window.document.querySelector('[data-subtab="summary-terraforming"]');
+    const summaryContent = dom.window.document.getElementById('summary-terraforming');
+    const worldContent = dom.window.document.getElementById('world-terraforming');
+
+    ctx.setTerraformingSummaryVisibility(true);
+    ctx.activateTerraformingSubtab('summary-terraforming');
+
+    expect(summaryButton.classList.contains('hidden')).toBe(false);
+    expect(summaryContent.classList.contains('hidden')).toBe(false);
+    expect(summaryContent.classList.contains('active')).toBe(true);
+
+    ctx.setTerraformingSummaryVisibility(false);
+
+    expect(summaryButton.classList.contains('hidden')).toBe(true);
+    expect(summaryContent.classList.contains('hidden')).toBe(true);
+    expect(summaryContent.classList.contains('active')).toBe(false);
+    expect(worldContent.classList.contains('active')).toBe(true);
+  });
+
+  test('openTerraformingWorldTab activates terraforming tab', () => {
+    const { dom, ctx } = loadTerraformingUI();
+    const activatedTabs = [];
+    ctx.tabManager = { activateTab: (id) => activatedTabs.push(id) };
+
+    ctx.openTerraformingWorldTab();
+
+    expect(activatedTabs).toEqual(['terraforming']);
+    const worldContent = dom.window.document.getElementById('world-terraforming');
+    expect(worldContent.classList.contains('active')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a default-visible terraforming tab with a new World subtab that is active and empty by default
- hide the summary subtab until terraforming measurements are researched and track the unlock via terraforming boolean flags
- ensure new games and loads open the terraforming world view and cover the new behavior with focused UI tests

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c86c81cf688327936d8675e5440de9