### PR TITLE
Add sulfuric acid rainout scaling in atmospheric chemistry

### DIFF
--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -571,6 +571,7 @@ class Terraforming extends EffectableEntity{
             realSeconds,
             durationSeconds,
             surfaceArea: this.celestialParameters.surfaceArea,
+            surfaceTemperatureK: this.temperature.value,
         });
 
         for (const [key, delta] of Object.entries(chemTotals.changes)) {


### PR DESCRIPTION
## Summary
- add a temperature-dependent sulfuric acid rainout term to the atmospheric chemistry model
- feed the current surface temperature into atmospheric chemistry updates
- cover the new acid rain behaviour and rate wiring with unit tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cb42d3bda48327a9b997ce52be148a