### PR TITLE
Hide planet visualizer debug controls by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,3 +187,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Introduced Mass Driver Foundations research to unlock the launcher network and surface disposal integration once the massDriverUnlocked flag is earned.
 - Resource disposal treats each active Mass Driver as a configurable number of spaceship equivalents (default 10) when calculating throughput.
 - Added a Bosch Reactor building that performs the Bosch reaction once research gated by the boschReactorUnlocked flag is completed.
+- Planet visualizer debug sliders are hidden by default; use the `debug_mode(true)` console command to reveal them, and the setting persists in save files.

--- a/src/css/planet-visualizer.css
+++ b/src/css/planet-visualizer.css
@@ -36,6 +36,10 @@
   margin-right: auto;
 }
 
+.planet-visualizer-debug--hidden {
+  display: none;
+}
+
 .pv-grid {
   display: grid;
   grid-template-columns: 120px minmax(0, 1fr) 110px;

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -48,7 +48,10 @@ let gameSettings = {
   disableDayNightCycle: false,
   preserveProjectAutoStart: false,
   autobuildAlsoSetsActive: true,
+  planetVisualizerDebugEnabled: false,
 };
+
+globalThis.planetVisualizerDebugEnabled = gameSettings.planetVisualizerDebugEnabled;
 let globalEffects = new EffectableEntity({description : 'Manages global effects'});
 let skillManager;
 let solisManager;

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -505,6 +505,14 @@ function loadGame(slotOrCustomString) {
       if(toggle){
         toggle.checked = gameSettings.useCelsius;
       }
+      const debugEnabled = !!gameSettings.planetVisualizerDebugEnabled;
+      if (typeof globalThis !== 'undefined') {
+        globalThis.planetVisualizerDebugEnabled = debugEnabled;
+      }
+      const pv = globalThis && globalThis.planetVisualizer;
+      if (pv && pv.setDebugMode) {
+        pv.setDebugMode(debugEnabled, { skipPersist: true });
+      }
       const silenceToggle = document.getElementById('solis-silence-toggle');
       if(silenceToggle){
         silenceToggle.checked = gameSettings.silenceSolisAlert;


### PR DESCRIPTION
## Summary
- hide the planet visualizer debug sliders by default and document the new behaviour
- persist a planet visualizer debug flag in game settings and restore it when loading saves
- add a `debug_mode` console command to toggle the controls and wire the UI to respect the stored flag

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cff3eb2c408327a7d3e874681ac058