### PR TITLE
Fix GHG automation visibility before research

### DIFF
--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -45,7 +45,13 @@ function applyCollapseState(structureName) {
   if (autoContainer) {
     Array.from(autoContainer.children).forEach(child => {
       if (child !== inputContainer) {
-        child.style.display = collapsed ? 'none' : '';
+        if (collapsed) {
+          child.dataset.prevDisplay = child.style.display;
+          child.style.display = 'none';
+        } else if (Object.prototype.hasOwnProperty.call(child.dataset, 'prevDisplay')) {
+          child.style.display = child.dataset.prevDisplay;
+          delete child.dataset.prevDisplay;
+        }
       }
     });
   }

--- a/tests/ghgFactoryTemperatureInput.test.js
+++ b/tests/ghgFactoryTemperatureInput.test.js
@@ -4,7 +4,8 @@ const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules',
 const { JSDOM } = require(jsdomPath);
 const vm = require('vm');
 
-function setup() {
+function setup(options = {}) {
+  const { bureauEnabled = true } = options;
   const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', { runScripts: 'outside-only' });
   const ctx = dom.getInternalVMContext();
   ctx.document = dom.window.document;
@@ -74,7 +75,7 @@ function setup() {
     maintenanceCost: {},
     updateResourceStorage: () => {},
     reversalAvailable: false,
-    isBooleanFlagSet: flag => flag === 'terraformingBureauFeature',
+    isBooleanFlagSet: flag => flag === 'terraformingBureauFeature' ? bureauEnabled : false,
     initUI: ctx.GhgFactory.prototype.initUI,
     updateUI: ctx.GhgFactory.prototype.updateUI,
   };
@@ -113,5 +114,11 @@ describe('GHG factory temperature control', () => {
       inputA.value = ctx.toDisplayTemperature(ctx.ghgFactorySettings.disableTempThreshold);
     }
     expect(parseFloat(inputA.value)).toBeCloseTo(1.85, 5);
+  });
+
+  test('controls hidden without terraforming bureau research', () => {
+    const { dom } = setup({ bureauEnabled: false });
+    const control = dom.window.document.querySelector('.ghg-temp-control');
+    expect(control.style.display).toBe('none');
   });
 });


### PR DESCRIPTION
## Summary
- preserve building-specific control visibility across collapse toggles so hidden automation stays hidden
- extend the GHG factory temperature control test to cover visibility when the Terraforming Bureau research is locked

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cd5d2d058c83279a2fab32d80b53aa