### PR TITLE
Fix milestone alerts when silenced

### DIFF
--- a/src/js/milestonesUI.js
+++ b/src/js/milestonesUI.js
@@ -1,6 +1,13 @@
 let milestoneAlertNeeded = false;
 let lastCompletableCount = 0;
 
+function getMilestoneSettings() {
+    if (typeof gameSettings !== 'undefined') {
+        return gameSettings;
+    }
+    return globalThis.gameSettings;
+}
+
 function isMilestoneSubtabUnlocked() {
     const doc = globalThis.document;
     if (!doc || !doc.querySelector) {
@@ -35,12 +42,14 @@ function createMilestonesUI() {
     const silenceToggle = document.createElement('input');
     silenceToggle.type = 'checkbox';
     silenceToggle.id = 'milestone-silence-toggle';
-    if (typeof gameSettings !== 'undefined') {
-        silenceToggle.checked = gameSettings.silenceMilestoneAlert || false;
+    const settings = getMilestoneSettings();
+    if (settings) {
+        silenceToggle.checked = settings.silenceMilestoneAlert || false;
     }
     silenceToggle.addEventListener('change', () => {
-        if (typeof gameSettings !== 'undefined') {
-            gameSettings.silenceMilestoneAlert = silenceToggle.checked;
+        const currentSettings = getMilestoneSettings();
+        if (currentSettings) {
+            currentSettings.silenceMilestoneAlert = silenceToggle.checked;
         }
         updateMilestoneAlert();
     });
@@ -164,7 +173,8 @@ function updateMilestoneAlert() {
     const alertEl = doc.getElementById ? doc.getElementById('terraforming-alert') : null;
     const subtabEl = doc.getElementById ? doc.getElementById('milestone-subtab-alert') : null;
     if (!alertEl && !subtabEl) return;
-    if (globalThis.gameSettings && globalThis.gameSettings.silenceMilestoneAlert) {
+    const settings = getMilestoneSettings();
+    if (settings && settings.silenceMilestoneAlert) {
         if (alertEl) alertEl.style.display = 'none';
         if (subtabEl) subtabEl.style.display = 'none';
         return;

--- a/tests/milestoneSilenceAlert.test.js
+++ b/tests/milestoneSilenceAlert.test.js
@@ -11,15 +11,16 @@ describe('silence milestone alert setting', () => {
       <div class="terraforming-subtab" data-subtab="milestone-terraforming">Milestones<span id="milestone-subtab-alert" class="milestone-alert">!</span></div>`, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.milestonesManager = { getCompletableMilestones: () => [{}] };
-    ctx.gameSettings = { silenceMilestoneAlert: true };
-    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'milestonesUI.js'), 'utf8');
+    const code = 'let gameSettings = { silenceMilestoneAlert: true };\n' +
+      fs.readFileSync(path.join(__dirname, '..', 'src/js', 'milestonesUI.js'), 'utf8');
     vm.runInContext(code, ctx);
 
     ctx.checkMilestoneAlert();
     ctx.updateMilestoneAlert();
     expect(dom.window.document.getElementById('terraforming-alert').style.display).toBe('none');
+    expect(dom.window.document.getElementById('milestone-subtab-alert').style.display).toBe('none');
 
-    ctx.gameSettings.silenceMilestoneAlert = false;
+    vm.runInContext('gameSettings.silenceMilestoneAlert = false;', ctx);
     ctx.updateMilestoneAlert();
     expect(dom.window.document.getElementById('terraforming-alert').style.display).toBe('inline');
     expect(dom.window.document.getElementById('milestone-subtab-alert').style.display).toBe('inline');


### PR DESCRIPTION
## Summary
- ensure the milestone alert silence toggle reads settings from either lexical or global sources
- keep both terraforming tab and milestone subtab alerts hidden whenever the silence option is enabled
- expand the milestone silence alert test to cover the silenced subtab indicator and lexical settings scenario

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cee98cc18c8327bcc635549e78e75e