### PR TITLE
Relocate factory maintenance reduction helper to aerostat

### DIFF
--- a/src/js/buildings/aerostat.js
+++ b/src/js/buildings/aerostat.js
@@ -1,4 +1,11 @@
-class Aerostat extends Colony {
+const BaseColony =
+  typeof Colony !== 'undefined'
+    ? Colony
+    : class {
+        constructor() {}
+      };
+
+class Aerostat extends BaseColony {
   constructor(config, colonyName) {
     super(config, colonyName);
     this.buoyancyNotes = 'Envelope lift systems nominal.';
@@ -9,8 +16,117 @@ class Aerostat extends Colony {
   }
 }
 
+function getFactoryTemperatureMaintenancePenaltyReduction(context = {}) {
+  const hasProvidedBuildings = Object.prototype.hasOwnProperty.call(
+    context,
+    'buildings'
+  );
+  const buildingCollection = hasProvidedBuildings
+    ? context.buildings
+    : typeof buildings !== 'undefined'
+      ? buildings
+      : undefined;
+
+  if (!buildingCollection) {
+    return 0;
+  }
+
+  let totalWorkerRequirement = 0;
+
+  for (const id in buildingCollection) {
+    if (!Object.prototype.hasOwnProperty.call(buildingCollection, id)) continue;
+
+    const building = buildingCollection[id];
+    if (!building) continue;
+
+    const perBuildingNeed =
+      typeof building.getTotalWorkerNeed === 'function'
+        ? building.getTotalWorkerNeed()
+        : building.requiresWorker || 0;
+
+    if (perBuildingNeed <= 0) continue;
+
+    const activeCount =
+      typeof building.active === 'number'
+        ? building.active
+        : typeof building.count === 'number'
+          ? building.count
+          : 0;
+
+    if (activeCount <= 0) continue;
+
+    const workerMultiplier =
+      typeof building.getEffectiveWorkerMultiplier === 'function'
+        ? building.getEffectiveWorkerMultiplier()
+        : 1;
+
+    totalWorkerRequirement +=
+      activeCount * perBuildingNeed * workerMultiplier;
+  }
+
+  if (totalWorkerRequirement <= 0) {
+    return 0;
+  }
+
+  const hasProvidedColonies = Object.prototype.hasOwnProperty.call(
+    context,
+    'colonies'
+  );
+  const colonyCollection = hasProvidedColonies
+    ? context.colonies
+    : typeof colonies !== 'undefined'
+      ? colonies
+      : undefined;
+
+  if (!colonyCollection) {
+    return 0;
+  }
+
+  const aerostat = colonyCollection.aerostat_colony;
+  if (!aerostat) {
+    return 0;
+  }
+
+  const baseCapacity = aerostat?.storage?.colony?.colonists || 0;
+  if (baseCapacity <= 0) {
+    return 0;
+  }
+
+  const storageMultiplier =
+    typeof aerostat.getEffectiveStorageMultiplier === 'function'
+      ? aerostat.getEffectiveStorageMultiplier()
+      : 1;
+
+  const activeAerostats =
+    typeof aerostat.active === 'number'
+      ? aerostat.active
+      : typeof aerostat.count === 'number'
+        ? aerostat.count
+        : 0;
+
+  if (activeAerostats <= 0) {
+    return 0;
+  }
+
+  const aerostatCapacity = activeAerostats * baseCapacity * storageMultiplier;
+
+  if (aerostatCapacity <= 0) {
+    return 0;
+  }
+
+  return Math.min(1, aerostatCapacity / totalWorkerRequirement);
+}
+
+Aerostat.getFactoryTemperatureMaintenancePenaltyReduction =
+  getFactoryTemperatureMaintenancePenaltyReduction;
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { Aerostat };
+  module.exports = {
+    Aerostat,
+    getFactoryTemperatureMaintenancePenaltyReduction
+  };
 } else {
   globalThis.Aerostat = Aerostat;
+  globalThis.getFactoryTemperatureMaintenancePenaltyReduction =
+    getFactoryTemperatureMaintenancePenaltyReduction;
 }

--- a/tests/temperatureMaintenancePenaltyBuildings.test.js
+++ b/tests/temperatureMaintenancePenaltyBuildings.test.js
@@ -4,6 +4,9 @@ global.EffectableEntity = EffectableEntity;
 global.lifeParameters = {};
 
 const Terraforming = require('../src/js/terraforming.js');
+const {
+  getFactoryTemperatureMaintenancePenaltyReduction
+} = require('../src/js/buildings/aerostat.js');
 Terraforming.prototype.updateLuminosity = function(){};
 Terraforming.prototype.updateSurfaceTemperature = function(){};
 Terraforming.prototype.updateSurfaceRadiation = function(){};
@@ -44,6 +47,104 @@ describe('temperature maintenance penalty applies to buildings', () => {
     expect(calls).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ targetId: 'mirror' })
     ]));
