### PR TITLE
Adjust game illumination scaling

### DIFF
--- a/src/js/planet-visualizer.js
+++ b/src/js/planet-visualizer.js
@@ -924,7 +924,7 @@
     getGameIllumination() {
       const flux = this.terraforming?.luminosity?.modifiedSolarFlux;
       if (typeof flux === 'number' && Number.isFinite(flux)) {
-        return Math.max(0, flux) / 1000;
+        return Math.max(0, flux) / 250;
       }
       if (typeof currentPlanetParameters !== 'undefined' && currentPlanetParameters?.celestialParameters) {
         const fallback = currentPlanetParameters.celestialParameters.starLuminosity;


### PR DESCRIPTION
## Summary
- scale the game illumination calculation by dividing the solar flux by 250 instead of 1000 to brighten the visualization

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c8bc2efc8883279a62bc771b5ea437