### PR TITLE
Gate terraforming visualizer animation on world subtab

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -461,7 +461,7 @@ function updateRender(force = false) {
     }
 
     if (isActive('terraforming')) {
-      updateTerraformingUI();
+      updateTerraformingUI(deltaSeconds);
       // Ensure the visualizer resizes once the tab becomes visible
       if (typeof window !== 'undefined' && window.planetVisualizer && typeof window.planetVisualizer.onResize === 'function') {
         window.planetVisualizer.onResize();
@@ -520,14 +520,10 @@ function updateRender(force = false) {
     updateColonySlidersUI();
     renderProjects();
     updateResearchUI();
-    updateTerraformingUI();
+    updateTerraformingUI(deltaSeconds);
     updateStatisticsDisplay();
     updateHopeUI();
     if (typeof updateSpaceUI === 'function') updateSpaceUI();
-  }
-
-  if (typeof window !== 'undefined' && window.planetVisualizer && typeof window.planetVisualizer.animate === 'function') {
-    window.planetVisualizer.animate(deltaSeconds);
   }
 
   // Milestones often affect multiple views; keep updated

--- a/tests/subtabManagerHelpers.test.js
+++ b/tests/subtabManagerHelpers.test.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function setupSubtabManagerFixture() {
+  const dom = new JSDOM(`<!DOCTYPE html>
+    <div class="tabs">
+      <div class="subtab active" data-subtab="one"></div>
+      <div class="subtab" data-subtab="two"></div>
+    </div>
+    <div id="one" class="content active"></div>
+    <div id="two" class="content"></div>`);
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  // Ensure ui-utils registers the activateSubtab helper used by SubtabManager
+  // eslint-disable-next-line global-require
+  require(path.join(__dirname, '..', 'src/js/ui-utils.js'));
+
+  // Load SubtabManager after globals are ready
+  // eslint-disable-next-line global-require
+  const SubtabManager = require(path.join(__dirname, '..', 'src/js/subtab-manager.js'));
+  const manager = new SubtabManager('.subtab', '.content');
+  return { manager, dom };
+}
+
+describe('SubtabManager helper methods', () => {
+  afterEach(() => {
+    if (global.window && typeof global.window.close === 'function') {
+      global.window.close();
+    }
+    jest.resetModules();
+    delete global.window;
+    delete global.document;
+    delete global.SubtabManager;
+    delete global.activateSubtab;
+    delete global.subtabScrollPositions;
+  });
+
+  test('getActiveId reads the DOM when no activation has occurred', () => {
+    const { manager } = setupSubtabManagerFixture();
+
+    expect(manager.getActiveId()).toBe('one');
+    expect(manager.isActive('one')).toBe(true);
+    expect(manager.isActive('two')).toBe(false);
+  });
+
+  test('getActiveId and isActive track updates and DOM changes', () => {
+    const { manager } = setupSubtabManagerFixture();
+
+    manager.activate('two');
+
+    expect(manager.getActiveId()).toBe('two');
+    expect(manager.isActive('two')).toBe(true);
+    expect(manager.isActive('one')).toBe(false);
+
+    // Simulate an external DOM toggle without calling activate
+    const tabOne = document.querySelector('[data-subtab="one"]');
+    const tabTwo = document.querySelector('[data-subtab="two"]');
+    const contentOne = document.getElementById('one');
+    const contentTwo = document.getElementById('two');
+    tabOne.classList.add('active');
+    tabTwo.classList.remove('active');
+    contentOne.classList.add('active');
+    contentTwo.classList.remove('active');
+
+    expect(manager.getActiveId()).toBe('one');
+    expect(manager.isActive('one')).toBe(true);
+    expect(manager.isActive('two')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extend SubtabManager with DOM-aware helpers to query active subtabs without breaking existing exports
- integrate the terraforming UI with the SubtabManager, only animating the planet visualizer when the world subtab is active, and expose helpers for other callers
- remove the render-loop animation hook and refresh the terraforming world subtab tests while adding coverage for the new SubtabManager API

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9c608ba408327a0a5281fe84f821c