### PR TITLE
Hide life terraforming subtab until life research unlock

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
         <div class="terraforming-subtabs">
           <div class="terraforming-subtab active" data-subtab="world-terraforming">World</div>
           <div class="terraforming-subtab hidden" data-subtab="summary-terraforming">Summary</div>
-          <div class="terraforming-subtab" data-subtab="life-terraforming">Life</div>
+          <div class="terraforming-subtab hidden" data-subtab="life-terraforming">Life</div>
           <div class="terraforming-subtab" data-subtab="milestone-terraforming">Milestones<span id="milestone-subtab-alert" class="milestone-alert">!</span></div>
         </div>
       <div class="terraforming-subtab-content-wrapper">
@@ -373,7 +373,7 @@
               <div id="play-time-display">0 days</div>
                <!-- Terraforming UI goes here -->
           </div>
-          <div id = "life-terraforming" class="terraforming-subtab-content">
+          <div id = "life-terraforming" class="terraforming-subtab-content hidden">
             <h2>Life</h2>
              <!-- Life UI goes here -->
           </div>

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1184,6 +1184,12 @@ const researchParameters = {
           {
             target: 'lifeDesigner',
             type: 'enable'
+          },
+          {
+            target: 'terraforming',
+            type: 'booleanFlag',
+            flagId: 'lifeDesignerUnlocked',
+            value: true
           }
         ],
       },

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -135,6 +135,7 @@ class Terraforming extends EffectableEntity{
 
     this.resources = resources;
     this.summaryUnlocked = false;
+    this.lifeDesignerUnlocked = false;
     this.initialLand = resources.surface?.land?.value || 0;
 
     // Clone so config values remain immutable
@@ -929,6 +930,9 @@ class Terraforming extends EffectableEntity{
       if (effect.flagId === 'summaryUnlocked' && typeof setTerraformingSummaryVisibility === 'function') {
         setTerraformingSummaryVisibility(!!effect.value);
       }
+      if (effect.flagId === 'lifeDesignerUnlocked' && typeof setTerraformingLifeVisibility === 'function') {
+        setTerraformingLifeVisibility(!!effect.value);
+      }
     }
 
     removeEffect(effect) {
@@ -940,6 +944,14 @@ class Terraforming extends EffectableEntity{
         typeof setTerraformingSummaryVisibility === 'function'
       ) {
         setTerraformingSummaryVisibility(false);
+      }
+      if (
+        effect.type === 'booleanFlag' &&
+        effect.flagId === 'lifeDesignerUnlocked' &&
+        !this.lifeDesignerUnlocked &&
+        typeof setTerraformingLifeVisibility === 'function'
+      ) {
+        setTerraformingLifeVisibility(false);
       }
       return result;
     }
@@ -954,6 +966,9 @@ class Terraforming extends EffectableEntity{
         initializeTerraformingTabs();
         if (typeof setTerraformingSummaryVisibility === 'function') {
           setTerraformingSummaryVisibility(this.summaryUnlocked);
+        }
+        if (typeof setTerraformingLifeVisibility === 'function') {
+          setTerraformingLifeVisibility(this.lifeDesignerUnlocked);
         }
         createTerraformingSummaryUI();
         if(!this.initialValuesCalculated){

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -26,6 +26,8 @@ const terraformingTabElements = {
   summaryContent: null,
   worldButton: null,
   worldContent: null,
+  lifeButton: null,
+  lifeContent: null,
 };
 
 function cacheTerraformingTabElements() {
@@ -59,6 +61,8 @@ function cacheTerraformingTabElements() {
   terraformingTabElements.summaryContent = terraformingTabElements.contentMap['summary-terraforming'] || null;
   terraformingTabElements.worldButton = terraformingTabElements.buttonMap['world-terraforming'] || null;
   terraformingTabElements.worldContent = terraformingTabElements.contentMap['world-terraforming'] || null;
+  terraformingTabElements.lifeButton = terraformingTabElements.buttonMap['life-terraforming'] || null;
+  terraformingTabElements.lifeContent = terraformingTabElements.contentMap['life-terraforming'] || null;
 
   return terraformingTabElements;
 }
@@ -83,6 +87,8 @@ function resetTerraformingUI() {
   terraformingTabElements.summaryContent = null;
   terraformingTabElements.worldButton = null;
   terraformingTabElements.worldContent = null;
+  terraformingTabElements.lifeButton = null;
+  terraformingTabElements.lifeContent = null;
   Object.keys(terraformingUICache).forEach(key => {
     terraformingUICache[key] = {};
   });
@@ -155,6 +161,26 @@ function setTerraformingSummaryVisibility(unlocked) {
     summaryButton.classList.add('hidden');
     summaryContent.classList.add('hidden');
     if (summaryButton.classList.contains('active') || summaryContent.classList.contains('active')) {
+      activateTerraformingSubtab('world-terraforming');
+    }
+  }
+}
+
+function setTerraformingLifeVisibility(unlocked) {
+  cacheTerraformingTabElements();
+
+  const { lifeButton, lifeContent } = terraformingTabElements;
+  if (!lifeButton || !lifeContent) {
+    return;
+  }
+
+  if (unlocked) {
+    lifeButton.classList.remove('hidden');
+    lifeContent.classList.remove('hidden');
+  } else {
+    lifeButton.classList.add('hidden');
+    lifeContent.classList.add('hidden');
+    if (lifeButton.classList.contains('active') || lifeContent.classList.contains('active')) {
       activateTerraformingSubtab('world-terraforming');
     }
   }

--- a/tests/lifeTerraformingUnlockResearch.test.js
+++ b/tests/lifeTerraformingUnlockResearch.test.js
@@ -1,0 +1,15 @@
+const researchParameters = require('../src/js/research-parameters.js');
+
+describe('Life research unlocks terraforming life subtab', () => {
+  test('Life Designing and Production enables terraforming life subtab flag', () => {
+    const lifeResearch = (researchParameters.terraforming || []).find(r => r.id === 'life');
+    expect(lifeResearch).toBeDefined();
+    const unlocksLifeSubtab = lifeResearch.effects.some(effect =>
+      effect.target === 'terraforming' &&
+      effect.type === 'booleanFlag' &&
+      effect.flagId === 'lifeDesignerUnlocked' &&
+      effect.value === true
+    );
+    expect(unlocksLifeSubtab).toBe(true);
+  });
+});

--- a/tests/terraformingWorldSubtab.test.js
+++ b/tests/terraformingWorldSubtab.test.js
@@ -9,11 +9,13 @@ function loadTerraformingUI() {
     <div class="terraforming-subtabs">
       <div class="terraforming-subtab active" data-subtab="world-terraforming"></div>
       <div class="terraforming-subtab hidden" data-subtab="summary-terraforming"></div>
+      <div class="terraforming-subtab hidden" data-subtab="life-terraforming"></div>
       <div class="terraforming-subtab" data-subtab="milestone-terraforming"></div>
     </div>
     <div class="terraforming-subtab-content-wrapper">
       <div id="world-terraforming" class="terraforming-subtab-content active"></div>
       <div id="summary-terraforming" class="terraforming-subtab-content hidden"></div>
+      <div id="life-terraforming" class="terraforming-subtab-content hidden"></div>
       <div id="milestone-terraforming" class="terraforming-subtab-content"></div>
     </div>`, { runScripts: 'outside-only' });
 
@@ -49,6 +51,33 @@ describe('Terraforming world subtab', () => {
     expect(summaryButton.classList.contains('hidden')).toBe(true);
     expect(summaryContent.classList.contains('hidden')).toBe(true);
     expect(summaryContent.classList.contains('active')).toBe(false);
+    expect(worldContent.classList.contains('active')).toBe(true);
+  });
+
+  test('life subtab unlock toggles visibility', () => {
+    const { dom, ctx } = loadTerraformingUI();
+    ctx.initializeTerraformingTabs();
+
+    const lifeButton = dom.window.document.querySelector('[data-subtab="life-terraforming"]');
+    const lifeContent = dom.window.document.getElementById('life-terraforming');
+    const worldContent = dom.window.document.getElementById('world-terraforming');
+
+    expect(lifeButton.classList.contains('hidden')).toBe(true);
+    expect(lifeContent.classList.contains('hidden')).toBe(true);
+
+    ctx.setTerraformingLifeVisibility(true);
+
+    expect(lifeButton.classList.contains('hidden')).toBe(false);
+    expect(lifeContent.classList.contains('hidden')).toBe(false);
+
+    ctx.activateTerraformingSubtab('life-terraforming');
+    expect(lifeContent.classList.contains('active')).toBe(true);
+
+    ctx.setTerraformingLifeVisibility(false);
+
+    expect(lifeButton.classList.contains('hidden')).toBe(true);
+    expect(lifeContent.classList.contains('hidden')).toBe(true);
+    expect(lifeContent.classList.contains('active')).toBe(false);
     expect(worldContent.classList.contains('active')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- hide the terraforming life subtab button and content until the life designer is unlocked
- toggle the life subtab via a terraforming boolean flag that Life Designing and Production now sets
- cover the new behaviour with UI and research parameter tests

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c8721baad48327acb9594e87427c75