### PR TITLE
Hide milestones subtab until terraforming research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 # Instructions
 - Document major feature updates in this file.
+- Milestones subtab remains hidden until Terraforming measurements research is completed.
 - Keep imports and exports browser friendly for loading via **index.html**.
 - The game needs to be able to run from a browser-like environment.
 - Place story projects in **progress-data.js** near the chapter where they unlock.

--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@
           <div class="terraforming-subtab active" data-subtab="world-terraforming">World</div>
           <div class="terraforming-subtab hidden" data-subtab="summary-terraforming">Summary</div>
           <div class="terraforming-subtab hidden" data-subtab="life-terraforming">Life</div>
-          <div class="terraforming-subtab" data-subtab="milestone-terraforming">Milestones<span id="milestone-subtab-alert" class="milestone-alert">!</span></div>
+          <div class="terraforming-subtab hidden" data-subtab="milestone-terraforming">Milestones<span id="milestone-subtab-alert" class="milestone-alert">!</span></div>
         </div>
       <div class="terraforming-subtab-content-wrapper">
           <div id="world-terraforming" class="terraforming-subtab-content active"></div>
@@ -380,7 +380,7 @@
             <h2>Life</h2>
              <!-- Life UI goes here -->
           </div>
-          <div id = "milestone-terraforming" class="terraforming-subtab-content">
+          <div id = "milestone-terraforming" class="terraforming-subtab-content hidden">
             <h2>Milestones</h2>
             <div class="milestone-options">
                 <label><input type="checkbox" id="milestone-silence-toggle"> Silence milestone alert</label>

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1000,6 +1000,12 @@ const researchParameters = {
             value: true
           },
           {
+            target: 'terraforming',
+            type: 'booleanFlag',
+            flagId: 'milestonesUnlocked',
+            value: true
+          },
+          {
             target: 'resource',
             resourceType: 'surface',
             targetId : 'liquidWater',

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -136,6 +136,7 @@ class Terraforming extends EffectableEntity{
     this.resources = resources;
     this.summaryUnlocked = false;
     this.lifeDesignerUnlocked = false;
+    this.milestonesUnlocked = false;
     this.initialLand = resources.surface?.land?.value || 0;
 
     // Clone so config values remain immutable
@@ -933,6 +934,9 @@ class Terraforming extends EffectableEntity{
       if (effect.flagId === 'lifeDesignerUnlocked' && typeof setTerraformingLifeVisibility === 'function') {
         setTerraformingLifeVisibility(!!effect.value);
       }
+      if (effect.flagId === 'milestonesUnlocked' && typeof setTerraformingMilestonesVisibility === 'function') {
+        setTerraformingMilestonesVisibility(!!effect.value);
+      }
     }
 
     removeEffect(effect) {
@@ -953,6 +957,14 @@ class Terraforming extends EffectableEntity{
       ) {
         setTerraformingLifeVisibility(false);
       }
+      if (
+        effect.type === 'booleanFlag' &&
+        effect.flagId === 'milestonesUnlocked' &&
+        !this.milestonesUnlocked &&
+        typeof setTerraformingMilestonesVisibility === 'function'
+      ) {
+        setTerraformingMilestonesVisibility(false);
+      }
       return result;
     }
 
@@ -969,6 +981,9 @@ class Terraforming extends EffectableEntity{
         }
         if (typeof setTerraformingLifeVisibility === 'function') {
           setTerraformingLifeVisibility(this.lifeDesignerUnlocked);
+        }
+        if (typeof setTerraformingMilestonesVisibility === 'function') {
+          setTerraformingMilestonesVisibility(this.milestonesUnlocked);
         }
         createTerraformingSummaryUI();
         if(!this.initialValuesCalculated){

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -29,6 +29,8 @@ const terraformingTabElements = {
   worldContent: null,
   lifeButton: null,
   lifeContent: null,
+  milestonesButton: null,
+  milestonesContent: null,
 };
 
 function cacheTerraformingTabElements() {
@@ -64,6 +66,8 @@ function cacheTerraformingTabElements() {
   terraformingTabElements.worldContent = terraformingTabElements.contentMap['world-terraforming'] || null;
   terraformingTabElements.lifeButton = terraformingTabElements.buttonMap['life-terraforming'] || null;
   terraformingTabElements.lifeContent = terraformingTabElements.contentMap['life-terraforming'] || null;
+  terraformingTabElements.milestonesButton = terraformingTabElements.buttonMap['milestone-terraforming'] || null;
+  terraformingTabElements.milestonesContent = terraformingTabElements.contentMap['milestone-terraforming'] || null;
 
   return terraformingTabElements;
 }
@@ -90,6 +94,8 @@ function resetTerraformingUI() {
   terraformingTabElements.worldContent = null;
   terraformingTabElements.lifeButton = null;
   terraformingTabElements.lifeContent = null;
+  terraformingTabElements.milestonesButton = null;
+  terraformingTabElements.milestonesContent = null;
   Object.keys(terraformingUICache).forEach(key => {
     terraformingUICache[key] = {};
   });
@@ -186,6 +192,26 @@ function setTerraformingLifeVisibility(unlocked) {
     lifeButton.classList.add('hidden');
     lifeContent.classList.add('hidden');
     if (lifeButton.classList.contains('active') || lifeContent.classList.contains('active')) {
+      activateTerraformingSubtab('world-terraforming');
+    }
+  }
+}
+
+function setTerraformingMilestonesVisibility(unlocked) {
+  cacheTerraformingTabElements();
+
+  const { milestonesButton, milestonesContent } = terraformingTabElements;
+  if (!milestonesButton || !milestonesContent) {
+    return;
+  }
+
+  if (unlocked) {
+    milestonesButton.classList.remove('hidden');
+    milestonesContent.classList.remove('hidden');
+  } else {
+    milestonesButton.classList.add('hidden');
+    milestonesContent.classList.add('hidden');
+    if (milestonesButton.classList.contains('active') || milestonesContent.classList.contains('active')) {
       activateTerraformingSubtab('world-terraforming');
     }
   }


### PR DESCRIPTION
## Summary
- hide the terraforming Milestones subtab and content until explicitly unlocked
- toggle the new `milestonesUnlocked` flag when Terraforming measurements research completes so the UI reappears
- note the unlock condition in AGENTS.md for future contributors

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68c875c9d0948327a3a16f156ebfff20