### PR TITLE
Preserve space storage priority selection through travel

### DIFF
--- a/src/js/projects/SpaceStorageProject.js
+++ b/src/js/projects/SpaceStorageProject.js
@@ -500,6 +500,7 @@ class SpaceStorageProject extends SpaceshipProject {
       repeatCount: this.repeatCount,
       usedStorage: this.usedStorage,
       resourceUsage: this.resourceUsage,
+      prioritizeMegaProjects: this.prioritizeMegaProjects,
     };
   }
 
@@ -507,6 +508,7 @@ class SpaceStorageProject extends SpaceshipProject {
     this.repeatCount = state.repeatCount || 0;
     this.usedStorage = state.usedStorage || 0;
     this.resourceUsage = state.resourceUsage || {};
+    this.prioritizeMegaProjects = state.prioritizeMegaProjects || false;
   }
 }
 

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -555,6 +555,7 @@ describe('Space Storage project', () => {
     project.repeatCount = 4;
     project.usedStorage = 500;
     project.resourceUsage = { metal: 300 };
+    project.prioritizeMegaProjects = true;
 
     const saved = project.saveTravelState();
     const loaded = new ctx.SpaceStorageProject(params, 'spaceStorage');
@@ -563,6 +564,7 @@ describe('Space Storage project', () => {
     expect(loaded.repeatCount).toBe(4);
     expect(loaded.usedStorage).toBe(500);
     expect(loaded.resourceUsage.metal).toBe(300);
+    expect(loaded.prioritizeMegaProjects).toBe(true);
   });
 
   test('transfers resources continuously based on mode', () => {


### PR DESCRIPTION
## Summary
- include the space storage prioritize-mega-projects flag when saving and restoring travel state so the checkbox survives planet transitions
- extend the travel state persistence test to cover the priority checkbox

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68c8718490fc8327aaeca252594bd528