### PR TITLE
Avoid persisting building boolean flags

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -102,6 +102,67 @@ class Building extends EffectableEntity {
     }
   }
 
+  saveState() {
+    return {
+      unlocked: this.unlocked,
+      count: this.count,
+      active: this.active,
+      productivity: this.productivity,
+      isHidden: this.isHidden,
+      alertedWhenUnlocked: this.alertedWhenUnlocked,
+      autoBuildEnabled: this.autoBuildEnabled,
+      autoBuildPercent: this.autoBuildPercent,
+      autoBuildPriority: this.autoBuildPriority,
+      autoBuildBasis: this.autoBuildBasis,
+      workerPriority: this.workerPriority,
+      autoActiveEnabled: this.autoActiveEnabled,
+      autoBuildPartial: this.autoBuildPartial,
+      reversalAvailable: this.reversalAvailable,
+      reverseEnabled: this.reverseEnabled,
+      autoReverse: this.autoReverse,
+      currentRecipeKey: this.currentRecipeKey
+    };
+  }
+
+  loadState(state = {}) {
+    this.booleanFlags = new Set();
+
+    if (!state || typeof state !== 'object') {
+      this._applyRecipeMapping();
+      this.updateResourceStorage();
+      this.maintenanceCost = this.calculateMaintenanceCost();
+      this.currentProduction = {};
+      this.currentConsumption = {};
+      this.currentMaintenance = {};
+      return;
+    }
+
+    if ('unlocked' in state) this.unlocked = state.unlocked;
+    if ('count' in state) this.count = state.count;
+    if ('active' in state) this.active = state.active;
+    if ('productivity' in state) this.productivity = state.productivity;
+    if ('isHidden' in state) this.isHidden = state.isHidden;
+    if ('alertedWhenUnlocked' in state) this.alertedWhenUnlocked = state.alertedWhenUnlocked;
+    if ('autoBuildEnabled' in state) this.autoBuildEnabled = state.autoBuildEnabled;
+    if ('autoBuildPercent' in state) this.autoBuildPercent = state.autoBuildPercent;
+    if ('autoBuildPriority' in state) this.autoBuildPriority = state.autoBuildPriority;
+    if ('autoBuildBasis' in state) this.autoBuildBasis = state.autoBuildBasis;
+    if ('workerPriority' in state) this.workerPriority = state.workerPriority;
+    if ('autoActiveEnabled' in state) this.autoActiveEnabled = state.autoActiveEnabled;
+    if ('autoBuildPartial' in state) this.autoBuildPartial = state.autoBuildPartial;
+    if ('reversalAvailable' in state) this.reversalAvailable = state.reversalAvailable;
+    if ('reverseEnabled' in state) this.reverseEnabled = state.reverseEnabled;
+    if ('autoReverse' in state) this.autoReverse = state.autoReverse;
+    if ('currentRecipeKey' in state) this.currentRecipeKey = state.currentRecipeKey;
+
+    this._applyRecipeMapping();
+    this.updateResourceStorage();
+    this.maintenanceCost = this.calculateMaintenanceCost();
+    this.currentProduction = {};
+    this.currentConsumption = {};
+    this.currentMaintenance = {};
+  }
+
   // External: enable reversal via effect
   enableReversal() {
     this.reversalAvailable = true;

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -93,6 +93,48 @@ class Colony extends Building {
     this.baseComfort = config.baseComfort;
   }
 
+  saveState() {
+    const base = super.saveState();
+    return {
+      ...base,
+      baseComfort: this.baseComfort,
+      filledNeeds: { ...this.filledNeeds },
+      luxuryResourcesEnabled: { ...this.luxuryResourcesEnabled },
+      obsolete: this.obsolete,
+      happiness: this.happiness
+    };
+  }
+
+  loadState(state = {}) {
+    super.loadState(state);
+    if (!state || typeof state !== 'object') {
+      this.rebuildFilledNeeds();
+      return;
+    }
+
+    if ('baseComfort' in state) {
+      this.baseComfort = state.baseComfort;
+    }
+    if (state.filledNeeds) {
+      this.filledNeeds = { ...state.filledNeeds };
+    } else {
+      this.filledNeeds = {};
+    }
+    if (state.luxuryResourcesEnabled) {
+      for (const resource in state.luxuryResourcesEnabled) {
+        this.luxuryResourcesEnabled[resource] = !!state.luxuryResourcesEnabled[resource];
+      }
+    }
+    if ('obsolete' in state) {
+      this.obsolete = state.obsolete;
+    }
+    if ('happiness' in state) {
+      this.happiness = state.happiness;
+    }
+
+    this.rebuildFilledNeeds();
+  }
+
   getConsumptionRatio(){
     // Calculate minRatio based on colonist availability
     const colonists = resources.colony.colonists.value;

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -41,8 +41,22 @@ function getGameState() {
   return {
     dayNightCycle: (typeof dayNightCycle !== 'undefined' && typeof dayNightCycle.saveState === 'function') ? dayNightCycle.saveState() : undefined,
     resources: typeof resources !== 'undefined' ? resources : undefined,
-    buildings: typeof buildings !== 'undefined' ? buildings : undefined,
-    colonies: typeof colonies !== 'undefined' ? colonies : undefined,
+    buildings: typeof buildings !== 'undefined'
+      ? Object.fromEntries(
+          Object.entries(buildings).map(([name, building]) => [
+            name,
+            (building && typeof building.saveState === 'function') ? building.saveState() : {}
+          ])
+        )
+      : undefined,
+    colonies: typeof colonies !== 'undefined'
+      ? Object.fromEntries(
+          Object.entries(colonies).map(([name, colony]) => [
+            name,
+            (colony && typeof colony.saveState === 'function') ? colony.saveState() : {}
+          ])
+        )
+      : undefined,
     projects: (typeof projectManager !== 'undefined' && typeof projectManager.saveState === 'function') ? projectManager.saveState() : undefined,
     research: (typeof researchManager !== 'undefined' && typeof researchManager.saveState === 'function') ? researchManager.saveState() : undefined,
     oreScanning: (typeof oreScanner !== 'undefined' && typeof oreScanner.saveState === 'function') ? oreScanner.saveState() : undefined,
@@ -230,24 +244,21 @@ function loadGame(slotOrCustomString) {
           const buildingState = gameState.buildings[buildingName];
           const building = buildings[buildingName];
           if (building) {
-            Object.assign(building, buildingState);
-            const newConfig = buildingsParameters[buildingName];
-            building.initializeFromConfig(newConfig, buildingName);
-            // After re-initializing, refresh base consumption and reapply recipe mapping
-            // so displayName/production/consumption match the saved currentRecipeKey
-            try {
-              building._baseConsumption = JSON.parse(JSON.stringify(building.consumption || {}));
-              if (typeof building._applyRecipeMapping === 'function') {
-                building._applyRecipeMapping();
-              }
-            } catch (e) { /* non-fatal */ }
-            // Reset effects applied from research
-            building.activeEffects = [];
-            if (building.booleanFlags && Array.isArray(building.booleanFlags)) {
-              building.booleanFlags = new Set(building.booleanFlags);
+            if (typeof building.loadState === 'function') {
+              building.loadState(buildingState);
             } else {
-              building.booleanFlags = new Set();
+              Object.assign(building, buildingState);
+              const newConfig = buildingsParameters ? buildingsParameters[buildingName] : undefined;
+              if (newConfig && typeof building.initializeFromConfig === 'function') {
+                building.initializeFromConfig(newConfig, buildingName);
+              }
+              if (Array.isArray(building.booleanFlags)) {
+                building.booleanFlags = new Set(building.booleanFlags);
+              } else if (!(building.booleanFlags instanceof Set)) {
+                building.booleanFlags = new Set();
+              }
             }
+            building.activeEffects = [];
             if(building.active == null){
               building.active = 0;
             }
@@ -265,16 +276,21 @@ function loadGame(slotOrCustomString) {
             const colonyState = gameState.colonies[colonyName];
             const colony = colonies[colonyName];
             if (colony) {
-              Object.assign(colony, colonyState);
-              const newConfig = colonyParameters[colonyName];
-              colony.initializeFromConfig(newConfig, colonyName);
-              // Reset effects applied from research
-              colony.activeEffects = [];
-              if (colony.booleanFlags && Array.isArray(colony.booleanFlags)) {
-                colony.booleanFlags = new Set(colony.booleanFlags);
+              if (typeof colony.loadState === 'function') {
+                colony.loadState(colonyState);
               } else {
-                colony.booleanFlags = new Set();
+                Object.assign(colony, colonyState);
+                const newConfig = colonyParameters ? colonyParameters[colonyName] : undefined;
+                if (newConfig && typeof colony.initializeFromConfig === 'function') {
+                  colony.initializeFromConfig(newConfig, colonyName);
+                }
+                if (Array.isArray(colony.booleanFlags)) {
+                  colony.booleanFlags = new Set(colony.booleanFlags);
+                } else if (!(colony.booleanFlags instanceof Set)) {
+                  colony.booleanFlags = new Set();
+                }
               }
+              colony.activeEffects = [];
             }
           }
         }

--- a/tests/buildingSaveLoadMethods.test.js
+++ b/tests/buildingSaveLoadMethods.test.js
@@ -1,0 +1,200 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+function createResource() {
+  return {
+    value: 0,
+    cap: 0,
+    hasCap: true,
+    maintenanceMultiplier: 1,
+    modifyRate: () => {},
+    updateStorageCap: () => {},
+    productionRate: 0,
+    consumptionRate: 0
+  };
+}
+
+function createBaseContext() {
+  const ctx = { console };
+  vm.createContext(ctx);
+  ctx.globalThis = ctx;
+  ctx.EffectableEntity = EffectableEntity;
+  ctx.maintenanceFraction = 0.1;
+  ctx.globalGameIsLoadingFromSave = false;
+  ctx.dayNightCycle = { isDay: () => true };
+  ctx.populationModule = { getWorkerAvailabilityRatio: () => 1 };
+  ctx.registerBuildingUnlockAlert = () => {};
+  ctx.buildings = {};
+
+  const colonyResources = {
+    energy: { ...createResource() },
+    metal: { ...createResource() },
+    food: { ...createResource() },
+    components: { ...createResource() },
+    electronics: { ...createResource() },
+    androids: { ...createResource() },
+    colonists: { value: 100, cap: 100, modifyRate: () => {}, productionRate: 0, consumptionRate: 0 }
+  };
+
+  ctx.resources = {
+    colony: colonyResources,
+    surface: { land: { reserve: () => {}, release: () => {}, value: 0, reserved: 0 } },
+    underground: {}
+  };
+
+  return ctx;
+}
+
+function loadBuildingInto(ctx) {
+  const buildingPath = path.join(__dirname, '..', 'src/js', 'building.js');
+  const code = fs.readFileSync(buildingPath, 'utf8');
+  vm.runInContext(code + '; this.Building = Building;', ctx);
+}
+
+function loadColonyInto(ctx) {
+  const colonyPath = path.join(__dirname, '..', 'src/js', 'colony.js');
+  const code = fs.readFileSync(colonyPath, 'utf8');
+  vm.runInContext(code + '; this.Colony = Colony;', ctx);
+}
+
+describe('Building save/load methods', () => {
+  test('Building.saveState and loadState preserve dynamic fields', () => {
+    const ctx = createBaseContext();
+    loadBuildingInto(ctx);
+
+    const config = {
+      name: 'Factory',
+      category: 'industry',
+      description: '',
+      cost: { colony: { energy: 1 } },
+      consumption: { colony: { energy: 1 } },
+      production: { colony: { metal: 1 } },
+      storage: {},
+      dayNightActivity: true,
+      canBeToggled: true,
+      requiresMaintenance: true,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: false,
+      surfaceArea: 0,
+      requiresProductivity: true,
+      requiresLand: 0,
+      temperatureMaintenanceImmune: false,
+      powerPerBuilding: 0,
+      recipes: {
+        base: { production: { colony: { metal: 1 } } },
+        alt: { production: { colony: { metal: 2 } }, displayName: 'Alt Factory' }
+      },
+      defaultRecipe: 'base'
+    };
+
+    const building = new ctx.Building(config, 'factory');
+    building.unlocked = true;
+    building.alertedWhenUnlocked = true;
+    building.count = 5;
+    building.active = 3;
+    building.productivity = 0.75;
+    building.isHidden = true;
+    building.autoBuildEnabled = true;
+    building.autoBuildPercent = 0.4;
+    building.autoBuildPriority = true;
+    building.autoBuildBasis = 'androids';
+    building.workerPriority = 1;
+    building.autoActiveEnabled = true;
+    building.autoBuildPartial = true;
+    building.reversalAvailable = true;
+    building.reverseEnabled = true;
+    building.autoReverse = true;
+    building.currentRecipeKey = 'alt';
+    building._applyRecipeMapping();
+    building.booleanFlags.add('customFlag');
+
+    const saved = building.saveState();
+    expect(saved.count).toBe(5);
+    expect(saved.booleanFlags).toBeUndefined();
+    saved.booleanFlags = ['legacyFlag'];
+
+    const restored = new ctx.Building(config, 'factory');
+    expect(restored.currentRecipeKey).toBe('base');
+    restored.loadState(saved);
+
+    expect(restored.unlocked).toBe(true);
+    expect(restored.count).toBe(5);
+    expect(restored.active).toBe(3);
+    expect(restored.productivity).toBe(0.75);
+    expect(restored.isHidden).toBe(true);
+    expect(restored.autoBuildEnabled).toBe(true);
+    expect(restored.autoBuildPercent).toBe(0.4);
+    expect(restored.autoBuildPriority).toBe(true);
+    expect(restored.autoBuildBasis).toBe('androids');
+    expect(restored.workerPriority).toBe(1);
+    expect(restored.autoActiveEnabled).toBe(true);
+    expect(restored.autoBuildPartial).toBe(true);
+    expect(restored.reversalAvailable).toBe(true);
+    expect(restored.reverseEnabled).toBe(true);
+    expect(restored.autoReverse).toBe(true);
+    expect(restored.currentRecipeKey).toBe('alt');
+    expect(restored.displayName).toBe('Alt Factory');
+    expect(restored.booleanFlags.size).toBe(0);
+    expect(restored.cost.colony.energy).toBe(1);
+    expect(restored.consumption.colony.energy).toBe(1);
+    expect(restored.production.colony.metal).toBe(2);
+  });
+
+  test('Colony overrides save/load to include unique fields', () => {
+    const ctx = createBaseContext();
+    loadBuildingInto(ctx);
+    loadColonyInto(ctx);
+
+    const config = {
+      name: 'Settlement',
+      category: 'colony',
+      description: '',
+      cost: { colony: { energy: 1 } },
+      consumption: { colony: { energy: 1, electronics: 1 } },
+      production: { colony: {} },
+      storage: {},
+      dayNightActivity: true,
+      canBeToggled: true,
+      requiresMaintenance: true,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true,
+      surfaceArea: 0,
+      requiresProductivity: true,
+      requiresLand: 0,
+      temperatureMaintenanceImmune: false,
+      powerPerBuilding: 0,
+      baseComfort: 5
+    };
+
+    const colony = new ctx.Colony(config, 'settlement');
+    colony.count = 4;
+    colony.active = 2;
+    colony.productivity = 0.6;
+    colony.baseComfort = 12;
+    colony.happiness = 0.8;
+    colony.obsolete = true;
+    colony.filledNeeds.energy = 0.5;
+    colony.filledNeeds.electronics = 0.2;
+    colony.luxuryResourcesEnabled.electronics = false;
+
+    const saved = colony.saveState();
+    const restored = new ctx.Colony(config, 'settlement');
+    restored.loadState(saved);
+
+    expect(restored.count).toBe(4);
+    expect(restored.active).toBe(2);
+    expect(restored.productivity).toBeCloseTo(0.6);
+    expect(restored.baseComfort).toBe(12);
+    expect(restored.happiness).toBeCloseTo(0.8);
+    expect(restored.obsolete).toBe(true);
+    expect(restored.filledNeeds.energy).toBeCloseTo(0.5);
+    expect(restored.filledNeeds.electronics).toBeCloseTo(0.2);
+    expect(restored.luxuryResourcesEnabled.electronics).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit saveState/loadState helpers to Building and Colony to persist runtime fields without overwriting configuration
- update save/load logic to call the new helpers while falling back to the old assignment path for legacy data
- ensure building save/load leaves boolean flag sets empty so effects can repopulate them on load and cover the behaviour in Jest tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cab1333924832788203bde09a7872a