### PR TITLE
Add hydrogen import special project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,3 +182,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Autobuild now highlights resources that stalled construction with an orange exclamation mark in the resource list.
 - Added a fullscreen loading overlay that displays while the game or a save file is loading.
 - Milestones subtab remains hidden until Terraforming measurements research is completed.
+- Added a hydrogen import special project mirroring nitrogen harvesting to gather atmospheric hydrogen when unlocked.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -252,6 +252,23 @@ const projectParameters = {
       maxPressure: 75
     }
   },
+  hydrogenSpaceMining: {
+    type: 'SpaceMiningProject',
+    name: "Hydrogen Importation",
+    category :"resources",
+    cost: {},
+    duration: 100000,
+    description: "Use your spaceships to recover hydrogen from the outer solar system. The first 100 spaceship assignments reduce the duration, every spaceship assignment afterward provides a multiplier.",
+    repeatable: true,
+    maxRepeatCount: Infinity,
+    unlocked: false,
+    attributes: {
+      spaceMining: true,
+      costPerShip: { colony: { metal: 100000, energy: 100000000000 } },
+      resourceGainPerShip: { atmospheric: { hydrogen: 1000000 } },
+      maxPressure: 75
+    }
+  },
   spaceElevator: {
     type: 'Project',
     name: "Space Elevator",
@@ -296,6 +313,14 @@ const projectParameters = {
         {
           target : 'project',
           targetId : 'nitrogenSpaceMining',
+          type : 'resourceCostMultiplier',
+          resourceCategory : 'colony',
+          resourceId : 'metal',
+          value : 0
+        },
+        {
+          target : 'project',
+          targetId : 'hydrogenSpaceMining',
           type : 'resourceCostMultiplier',
           resourceCategory : 'colony',
           resourceId : 'metal',

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -926,6 +926,13 @@ const researchParameters = {
           },
           {
             target: 'project',
+            targetId: 'hydrogenSpaceMining',
+            type: 'booleanFlag',
+            flagId: 'atmosphericMonitoring',
+            value: true
+          },
+          {
+            target: 'project',
             targetId: 'disposeResources',
             type: 'booleanFlag',
             flagId: 'atmosphericMonitoring',
@@ -1237,7 +1244,20 @@ const researchParameters = {
             type: 'enable'
           }
         ],
-      },  
+      },
+      {
+        id: 'hydrogenImport',
+        name: 'Hydrogen Importation',
+        description: 'Import hydrogen to stockpile a reducing gas for industry and fuel.',
+        cost: { research: 10000000000 },
+        prerequisites: [],
+        effects: [
+          {target : 'project',
+            targetId : 'hydrogenSpaceMining',
+            type: 'enable'
+          }
+        ],
+      },
       {
         id: 'magneticShield',
         name: 'Magnetic Shield',

--- a/src/js/rwgEffectsUI.js
+++ b/src/js/rwgEffectsUI.js
@@ -9,6 +9,7 @@ let _rwgEffectsLastKey = '';
 // Friendly labels for projects and buildings
 const RWG_PROJECT_NAMES = {
   nitrogenSpaceMining: 'Nitrogen Importation',
+  hydrogenSpaceMining: 'Hydrogen Importation',
   carbonSpaceMining: 'Carbon Importation',
   waterSpaceMining: 'Water Importation',
 };

--- a/tests/atmosphericMonitoringResearch.test.js
+++ b/tests/atmosphericMonitoringResearch.test.js
@@ -6,7 +6,7 @@ const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.j
 const code = fs.readFileSync(researchPath, 'utf8');
 
 describe('Atmospheric Monitoring research', () => {
-  test('adds flag to carbon and nitrogen mining projects', () => {
+  test('adds flag to carbon, nitrogen, and hydrogen mining projects', () => {
     const ctx = {};
     vm.createContext(ctx);
     vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
@@ -28,7 +28,15 @@ describe('Atmospheric Monitoring research', () => {
       e.flagId === 'atmosphericMonitoring' &&
       e.value === true
     );
+    const hydrogenFlag = research.effects.find(e =>
+      e.target === 'project' &&
+      e.targetId === 'hydrogenSpaceMining' &&
+      e.type === 'booleanFlag' &&
+      e.flagId === 'atmosphericMonitoring' &&
+      e.value === true
+    );
     expect(carbonFlag).toBeDefined();
     expect(nitrogenFlag).toBeDefined();
+    expect(hydrogenFlag).toBeDefined();
   });
 });

--- a/tests/hydrogenImportProject.test.js
+++ b/tests/hydrogenImportProject.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const paramsPath = path.join(__dirname, '..', 'src/js', 'project-parameters.js');
+const code = fs.readFileSync(paramsPath, 'utf8');
+
+describe('Hydrogen Importation project', () => {
+  test('mirrors nitrogen import settings for hydrogen', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.projectParameters = projectParameters;', ctx);
+    const hydrogen = ctx.projectParameters.hydrogenSpaceMining;
+    const nitrogen = ctx.projectParameters.nitrogenSpaceMining;
+
+    expect(hydrogen).toBeDefined();
+    expect(hydrogen.type).toBe('SpaceMiningProject');
+    expect(hydrogen.unlocked).toBe(false);
+    expect(hydrogen.duration).toBe(nitrogen.duration);
+    expect(hydrogen.repeatable).toBe(true);
+    expect(hydrogen.attributes.spaceMining).toBe(true);
+    expect(hydrogen.attributes.maxPressure).toBe(nitrogen.attributes.maxPressure);
+    expect(hydrogen.attributes.costPerShip.colony.metal)
+      .toBe(nitrogen.attributes.costPerShip.colony.metal);
+    expect(hydrogen.attributes.costPerShip.colony.energy)
+      .toBe(nitrogen.attributes.costPerShip.colony.energy);
+    expect(hydrogen.attributes.resourceGainPerShip.atmospheric)
+      .toHaveProperty('hydrogen', 1000000);
+    expect(nitrogen.attributes.resourceGainPerShip.atmospheric)
+      .toHaveProperty('inertGas', 1000000);
+  });
+});


### PR DESCRIPTION
## Summary
- add a hydrogen import special project that mirrors nitrogen harvesting and integrates with the space elevator cost reduction
- introduce hydrogen import research support, extend atmospheric monitoring toggles, and update UI/tests for the new project

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cf21bf8e148327b2acf8e05e6b4c9b