### PR TITLE
Explain resource exclamation warnings in tooltip

### DIFF
--- a/src/css/resource.css
+++ b/src/css/resource.css
@@ -85,6 +85,18 @@
     display: none;
   }
 
+  .resource-tooltip-warning {
+    margin-top: 6px;
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .resource-tooltip-warning-text {
+    flex: 1;
+    line-height: 1.3;
+  }
+
 .resource-wrapper {
   background-color: #f4f4f4;
   padding-right: 5px;


### PR DESCRIPTION
## Summary
- add a warning section to resource tooltips so exclamation marks point to their cause
- describe autobuild shortages, android caps, and biomass die-off directly in the tooltip
- style the tooltip warning row for clear alignment with the info icon

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cef93c908883279a57965c84a38a4e