### PR TITLE
Align colony card header font sizes

### DIFF
--- a/src/css/colonies.css
+++ b/src/css/colonies.css
@@ -28,6 +28,11 @@
     justify-self: start;
   }
 
+  #colony-sliders-container .card-title,
+  #construction-office-container .card-title {
+      font-size: calc(14px * 1.1);
+  }
+
   .growth-rate-line {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- ensure the Colony Management and Construction Office cards reuse the Growth Rate header sizing

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9e99cd43083279489d78360886dd3