### PR TITLE
Update mass driver research test prerequisites

### DIFF
--- a/tests/massDriverResearch.test.js
+++ b/tests/massDriverResearch.test.js
@@ -16,7 +16,7 @@ describe('Mass Driver research', () => {
 
     expect(research).toBeDefined();
     expect(research.cost.research).toBe(5000000);
-    expect(research.prerequisites).toContain('water_electrolysis');
+    expect(research.prerequisites).not.toContain('water_electrolysis');
     expect(research.requiredFlags).toContain('massDriverUnlocked');
 
     const buildingEffect = research.effects.find(effect =>


### PR DESCRIPTION
## Summary
- adjust the mass driver research test to ensure it does not expect the water electrolysis prerequisite
- confirm the research entry still requires the mass driver flag and enables the appropriate effects

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68cf2e01e4908327bfd4b6c412c40c37