### PR TITLE
Fix factory automation settings persistence on save/load

### DIFF
--- a/src/js/save.js
+++ b/src/js/save.js
@@ -21,6 +21,42 @@ var oxygenFactorySettingsRef = oxygenFactorySettingsRef ||
     ? OxygenFactoryClassRef.getAutomationSettings()
     : globalThis.oxygenFactorySettings);
 
+function refreshFactoryAutomationRefs() {
+  if (!GhgFactoryClassRef) {
+    if (typeof require !== 'undefined') {
+      try {
+        GhgFactoryClassRef = require('./buildings/GhgFactory.js').GhgFactory;
+      } catch (e) {}
+    }
+    if (!GhgFactoryClassRef && globalThis && globalThis.GhgFactory) {
+      GhgFactoryClassRef = globalThis.GhgFactory;
+    }
+  }
+  const ghgSettings = GhgFactoryClassRef && GhgFactoryClassRef.getAutomationSettings
+    ? GhgFactoryClassRef.getAutomationSettings()
+    : (globalThis && globalThis.ghgFactorySettings);
+  if (ghgSettings) {
+    ghgFactorySettingsRef = ghgSettings;
+  }
+
+  if (!OxygenFactoryClassRef) {
+    if (typeof require !== 'undefined') {
+      try {
+        OxygenFactoryClassRef = require('./buildings/OxygenFactory.js').OxygenFactory;
+      } catch (e) {}
+    }
+    if (!OxygenFactoryClassRef && globalThis && globalThis.OxygenFactory) {
+      OxygenFactoryClassRef = globalThis.OxygenFactory;
+    }
+  }
+  const oxygenSettings = OxygenFactoryClassRef && OxygenFactoryClassRef.getAutomationSettings
+    ? OxygenFactoryClassRef.getAutomationSettings()
+    : (globalThis && globalThis.oxygenFactorySettings);
+  if (oxygenSettings) {
+    oxygenFactorySettingsRef = oxygenSettings;
+  }
+}
+
 globalGameIsLoadingFromSave = false;
 
 let loadingOverlayElement = null;
