### PR TITLE
Use physics cloud fraction for planet visualizer

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -483,7 +483,10 @@ function updateRender(force = false) {
           const pct = (x) => Math.max(0, Math.min(100, x * 100));
           pv.viz.coverage.water = pct(waterFrac);
           pv.viz.coverage.life = pct(lifeFrac);
-          pv.viz.coverage.cloud = pv.viz.coverage.water;
+          const cloudFrac = Number.isFinite(terraforming?.luminosity?.cloudFraction)
+            ? Math.max(0, Math.min(1, terraforming.luminosity.cloudFraction))
+            : waterFrac;
+          pv.viz.coverage.cloud = pct(cloudFrac);
 
           // Zonal coverages for rendering bands
           const zones = ['tropical', 'temperate', 'polar'];

--- a/src/js/planet-visualizer/core.js
+++ b/src/js/planet-visualizer/core.js
@@ -353,8 +353,14 @@
         z[zone].life = Math.max(0, Math.min(1, Number(b) || 0));
       }
       const avg = (a, b, c) => (a + b + c) / 3;
-      this.viz.coverage.water = avg(z.tropical.water, z.temperate.water, z.polar.water) * 100;
-      this.viz.coverage.life = avg(z.tropical.life, z.temperate.life, z.polar.life) * 100;
+      const avgWater = avg(z.tropical.water, z.temperate.water, z.polar.water);
+      const avgLife = avg(z.tropical.life, z.temperate.life, z.polar.life);
+      const cloudFraction = Number.isFinite(t?.luminosity?.cloudFraction)
+        ? Math.max(0, Math.min(1, t.luminosity.cloudFraction))
+        : avgWater;
+      this.viz.coverage.water = avgWater * 100;
+      this.viz.coverage.life = avgLife * 100;
+      this.viz.coverage.cloud = Math.max(0, Math.min(100, cloudFraction * 100));
     }
 
     getCurrentPopulation() {

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -310,6 +310,8 @@ class Terraforming extends EffectableEntity{
       groundAlbedo: 0,
       surfaceAlbedo: 0,
       actualAlbedo: 0,
+      cloudFraction: 0,
+      hazeFraction: 0,
       initialSurfaceAlbedo: undefined,
       initialActualAlbedo: undefined,
       solarFlux: 0,
@@ -604,6 +606,8 @@ class Terraforming extends EffectableEntity{
       this.luminosity.surfaceAlbedo = this.calculateSurfaceAlbedo();
       const albRes = this.calculateActualAlbedo();
       this.luminosity.actualAlbedo = albRes.albedo;
+      this.luminosity.cloudFraction = albRes.cloudFraction;
+      this.luminosity.hazeFraction = albRes.hazeFraction;
       this.luminosity.cloudHazePenalty = albRes.penalty;
       this.luminosity.albedo = this.luminosity.surfaceAlbedo;
       this.luminosity.solarFlux = this.calculateSolarFlux(this.celestialParameters.distanceFromSun * AU_METER);
@@ -1026,7 +1030,9 @@ class Terraforming extends EffectableEntity{
         const result = calculateActualAlbedoPhysics(surf, pressureBar, composition, gSurface, aerosolsSW) || {};
         const comps = result.components || {};
         const penalty = (comps.dA_ch4 || 0) + (comps.dA_calcite || 0) + (comps.dA_cloud || 0);
-        return { albedo: result.albedo, penalty };
+        const cloudFraction = Number.isFinite(result.cfCloud) ? result.cfCloud : 0;
+        const hazeFraction = Number.isFinite(result.cfHaze) ? result.cfHaze : 0;
+        return { albedo: result.albedo, penalty, cloudFraction, hazeFraction };
     }
 
     _updateZonalCoverageCache() {


### PR DESCRIPTION
## Summary
- store the cloud and haze fractions returned by calculateActualAlbedoPhysics on the terraforming luminosity state
- update the planet visualizer to read the cloud fraction from terraforming data instead of mirroring water coverage
- propagate the physics-provided cloud fraction through the game render loop so coverage percentages stay in sync

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cba168e540832790ba700a171a47c8