### PR TITLE
Expose buildings to the global scope

### DIFF
--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -18,6 +18,13 @@ let maintenanceFraction = currentPlanetParameters.buildingParameters.maintenance
 let shipEfficiency = 1;
 let dayNightCycle;
 let buildings = {};
+Object.defineProperty(globalThis, 'buildings', {
+  get: () => buildings,
+  set: (value) => {
+    buildings = value;
+  },
+  configurable: true,
+});
 let colonies = {};
 let structures = {};
 let populationModule;


### PR DESCRIPTION
## Summary
- expose the buildings collection through `globalThis.buildings` so UI modules like mass driver info can read the latest active counts

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cf2f5ff8988327844a5b16efc55f25