### PR TITLE
Give growth temperature tolerance a base 1°C width

### DIFF
--- a/src/js/life.js
+++ b/src/js/life.js
@@ -7,6 +7,12 @@ const baseTemperatureRanges = {
 
 // Default optimal growth temperature (20°C in Kelvin)
 const BASE_OPTIMAL_GROWTH_TEMPERATURE = 293.15;
+const BASE_GROWTH_TEMPERATURE_TOLERANCE = 1; // Degrees Celsius of free tolerance
+const GROWTH_TEMPERATURE_TOLERANCE_PER_POINT = 0.5; // Additional tolerance per point
+
+function calculateGrowthTemperatureTolerance(points) {
+  return BASE_GROWTH_TEMPERATURE_TOLERANCE + points * GROWTH_TEMPERATURE_TOLERANCE_PER_POINT;
+}
 
 const lifeDesignerConfig = {
   maxPoints : 0
@@ -40,7 +46,7 @@ class LifeAttribute {
           BASE_OPTIMAL_GROWTH_TEMPERATURE + this.value
         ).toFixed(2) + 'K';
       case 'growthTemperatureTolerance':
-        return (this.value * 0.5).toFixed(2);
+        return calculateGrowthTemperatureTolerance(this.value).toFixed(2);
       case 'photosynthesisEfficiency':
         return (0.00008*this.value).toFixed(5); // Adjust as needed
       case 'radiationTolerance':
@@ -109,6 +115,10 @@ class LifeDesign {
 
   getBaseGrowthRate() {
     return this.photosynthesisEfficiency.getConvertedValue();
+  }
+
+  getGrowthTemperatureToleranceWidth() {
+    return calculateGrowthTemperatureTolerance(this.growthTemperatureTolerance.value);
   }
 
   getRadiationMitigationRatio() {
@@ -364,7 +374,7 @@ class LifeDesign {
   temperatureGrowthMultiplierZone(zoneName) {
       const zoneData = terraforming.temperature.zones[zoneName];
       const optimal = BASE_OPTIMAL_GROWTH_TEMPERATURE + this.optimalGrowthTemperature.value;
-      const tolerance = this.growthTemperatureTolerance.value * 0.5;
+      const tolerance = this.getGrowthTemperatureToleranceWidth();
       if (tolerance <= 0) {
           return zoneData.day === optimal ? 1 : 0;
       }

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -766,7 +766,7 @@ function updateLifeStatusTable() {
 
     const survivalRange = designToCheck.getTemperatureRanges().survival;
     const optimal = BASE_OPTIMAL_GROWTH_TEMPERATURE + designToCheck.optimalGrowthTemperature.value;
-    const tolerance = designToCheck.growthTemperatureTolerance.value * 0.5;
+    const tolerance = designToCheck.getGrowthTemperatureToleranceWidth();
     const calcGrowthMult = temp => {
         if (tolerance <= 0) return temp === optimal ? 1 : 0;
         const diff = temp - optimal;

--- a/tests/lifeDayNightTemperatureDisplay.test.js
+++ b/tests/lifeDayNightTemperatureDisplay.test.js
@@ -57,7 +57,7 @@ describe('life day/night temperature rows', () => {
     ctx.updateLifeUI();
 
     const getText = id => dom.window.document.getElementById(id).textContent;
-    expect(getText('day-temp-tropical')).toBe('300.00 ⚠');
+    expect(getText('day-temp-tropical')).toBe('300.00 ✅');
     expect(getText('night-temp-temperate')).toBe('270.00 ❌');
 
     expect(getText('day-temp-global')).toBe('✅');

--- a/tests/lifeGrowthTempToleranceUnit.test.js
+++ b/tests/lifeGrowthTempToleranceUnit.test.js
@@ -8,6 +8,35 @@ describe('growth temperature tolerance display', () => {
     const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
     vm.runInNewContext(lifeCode + '; this.LifeAttribute = LifeAttribute;', ctx);
     const attr = new ctx.LifeAttribute('growthTemperatureTolerance', 6, '', '', 40);
-    expect(attr.getConvertedValue()).toBe('3.00');
+    expect(attr.getConvertedValue()).toBe('4.00');
+  });
+
+  test('growth multiplier uses base tolerance', () => {
+    const ctx = {
+      EffectableEntity: class {},
+      formatNumber: value => value.toString(),
+      toDisplayTemperature: value => value,
+      getTemperatureUnit: () => 'K',
+      terraforming: {
+        temperature: {
+          zones: {
+            tropical: { day: 293.15 },
+            temperate: { day: 293.15 },
+            polar: { day: 293.15 }
+          }
+        }
+      }
+    };
+
+    const lifeCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'life.js'), 'utf8');
+    vm.runInNewContext(lifeCode + '; this.LifeDesign = LifeDesign;', ctx);
+
+    const design = new ctx.LifeDesign(0, 0, 0, 0, 0, 0, 0, 0);
+
+    expect(design.temperatureGrowthMultiplierZone('tropical')).toBeCloseTo(1, 6);
+
+    ctx.terraforming.temperature.zones.tropical.day = 294.15;
+
+    expect(design.temperatureGrowthMultiplierZone('tropical')).toBeCloseTo(Math.exp(-0.5), 6);
   });
 });


### PR DESCRIPTION
## Summary
- add a shared helper that grants life designs a free 1 °C growth temperature tolerance and reuse it for conversions
- update the life UI growth multiplier calculations to rely on the new helper
- refresh existing tests and add coverage to confirm the baseline tolerance and updated display

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cef2c0d93c83278feb9eb48d9568ae