@@ -84,6 +120,7 @@ function recalculateLandUsage() {
 }
 
 function getGameState() {
+  refreshFactoryAutomationRefs();
   return {
     dayNightCycle: (typeof dayNightCycle !== 'undefined' && typeof dayNightCycle.saveState === 'function') ? dayNightCycle.saveState() : undefined,
     resources: typeof resources !== 'undefined' ? resources : undefined,
@@ -156,6 +193,7 @@ function loadGame(slotOrCustomString) {
 
   showLoadingOverlay();
   globalGameIsLoadingFromSave = true;
+  refreshFactoryAutomationRefs();
 
   try {
     const gameState = JSON.parse(savedState);

--- a/tests/factoryAutomationSaveIntegration.test.js
+++ b/tests/factoryAutomationSaveIntegration.test.js
@@ -1,0 +1,119 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('factory automation settings integrate with save system', () => {
+  test('late factory registration still saves automation settings', () => {
+    const ctx = { console };
+    ctx.globalThis = ctx;
+    ctx.JSON = JSON;
+
+    ctx.dayNightCycle = { saveState: () => ({}), loadState: () => {} };
+    ctx.resources = {};
+    ctx.buildings = {};
+    ctx.colonies = {};
+    ctx.projectManager = { saveState: () => ({}) };
+    ctx.researchManager = { saveState: () => ({}) };
+    ctx.oreScanner = { saveState: () => ({}) };
+    ctx.terraforming = { saveState: () => ({}) };
+    ctx.storyManager = { saveState: () => ({}), loadState: () => {}, appliedEffects: [], reapplyEffects: () => {} };
+    ctx.journalEntrySources = [];
+    ctx.journalHistorySources = [];
+    ctx.goldenAsteroid = { saveState: () => ({}) };
+    ctx.nanotechManager = { saveState: () => ({}) };
+    ctx.solisManager = { saveState: () => ({}) };
+    ctx.warpGateCommand = { saveState: () => ({}) };
+    ctx.lifeDesigner = { saveState: () => ({}) };
+    ctx.milestonesManager = { saveState: () => ({}) };
+    ctx.skillManager = { saveState: () => ({}) };
+    ctx.spaceManager = { saveState: () => ({}) };
+    ctx.selectedBuildCounts = {};
+    ctx.gameSettings = {};
+    ctx.colonySliderSettings = { saveState: () => ({}) };
+    ctx.saveConstructionOfficeState = () => ({}) ;
+    ctx.playTimeSeconds = 0;
+    ctx.totalPlayTimeSeconds = 0;
+    ctx.document = { getElementById: () => null, body: { classList: { toggle: () => {} } } };
+
+    const saveCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'save.js'), 'utf8');
+    vm.createContext(ctx);
+    vm.runInContext(`${saveCode}; this.getGameStateRef = getGameState;`, ctx);
+
+    class FakeGhgFactory {
+      static getAutomationSettings() {
+        if (!this.settings) {
+          this.settings = {
+            autoDisableAboveTemp: false,
+            disableTempThreshold: 280,
+            reverseTempThreshold: 285
+          };
+        }
+        return this.settings;
+      }
+      static saveAutomationSettings() {
+        const s = this.getAutomationSettings();
+        return {
+          autoDisableAboveTemp: !!s.autoDisableAboveTemp,
+          disableTempThreshold: s.disableTempThreshold,
+          reverseTempThreshold: s.reverseTempThreshold
+        };
+      }
+      static loadAutomationSettings(saved) {
+        const s = this.getAutomationSettings();
+        if (saved && typeof saved === 'object') {
+          if ('autoDisableAboveTemp' in saved) s.autoDisableAboveTemp = !!saved.autoDisableAboveTemp;
+          if ('disableTempThreshold' in saved) s.disableTempThreshold = saved.disableTempThreshold;
+          if ('reverseTempThreshold' in saved) s.reverseTempThreshold = saved.reverseTempThreshold;
+        }
+        return s;
+      }
+    }
+
+    class FakeOxygenFactory {
+      static getAutomationSettings() {
+        if (!this.settings) {
+          this.settings = {
+            autoDisableAbovePressure: false,
+            disablePressureThreshold: 15
+          };
+        }
+        return this.settings;
+      }
+      static saveAutomationSettings() {
+        const s = this.getAutomationSettings();
+        return {
+          autoDisableAbovePressure: !!s.autoDisableAbovePressure,
+          disablePressureThreshold: s.disablePressureThreshold
+        };
+      }
+      static loadAutomationSettings(saved) {
+        const s = this.getAutomationSettings();
+        if (saved && typeof saved === 'object') {
+          if ('autoDisableAbovePressure' in saved) s.autoDisableAbovePressure = !!saved.autoDisableAbovePressure;
+          if ('disablePressureThreshold' in saved) s.disablePressureThreshold = saved.disablePressureThreshold;
+        }
+        return s;
+      }
+    }
+
+    ctx.GhgFactory = FakeGhgFactory;
+    ctx.ghgFactorySettings = FakeGhgFactory.getAutomationSettings();
+    ctx.OxygenFactory = FakeOxygenFactory;
+    ctx.oxygenFactorySettings = FakeOxygenFactory.getAutomationSettings();
+
+    ctx.ghgFactorySettings.autoDisableAboveTemp = true;
+    ctx.oxygenFactorySettings.autoDisableAbovePressure = true;
+
+    const snapshot = ctx.getGameStateRef();
+
+    expect(snapshot.ghgFactorySettings).toEqual({
+      autoDisableAboveTemp: true,
+      disableTempThreshold: 280,
+      reverseTempThreshold: 285
+    });
+    expect(snapshot.oxygenFactorySettings).toEqual({
+      autoDisableAbovePressure: true,
+      disablePressureThreshold: 15
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- refresh automation class references when preparing save data or loading a game so the GHG and oxygen factory settings persist
- cover the late-registration scenario with an integration test that exercises save.js through a vm context

## Testing
- CI=true npm test *(fails: tests/surfaceMeltProportional.test.js already fails on baseline; automation persistence covered by new test)*

------
https://chatgpt.com/codex/tasks/task_b_68cd94306da08327ac86ba730b62a986