### PR TITLE
Ensure GHG temp updates ignore heat capacity

### DIFF
--- a/src/js/buildings/GhgFactory.js
+++ b/src/js/buildings/GhgFactory.js
@@ -28,7 +28,7 @@ class GhgFactory extends Building {
     const restoreTempState = terraforming?.restoreTemperatureState?.bind(terraforming);
     const applyTempUpdate = () => {
       if (terraforming?.updateSurfaceTemperature) {
-        terraforming.updateSurfaceTemperature();
+        terraforming.updateSurfaceTemperature(0, { ignoreHeatCapacity: true });
       }
     };
     const evaluateTemperature = (applyChange, evaluate, revertChange) => {


### PR DESCRIPTION
## Summary
- update the GHG factory's applyTempUpdate helper to pass `ignoreHeatCapacity` so terraforming temperature snapshots react immediately
- confirm other references in the class only guard the helper with type checks

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68ce16b1816c8327ab279aad310d23c4