### PR TITLE
Limit Aerostat colonies by initial land

### DIFF
--- a/src/js/buildings/aerostat.js
+++ b/src/js/buildings/aerostat.js
@@ -11,6 +11,67 @@ class Aerostat extends BaseColony {
     this.buoyancyNotes = 'Aerostats are immune to the pressure and temperature penalties.';
   }
 
+  _getInitialLand() {
+    if (typeof terraforming === 'undefined') {
+      return 0;
+    }
+
+    const { initialLand } = terraforming;
+    return typeof initialLand === 'number' && isFinite(initialLand) && initialLand > 0
+      ? initialLand
+      : 0;
+  }
+
+  _getBuildLimit() {
+    const initialLand = this._getInitialLand();
+    if (initialLand <= 0) {
+      return 0;
+    }
+
+    return Math.floor(initialLand * 0.2);
+  }
+
+  _getRemainingBuildCapacity() {
+    const limit = this._getBuildLimit();
+    if (limit <= 0) {
+      return 0;
+    }
+
+    return Math.max(0, limit - this.count);
+  }
+
+  build(buildCount = 1, activate = true) {
+    const remaining = this._getRemainingBuildCapacity();
+    if (remaining <= 0) {
+      return false;
+    }
+
+    const allowed = Math.min(buildCount, remaining);
+    if (allowed <= 0 || typeof BaseColony.prototype.build !== 'function') {
+      return false;
+    }
+
+    return super.build(allowed, activate);
+  }
+
+  maxBuildable(reservePercent = 0) {
+    const remaining = this._getRemainingBuildCapacity();
+    if (remaining <= 0) {
+      return 0;
+    }
+
+    let baseMax = remaining;
+    if (typeof BaseColony.prototype.maxBuildable === 'function') {
+      baseMax = super.maxBuildable(reservePercent);
+    }
+
+    if (!Number.isFinite(baseMax)) {
+      return remaining;
+    }
+
+    return Math.max(0, Math.min(baseMax, remaining));
+  }
+
   getBuoyancySummary() {
     return this.buoyancyNotes;
   }

--- a/tests/aerostatBuildCap.test.js
+++ b/tests/aerostatBuildCap.test.js
@@ -1,0 +1,107 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+
+const OriginalColony = global.Colony;
+const originalResources = global.resources;
+const originalBuildings = global.buildings;
+const originalTerraforming = global.terraforming;
+
+class TestColony extends Building {
+  constructor(config, name) {
+    super(config, name);
+  }
+}
+
+global.Colony = TestColony;
+
+const { Aerostat } = require('../src/js/buildings/aerostat.js');
+
+describe('Aerostat build cap', () => {
+  let baseConfig;
+  const originalMaintenanceFraction = global.maintenanceFraction;
+  const originalDayNightCycle = global.dayNightCycle;
+
+  beforeEach(() => {
+    baseConfig = {
+      name: 'Aerostat Colony',
+      category: 'Colony',
+      cost: {},
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      requiresDeposit: false,
+      requiresWorker: 0,
+      unlocked: true,
+      requiresLand: 0
+    };
+
+    global.maintenanceFraction = 0;
+    global.dayNightCycle = { isDay: () => true };
+    global.resources = {
+      colony: {},
+      surface: {
+        land: {
+          value: 0,
+          reserved: 0,
+          reserve(amount) {
+            this.reserved += amount;
+          },
+          release(amount) {
+            this.reserved -= amount;
+          }
+        }
+      },
+      underground: {}
+    };
+    global.buildings = {};
+    global.terraforming = { initialLand: 100 };
+  });
+
+  afterEach(() => {
+    global.maintenanceFraction = originalMaintenanceFraction;
+    global.dayNightCycle = originalDayNightCycle;
+  });
+
+  afterAll(() => {
+    global.Colony = OriginalColony;
+    global.resources = originalResources;
+    global.buildings = originalBuildings;
+    global.terraforming = originalTerraforming;
+  });
+
+  test('build enforces 0.2 per initial land cap', () => {
+    const aerostat = new Aerostat(baseConfig, 'aerostat_colony');
+    expect(aerostat.build(30)).toBe(true);
+    expect(aerostat.count).toBe(20);
+    expect(aerostat.build(1)).toBe(false);
+    expect(aerostat.count).toBe(20);
+  });
+
+  test('maxBuildable respects resource limits and cap', () => {
+    global.resources.colony.metal = {
+      value: 15,
+      cap: 15,
+      reserved: 0,
+      decrease(amount) {
+        this.value -= amount;
+      }
+    };
+
+    const configWithCost = {
+      ...baseConfig,
+      cost: { colony: { metal: 1 } }
+    };
+
+    const aerostat = new Aerostat(configWithCost, 'aerostat_colony');
+    expect(aerostat.maxBuildable()).toBe(15);
+    aerostat.count = 12;
+    expect(aerostat.maxBuildable()).toBe(8);
+    aerostat.count = 20;
+    expect(aerostat.maxBuildable()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- cap Aerostat colony builds at 0.2 per initial land by overriding the build and maxBuildable logic
- add Jest coverage ensuring the cap and resource-limited builds behave correctly

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9ef85c6e48327bd909375b035575a