### PR TITLE
Prevent aerostat construction when lift is insufficient

### DIFF
--- a/src/js/buildings/aerostat.js
+++ b/src/js/buildings/aerostat.js
@@ -52,6 +52,11 @@ class Aerostat extends BaseColony {
       return false;
     }
 
+    const lift = this.getCurrentLift();
+    if (this.isLiftBelowThreshold(lift)) {
+      return false;
+    }
+
     const allowed = Math.min(buildCount, remaining);
     if (allowed <= 0 || typeof BaseColony.prototype.build !== 'function') {
       return false;
@@ -63,6 +68,10 @@ class Aerostat extends BaseColony {
   maxBuildable(reservePercent = 0) {
     const remaining = this._getRemainingBuildCapacity();
     if (remaining <= 0) {
+      return 0;
+    }
+
+    if (this.isLiftBelowThreshold()) {
       return 0;
     }
 
@@ -79,7 +88,13 @@ class Aerostat extends BaseColony {
   }
 
   getBuoyancySummary() {
-    return this.buoyancyNotes;
+    let summary = this.buoyancyNotes;
+    const lift = this.getCurrentLift();
+    if (this.isLiftBelowThreshold(lift)) {
+      summary +=
+        ' Current lift is below the minimum operational requirement, preventing aerostat activation and construction.';
+    }
+    return summary;
   }
 
   getMinimumOperationalLift() {


### PR DESCRIPTION
## Summary
- prevent aerostat colonies from being constructed whenever atmospheric lift is below the operational minimum and surface the warning in the buoyancy summary
- guard the aerostat build estimator against low-lift conditions so automation respects the restriction
- extend aerostat build cap tests to cover the new lift checks and warning message

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9f69cbcfc83278ecfd4f6aff15903