### PR TITLE
Fix export ship cap display

### DIFF
--- a/src/js/projects/SpaceExportProject.js
+++ b/src/js/projects/SpaceExportProject.js
@@ -12,7 +12,9 @@ class SpaceExportProject extends SpaceExportBaseProject {
 
   getMaxAssignableShips() {
     const capacity = this.getShipCapacity() || 1;
-    return Math.floor((this.getEffectiveDuration()/1000)*this.getExportCap() / capacity);
+    const baseDuration = this.isBooleanFlagSet('instantDuration') ? 1000 : this.duration;
+    const effectiveDuration = this.applyDurationEffects(baseDuration);
+    return Math.floor((effectiveDuration / 1000) * this.getExportCap() / capacity);
   }
 
   assignSpaceships(count) {

--- a/tests/spaceExportMaxAssignableShips.test.js
+++ b/tests/spaceExportMaxAssignableShips.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('SpaceExportProject max assignable ships', () => {
+  function setupContext() {
+    const ctx = {
+      console,
+      EffectableEntity,
+      shipEfficiency: 1,
+      projectElements: {},
+      formatNumber: (value) => value,
+      formatBigInteger: (value) => value.toString(),
+    };
+
+    ctx.resources = {
+      colony: { metal: { displayName: 'Metal', value: 0 } },
+      special: { spaceships: { value: 0 } },
+    };
+
+    vm.createContext(ctx);
+
+    const projectsPath = path.join(__dirname, '..', 'src/js', 'projects.js');
+    const projectsCode = fs.readFileSync(projectsPath, 'utf8');
+    vm.runInContext(`${projectsCode}; this.Project = Project;`, ctx);
+
+    const spaceshipPath = path.join(__dirname, '..', 'src/js/projects', 'SpaceshipProject.js');
+    const spaceshipCode = fs.readFileSync(spaceshipPath, 'utf8');
+    vm.runInContext(`${spaceshipCode}; this.SpaceshipProject = SpaceshipProject;`, ctx);
+
+    const exportBasePath = path.join(__dirname, '..', 'src/js/projects', 'SpaceExportBaseProject.js');
+    const exportBaseCode = fs.readFileSync(exportBasePath, 'utf8');
+    vm.runInContext(`${exportBaseCode}; this.SpaceExportBaseProject = SpaceExportBaseProject;`, ctx);
+
+    const exportPath = path.join(__dirname, '..', 'src/js/projects', 'SpaceExportProject.js');
+    const exportCode = fs.readFileSync(exportPath, 'utf8');
+    vm.runInContext(`${exportCode}; this.SpaceExportProject = SpaceExportProject;`, ctx);
+
+    return ctx;
+  }
+
+  test('getMaxAssignableShips is independent of current assignment below continuous threshold', () => {
+    const ctx = setupContext();
+    ctx.resources.special.spaceships.value = 200;
+
+    const config = {
+      name: 'export',
+      category: 'resources',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: true,
+      attributes: {
+        spaceExport: true,
+        disposalAmount: 1000,
+        disposable: { colony: ['metal'] },
+        defaultDisposal: { category: 'colony', resource: 'metal' },
+      },
+    };
+
+    const project = new ctx.SpaceExportProject(config, 'export');
+
+    const maxBefore = project.getMaxAssignableShips();
+    project.assignSpaceships(50);
+    const maxAfter = project.getMaxAssignableShips();
+
+    expect(maxAfter).toBe(maxBefore);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure SpaceExportProject calculates its max assignable ships using the base duration so the value no longer shrinks when assigning 2-100 vessels
- add a regression test covering the discrete max-cap calculation for the funding export project

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68ce13182f7c83278eb431ad9cab2a43