### PR TITLE
Hide RWG small resources flagged as hidden

### DIFF
--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -596,12 +596,12 @@ function renderWorldDetail(res, seedUsed, forcedType) {
         </div>
         <div>
           <h4>Surface</h4>
-          ${renderResourceRow('Land (ha)', surf.land?.initialValue)}
-          ${renderResourceRow('Ice', surf.ice?.initialValue)}
-          ${renderResourceRow('Water', surf.liquidWater?.initialValue)}
-          ${renderResourceRow('Dry Ice', surf.dryIce?.initialValue)}
-          ${renderResourceRow('Liquid CH₄', surf.liquidMethane?.initialValue)}
-          ${renderResourceRow('CH₄ Ice', surf.hydrocarbonIce?.initialValue)}
+          ${renderResourceRow('Land (ha)', surf.land)}
+          ${renderResourceRow('Ice', surf.ice)}
+          ${renderResourceRow('Water', surf.liquidWater)}
+          ${renderResourceRow('Dry Ice', surf.dryIce)}
+          ${renderResourceRow('Liquid CH₄', surf.liquidMethane)}
+          ${renderResourceRow('CH₄ Ice', surf.hydrocarbonIce)}
         </div>
       </div>
     </div>`;
@@ -635,9 +635,11 @@ function estimateEquilibriumTemp(res, fluxWm2) {
   }
 }
 
-function renderResourceRow(label, value) {
+function renderResourceRow(label, resource) {
+  const amount = resource?.initialValue;
+  if (resource?.hideWhenSmall && Math.abs(amount ?? 0) < 1e-4) return '';
   const fmt = typeof formatNumber === 'function' ? formatNumber : (n => n);
-  const v = (value === undefined || value === null) ? '—' : fmt(value);
+  const v = (amount === undefined || amount === null) ? '—' : fmt(amount);
   return `<div class="rwg-row"><span>${label}</span><span>${v}</span></div>`;
 }
 

--- a/tests/rwgHideSmallSurfaceResources.test.js
+++ b/tests/rwgHideSmallSurfaceResources.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require(path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom'));
+
+function setup() {
+  const ctx = {
+    console,
+    document: {
+      addEventListener: () => {},
+      getElementById: () => null
+    },
+    formatNumber: n => n,
+    calculateAtmosphericPressure: () => 0,
+    dayNightTemperaturesModel: () => ({ mean: 0, day: 0, night: 0 }),
+    toDisplayTemperature: v => v,
+    getTemperatureUnit: () => 'K',
+    equilibratedWorlds: new Set()
+  };
+  vm.createContext(ctx);
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwgUI.js'), 'utf8');
+  vm.runInContext(code, ctx);
+  return ctx;
+}
+
+describe('RWG UI small resource display', () => {
+  test('hides surface resources flagged with hideWhenSmall when value is tiny', () => {
+    const ctx = setup();
+    const res = {
+      merged: {
+        name: 'Tiny Resource World',
+        celestialParameters: {
+          gravity: 9.5,
+          radius: 6200,
+          albedo: 0.3,
+          rotationPeriod: 24,
+          distanceFromSun: 1
+        },
+        classification: { archetype: 'mars-like' },
+        resources: {
+          surface: {
+            land: { initialValue: 5e7 },
+            ice: { initialValue: 1e6 },
+            liquidWater: { initialValue: 2e6 },
+            dryIce: { initialValue: 0, hideWhenSmall: true },
+            liquidMethane: { initialValue: 5e-5, hideWhenSmall: true },
+            hydrocarbonIce: { initialValue: 5e3 }
+          },
+          atmospheric: {}
+        }
+      },
+      orbitAU: 1,
+      star: {
+        name: 'Test Star',
+        spectralType: 'G',
+        luminositySolar: 1,
+        massSolar: 1,
+        temperatureK: 5800
+      }
+    };
+
+    const html = ctx.renderWorldDetail(res, 'seed');
+    const dom = new JSDOM(html);
+    const surfaceSection = Array.from(dom.window.document.querySelectorAll('.rwg-columns > div'))
+      .find(col => col.querySelector('h4')?.textContent === 'Surface');
+    const labels = surfaceSection
+      ? Array.from(surfaceSection.querySelectorAll('.rwg-row span:first-child')).map(el => el.textContent)
+      : [];
+
+    expect(labels).toContain('Land (ha)');
+    expect(labels).toContain('Water');
+    expect(labels).not.toContain('Dry Ice');
+    expect(labels).not.toContain('Liquid CH₄');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid rendering random world surface rows for resources marked hideWhenSmall with negligible amounts
- pass resource objects into renderResourceRow so the helper can respect hideWhenSmall flags
- add a regression test covering the RWG surface display of small hideWhenSmall resources

## Testing
- CI=true npm test *(fails: tests/autobuildLandPartial.test.js)*
- npx jest tests/autobuildLandPartial.test.js *(fails)*

------
https://chatgpt.com/codex/tasks/task_b_68cef512a62c8327a1ba58b2db8df27c