### PR TITLE
Add Mass Driver building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,3 +182,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Autobuild now highlights resources that stalled construction with an orange exclamation mark in the resource list.
 - Added a fullscreen loading overlay that displays while the game or a save file is loading.
 - Milestones subtab remains hidden until Terraforming measurements research is completed.
+- Added a Mass Driver building that is locked by default and costs ten times an oxygen factory.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -827,6 +827,7 @@ const constructors = {
   oreMine: 'OreMine',
   ghgFactory: 'GhgFactory',
   oxygenFactory: 'OxygenFactory',
+  massDriver: 'MassDriver',
   biodome: 'Biodome',
   dysonReceiver: 'dysonReceiver',
   solarPanel: 'solarPanel'

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -535,6 +535,21 @@ const buildingsParameters = {
     maintenanceFactor: 1,
     unlocked: false
   },
+  massDriver: {
+    name: 'Mass Driver',
+    category: 'terraforming',
+    description: 'Electromagnetic launcher prototype awaiting future upgrades.',
+    cost: { colony: { metal: 10000, glass : 100, components: 100, electronics: 100 } },
+    consumption: {},
+    production: {},
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: true,
+    requiresWorker: 0,
+    maintenanceFactor: 1,
+    unlocked: false
+  },
   biodome:{
     name: 'Biodome',
     category: 'terraforming',

--- a/src/js/buildings/MassDriver.js
+++ b/src/js/buildings/MassDriver.js
@@ -1,0 +1,7 @@
+class MassDriver extends Building {}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { MassDriver };
+} else {
+  globalThis.MassDriver = MassDriver;
+}

--- a/tests/massDriverBuilding.test.js
+++ b/tests/massDriverBuilding.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { initializeBuildings, Building } = require('../src/js/building.js');
+global.Building = Building;
+const { MassDriver } = require('../src/js/buildings/MassDriver.js');
+global.initializeBuildingTabs = () => {};
+
+describe('Mass Driver building', () => {
+  test('Mass Driver costs 10x an oxygen factory and is locked by default', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildings-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.buildingsParameters = buildingsParameters;', ctx);
+    const massDriver = ctx.buildingsParameters.massDriver;
+    const oxygenFactory = ctx.buildingsParameters.oxygenFactory;
+
+    expect(massDriver).toBeDefined();
+    expect(oxygenFactory).toBeDefined();
+    expect(massDriver.unlocked).toBe(false);
+
+    const expectedCost = {};
+    for (const [resource, amount] of Object.entries(oxygenFactory.cost.colony)) {
+      expectedCost[resource] = amount * 10;
+    }
+    expect(massDriver.cost.colony).toEqual(expectedCost);
+  });
+
+  test('initializeBuildings uses the MassDriver subclass', () => {
+    const params = {
+      massDriver: {
+        name: 'Mass Driver',
+        category: 'terraforming',
+        description: '',
+        cost: {},
+        consumption: {},
+        production: {},
+        storage: {},
+        dayNightActivity: false,
+        canBeToggled: true,
+        requiresMaintenance: true,
+        maintenanceFactor: 1,
+        requiresDeposit: null,
+        requiresWorker: 0,
+        unlocked: false
+      }
+    };
+
+    const buildings = initializeBuildings(params);
+    expect(buildings.massDriver).toBeInstanceOf(MassDriver);
+  });
+});


### PR DESCRIPTION
## Summary
- add the Mass Driver building definition with a cost ten times that of an oxygen factory and keep it locked by default
- register the Mass Driver subclass and create a no-op implementation placeholder
- cover the new configuration with initialization and cost verification tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cf21e725808327ac0afd8d918036f7