### PR TITLE
Add planet base color support to visualizer

### DIFF
--- a/src/css/planet-visualizer.css
+++ b/src/css/planet-visualizer.css
@@ -46,7 +46,8 @@
 
 .pv-row-label { color: #bbb; }
 .pv-row-value { text-align: right; overflow: hidden; }
-.pv-row-value input[type="number"] {
+.pv-row-value input[type="number"],
+.pv-row-value input[type="text"] {
   width: 100%;
   min-width: 0;
   height: 20px;
@@ -72,6 +73,18 @@
   min-width: 0;
   max-width: 100%;
   box-sizing: border-box;
+}
+.planet-visualizer-debug input[type="color"] {
+  width: 100%;
+  min-width: 0;
+  height: 24px;
+  padding: 0;
+  border: 1px solid #555;
+  background: #1b1b1b;
+  border-radius: 3px;
+}
+.pv-row-value input[type="text"] {
+  text-transform: uppercase;
 }
 .pv-controls { margin-top: 8px; display: flex; gap: 8px; }
 .pv-controls button { font-size: 12px; padding: 3px 6px; }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -490,6 +490,10 @@ function updateRender(force = false) {
             };
           }
           pv.viz.zonalCoverage = zonal;
+          if (typeof pv.setBaseColor === 'function') {
+            const baseColor = currentPlanetParameters?.visualization?.baseColor;
+            pv.setBaseColor(baseColor, { fromGame: true });
+          }
         }
       } catch (e) {
         // Non-fatal if terraforming utilities are not ready yet

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -110,6 +110,9 @@ const defaultPlanetParameters = {
     albedo: 0.21, // Default (Mars)
     rotationPeriod: 24.6, // hours, Default (Mars)
     starLuminosity: 1, // Multiplier relative to Sol
+  },
+  visualization: {
+    baseColor: '#8a2a2a',
   }
 };
 
@@ -201,7 +204,10 @@ const marsOverrides = {
       "ice": 1436178044031.2847
     }
   },
-  fundingRate: 10
+  fundingRate: 10,
+  visualization: {
+    baseColor: '#8a2a2a',
+  }
 };
 
 const titanOverrides = {
@@ -311,6 +317,9 @@ const titanOverrides = {
       parentBeltAtRef_mSvPerDay: 3.5,      // chosen so Titan @20.3 RS is ~0.05 airless
       beltFalloffExp: 6
     }
+  },
+  visualization: {
+    baseColor: '#8a6a38',
   }
 };
 
@@ -412,6 +421,9 @@ const callistoOverrides = {
       parentBeltAtRef_mSvPerDay: 5400,     // airless daily dose at Europa
       beltFalloffExp: 10                  // middle of 9.5–10.5 range
     }
+  },
+  visualization: {
+    baseColor: '#828a93',
   }
 };
 
@@ -524,6 +536,9 @@ const ganymedeOverrides = {
       parentBeltAtRef_mSvPerDay: 5400,     // airless daily dose at Europa
       beltFalloffExp: 10
     }
+  },
+  visualization: {
+    baseColor: '#786355',
   }
 };
 
@@ -600,8 +615,11 @@ const vega2Overrides = {
     radius: 5051.8,         // km
     mass: 1.867e24,         // kg
     albedo: 0.3,           // bright surface; no clouds unless added later
-    rotationPeriod: 18,    
+    rotationPeriod: 18,
     starLuminosity: 40
+  },
+  visualization: {
+    baseColor: '#a87d4f',
   }
 };
 
@@ -673,6 +691,9 @@ const venusOverrides = {
     albedo: 0.15,
     rotationPeriod: 5832, // hours (~243 Earth days)
     starLuminosity: 1
+  },
+  visualization: {
+    baseColor: '#d0b271',
   }
 };
 

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -85,6 +85,23 @@ const RWG_WORLD_TYPES = {
   "hot-rocky": { displayName: "Hot Rocky" },
 };
 
