### PR TITLE
Persist factory automation settings

### DIFF
--- a/src/js/save.js
+++ b/src/js/save.js
@@ -1,16 +1,24 @@
+var GhgFactoryClassRef = GhgFactoryClassRef ||
+  (typeof require !== 'undefined'
+    ? (() => {
+        try { return require('./buildings/GhgFactory.js').GhgFactory; }
+        catch (e) { return globalThis.GhgFactory; }
+      })()
+    : globalThis.GhgFactory);
 var ghgFactorySettingsRef = ghgFactorySettingsRef ||
-  (typeof require !== 'undefined'
-    ? (() => {
-        try { return require('./buildings/GhgFactory.js').ghgFactorySettings; }
-        catch (e) { return globalThis.ghgFactorySettings; }
-      })()
+  (GhgFactoryClassRef && GhgFactoryClassRef.getAutomationSettings
+    ? GhgFactoryClassRef.getAutomationSettings()
     : globalThis.ghgFactorySettings);
-var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
+var OxygenFactoryClassRef = OxygenFactoryClassRef ||
   (typeof require !== 'undefined'
     ? (() => {
-        try { return require('./buildings/OxygenFactory.js').oxygenFactorySettings; }
-        catch (e) { return globalThis.oxygenFactorySettings; }
+        try { return require('./buildings/OxygenFactory.js').OxygenFactory; }
+        catch (e) { return globalThis.OxygenFactory; }
       })()
+    : globalThis.OxygenFactory);
+var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
+  (OxygenFactoryClassRef && OxygenFactoryClassRef.getAutomationSettings
+    ? OxygenFactoryClassRef.getAutomationSettings()
     : globalThis.oxygenFactorySettings);
 
 globalGameIsLoadingFromSave = false;
@@ -113,8 +121,12 @@ function getGameState() {
     selectedBuildCounts: typeof selectedBuildCounts !== 'undefined' ? selectedBuildCounts : undefined,
     settings: typeof gameSettings !== 'undefined' ? gameSettings : undefined,
     colonySliderSettings: (typeof colonySliderSettings !== 'undefined' && typeof colonySliderSettings.saveState === 'function') ? colonySliderSettings.saveState() : undefined,
-    ghgFactorySettings: typeof ghgFactorySettingsRef !== 'undefined' ? ghgFactorySettingsRef : undefined,
-    oxygenFactorySettings: typeof oxygenFactorySettingsRef !== 'undefined' ? oxygenFactorySettingsRef : undefined,
+    ghgFactorySettings: GhgFactoryClassRef && typeof GhgFactoryClassRef.saveAutomationSettings === 'function'
+      ? GhgFactoryClassRef.saveAutomationSettings()
+      : (typeof ghgFactorySettingsRef !== 'undefined' ? ghgFactorySettingsRef : undefined),
+    oxygenFactorySettings: OxygenFactoryClassRef && typeof OxygenFactoryClassRef.saveAutomationSettings === 'function'
+      ? OxygenFactoryClassRef.saveAutomationSettings()
+      : (typeof oxygenFactorySettingsRef !== 'undefined' ? oxygenFactorySettingsRef : undefined),
     constructionOffice: typeof saveConstructionOfficeState === 'function' ? saveConstructionOfficeState() : undefined,
     playTimeSeconds: typeof playTimeSeconds !== 'undefined' ? playTimeSeconds : undefined,
     totalPlayTimeSeconds: typeof totalPlayTimeSeconds !== 'undefined' ? totalPlayTimeSeconds : undefined
@@ -502,12 +514,22 @@ function loadGame(slotOrCustomString) {
     }
 
     if(gameState.ghgFactorySettings){
-      Object.assign(ghgFactorySettings, gameState.ghgFactorySettings);
-      enforceGhgFactoryTempGap();
+      if (GhgFactoryClassRef && typeof GhgFactoryClassRef.loadAutomationSettings === 'function') {
+        GhgFactoryClassRef.loadAutomationSettings(gameState.ghgFactorySettings);
+      } else if (ghgFactorySettingsRef) {
+        Object.assign(ghgFactorySettingsRef, gameState.ghgFactorySettings);
+        if (typeof enforceGhgFactoryTempGap === 'function') {
+          enforceGhgFactoryTempGap();
+        }
+      }
     }
 
     if(gameState.oxygenFactorySettings){
-      Object.assign(oxygenFactorySettings, gameState.oxygenFactorySettings);
+      if (OxygenFactoryClassRef && typeof OxygenFactoryClassRef.loadAutomationSettings === 'function') {
+        OxygenFactoryClassRef.loadAutomationSettings(gameState.oxygenFactorySettings);
+      } else if (oxygenFactorySettingsRef) {
+        Object.assign(oxygenFactorySettingsRef, gameState.oxygenFactorySettings);
+      }
     }
 
       if(gameState.constructionOffice && typeof loadConstructionOfficeState === 'function'){

--- a/tests/automationSettingsPersistence.test.js
+++ b/tests/automationSettingsPersistence.test.js
@@ -1,0 +1,61 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+const { GhgFactory } = require('../src/js/buildings/GhgFactory.js');
+const { OxygenFactory } = require('../src/js/buildings/OxygenFactory.js');
+
+describe('Factory automation settings persistence', () => {
+  beforeEach(() => {
+    GhgFactory.loadAutomationSettings({});
+    OxygenFactory.loadAutomationSettings({});
+  });
+
+  test('GHG factory saves and loads automation settings', () => {
+    GhgFactory.loadAutomationSettings({
+      autoDisableAboveTemp: true,
+      disableTempThreshold: 290,
+      reverseTempThreshold: 296
+    });
+    const snapshot = GhgFactory.saveAutomationSettings();
+    expect(snapshot).toEqual({
+      autoDisableAboveTemp: true,
+      disableTempThreshold: 290,
+      reverseTempThreshold: 296
+    });
+    snapshot.autoDisableAboveTemp = false;
+    const current = GhgFactory.getAutomationSettings();
+    expect(current.autoDisableAboveTemp).toBe(true);
+
+    GhgFactory.loadAutomationSettings({
+      autoDisableAboveTemp: false,
+      disableTempThreshold: 275
+    });
+    const adjusted = GhgFactory.getAutomationSettings();
+    expect(adjusted.autoDisableAboveTemp).toBe(false);
+    expect(adjusted.disableTempThreshold).toBe(275);
+    const partialSnapshot = GhgFactory.saveAutomationSettings();
+    expect(partialSnapshot.reverseTempThreshold).toBeCloseTo(adjusted.reverseTempThreshold, 5);
+    expect(Number.isFinite(adjusted.reverseTempThreshold)).toBe(true);
+  });
+
+  test('Oxygen factory saves and loads automation settings', () => {
+    OxygenFactory.loadAutomationSettings({
+      autoDisableAbovePressure: true,
+      disablePressureThreshold: 25
+    });
+    const snapshot = OxygenFactory.saveAutomationSettings();
+    expect(snapshot).toEqual({
+      autoDisableAbovePressure: true,
+      disablePressureThreshold: 25
+    });
+    snapshot.disablePressureThreshold = 99;
+    const current = OxygenFactory.getAutomationSettings();
+    expect(current.disablePressureThreshold).toBe(25);
+
+    OxygenFactory.loadAutomationSettings({});
+    const reset = OxygenFactory.getAutomationSettings();
+    expect(reset.autoDisableAbovePressure).toBe(false);
+    expect(reset.disablePressureThreshold).toBe(15);
+  });
+});


### PR DESCRIPTION
## Summary
- manage GHG and oxygen factory automation settings through their classes with helper access for UI contexts
- expose save/load helpers for these automation controls and have the save system use them
- add unit coverage to confirm automation settings persist correctly

## Testing
- CI=true npm test *(fails: surfaceMeltProportional.test.js also fails on main)*

------
https://chatgpt.com/codex/tasks/task_b_68cd8fc39b988327bec8693a9cef45df