### PR TITLE
Add temperature snapshot helpers and use them in evaluations

### DIFF
--- a/src/js/projects/SpaceDisposalProject.js
+++ b/src/js/projects/SpaceDisposalProject.js
@@ -58,6 +58,10 @@ class SpaceDisposalProject extends SpaceExportBaseProject {
     const removal = Math.min(removed, originalAmount);
     const originalTemp = terraforming.temperature.value;
 
+    const saveTempState = terraforming.saveTemperatureState?.bind(terraforming);
+    const restoreTempState = terraforming.restoreTemperatureState?.bind(terraforming);
+    const snapshot = saveTempState ? saveTempState() : null;
+
     ghg.value = originalAmount - removal;
     if (typeof terraforming.updateSurfaceTemperature === 'function') {
       terraforming.updateSurfaceTemperature();
@@ -65,7 +69,9 @@ class SpaceDisposalProject extends SpaceExportBaseProject {
     const newTemp = terraforming.temperature.value;
 
     ghg.value = originalAmount;
-    if (typeof terraforming.updateSurfaceTemperature === 'function') {
+    if (snapshot && restoreTempState) {
+      restoreTempState(snapshot);
+    } else if (typeof terraforming.updateSurfaceTemperature === 'function') {
       terraforming.updateSurfaceTemperature();
     }
 

--- a/src/js/projects/SpaceMirrorFacilityProject.js
+++ b/src/js/projects/SpaceMirrorFacilityProject.js
@@ -1331,6 +1331,15 @@ function runAdvancedOversightAssignments(project) {
         terraforming.updateSurfaceTemperature();
       }
     };
+    const saveTempState = terraforming?.saveTemperatureState?.bind(terraforming);
+    const restoreTempState = terraforming?.restoreTemperatureState?.bind(terraforming);
+    const rollbackTemps = (snapshot) => {
+      if (snapshot && restoreTempState) {
+        restoreTempState(snapshot);
+      } else {
+        updateTemps();
+      }
+    };
 
     const readTemps = () => {
       const out = {};
@@ -1500,6 +1509,7 @@ function runAdvancedOversightAssignments(project) {
       changer();
       const changed = !(shallowEqual(assignM, snapM) && shallowEqual(assignL, snapL) && shallowEqual(reverse, snapR));
       if (changed) {
+        const snapshot = saveTempState ? saveTempState() : null;
         // Only recompute temps when something actually changed
         updateTemps();
         const out = evaluator();
@@ -1507,7 +1517,7 @@ function runAdvancedOversightAssignments(project) {
         Object.assign(assignM, snapM);
         Object.assign(assignL, snapL);
         Object.assign(reverse, snapR);
-        updateTemps();
+        rollbackTemps(snapshot);
         return out;
       } else {
         // No change; evaluate on current state without recomputing temps


### PR DESCRIPTION
## Summary
- add Terraforming.saveTemperatureState/restoreTemperatureState so callers can capture and roll back derived temperature and luminosity data
- update the greenhouse gas factory along with space disposal and mirror oversight logic to use temperature snapshots instead of extra updateSurfaceTemperature calls

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cb67203bd483279f85a198ab8b6dcc