### PR TITLE
Fix zonal resource disposal handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -521,3 +521,4 @@ The Random World Generator manager builds procedural planets and moons with lock
 - Space mirror facility now provides quick build buttons for mirrors and lanterns beneath their status cards.
 - Mirror and lantern quick build controls only appear once the Space Mirror Facility project is complete.
 - Regular researches remain fully visible after unlocking the space tab via a `stopHidingRegular` flag on the ResearchManager.
+- Resource disposal now removes zonal surface stores proportionally for discrete and continuous runs.

--- a/tests/spaceDisposalProject.test.js
+++ b/tests/spaceDisposalProject.test.js
@@ -3,19 +3,46 @@ const path = require('path');
 const vm = require('vm');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 
+function createDisposalContext() {
+  const ctx = {
+    console,
+    EffectableEntity,
+    shipEfficiency: 1,
+    projectElements: {},
+    formatNumber: n => n,
+    formatBigInteger: n => n,
+    formatTotalCostDisplay: () => '',
+    formatTotalResourceGainDisplay: () => '',
+    formatTotalMaintenanceDisplay: () => '',
+    calculateProjectProductivities: () => ({}),
+  };
+  vm.createContext(ctx);
+
+  const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+  const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
+  vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
+  const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
+  vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
+  const disposalSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceDisposalProject.js'), 'utf8');
+  vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+
+  ctx.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+  ctx.ZONES = ['tropical', 'temperate', 'polar'];
+  return ctx;
+}
+
+function createResource(value) {
+  return {
+    value,
+    increase(amount) { this.value += amount; },
+    decrease(amount) { this.value = Math.max(0, this.value - amount); },
+  };
+}
+
 describe('SpaceDisposalProject', () => {
   test('initializes from parameters and calculates disposal', () => {
-    const ctx = { console, EffectableEntity, shipEfficiency: 1 };
-    vm.createContext(ctx);
-
-    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
-    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
-    const spaceshipCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceshipProject.js'), 'utf8');
-    vm.runInContext(spaceshipCode + '; this.SpaceshipProject = SpaceshipProject;', ctx);
-    const exportBase = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceExportBaseProject.js'), 'utf8');
-    vm.runInContext(exportBase + '; this.SpaceExportBaseProject = SpaceExportBaseProject;', ctx);
-    const disposalSubclass = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'SpaceDisposalProject.js'), 'utf8');
-    vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
+    const ctx = createDisposalContext();
     const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
     vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
 
@@ -30,5 +57,120 @@ describe('SpaceDisposalProject', () => {
     const disposal = project.calculateSpaceshipTotalDisposal();
 
     expect(disposal.surface.liquidWater).toBeCloseTo(config.attributes.disposalAmount);
+  });
+
+  test('discrete disposal removes zonal water proportionally', () => {
+    const ctx = createDisposalContext();
+    ctx.resources = {
+      surface: { liquidWater: createResource(1000) },
+      colony: {},
+      special: { spaceships: { value: 200 } },
+      atmospheric: {},
+    };
+    ctx.terraforming = {
+      zonalWater: {
+        tropical: { liquid: 600, ice: 0 },
+        temperate: { liquid: 300, ice: 0 },
+        polar: { liquid: 100, ice: 0 },
+      },
+      zonalCO2: {
+        tropical: { ice: 0, liquid: 0 },
+        temperate: { ice: 0, liquid: 0 },
+        polar: { ice: 0, liquid: 0 },
+      },
+      zonalSurface: {},
+    };
+
+    const config = {
+      name: 'dispose',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        costPerShip: {},
+        disposalAmount: 400,
+        disposable: { surface: ['liquidWater'] },
+        defaultDisposal: { category: 'surface', resource: 'liquidWater' },
+      },
+    };
+
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    ctx.projectManager.projects.dispose = project;
+
+    project.assignSpaceships(50);
+    expect(project.isContinuous()).toBe(false);
+
+    const started = project.start(ctx.resources);
+    expect(started).toBe(true);
+
+    expect(ctx.terraforming.zonalWater.tropical.liquid).toBeCloseTo(360);
+    expect(ctx.terraforming.zonalWater.temperate.liquid).toBeCloseTo(180);
+    expect(ctx.terraforming.zonalWater.polar.liquid).toBeCloseTo(60);
+    expect(ctx.resources.surface.liquidWater.value).toBeCloseTo(600);
+  });
+
+  test('continuous disposal removes zonal water each tick', () => {
+    const ctx = createDisposalContext();
+    ctx.resources = {
+      surface: { liquidWater: createResource(20000) },
+      colony: {},
+      special: { spaceships: { value: 400 } },
+      atmospheric: {},
+    };
+    ctx.terraforming = {
+      zonalWater: {
+        tropical: { liquid: 12000, ice: 0 },
+        temperate: { liquid: 6000, ice: 0 },
+        polar: { liquid: 2000, ice: 0 },
+      },
+      zonalCO2: {
+        tropical: { ice: 0, liquid: 0 },
+        temperate: { ice: 0, liquid: 0 },
+        polar: { ice: 0, liquid: 0 },
+      },
+      zonalSurface: {},
+    };
+
+    const config = {
+      name: 'dispose',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: true,
+      maxRepeatCount: Infinity,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        costPerShip: {},
+        disposalAmount: 100,
+        disposable: { surface: ['liquidWater'] },
+        defaultDisposal: { category: 'surface', resource: 'liquidWater' },
+      },
+    };
+
+    const project = new ctx.SpaceDisposalProject(config, 'dispose');
+    ctx.projectManager.projects.dispose = project;
+
+    project.assignSpaceships(150);
+    expect(project.isContinuous()).toBe(true);
+    project.start(ctx.resources);
+
+    const accumulatedChanges = {
+      surface: { liquidWater: 0 },
+      colony: { funding: 0 },
+    };
+
+    project.applyCostAndGain(1000, accumulatedChanges, 1);
+
+    expect(accumulatedChanges.surface.liquidWater).toBeCloseTo(-15000);
+    expect(ctx.terraforming.zonalWater.tropical.liquid).toBeCloseTo(3000);
+    expect(ctx.terraforming.zonalWater.temperate.liquid).toBeCloseTo(1500);
+    expect(ctx.terraforming.zonalWater.polar.liquid).toBeCloseTo(500);
   });
 });


### PR DESCRIPTION
## Summary
- distribute space disposal removals across zonal surface stores and clamp actual removal in discrete and continuous modes
- update disposal shortfall tracking and funding calculations to use the actual exported amount and added targeted tests

## Testing
- `CI=true npm test 2>&1 | tee test.log`


------
https://chatgpt.com/codex/tasks/task_b_68c8a4c08ce48327843bc4a91625271c