### PR TITLE
Remove Bosch Reactor dependency on water electrolysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,3 +185,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Added a Mass Driver building that is locked by default and costs ten times an oxygen factory.
 - Added a hydrogen import special project mirroring nitrogen harvesting to gather atmospheric hydrogen when unlocked.
 - Introduced Mass Driver Foundations research to unlock the launcher network and surface disposal integration once the massDriverUnlocked flag is earned.
+- Added a Bosch Reactor building that performs the Bosch reaction once research gated by the boschReactorUnlocked flag is completed.

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -535,6 +535,24 @@ const buildingsParameters = {
     maintenanceFactor: 1,
     unlocked: false
   },
+  boschReactor: {
+    name: 'Bosch Reactor',
+    category: 'terraforming',
+    description: 'Consumes hydrogen and carbon dioxide in the Bosch reaction to produce water.',
+    cost: { colony: { metal: 1000, glass : 10, components: 10, electronics: 10 } },
+    consumption: {
+      colony: { energy: 24000000 },
+      atmospheric: { carbonDioxide: 100, hydrogen: 9.09 }
+    },
+    production: { colony: { water: 81.82 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: true,
+    requiresWorker: 0,
+    maintenanceFactor: 1,
+    unlocked: false
+  },
   massDriver: {
     name: 'Mass Driver',
     category: 'terraforming',

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1121,11 +1121,26 @@ const researchParameters = {
         ],
       },
       {
-        id: 'mass_driver',
-        name: 'Mass Driver',
+        id: 'bosch_reactor',
+        name: 'Bosch Reactor',
+        description: 'Unlocks reactors that combine carbon dioxide and hydrogen into water via the Bosch reaction.',
+        cost: { research: 150000 },
+        prerequisites: [],
+        requiredFlags: ['boschReactorUnlocked'],
+        effects: [
+          {
+            target: 'building',
+            targetId: 'boschReactor',
+            type: 'enable'
+          },
+        ],
+      },
+      {
+        id: 'mass_driver_foundations',
+        name: 'Mass Driver Foundations',
         description: 'Unlocks experimental mass driver launch facilities for disposing resources off-world.',
         cost: { research: 5_000_000 },
-        prerequisites: [],
+        prerequisites: ['water_electrolysis'],
         requiredFlags: ['massDriverUnlocked'],
         effects: [
           {

--- a/tests/boschReactorBuilding.test.js
+++ b/tests/boschReactorBuilding.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Bosch Reactor building', () => {
+  test('is locked by default and converts CO2 and hydrogen into water', () => {
+    const filePath = path.join(__dirname, '..', 'src/js', 'buildings-parameters.js');
+    const code = fs.readFileSync(filePath, 'utf8');
+
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.buildingsParameters = buildingsParameters;', ctx);
+
+    const boschReactor = ctx.buildingsParameters.boschReactor;
+    const oxygenFactory = ctx.buildingsParameters.oxygenFactory;
+
+    expect(boschReactor).toBeDefined();
+    expect(oxygenFactory).toBeDefined();
+
+    expect(boschReactor.unlocked).toBe(false);
+    expect(boschReactor.category).toBe('terraforming');
+    expect(boschReactor.cost.colony).toEqual(oxygenFactory.cost.colony);
+
+    expect(boschReactor.consumption.colony.energy).toBe(24000000);
+    expect(boschReactor.consumption.atmospheric).toMatchObject({
+      carbonDioxide: 100,
+      hydrogen: 9.09,
+    });
+
+    expect(boschReactor.production.colony).toMatchObject({ water: 81.82 });
+    Object.values(boschReactor.production).forEach((category) => {
+      expect(category.carbon).toBeUndefined();
+    });
+  });
+});

--- a/tests/boschReactorResearch.test.js
+++ b/tests/boschReactorResearch.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Bosch Reactor research', () => {
+  test('requires boschReactorUnlocked flag and unlocks the building', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+
+    const terraformingResearch = ctx.researchParameters.terraforming;
+    const research = terraformingResearch.find((entry) => entry.id === 'bosch_reactor');
+
+    expect(research).toBeDefined();
+    expect(research.cost.research).toBe(150000);
+    expect(research.prerequisites).toEqual([]);
+    expect(research.requiredFlags).toContain('boschReactorUnlocked');
+
+    const buildingEffect = research.effects.find((effect) => (
+      effect.target === 'building' &&
+      effect.targetId === 'boschReactor' &&
+      effect.type === 'enable'
+    ));
+    expect(buildingEffect).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add Bosch Reactor building parameters that convert carbon dioxide and hydrogen into water without creating carbon
- add Bosch Reactor research gated by the boschReactorUnlocked flag without requiring Water Electrolysis as a prerequisite and align Mass Driver Foundations metadata with tests
- document the new feature in AGENTS.md and add regression tests for the building and research definitions

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cf29287d8483279f3a3a95d2f577dc