### PR TITLE
Update atmospheric molecular weight calculation

### DIFF
--- a/tests/atmosphericUtils.test.js
+++ b/tests/atmosphericUtils.test.js
@@ -1,10 +1,49 @@
-const { calculateMolecularWeight, calculateSpecificLift, approximateSpecificLift } = require('../src/js/terraforming/atmospheric-utils.js');
+const {
+  MOLECULAR_WEIGHTS,
+  calculateMolecularWeight,
+  calculateSpecificLift,
+  approximateSpecificLift
+} = require('../src/js/terraforming/atmospheric-utils.js');
+
+const MASS_PER_TON = 1e6;
 
 describe('atmospheric-utils', () => {
-  test('calculates mean molecular weight of atmosphere', () => {
-    const composition = { N2: 0.78, O2: 0.21, Ar: 0.01 };
-    const mw = calculateMolecularWeight(composition);
-    expect(mw).toBeCloseTo(28.97, 2);
+  describe('calculateMolecularWeight', () => {
+    test('calculates mean molecular weight from atmospheric resource masses', () => {
+      const atmosphere = {
+        carbonDioxide: { value: 10 },
+        oxygen: { value: 5 },
+        inertGas: { value: 30 },
+        atmosphericWater: { value: 2 },
+        greenhouseGas: { value: 0.5 }
+      };
+
+      const totalMass = (10 + 5 + 30 + 2 + 0.5) * MASS_PER_TON;
+      const totalMoles =
+        (10 * MASS_PER_TON) / MOLECULAR_WEIGHTS.CO2 +
+        (5 * MASS_PER_TON) / MOLECULAR_WEIGHTS.O2 +
+        (30 * MASS_PER_TON) / MOLECULAR_WEIGHTS.N2 +
+        (2 * MASS_PER_TON) / MOLECULAR_WEIGHTS.H2O +
+        (0.5 * MASS_PER_TON) / MOLECULAR_WEIGHTS.SF6;
+
+      const expected = totalMass / totalMoles;
+      const mw = calculateMolecularWeight(atmosphere);
+      expect(mw).toBeCloseTo(expected, 6);
+    });
+
+    test('supports numeric masses and ignores unknown gases', () => {
+      const mix = { CO2: 1, O2: 1, unknownGas: 4 };
+      const totalMass = 2 * MASS_PER_TON;
+      const totalMoles =
+        (1 * MASS_PER_TON) / MOLECULAR_WEIGHTS.CO2 +
+        (1 * MASS_PER_TON) / MOLECULAR_WEIGHTS.O2;
+      const expected = totalMass / totalMoles;
+      expect(calculateMolecularWeight(mix)).toBeCloseTo(expected, 6);
+    });
+
+    test('returns zero when no known gases are present', () => {
+      expect(calculateMolecularWeight({ unknown: { value: 12 } })).toBe(0);
+    });
   });
 
   test('calculates specific lift with full and approximate formulas', () => {


### PR DESCRIPTION
## Summary
- derive atmospheric molecular weight from the actual atmospheric resource masses
- extend molecular weight data with aliases for in-game resource keys
- refresh atmospheric utility tests to cover mass-based inputs and unknown gases

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68c9e60b33a48327a035ec1d654f9a96