+const RWG_TYPE_BASE_COLORS = {
+  "mars-like": "#8a2a2a",
+  "cold-desert": "#b38c61",
+  "icy-moon": "#7a8797",
+  "titan-like": "#8a6a38",
+  "carbon-planet": "#2c2b30",
+  "desiccated-desert": "#caa16a",
+  "super-earth": "#4c6f4e",
+  "venus-like": "#cdb675",
+  rocky: "#806a58",
+  "hot-rocky": "#6d3f2f",
+};
+
+function pickBaseColorForType(type) {
+  return RWG_TYPE_BASE_COLORS[type] || "#7a4a3a";
+}
+
 // ===================== Parameter Pack (edit here) =====================
 const DEFAULT_PARAMS = {
   naming: {
@@ -570,6 +587,7 @@ function buildPlanetOverride({ seed, star, aAU, isMoon, forcedType }, params) {
     habitableZone: star.habitableZone || { inner: 0.95 * sScale, outer: 1.37 * sScale }
   };
 
+  const baseColor = pickBaseColorForType(classification?.type || type);
   const overrides = {
     name: planetName(seed, params),
     resources: { colony: deepMerge(defaultPlanetParameters.resources.colony), surface, underground, atmospheric: atmo, special },
@@ -582,6 +600,7 @@ function buildPlanetOverride({ seed, star, aAU, isMoon, forcedType }, params) {
     celestialParameters: { distanceFromSun: aAU, gravity: bulk.gravity, radius: bulk.radius_km, mass: bulk.mass, albedo, rotationPeriod: rotation, starLuminosity: sLum, parentBody, surfaceArea, temperature: { day: temps.day, night: temps.night, mean: temps.mean }, actualAlbedo: temps.albedo, cloudFraction: temps.cfCloud, hazeFraction: temps.cfHaze, hasNaturalMagnetosphere },
     star: starOverride,
     classification: { archetype: type, TeqK: Math.round(classification.Teq) },
+    visualization: { baseColor },
     rwgMeta: { generatorSeedInt: seed }
   };
   return overrides;
@@ -766,6 +785,7 @@ if (typeof globalThis !== "undefined") {
   globalThis.generateSystem = generateSystem;
   globalThis.DEFAULT_PARAMS = DEFAULT_PARAMS;
   globalThis.RWG_WORLD_TYPES = RWG_WORLD_TYPES;
+  globalThis.RWG_TYPE_BASE_COLORS = RWG_TYPE_BASE_COLORS;
 }
 
 // CommonJS exports
@@ -777,5 +797,6 @@ try {
     generateSystem,
     DEFAULT_PARAMS,
     RWG_WORLD_TYPES,
+    RWG_TYPE_BASE_COLORS,
   };
 } catch (_) {}

--- a/tests/planetBaseColor.test.js
+++ b/tests/planetBaseColor.test.js
@@ -1,0 +1,32 @@
+const { planetParameters } = require('../src/js/planet-parameters.js');
+const { generateRandomPlanet, RWG_TYPE_BASE_COLORS } = require('../src/js/rwg.js');
+
+describe('Story planet base colors', () => {
+  const expected = {
+    mars: '#8a2a2a',
+    titan: '#8a6a38',
+    callisto: '#828a93',
+    ganymede: '#786355',
+    vega2: '#a87d4f',
+    venus: '#d0b271',
+  };
+
+  Object.entries(expected).forEach(([key, color]) => {
+    test(`${key} defines a base color`, () => {
+      expect(planetParameters[key]).toBeDefined();
+      expect(planetParameters[key].visualization).toBeDefined();
+      expect(planetParameters[key].visualization.baseColor).toBe(color);
+    });
+  });
+});
+
+describe('Random world generator base colors', () => {
+  Object.entries(RWG_TYPE_BASE_COLORS).forEach(([type, color], index) => {
+    test(`type ${type} uses mapped base color`, () => {
+      const seed = `color-${type}-${index}`;
+      const { override } = generateRandomPlanet(seed, { type });
+      expect(override.visualization).toBeDefined();
+      expect(override.visualization.baseColor).toBe(color);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add visualization base colors to story planets and update the random world generator to emit archetype-specific colors
- enhance the planet visualizer to respect the base color, regenerate terrain gradients, and expose a debug color picker with supporting styles
- update the game loop to push base color changes to the visualizer and cover the new behaviour with automated tests

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c8be38e2708332a9feb31664c63b32