### PR TITLE
Keep worker priority controls black during shortages

### DIFF
--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -842,7 +842,15 @@ function updateDecreaseButtonText(button, buildCount) {
       }
       const hasEnough = item.available >= requiredAmount;
       const color = hasEnough ? '' : item.insufficientColor;
-      if (span.style.color !== color) {
+      if (item.key === 'colony.workers') {
+        if (span.style.color) {
+          span.style.color = '';
+        }
+        const textSpan = span._textSpan;
+        if (textSpan && textSpan.style.color !== color) {
+          textSpan.style.color = color;
+        }
+      } else if (span.style.color !== color) {
         span.style.color = color;
       }
     });


### PR DESCRIPTION
## Summary
- limit worker shortage styling to the workers label so priority controls stay black

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cd4f6054e08327b16b248a3c9a58b5