### PR TITLE
Implement aerostat lift safety shutdown

### DIFF
--- a/src/js/buildings/aerostat.js
+++ b/src/js/buildings/aerostat.js
@@ -9,10 +9,178 @@ class Aerostat extends BaseColony {
   constructor(config, colonyName) {
     super(config, colonyName);
     this.buoyancyNotes = 'Aerostats are immune to the pressure and temperature penalties.  Aerostats will form small communities, allowing the use of factories.';
+    this._liftDisableAccumulator = 0;
+    this._liftBelowThreshold = false;
   }
 
   getBuoyancySummary() {
     return this.buoyancyNotes;
+  }
+
+  getMinimumOperationalLift() {
+    if (typeof AEROSTAT_MINIMUM_OPERATIONAL_LIFT === 'number') {
+      return AEROSTAT_MINIMUM_OPERATIONAL_LIFT;
+    }
+    return 0.2;
+  }
+
+  getAtmosphericComposition() {
+    if (
+      typeof terraforming !== 'undefined' &&
+      terraforming &&
+      terraforming.resources &&
+      terraforming.resources.atmospheric
+    ) {
+      return terraforming.resources.atmospheric;
+    }
+    if (
+      typeof resources !== 'undefined' &&
+      resources &&
+      resources.atmospheric
+    ) {
+      return resources.atmospheric;
+    }
+    return null;
+  }
+
+  getCurrentLift() {
+    if (
+      typeof calculateMolecularWeight !== 'function' ||
+      typeof calculateSpecificLift !== 'function'
+    ) {
+      return null;
+    }
+
+    const atmosphere = this.getAtmosphericComposition();
+    if (!atmosphere) {
+      return null;
+    }
+
+    const molecularWeight = calculateMolecularWeight(atmosphere);
+    if (!Number.isFinite(molecularWeight) || molecularWeight <= 0) {
+      return null;
+    }
+
+    const pressure =
+      typeof AEROSTAT_STANDARD_PRESSURE_PA === 'number'
+        ? AEROSTAT_STANDARD_PRESSURE_PA
+        : 101325;
+    const temperature =
+      typeof AEROSTAT_STANDARD_TEMPERATURE_K === 'number'
+        ? AEROSTAT_STANDARD_TEMPERATURE_K
+        : 273.15 + 21;
+    const internalMolWeight =
+      typeof AEROSTAT_INTERNAL_AIR_MOL_WEIGHT === 'number'
+        ? AEROSTAT_INTERNAL_AIR_MOL_WEIGHT
+        : 29;
+
+    const lift = calculateSpecificLift(
+      pressure,
+      temperature,
+      molecularWeight,
+      internalMolWeight
+    );
+
+    if (!Number.isFinite(lift)) {
+      return null;
+    }
+
+    return lift;
+  }
+
+  isLiftBelowThreshold(liftValue) {
+    const lift = liftValue ?? this.getCurrentLift();
+    if (lift === null) {
+      this._liftBelowThreshold = false;
+      return false;
+    }
+    const below = lift < this.getMinimumOperationalLift();
+    this._liftBelowThreshold = below;
+    return below;
+  }
+
+  filterActivationChange(change) {
+    if (!Number.isFinite(change)) {
+      return 0;
+    }
+
+    const sanitized = Math.trunc(change);
+    if (sanitized > 0 && this.isLiftBelowThreshold()) {
+      return 0;
+    }
+    return sanitized;
+  }
+
+  update(deltaTime = 0) {
+    if (!Number.isFinite(deltaTime) || deltaTime <= 0) {
+      return;
+    }
+
+    const lift = this.getCurrentLift();
+    const belowThreshold = this.isLiftBelowThreshold(lift);
+
+    if (!belowThreshold) {
+      this._liftDisableAccumulator = 0;
+      return;
+    }
+
+    const totalBuilt = typeof this.count === 'number' ? this.count : 0;
+    if (totalBuilt <= 0) {
+      this._liftDisableAccumulator = 0;
+      return;
+    }
+
+    const currentlyActive = typeof this.active === 'number' ? this.active : 0;
+    if (currentlyActive <= 0) {
+      this._liftDisableAccumulator = 0;
+      return;
+    }
+
+    const seconds = deltaTime / 1000;
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return;
+    }
+
+    const disablePerSecond = totalBuilt * 0.01;
+    if (disablePerSecond <= 0) {
+      return;
+    }
+
+    this._liftDisableAccumulator += disablePerSecond * seconds;
+
+    if (this._liftDisableAccumulator < 1) {
+      return;
+    }
+
+    let toDisable = Math.floor(this._liftDisableAccumulator);
+    if (toDisable < 1) {
+      toDisable = 1;
+    }
+
+    this._liftDisableAccumulator = Math.max(
+      0,
+      this._liftDisableAccumulator - toDisable
+    );
+
+    const newActive = Math.max(0, currentlyActive - toDisable);
+    if (newActive === currentlyActive) {
+      return;
+    }
+
+    const change = newActive - currentlyActive;
+    this.active = newActive;
+
+    if (this.requiresLand && typeof this.adjustLand === 'function') {
+      this.adjustLand(change);
+    }
+
+    if (typeof this.updateResourceStorage === 'function') {
+      if (typeof resources !== 'undefined') {
+        this.updateResourceStorage(resources);
+      } else {
+        this.updateResourceStorage();
+      }
+    }
   }
 }
 

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -358,6 +358,10 @@ function produceResources(deltaTime, buildings) {
   for (const buildingName in buildings) {
     const building = buildings[buildingName];
 
+    if (building && typeof building.update === 'function') {
+      building.update(deltaTime);
+    }
+
     // Set productivity to 0 if it's nighttime and the building is inactive during the night
     if (!isDay && building.dayNightActivity) {
       building.productivity = 0;

--- a/tests/aerostatLiftAutoDisable.test.js
+++ b/tests/aerostatLiftAutoDisable.test.js
@@ -1,0 +1,131 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+
+global.Colony = class {
+  constructor(config) {
+    this.consumption = config.consumption || {};
+    this.production = config.production || {};
+    this.storage = config.storage || {};
+    this.cost = config.cost || {};
+    this.dayNightActivity = !!config.dayNightActivity;
+    this.canBeToggled = !!config.canBeToggled;
+    this.requiresMaintenance = !!config.requiresMaintenance;
+    this.maintenanceFactor = config.maintenanceFactor || 0;
+    this.requiresDeposit = config.requiresDeposit || null;
+    this.requiresWorker = config.requiresWorker || 0;
+    this.unlocked = config.unlocked !== undefined ? config.unlocked : true;
+    this.surfaceArea = config.surfaceArea || 0;
+    this.requiresProductivity =
+      typeof config.requiresProductivity !== 'undefined'
+        ? config.requiresProductivity
+        : true;
+    this.requiresLand = config.requiresLand || 0;
+  }
+
+  updateResourceStorage() {}
+  adjustLand() {}
+  getEffectiveStorageMultiplier() { return 1; }
+};
+
+const { Aerostat } = require('../src/js/buildings/aerostat.js');
+
+describe('Aerostat lift safeguards', () => {
+  let aerostat;
+  let currentLift;
+
+  beforeEach(() => {
+    currentLift = 0.1;
+    global.resources = {
+      atmospheric: {},
+      colony: {}
+    };
+    global.AEROSTAT_MINIMUM_OPERATIONAL_LIFT = 0.2;
+    global.calculateMolecularWeight = jest.fn(() => 44);
+    global.calculateSpecificLift = jest.fn(() => currentLift);
+
+    const config = {
+      name: 'Aerostat Colony',
+      category: 'Colony',
+      description: '',
+      cost: { colony: {} },
+      consumption: { colony: {} },
+      production: { colony: {} },
+      storage: { colony: { colonists: 10 } },
+      baseComfort: 0,
+      dayNightActivity: false,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      maintenanceFactor: 0,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true,
+      requiresLand: 0
+    };
+
+    aerostat = new Aerostat(config, 'aerostat_colony');
+    aerostat.count = 100;
+    aerostat.active = 100;
+    aerostat.updateResourceStorage = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete global.terraforming;
+  });
+
+  afterAll(() => {
+    delete global.Colony;
+    delete global.calculateMolecularWeight;
+    delete global.calculateSpecificLift;
+    delete global.AEROSTAT_MINIMUM_OPERATIONAL_LIFT;
+  });
+
+  test('automatically disables aerostats when lift falls below the threshold', () => {
+    currentLift = 0.05;
+    aerostat.count = 200;
+    aerostat.active = 200;
+
+    aerostat.update(1000);
+
+    expect(aerostat.active).toBe(198);
+    expect(aerostat.updateResourceStorage).toHaveBeenCalled();
+  });
+
+  test('accumulates fractional disable rates across multiple updates', () => {
+    currentLift = 0.05;
+    aerostat.updateResourceStorage.mockClear();
+
+    aerostat.update(250);
+    expect(aerostat.active).toBe(100);
+    expect(aerostat.updateResourceStorage).not.toHaveBeenCalled();
+
+    aerostat.update(250);
+    aerostat.update(250);
+    expect(aerostat.active).toBe(100);
+
+    aerostat.update(250);
+    expect(aerostat.active).toBe(99);
+    expect(aerostat.updateResourceStorage).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not disable aerostats when lift is sufficient', () => {
+    currentLift = 0.5;
+    aerostat._liftDisableAccumulator = 3;
+
+    aerostat.update(1000);
+
+    expect(aerostat.active).toBe(100);
+    expect(aerostat._liftDisableAccumulator).toBe(0);
+  });
+
+  test('prevents activation increases while lift is below threshold', () => {
+    currentLift = 0.05;
+    expect(aerostat.filterActivationChange(5)).toBe(0);
+    expect(aerostat.filterActivationChange(-3)).toBe(-3);
+
+    currentLift = 0.5;
+    expect(aerostat.filterActivationChange(4)).toBe(4);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add lift-based safety logic to the Aerostat colony, automatically disabling units when lift falls too low and blocking reactivation attempts
- hook the building update loop and activation controls so aerostat shutdowns run each tick while respecting land adjustments
- cover the new behaviour with automated tests for capacity loss and activation filtering

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9f20e99b0832783d4457b1c72fd28