### PR TITLE
Preserve auto-build controls after collapsing building cards

### DIFF
--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -46,7 +46,9 @@ function applyCollapseState(structureName) {
     Array.from(autoContainer.children).forEach(child => {
       if (child !== inputContainer) {
         if (collapsed) {
-          child.dataset.prevDisplay = child.style.display;
+          if (!Object.prototype.hasOwnProperty.call(child.dataset, 'prevDisplay')) {
+            child.dataset.prevDisplay = child.style.display;
+          }
           child.style.display = 'none';
         } else if (Object.prototype.hasOwnProperty.call(child.dataset, 'prevDisplay')) {
           child.style.display = child.dataset.prevDisplay;

--- a/tests/buildingCollapse.test.js
+++ b/tests/buildingCollapse.test.js
@@ -74,7 +74,7 @@ describe('building collapse arrow', () => {
     const row = ctx.createStructureRow(structure, () => {}, () => {}, false);
     dom.window.document.body.appendChild(row);
 
-    return { dom, row };
+    return { dom, row, applyCollapseState: ctx.applyCollapseState };
   }
 
   test('arrow toggles collapsed state and hides details', () => {
@@ -98,5 +98,22 @@ describe('building collapse arrow', () => {
     expect(arrow.textContent).toBe('▼');
     expect(cost.style.display).toBe('');
     expect(autoTarget.style.display).toBe('');
+  });
+
+  test('auto-build controls recover after updates while collapsed', () => {
+    const { dom, row, applyCollapseState } = setup();
+    const arrow = row.querySelector('.collapse-arrow');
+    const autoTarget = row.querySelector('.auto-build-target-container');
+    const setActive = row.querySelector('.auto-build-setactive-container');
+
+    arrow.dispatchEvent(new dom.window.Event('click'));
+    expect(autoTarget.style.display).toBe('none');
+    expect(setActive.style.display).toBe('none');
+
+    applyCollapseState('testStruct');
+
+    arrow.dispatchEvent(new dom.window.Event('click'));
+    expect(autoTarget.style.display).toBe('');
+    expect(setActive.style.display).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- ensure auto-build UI children remember their original display when building cards collapse
- add a regression test that simulates repeated collapse updates to keep target and set-active controls visible

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cd618be7288327be9a392c97d646dd