### PR TITLE
Adjust gravity build cost penalty scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@
 - Building-specific logic resides in dedicated subclasses under `src/js/buildings/`. To add a new building type, create a subclass and register it in `initializeBuildings`.
 - Added a fullscreen loading overlay that displays while the game or a save file is loading.
 
+## Updates
+- High-gravity worlds now apply compounded building and colony cost multipliers, and the Terraforming Others panel shows the current gravity alongside any active gravity penalty.
+
 # Overview of code
 This repository contains a browser-based incremental game written in JavaScript. The
 entry point **index.html** loads scripts that create resources, buildings, colonies,

--- a/src/js/terraforming/terraformingUI.js
+++ b/src/js/terraforming/terraformingUI.js
@@ -987,6 +987,17 @@ function updateLifeBox() {
       const orbRad = typeof terraforming.orbitalRadiation === 'number' ? terraforming.orbitalRadiation : 0;
       const rad = typeof terraforming.surfaceRadiation === 'number' ? terraforming.surfaceRadiation : 0;
       const radPenalty = typeof terraforming.radiationPenalty === 'number' ? terraforming.radiationPenalty : 0;
+      const gravityValue = Number.isFinite(terraforming.celestialParameters.gravity)
+        ? terraforming.celestialParameters.gravity
+        : 0;
+      const gravityPenaltyData = terraforming.gravityCostPenalty || { multiplier: 1 };
+      const gravityPenaltyMultiplier = Number.isFinite(gravityPenaltyData.multiplier)
+        ? gravityPenaltyData.multiplier
+        : 1;
+      const gravityPenaltyPercent = (gravityPenaltyMultiplier - 1) * 100;
+      const gravityPenaltyText = gravityPenaltyMultiplier > 1
+        ? `+${formatNumber(gravityPenaltyPercent, false, 2)}% build cost`
+        : '';
 
     magnetosphereBox.innerHTML = `
       <h3>${terraforming.magnetosphere.name}</h3>
@@ -994,10 +1005,16 @@ function updateLifeBox() {
         <p>Orbital radiation: <span id="orbital-radiation">${formatRadiation(orbRad)}</span> mSv/day</p>
         <p>Surface radiation: <span id="surface-radiation">${formatRadiation(rad)}</span> mSv/day</p>
         <p id="radiation-penalty-row">Radiation penalty: <span id="surface-radiation-penalty">${formatNumber(radPenalty * 100, false, 0)}</span>%</p>
+        <p>Gravity: <span id="terraforming-gravity-value">${formatNumber(gravityValue, false, 2)}</span> m/s²</p>
+        <p id="gravity-penalty-row">Gravity penalty: <span id="terraforming-gravity-penalty">${gravityPenaltyText}</span></p>
       `;
     if ((radPenalty || 0) < 0.0001) {
       const penaltyRow = magnetosphereBox.querySelector('#radiation-penalty-row');
       if (penaltyRow) penaltyRow.style.display = 'none';
+    }
+    if (gravityPenaltyMultiplier <= 1) {
+      const gravityPenaltyRow = magnetosphereBox.querySelector('#gravity-penalty-row');
+      if (gravityPenaltyRow) gravityPenaltyRow.style.display = 'none';
     }
     const magnetosphereHeading = magnetosphereBox.querySelector('h3');
     if (magnetosphereHeading) {
@@ -1010,7 +1027,10 @@ function updateLifeBox() {
       status: magnetosphereBox.querySelector('#magnetosphere-status'),
       surfaceRadiation: magnetosphereBox.querySelector('#surface-radiation'),
       orbitalRadiation: magnetosphereBox.querySelector('#orbital-radiation'),
-      surfaceRadiationPenalty: magnetosphereBox.querySelector('#surface-radiation-penalty')
+      surfaceRadiationPenalty: magnetosphereBox.querySelector('#surface-radiation-penalty'),
+      gravityValue: magnetosphereBox.querySelector('#terraforming-gravity-value'),
+      gravityPenaltyRow: magnetosphereBox.querySelector('#gravity-penalty-row'),
+      gravityPenaltyValue: magnetosphereBox.querySelector('#terraforming-gravity-penalty')
     };
   }
 
@@ -1023,6 +1043,9 @@ function updateLifeBox() {
     const surfaceRadiation = els.surfaceRadiation;
     const orbitalRadiation = els.orbitalRadiation;
     const surfaceRadiationPenalty = els.surfaceRadiationPenalty;
+    const gravityValue = els.gravityValue;
+    const gravityPenaltyRow = els.gravityPenaltyRow;
+    const gravityPenaltyValue = els.gravityPenaltyValue;
 
     // Update status based on natural or artificial magnetosphere
     const magnetosphereStatusText = terraforming.celestialParameters.hasNaturalMagnetosphere
@@ -1049,6 +1072,29 @@ function updateLifeBox() {
       } else {
         penaltyRow.style.display = '';
         surfaceRadiationPenalty.textContent = formatNumber(penaltyValue * 100, false, 0);
+      }
+    }
+
+    if (gravityValue) {
+      const gravity = Number.isFinite(terraforming.celestialParameters.gravity)
+        ? terraforming.celestialParameters.gravity
+        : 0;
+      gravityValue.textContent = formatNumber(gravity, false, 2);
+    }
+
+    if (gravityPenaltyRow && gravityPenaltyValue) {
+      let penaltyMultiplier = 1;
+      const penaltyData = terraforming.gravityCostPenalty;
+      if (penaltyData && Number.isFinite(penaltyData.multiplier)) {
+        penaltyMultiplier = penaltyData.multiplier;
+      }
+      if (penaltyMultiplier > 1) {
+        gravityPenaltyRow.style.display = '';
+        const percent = (penaltyMultiplier - 1) * 100;
+        gravityPenaltyValue.textContent = `+${formatNumber(percent, false, 2)}% build cost`;
+      } else {
+        gravityPenaltyRow.style.display = 'none';
+        gravityPenaltyValue.textContent = '';
       }
     }
 

--- a/tests/gravityCostPenalty.test.js
+++ b/tests/gravityCostPenalty.test.js
@@ -1,0 +1,136 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+global.EffectableEntity = EffectableEntity;
+global.lifeParameters = {};
+
+const Terraforming = require('../src/js/terraforming.js');
+Terraforming.prototype.updateLuminosity = function() {};
+Terraforming.prototype.updateSurfaceTemperature = function() {};
+Terraforming.prototype.updateSurfaceRadiation = function() {};
+
+describe('gravity cost penalty', () => {
+  test('calculateGravityCostPenalty handles threshold behavior', () => {
+    const low = Terraforming.prototype.calculateGravityCostPenalty.call({
+      celestialParameters: { gravity: 8 }
+    });
+    expect(low).toEqual({ multiplier: 1, linearIncrease: 0, exponentialIncrease: 0 });
+
+    const mid = Terraforming.prototype.calculateGravityCostPenalty.call({
+      celestialParameters: { gravity: 12 }
+    });
+    expect(mid.linearIncrease).toBeCloseTo(0.2);
+    expect(mid.exponentialIncrease).toBe(0);
+    expect(mid.multiplier).toBeCloseTo(1.2);
+
+    const high = Terraforming.prototype.calculateGravityCostPenalty.call({
+      celestialParameters: { gravity: 25 }
+    });
+    const expectedMultiplier = 1 + (15 * 0.1) + (Math.pow(2, 0.5) - 1);
+    expect(high.linearIncrease).toBeCloseTo(1.5);
+    expect(high.exponentialIncrease).toBeCloseTo(Math.pow(2, 0.5) - 1);
+    expect(high.multiplier).toBeCloseTo(expectedMultiplier);
+  });
+
+  test('applyTerraformingEffects applies gravity multiplier to build costs', () => {
+    global.resources = {
+      atmospheric: {},
+      special: { albedoUpgrades: { value: 0 } },
+      surface: {},
+      colony: {}
+    };
+    global.currentPlanetParameters = {
+      resources: {
+        atmospheric: {},
+        surface: {},
+        underground: {},
+        colony: {}
+      },
+      celestialParameters: {
+        gravity: 25,
+        radius: 1,
+        distanceFromSun: 1,
+        albedo: 0.1
+      }
+    };
+    const originalBuildings = global.buildings;
+    const originalColonies = global.colonies;
+    global.buildings = {
+      sampleBuilding: {
+        cost: {
+          colony: { metal: 10 },
+          surface: { land: 2 }
+        }
+      }
+    };
+    global.colonies = {
+      sample_colony: {
+        cost: {
+          colony: { metal: 20 }
+        }
+      }
+    };
+    global.structures = { ...global.buildings, ...global.colonies };
+    global.projectManager = { projects: {}, isBooleanFlagSet: () => false };
+    global.populationModule = {};
+    global.tabManager = {};
+    global.fundingModule = {};
+    global.lifeDesigner = {};
+    global.lifeManager = new EffectableEntity({ description: 'life' });
+    global.oreScanner = {};
+
+    const tf = new Terraforming(global.resources, {
+      distanceFromSun: 1,
+      radius: 1,
+      gravity: 25,
+      albedo: 0.1
+    });
+    tf.calculateSolarPanelMultiplier = () => 1;
+    tf.calculateWindTurbineMultiplier = () => 1;
+    tf.calculateColonyEnergyPenalty = () => 1;
+    tf.calculateColonyPressureCostPenalty = () => 1;
+    tf.calculateMaintenancePenalty = () => 1;
+    tf.getFactoryTemperatureMaintenancePenaltyReduction = () => 0;
+
+    const originalAdd = global.addEffect;
+    const mockAdd = jest.fn();
+    global.addEffect = mockAdd;
+
+    tf.applyTerraformingEffects();
+
+    const calls = mockAdd.mock.calls.map(call => call[0]);
+    const gravityEffects = calls.filter(effect => effect && effect.effectId && effect.effectId.startsWith('gravityCostPenalty'));
+    const expectedMultiplier = 1 + (15 * 0.1) + (Math.pow(2, 0.5) - 1);
+
+    const buildingMetal = gravityEffects.find(effect =>
+      effect.target === 'building' &&
+      effect.targetId === 'sampleBuilding' &&
+      effect.resourceCategory === 'colony' &&
+      effect.resourceId === 'metal'
+    );
+    expect(buildingMetal).toBeDefined();
+    expect(buildingMetal.value).toBeCloseTo(expectedMultiplier);
+
+    const buildingLand = gravityEffects.find(effect =>
+      effect.target === 'building' &&
+      effect.targetId === 'sampleBuilding' &&
+      effect.resourceCategory === 'surface' &&
+      effect.resourceId === 'land'
+    );
+    expect(buildingLand).toBeDefined();
+    expect(buildingLand.value).toBeCloseTo(expectedMultiplier);
+
+    const colonyMetal = gravityEffects.find(effect =>
+      effect.target === 'colony' &&
+      effect.targetId === 'sample_colony' &&
+      effect.resourceCategory === 'colony' &&
+      effect.resourceId === 'metal'
+    );
+    expect(colonyMetal).toBeDefined();
+    expect(colonyMetal.value).toBeCloseTo(expectedMultiplier);
+
+    global.addEffect = originalAdd;
+    global.buildings = originalBuildings;
+    global.colonies = originalColonies;
+    delete global.structures;
+  });
+});


### PR DESCRIPTION
## Summary
- raise the linear gravity cost increase to 0.1 per m/s² above the threshold while keeping exponential scaling intact
- apply the gravity penalty by iterating the combined structures collection so buildings and colonies share the same path
- update the gravity cost penalty tests to reflect the new scaling and combined structures handling

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68ce1505e3ac8327bc1e9b1feb3eba01