### PR TITLE
Rename ship cost labels to shipment wording

### DIFF
--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -94,7 +94,7 @@ class SpaceshipProject extends Project {
             })
         )
         .join(', ');
-      elements.costPerShipElement.textContent = `Cost per Ship: ${costPerShipText}`;
+      elements.costPerShipElement.textContent = `Cost per Shipment: ${costPerShipText}`;
     }
 
     if (elements.totalCostElement && this.assignedSpaceships != null) {
@@ -115,7 +115,7 @@ class SpaceshipProject extends Project {
               return `${resourceDisplayName}: ${formatNumber(amount, true)}`;
             })
         ).join(', ');
-      elements.resourceGainPerShipElement.textContent = `Gain per Ship: ${gainPerShipText}`;
+      elements.resourceGainPerShipElement.textContent = `Gain per Shipment: ${gainPerShipText}`;
     }
 
     if (elements.totalGainElement && this.assignedSpaceships != null) {

--- a/tests/spaceStorageProject.test.js
+++ b/tests/spaceStorageProject.test.js
@@ -273,7 +273,7 @@ describe('Space Storage project', () => {
 
     const costEls = container.querySelectorAll(`#${project.name}-cost-per-ship`);
     expect(costEls.length).toBe(1);
-    expect(costEls[0].textContent).toContain('Cost per Ship');
+    expect(costEls[0].textContent).toContain('Cost per Shipment');
     expect(costEls[0].textContent).toContain('Energy');
   });
 


### PR DESCRIPTION
## Summary
- update SpaceshipProject cost and gain labels to say "Cost per Shipment" and "Gain per Shipment"
- adjust space storage project test expectation to the new shipment wording

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68ceea712ef48327a6b0933bb658f5c7