### PR TITLE
Add aerostat lift telemetry

### DIFF
--- a/src/css/colonies.css
+++ b/src/css/colonies.css
@@ -322,4 +322,33 @@ input[type="range"].pretty-slider::-moz-range-thumb {
   margin: 0;
 }
 
+.colony-buoyancy-card .colony-buoyancy-lift-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.colony-buoyancy-card .colony-buoyancy-lift-label {
+  font-weight: 600;
+}
+
+.colony-buoyancy-card .colony-buoyancy-lift-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.colony-buoyancy-card .colony-buoyancy-notes {
+  margin-top: 12px;
+}
+
+.colony-buoyancy-card .colony-buoyancy-notes-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.colony-buoyancy-card .colony-buoyancy-notes-list {
+  margin: 0 0 0 20px;
+  padding: 0;
+}
+
 


### PR DESCRIPTION
## Summary
- compute the aerostat colony's standard specific lift from atmospheric-utils under a fixed pressure and temperature
- surface the lift reading, tooltip details, and aerostat operation notes inside the buoyancy card
- add styling hooks for the new lift row and notes list in the colony UI

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9eae67bd08327bf9765b8d2f77a5c