### PR TITLE
Prevent aerostat mitigation from benefiting ore mines

### DIFF
--- a/src/js/buildings/aerostat.js
+++ b/src/js/buildings/aerostat.js
@@ -16,6 +16,12 @@ class Aerostat extends BaseColony {
   }
 }
 
+const FACTORY_MITIGATION_EXCLUDED_BUILDINGS = ['oreMine'];
+
+function isBuildingEligibleForFactoryMitigation(id) {
+  return FACTORY_MITIGATION_EXCLUDED_BUILDINGS.indexOf(id) === -1;
+}
+
 function getFactoryTemperatureMaintenancePenaltyReduction(context = {}) {
   const hasProvidedBuildings = Object.prototype.hasOwnProperty.call(
     context,
@@ -35,6 +41,8 @@ function getFactoryTemperatureMaintenancePenaltyReduction(context = {}) {
 
   for (const id in buildingCollection) {
     if (!Object.prototype.hasOwnProperty.call(buildingCollection, id)) continue;
+
+    if (!isBuildingEligibleForFactoryMitigation(id)) continue;
 
     const building = buildingCollection[id];
     if (!building) continue;
@@ -65,7 +73,7 @@ function getFactoryTemperatureMaintenancePenaltyReduction(context = {}) {
   }
 
   if (totalWorkerRequirement <= 0) {
-    return 0;
+    return 1;
   }
 
   const hasProvidedColonies = Object.prototype.hasOwnProperty.call(
@@ -120,13 +128,19 @@ function getFactoryTemperatureMaintenancePenaltyReduction(context = {}) {
 Aerostat.getFactoryTemperatureMaintenancePenaltyReduction =
   getFactoryTemperatureMaintenancePenaltyReduction;
 
+Aerostat.isBuildingEligibleForFactoryMitigation =
+  isBuildingEligibleForFactoryMitigation;
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     Aerostat,
-    getFactoryTemperatureMaintenancePenaltyReduction
+    getFactoryTemperatureMaintenancePenaltyReduction,
+    isBuildingEligibleForFactoryMitigation
   };
 } else {
   globalThis.Aerostat = Aerostat;
   globalThis.getFactoryTemperatureMaintenancePenaltyReduction =
     getFactoryTemperatureMaintenancePenaltyReduction;
+  globalThis.isBuildingEligibleForFactoryMitigation =
+    isBuildingEligibleForFactoryMitigation;
 }

--- a/tests/temperatureMaintenancePenaltyBuildings.test.js
+++ b/tests/temperatureMaintenancePenaltyBuildings.test.js
@@ -100,6 +100,103 @@ describe('temperature maintenance penalty applies to buildings', () => {
     global.addEffect = originalAdd;
   });
 
+  test('ignores ore mines when calculating aerostat mitigation', () => {
+    global.resources = { atmospheric:{}, special:{ albedoUpgrades:{ value:0 } }, surface:{}, colony:{} };
+    const factory = {
+      active: 1,
+      requiresWorker: 10,
+      getTotalWorkerNeed: () => 10,
+      getEffectiveWorkerMultiplier: () => 1
+    };
+    const oreMine = {
+      active: 1,
+      requiresWorker: 10,
+      getTotalWorkerNeed: () => 10,
+      getEffectiveWorkerMultiplier: () => 1
+    };
+    global.buildings = { factory, oreMine };
+    global.colonies = {
+      aerostat_colony: {
+        active: 1,
+        storage: { colony: { colonists: 10 } },
+        getEffectiveStorageMultiplier: () => 1
+      }
+    };
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, { distanceFromSun:1, radius:1, gravity:1, albedo:0 });
+    tf.temperature = { value: 473.15 };
+    tf.calculateColonyEnergyPenalty = () => 1;
+    tf.calculateMaintenancePenalty = () => 2;
+    tf.calculateSolarPanelMultiplier = () => 1;
+    tf.calculateWindTurbineMultiplier = () => 1;
+
+    const originalAdd = global.addEffect;
+    const mockAdd = jest.fn();
+    global.addEffect = mockAdd;
+
+    expect(getFactoryTemperatureMaintenancePenaltyReduction()).toBe(1);
+    expect(tf.getFactoryTemperatureMaintenancePenaltyReduction()).toBe(1);
+
+    const expectedMaintenancePenalty = tf.calculateMaintenancePenalty();
+    tf.applyTerraformingEffects();
+
+    const factoryPenalty = mockAdd.mock.calls
+      .map(c => c[0])
+      .find(e => e.target === 'building' && e.targetId === 'factory' && e.effectId === 'temperatureMaintenancePenalty');
+    expect(factoryPenalty).toBeDefined();
+    expect(factoryPenalty.value).toBe(1);
+
+    const oreMinePenalty = mockAdd.mock.calls
+      .map(c => c[0])
+      .find(e => e.target === 'building' && e.targetId === 'oreMine' && e.effectId === 'temperatureMaintenancePenalty');
+    expect(oreMinePenalty).toBeDefined();
+    expect(oreMinePenalty.value).toBe(expectedMaintenancePenalty);
+
+    global.addEffect = originalAdd;
+  });
+
+  test('assumes full mitigation when no eligible factories require workers', () => {
+    global.resources = { atmospheric:{}, special:{ albedoUpgrades:{ value:0 } }, surface:{}, colony:{} };
+    const oreMine = {
+      active: 1,
+      requiresWorker: 10,
+      getTotalWorkerNeed: () => 10,
+      getEffectiveWorkerMultiplier: () => 1
+    };
+    global.buildings = { oreMine };
+    global.colonies = {
+      aerostat_colony: {
+        active: 1,
+        storage: { colony: { colonists: 10 } },
+        getEffectiveStorageMultiplier: () => 1
+      }
+    };
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, { distanceFromSun:1, radius:1, gravity:1, albedo:0 });
+    tf.temperature = { value: 473.15 };
+    tf.calculateColonyEnergyPenalty = () => 1;
+    tf.calculateMaintenancePenalty = () => 2;
+    tf.calculateSolarPanelMultiplier = () => 1;
+    tf.calculateWindTurbineMultiplier = () => 1;
+
+    expect(getFactoryTemperatureMaintenancePenaltyReduction()).toBe(1);
+    expect(tf.getFactoryTemperatureMaintenancePenaltyReduction()).toBe(1);
+  });
+
   test('applies partial reduction when aerostat capacity is limited', () => {
     global.resources = { atmospheric:{}, special:{ albedoUpgrades:{ value:0 } }, surface:{}, colony:{} };
     const factory = {


### PR DESCRIPTION
## Summary
- share a helper to identify buildings eligible for aerostat mitigation so ore mines are skipped when tallying workers
- assume full mitigation when no eligible worker requirement exists and keep ore mines on the base maintenance penalty
- extend the temperature maintenance penalty tests to cover ore mine exclusions and the zero eligible factory case

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68c9f16e46148327ac276b117df1d71e