### PR TITLE
Skip off-planet story projects

### DIFF
--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -580,6 +580,21 @@ class ProjectManager extends EffectableEntity {
     this.projectOrder = [];
   }
 
+  isProjectRelevantToCurrentPlanet(project) {
+    const targetPlanet = project?.category === 'story' ? project.attributes?.planet : null;
+    const globalContext = typeof globalThis !== 'undefined' ? globalThis : {};
+    const manager = this.spaceManager || globalContext.spaceManager;
+    const fallbackParameters = manager?.currentPlanetParameters || globalContext.currentPlanetParameters;
+    const currentPlanetKey =
+      manager?.getCurrentPlanetKey?.() ??
+      manager?.currentPlanetKey ??
+      fallbackParameters?.key ??
+      fallbackParameters?.planetKey ??
+      null;
+
+    return !targetPlanet || !currentPlanetKey || targetPlanet === currentPlanetKey;
+  }
+
   getDurationMultiplier() {
     let multiplier = 1;
     for (const effect of this.activeEffects) {
@@ -654,6 +669,10 @@ class ProjectManager extends EffectableEntity {
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
 
+      if (!this.isProjectRelevantToCurrentPlanet(project)) {
+        continue;
+      }
+
       if (typeof project.autoAssign === 'function') {
         project.autoAssign();
       }
@@ -691,6 +710,9 @@ class ProjectManager extends EffectableEntity {
   applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
+      if (!this.isProjectRelevantToCurrentPlanet(project)) {
+        continue;
+      }
       if (typeof project.applyCostAndGain === 'function') {
         project.applyCostAndGain(deltaTime, accumulatedChanges, productivity);
       }

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -328,6 +328,9 @@ function calculateProductionRates(deltaTime, buildings) {
   if (projectManager) {
     for (const name in projectManager.projects) {
       const project = projectManager.projects[name];
+      if (projectManager.isProjectRelevantToCurrentPlanet?.(project) === false) {
+        continue;
+      }
       if (project && project.treatAsBuilding && typeof project.estimateCostAndGain === 'function') {
         project.estimateCostAndGain(deltaTime, true);
       }
@@ -415,6 +418,9 @@ function produceResources(deltaTime, buildings) {
   if (projectManager) {
     for (const name in projectManager.projects) {
       const project = projectManager.projects[name];
+      if (projectManager.isProjectRelevantToCurrentPlanet?.(project) === false) {
+        continue;
+      }
       if (project && project.treatAsBuilding && typeof project.applyCostAndGain === 'function') {
         if (typeof project.estimateCostAndGain === 'function') {
           project.estimateCostAndGain(deltaTime, true, 1);
@@ -467,6 +473,9 @@ function produceResources(deltaTime, buildings) {
     for (const name of names) {
       const project = projectManager.projects?.[name];
       if (!project || project.treatAsBuilding) continue;
+      if (projectManager.isProjectRelevantToCurrentPlanet?.(project) === false) {
+        continue;
+      }
       if (typeof project.estimateCostAndGain !== 'function' || typeof project.applyCostAndGain !== 'function') {
         continue;
       }
@@ -478,6 +487,9 @@ function produceResources(deltaTime, buildings) {
       const data = projectData[name];
       if (!data || data.project.treatAsBuilding) continue;
       const { project } = data;
+      if (projectManager.isProjectRelevantToCurrentPlanet?.(project) === false) {
+        continue;
+      }
 //      const productivity = productivityMap[name] ?? 1;
       const productivity = 1;
       if (project.autoStart === false) {


### PR DESCRIPTION
## Summary
- add a ProjectManager helper to check whether a story project targets the active planet and use it to guard automation and cost/gain updates
- skip cost/gain estimation and treat-as-building processing for story projects that belong to another planet

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68ce1b936fa88327851f402cbe91c012