+
+    global.addEffect = originalAdd;
+  });
+
+  test('reduces penalty for factories based on aerostat capacity', () => {
+    global.resources = { atmospheric:{}, special:{ albedoUpgrades:{ value:0 } }, surface:{}, colony:{} };
+    const factory = {
+      active: 1,
+      requiresWorker: 5,
+      getTotalWorkerNeed: () => 5,
+      getEffectiveWorkerMultiplier: () => 1
+    };
+    global.buildings = { factory };
+    global.colonies = {
+      aerostat_colony: {
+        active: 1,
+        storage: { colony: { colonists: 10 } },
+        getEffectiveStorageMultiplier: () => 1
+      }
+    };
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, { distanceFromSun:1, radius:1, gravity:1, albedo:0 });
+    tf.temperature = { value: 473.15 };
+    tf.calculateColonyEnergyPenalty = () => 1;
+    tf.calculateMaintenancePenalty = () => 2;
+    tf.calculateSolarPanelMultiplier = () => 1;
+    tf.calculateWindTurbineMultiplier = () => 1;
+
+    const originalAdd = global.addEffect;
+    const mockAdd = jest.fn();
+    global.addEffect = mockAdd;
+
+    expect(getFactoryTemperatureMaintenancePenaltyReduction()).toBe(1);
+    expect(tf.getFactoryTemperatureMaintenancePenaltyReduction()).toBe(1);
+
+    tf.applyTerraformingEffects();
+
+    const buildingPenalty = mockAdd.mock.calls
+      .map(c => c[0])
+      .find(e => e.target === 'building' && e.targetId === 'factory' && e.effectId === 'temperatureMaintenancePenalty');
+    expect(buildingPenalty).toBeDefined();
+    expect(buildingPenalty.value).toBe(1);
+
+    global.addEffect = originalAdd;
+  });
+
+  test('applies partial reduction when aerostat capacity is limited', () => {
+    global.resources = { atmospheric:{}, special:{ albedoUpgrades:{ value:0 } }, surface:{}, colony:{} };
+    const factory = {
+      active: 2,
+      requiresWorker: 20,
+      getTotalWorkerNeed: () => 20,
+      getEffectiveWorkerMultiplier: () => 1
+    };
+    global.buildings = { factory };
+    global.colonies = {
+      aerostat_colony: {
+        active: 1,
+        storage: { colony: { colonists: 10 } },
+        getEffectiveStorageMultiplier: () => 1
+      }
+    };
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, { distanceFromSun:1, radius:1, gravity:1, albedo:0 });
+    tf.temperature = { value: 473.15 };
+    tf.calculateColonyEnergyPenalty = () => 1;
+    tf.calculateMaintenancePenalty = () => 2;
+    tf.calculateSolarPanelMultiplier = () => 1;
+    tf.calculateWindTurbineMultiplier = () => 1;
+
+    const originalAdd = global.addEffect;
+    const mockAdd = jest.fn();
+    global.addEffect = mockAdd;
+
+    expect(getFactoryTemperatureMaintenancePenaltyReduction()).toBeCloseTo(0.25);
+    expect(tf.getFactoryTemperatureMaintenancePenaltyReduction()).toBeCloseTo(0.25);
+
+    tf.applyTerraformingEffects();
+
+    const buildingPenalty = mockAdd.mock.calls
+      .map(c => c[0])
+      .find(e => e.target === 'building' && e.targetId === 'factory' && e.effectId === 'temperatureMaintenancePenalty');
+    expect(buildingPenalty).toBeDefined();
+    expect(buildingPenalty.value).toBeCloseTo(1.75);
 
     global.addEffect = originalAdd;
   });


### PR DESCRIPTION
## Summary
- move the factory temperature maintenance penalty helper into `aerostat.js` so it can be shared outside the terraforming module
- have `terraforming.js` import the helper and delegate its factory maintenance penalty calculation to it
- update the temperature maintenance penalty tests to exercise the exported helper as well as the terraforming wrapper

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68c9e96956a88327b5e0b35c63e614f2