### PR TITLE
Hide hydrogen import research behind unlock flag

### DIFF
--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1251,6 +1251,7 @@ const researchParameters = {
         description: 'Import hydrogen to stockpile a reducing gas for industry and fuel.',
         cost: { research: 10000000000 },
         prerequisites: [],
+        requiredFlags: ['importHydrogenUnlocked'],
         effects: [
           {target : 'project',
             targetId : 'hydrogenSpaceMining',

--- a/tests/hydrogenImportResearchFlag.test.js
+++ b/tests/hydrogenImportResearchFlag.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Hydrogen Importation research visibility', () => {
+  test('requires the importHydrogenUnlocked flag', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+    const terraforming = ctx.researchParameters.terraforming;
+    const research = terraforming.find(r => r.id === 'hydrogenImport');
+
+    expect(research).toBeDefined();
+    expect(research.requiredFlags).toContain('importHydrogenUnlocked');
+  });
+});


### PR DESCRIPTION
## Summary
- require the `importHydrogenUnlocked` flag before showing the Hydrogen Importation research entry
- remove the temporary Ganymede reward that granted the flag so Venus can handle the unlock later
- keep regression coverage ensuring the Hydrogen Importation research requires the unlock flag

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cf250ae5bc8327b9898e88143b2b18