### PR TITLE
Skip resource warnings when land or deposits limit autobuild

### DIFF
--- a/tests/autobuildLandPartial.test.js
+++ b/tests/autobuildLandPartial.test.js
@@ -25,6 +25,6 @@ describe('autoBuild limited by land', () => {
 
     expect(building.build).toHaveBeenCalledWith(5, false);
     expect(building.autoBuildPartial).toBe(true);
-    expect(global.resources.surface.land.autobuildShortage).toBe(true);
+    expect(global.resources.surface.land.autobuildShortage).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- stop applying autobuild shortage flags whenever land or deposit availability is the limiting factor
- extend the deposit exhaustion test and add a land-limited scenario to ensure no other resources gain warnings when those limits apply

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cef4a053d0832780204519af36d851