### PR TITLE
Show day temperature trends in space mirror facility

### DIFF
--- a/tests/spaceMirrorDayTemperatureDisplay.test.js
+++ b/tests/spaceMirrorDayTemperatureDisplay.test.js
@@ -13,9 +13,9 @@ describe('space mirror day temperature display', () => {
     global.terraforming = {
       calculateZoneSolarFlux: () => 0,
       temperature: { zones: {
-        tropical: { day: 300, value: 0 },
-        temperate: { day: 280, value: 0 },
-        polar: { day: 260, value: 0 },
+        tropical: { day: 300, value: 295, trendValue: 298 },
+        temperate: { day: 280, value: 276, trendValue: 274 },
+        polar: { day: 260, value: 258, trendValue: 257 },
       } }
     };
 
@@ -30,10 +30,10 @@ describe('space mirror day temperature display', () => {
     updateZonalFluxTable();
 
     const header = dom.window.document.querySelector('#mirror-flux-table thead tr th:nth-child(4)').textContent;
-    expect(header).toBe('Day Temperature (K)');
-    expect(dom.window.document.getElementById('mirror-day-temp-tropical').textContent).toBe('300.00');
-    expect(dom.window.document.getElementById('mirror-day-temp-temperate').textContent).toBe('280.00');
-    expect(dom.window.document.getElementById('mirror-day-temp-polar').textContent).toBe('260.00');
+    expect(header).toBe('Day Temperature (K) Current / Trend');
+    expect(dom.window.document.getElementById('mirror-day-temp-tropical').textContent).toBe('300.00 / 303.00');
+    expect(dom.window.document.getElementById('mirror-day-temp-temperate').textContent).toBe('280.00 / 278.00');
+    expect(dom.window.document.getElementById('mirror-day-temp-polar').textContent).toBe('260.00 / 259.00');
 
     delete global.document;
     delete global.getTemperatureUnit;


### PR DESCRIPTION
## Summary
- update the space mirror facility flux table header to note that day temperatures show current and trend values
- calculate zonal day temperature trends from the mean trend plus day/night offset and render them alongside current readings
- extend the day temperature display test to assert the new header text and combined current/trend output

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cd684c2c248327880a5a904f3722bb