### PR TITLE
Ensure mechanical assistance slider effect replacement is tested

### DIFF
--- a/tests/colonySliders.test.js
+++ b/tests/colonySliders.test.js
@@ -140,12 +140,17 @@ describe('colony sliders', () => {
     setMechanicalAssistance(-1);
     expect(colonySliderSettings.mechanicalAssistance).toBe(0);
     researchColonies.forEach(colonyId => {
-      expect(removeEffect).toHaveBeenCalledWith(expect.objectContaining({
+      expect(addEffect).toHaveBeenCalledWith(expect.objectContaining({
         target: 'colony',
         targetId: colonyId,
+        type: 'addResourceConsumption',
+        resourceCategory: 'colony',
+        resourceId: 'components',
+        amount: 0,
         effectId: 'mechanicalAssistanceComponents'
       }));
     });
+    expect(removeEffect).not.toHaveBeenCalled();
 
     addEffect.mockClear();
     setMechanicalAssistance(5);


### PR DESCRIPTION
## Summary
- update the mechanical assistance slider test to expect the components consumption effect to be replaced with a zero amount instead of removed

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68cf77bdacec83278b10cef200096eae