### PR TITLE
Hide zero-value RWG gases flagged hideWhenSmall

### DIFF
--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -665,13 +665,17 @@ function renderAtmoTable(res) {
     { label: 'H₂SO₄', key: 'sulfuricAcid' }
   ];
   const fmt = typeof formatNumber === 'function' ? formatNumber : (n => n);
+  const defaults = globalThis.defaultPlanetParameters?.resources?.atmospheric || {};
   const cells = rows.map(r => {
-    const amt = res.merged?.resources?.atmospheric?.[r.key]?.initialValue;
+    const resource = res.merged?.resources?.atmospheric?.[r.key];
+    const amt = resource?.initialValue;
+    const hideSmall = resource?.hideWhenSmall ?? defaults[r.key]?.hideWhenSmall;
+    if (hideSmall && Math.abs(amt ?? 0) < 1e-4) return '';
     const amtText = (amt === undefined || amt === null) ? '—' : fmt(amt);
     const kPa = estimateGasPressure(res, r.key);
     const pText = (typeof kPa === 'number' && isFinite(kPa)) ? `${formatNumber(kPa)}Pa` : '—';
     return `<div class="rwg-row"><span>${r.label}</span><span>${amtText}</span><span>${pText}</span></div>`;
-  }).join('');
+  }).filter(Boolean).join('');
   // Header row
   const header = `<div class="rwg-row"><span><strong>Gas</strong></span><span><strong>Amount</strong></span><span><strong>Pressure</strong></span></div>`;
   return `<div class="rwg-atmo-table">${header}${cells}</div>`;

--- a/tests/rwgAtmosphereMetadata.test.js
+++ b/tests/rwgAtmosphereMetadata.test.js
@@ -1,0 +1,17 @@
+describe('Random World Generator atmosphere metadata', () => {
+  test('propagates hideWhenSmall flags for atmospheric resources', () => {
+    jest.resetModules();
+    const { defaultPlanetParameters } = require('../src/js/planet-parameters.js');
+    global.defaultPlanetParameters = defaultPlanetParameters;
+    try {
+      const { generateRandomPlanet } = require('../src/js/rwg.js');
+      const result = generateRandomPlanet(12345, { type: 'mars-like' });
+      const atmospheric = result?.override?.resources?.atmospheric || {};
+
+      expect(atmospheric.hydrogen?.hideWhenSmall).toBe(true);
+      expect(atmospheric.sulfuricAcid?.hideWhenSmall).toBe(true);
+    } finally {
+      delete global.defaultPlanetParameters;
+    }
+  });
+});

--- a/tests/rwgHideSmallSurfaceResources.test.js
+++ b/tests/rwgHideSmallSurfaceResources.test.js
@@ -72,4 +72,54 @@ describe('RWG UI small resource display', () => {
     expect(labels).not.toContain('Dry Ice');
     expect(labels).not.toContain('Liquid CH₄');
   });
+
+  test('hides atmospheric resources flagged with hideWhenSmall when value is tiny', () => {
+    const ctx = setup();
+    const res = {
+      merged: {
+        name: 'Thin Air World',
+        celestialParameters: {
+          gravity: 9.5,
+          radius: 6200,
+          albedo: 0.3,
+          rotationPeriod: 24,
+          distanceFromSun: 1
+        },
+        classification: { archetype: 'mars-like' },
+        resources: {
+          surface: {
+            land: { initialValue: 5e7 },
+            ice: { initialValue: 1e6 },
+            liquidWater: { initialValue: 2e6 }
+          },
+          atmospheric: {
+            carbonDioxide: { initialValue: 1e6 },
+            inertGas: { initialValue: 5e5 },
+            hydrogen: { initialValue: 0, hideWhenSmall: true },
+            atmosphericMethane: { initialValue: 0, hideWhenSmall: true }
+          }
+        }
+      },
+      orbitAU: 1,
+      star: {
+        name: 'Test Star',
+        spectralType: 'G',
+        luminositySolar: 1,
+        massSolar: 1,
+        temperatureK: 5800
+      }
+    };
+
+    const html = ctx.renderWorldDetail(res, 'seed');
+    const dom = new JSDOM(html);
+    const atmoSection = Array.from(dom.window.document.querySelectorAll('.rwg-columns > div'))
+      .find(col => col.querySelector('h4')?.textContent === 'Atmosphere');
+    const labels = atmoSection
+      ? Array.from(atmoSection.querySelectorAll('.rwg-row span:first-child')).map(el => el.textContent)
+      : [];
+
+    expect(labels).toContain('CO₂');
+    expect(labels).not.toContain('H₂');
+    expect(labels).not.toContain('CH₄');
+  });
 });


### PR DESCRIPTION
## Summary
- preserve hideWhenSmall metadata when the RWG builds atmospheric resources
- skip rendering atmospheric rows for zero-value gases flagged hideWhenSmall
- add coverage for RWG UI and generator behaviour

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cef8ffb1ec8327be108c21142c3e5d