### PR TITLE
Support WGC natural scientist story placeholder

### DIFF
--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -9,23 +9,38 @@ function joinLines(text) {
     return Array.isArray(text) ? text.join('\n') : text;
 }
 
+function formatWGCTeamMemberName(member, fallback) {
+    const parts = [member?.firstName, member?.lastName].filter(Boolean);
+    const name = parts.join(' ');
+    return name || fallback;
+}
+
 function getWGCTeamLeaderName(index) {
     try {
         const leader = warpGateCommand.teams[index][0];
-        const first = leader.firstName;
-        const last = leader.lastName ? ` ${leader.lastName}` : '';
-        const name = first ? first + last : '';
-        return name || `Team Leader ${index + 1}`;
+        return formatWGCTeamMemberName(leader, `Team Leader ${index + 1}`);
     } catch {
         return `Team Leader ${index + 1}`;
     }
 }
 
+function getWGCTeamNaturalScientistName(index) {
+    try {
+        const team = warpGateCommand.teams[index] || [];
+        const scientist = team.find(member => member?.classType === 'Natural Scientist');
+        return formatWGCTeamMemberName(scientist, 'Sam');
+    } catch {
+        return 'Sam';
+    }
+}
+
 function resolveStoryPlaceholders(text) {
     const leaderName = getWGCTeamLeaderName(0);
+    const scientistName = getWGCTeamNaturalScientistName(0);
     return text
         .replace(/\$WGC_TEAM1_LEADER\$/g, leaderName)
-        .replace(/\$WGC_TEAM_LEADER\$/g, leaderName);
+        .replace(/\$WGC_TEAM_LEADER\$/g, leaderName)
+        .replace(/\$WGC_TEAM1_NATSCIENTIST\$/g, scientistName);
 }
 
 function compareValues(current, target, comparison = 'gte') {

--- a/tests/wgcTeamLeaderPlaceholder.test.js
+++ b/tests/wgcTeamLeaderPlaceholder.test.js
@@ -46,4 +46,27 @@ describe('WGC team leader placeholder', () => {
     event.trigger();
     expect(ctx.addJournalEntry).toHaveBeenCalledWith('Leader: Eve Doe.', 'e', { type: 'chapter', id: 'e' });
   });
+
+  test('replaces natural scientist placeholder with member name', () => {
+    const ctx = createContext({ teams: [[
+      { firstName: 'Eve', lastName: 'Doe' },
+      { firstName: 'Nina', lastName: 'Khan', classType: 'Natural Scientist' }
+    ]] });
+    const progressData = { chapters: [{ id: 'f', type: 'journal', narrative: 'Scientist: $WGC_TEAM1_NATSCIENTIST$.' }] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.window.storyManager = manager;
+    const event = manager.findEventById('f');
+    event.trigger();
+    expect(ctx.addJournalEntry).toHaveBeenCalledWith('Scientist: Nina Khan.', 'f', { type: 'chapter', id: 'f' });
+  });
+
+  test('defaults when natural scientist missing', () => {
+    const ctx = createContext({ teams: [[{ firstName: 'Eve', lastName: 'Doe' }]] });
+    const progressData = { chapters: [{ id: 'g', type: 'journal', narrative: '$WGC_TEAM1_NATSCIENTIST$' }] };
+    const manager = new ctx.StoryManager(progressData);
+    ctx.window.storyManager = manager;
+    const event = manager.findEventById('g');
+    event.trigger();
+    expect(ctx.addJournalEntry).toHaveBeenCalledWith('Sam', 'g', { type: 'chapter', id: 'g' });
+  });
 });


### PR DESCRIPTION
## Summary
- add shared formatter and lookup to resolve the new $WGC_TEAM1_NATSCIENTIST$ story placeholder
- extend placeholder tests to cover the natural scientist name and fallback behaviour

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d07dc14e948327ad31409264c78421