### PR TITLE
Hide locked storage entries while preserving capacity

### DIFF
--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -149,13 +149,15 @@ class Resource extends EffectableEntity {
           .reduce((sum, e) => sum + e.value, 0)
       : 0;
     newCap += bonus;
+
     for (const structureName in structures) {
       const structure = structures[structureName];
-      if (structure.storage && structure.active > 0) {
-        if (structure.storage.colony && structure.storage.colony[this.name]) {
-          newCap += structure.active * structure.storage.colony[this.name] * structure.getEffectiveStorageMultiplier();
-        }
-      }
+      if (!structure.storage || structure.active <= 0) continue;
+
+      const storageByCategory = structure.storage[this.category];
+      if (!storageByCategory || storageByCategory[this.name] === undefined) continue;
+
+      newCap += structure.active * storageByCategory[this.name] * structure.getEffectiveStorageMultiplier();
     }
     this.cap = this.hasCap ? newCap : Infinity;
   }

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -1318,8 +1318,10 @@ function formatStorageDetails(storageObject) {
   for (const category in storageObject) {
     for (const resource in storageObject[category]) {
       const storageAmount = storageObject[category][resource];
-      if (storageAmount > 0) {
-        storageDetails += `${formatNumber(storageAmount, true, 2)} ${resources[category][resource].displayName}, `;
+      const resourceEntry = resources?.[category]?.[resource];
+      if (storageAmount > 0 && resourceEntry?.unlocked) {
+        const displayName = resourceEntry.displayName || resource;
+        storageDetails += `${formatNumber(storageAmount, true, 2)} ${displayName}, `;
       }
     }
   }

--- a/tests/buildingStorageUnlockedResources.test.js
+++ b/tests/buildingStorageUnlockedResources.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Resource } = require('../src/js/resource.js');
+
+function loadFormatStorageDetails(resources) {
+  const dom = new JSDOM('<!DOCTYPE html><div></div>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.formatNumber = value => value;
+  ctx.resources = resources;
+  ctx.buildings = {};
+  ctx.colonies = {};
+  ctx.terraforming = { celestialParameters: {} };
+  ctx.Colony = class {};
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+  return ctx.formatStorageDetails;
+}
+
+describe('building storage display handling', () => {
+  let resource;
+
+  beforeEach(() => {
+    global.structures = {
+      storageDepot: {
+        storage: { colony: { metal: 1000 } },
+        active: 1,
+        getEffectiveStorageMultiplier: () => 1
+      }
+    };
+
+    resource = new Resource({
+      name: 'metal',
+      category: 'colony',
+      displayName: 'Metal',
+      hasCap: true,
+      baseCap: 0,
+      unlocked: false
+    });
+  });
+
+  afterEach(() => {
+    global.structures = {};
+  });
+
+  test('building storage applies even when resource locked', () => {
+    resource.updateStorageCap();
+    expect(resource.cap).toBe(1000);
+  });
+
+  test('storage display omits locked resources', () => {
+    const formatStorageDetails = loadFormatStorageDetails({
+      colony: {
+        metal: { displayName: 'Metal', unlocked: false },
+        water: { displayName: 'Water', unlocked: true }
+      }
+    });
+
+    const storageText = formatStorageDetails({ colony: { metal: 500, water: 200 } });
+    expect(storageText).toBe('200 Water');
+  });
+
+  test('storage display returns empty when all resources locked', () => {
+    const formatStorageDetails = loadFormatStorageDetails({
+      colony: {
+        metal: { displayName: 'Metal', unlocked: false }
+      }
+    });
+
+    const storageText = formatStorageDetails({ colony: { metal: 500 } });
+    expect(storageText).toBe('');
+  });
+});

--- a/tests/storageProvidesScaleWithBuildCount.test.js
+++ b/tests/storageProvidesScaleWithBuildCount.test.js
@@ -10,7 +10,7 @@ const { getProdConsSections } = (() => {
   const ctx = dom.getInternalVMContext();
   ctx.formatNumber = n => n;
   ctx.formatStorageDetails = storage => `${storage.colony.water} Water`;
-  ctx.resources = { colony: { water: { displayName: 'Water' } } };
+  ctx.resources = { colony: { water: { displayName: 'Water', unlocked: true } } };
   ctx.terraforming = { celestialParameters: {} };
   ctx.Colony = class {};
   const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'structuresUI.js'), 'utf8');


### PR DESCRIPTION
## Summary
- ensure resource storage caps still receive building contributions before a resource unlocks
- suppress locked resources from storage details shown in the building panel
- add tests covering locked resource storage display behaviour and mark fixture resources as unlocked where storage output is expected

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68ce12e6279c8327afea61b7ff0393c7