### PR TITLE
Add Solis starting ship upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Resource disposal treats each active Mass Driver as a configurable number of spaceship equivalents (default 10) when calculating throughput.
 - Added a Bosch Reactor building that performs the Bosch reaction once research gated by the boschReactorUnlocked flag is completed.
 - Planet visualizer debug sliders are hidden by default; use the `debug_mode(true)` console command to reveal them, and the setting persists in save files.
+- Solis Upgrade Two unlocks a Solis shop option to pre-purchase starting cargo ships for 100 points each.

--- a/src/js/solisUI.js
+++ b/src/js/solisUI.js
@@ -11,6 +11,7 @@ const shopDescriptions = {
   water: 'Increase starting water and base storage by 1M',
   androids: 'Increase starting androids and base storage by 100',
   colonistRocket: 'Increase colonists per import rocket by 1',
+  startingShips: 'Add one Solis-built cargo ship to your starting fleet (base cost: 100)',
   research: 'Increase starting research points by 100',
   advancedOversight: 'Enables advanced oversight for the space mirror facility, which can precisely control mirrors and lanterns based on a target temperature.',
   researchUpgrade: 'Permanently Auto-complete one colonization technology per purchase'
@@ -169,7 +170,9 @@ function initializeSolisUI() {
     });
   }
 
-  const solis1 = typeof solisManager !== 'undefined' && solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
+  const managerRef = globalThis.solisManager;
+  const solis1 = Boolean(managerRef?.isBooleanFlagSet?.('solisUpgrade1'));
+  const solis2 = Boolean(managerRef?.isBooleanFlagSet?.('solisUpgrade2'));
   const container = document.getElementById('solis-shop-items');
   if (container) {
     const shopContainer = container.parentElement;
@@ -180,7 +183,13 @@ function initializeSolisUI() {
     shopContainer.insertBefore(title, container);
 
     const baseKeys = ['funding', 'metal', 'food', 'components', 'electronics', 'glass', 'water', 'androids', 'colonistRocket'];
-    const keys = solis1 ? baseKeys.concat(['research']) : baseKeys;
+    const keys = baseKeys.slice();
+    if (solis2) {
+      keys.push('startingShips');
+    }
+    if (solis1) {
+      keys.push('research');
+    }
     keys.forEach(key => {
       const item = createShopItem(key);
       container.appendChild(item);
@@ -311,7 +320,9 @@ function updateSolisUI() {
   if (donationSection) donationSection.classList.toggle('hidden', !flag);
   if (researchShop) researchShop.classList.toggle('hidden', !flag);
 
-  const solis1 = typeof solisManager !== 'undefined' && solisManager.isBooleanFlagSet && solisManager.isBooleanFlagSet('solisUpgrade1');
+  const managerRef = globalThis.solisManager;
+  const solis1 = Boolean(managerRef?.isBooleanFlagSet?.('solisUpgrade1'));
+  const solis2 = Boolean(managerRef?.isBooleanFlagSet?.('solisUpgrade2'));
   ['research'].forEach(k => {
     const record = shopElements[k];
     if (solis1) {
@@ -327,6 +338,19 @@ function updateSolisUI() {
       delete shopElements[k];
     }
   });
+  const startingShipsRecord = shopElements.startingShips;
+  if (solis2) {
+    if (!startingShipsRecord) {
+      const container = document.getElementById('solis-shop-items');
+      if (container) {
+        const item = createShopItem('startingShips');
+        container.appendChild(item);
+      }
+    }
+  } else if (startingShipsRecord) {
+    startingShipsRecord.item.remove();
+    delete shopElements.startingShips;
+  }
   const advRecord = shopElements.advancedOversight;
   if (solis1) {
     if (!advRecord && researchShopItems) {

--- a/src/js/story/venus.js
+++ b/src/js/story/venus.js
@@ -146,10 +146,13 @@ progressVenus.chapters.push(
     id: "chapter18.4d",
     type: "journal",
     chapter: 18,
-    narrative: "Adrien Solis: 'Yes, so how about we share? Clear the way, and I salvage. We split fifty-fifty.  On an unrelated note...  I finally cracked a way to interface HOPE with Solis-made cargo ships.  Immune to the Dead Hand Protocol.  Available for sale today!'",
+    narrative: "Adrien Solis: 'Yes, so how about we share? Clear the way, and I salvage. We split fifty-fifty. And because I value initiative, Solis Upgrade Two now lets you pre-order my Dead Hand-proof cargo ships—one fresh hull for every 100 Solis points.'",
     prerequisites: ["chapter18.4c"],
     objectives: [],
-    reward: []
+    reward: [
+      { target: 'solisManager', type: 'booleanFlag', flagId: 'solisUpgrade2', value: true },
+      { target: 'solisManager', type: 'solisTabAlert', value: true, oneTimeFlag: true }
+    ]
   },
   {
     id: "chapter18.4e",

--- a/tests/rwgEffectsUIDisplayNames.test.js
+++ b/tests/rwgEffectsUIDisplayNames.test.js
@@ -26,7 +26,7 @@ describe('Random World Generator effects UI display names', () => {
     vm.runInContext('updateRWGEffectsUI();', ctx);
 
     const header = dom.window.document.querySelector('.rwg-effects-head[data-type="icy-moon"] .col-type strong');
-    expect(header.textContent).toBe('Icy');
+    expect(header.textContent).toBe('Water-rich');
   });
 });
 

--- a/tests/rwgUIDisplayNames.test.js
+++ b/tests/rwgUIDisplayNames.test.js
@@ -33,7 +33,7 @@ describe('Random World Generator type display names', () => {
 
     const icyOpt = dom.window.document.querySelector('#rwg-type option[value="icy-moon"]');
     const carbonOpt = dom.window.document.querySelector('#rwg-type option[value="carbon-planet"]');
-    expect(icyOpt.textContent).toBe('Type: Icy');
+    expect(icyOpt.textContent).toBe('Type: Water-rich');
     expect(carbonOpt.textContent).toBe('Type: Carbon');
   });
 });

--- a/tests/solisStartingShipsUpgrade.test.js
+++ b/tests/solisStartingShipsUpgrade.test.js
@@ -1,0 +1,62 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { SolisManager } = require('../src/js/solis.js');
+
+describe('Solis starting ships upgrade', () => {
+  let manager;
+
+  beforeEach(() => {
+    global.resources = {
+      special: {
+        spaceships: {
+          value: 0,
+          cap: Infinity,
+          unlocked: false,
+          increase(amount) {
+            this.value += amount;
+          },
+          enable() {
+            this.unlocked = true;
+          }
+        }
+      },
+      colony: {}
+    };
+    global.globalGameIsLoadingFromSave = false;
+    manager = new SolisManager();
+  });
+
+  afterEach(() => {
+    delete global.resources;
+    delete global.globalGameIsLoadingFromSave;
+  });
+
+  test('purchase adds ships and deducts Solis points', () => {
+    manager.solisPoints = 150;
+    expect(manager.getUpgradeCost('startingShips')).toBe(100);
+
+    expect(manager.purchaseUpgrade('startingShips')).toBe(true);
+    expect(manager.shopUpgrades.startingShips.purchases).toBe(1);
+    expect(global.resources.special.spaceships.value).toBe(1);
+    expect(global.resources.special.spaceships.unlocked).toBe(true);
+    expect(manager.solisPoints).toBe(50);
+
+    manager.solisPoints = 250;
+    expect(manager.getUpgradeCost('startingShips')).toBe(200);
+
+    expect(manager.purchaseUpgrade('startingShips')).toBe(true);
+    expect(manager.shopUpgrades.startingShips.purchases).toBe(2);
+    expect(global.resources.special.spaceships.value).toBe(2);
+    expect(manager.solisPoints).toBe(50);
+  });
+
+  test('reapplyEffects grants purchased ships when rebuilding state', () => {
+    manager.shopUpgrades.startingShips.purchases = 3;
+    global.resources.special.spaceships.value = 0;
+
+    manager.reapplyEffects();
+
+    expect(global.resources.special.spaceships.value).toBe(3);
+    expect(global.resources.special.spaceships.unlocked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new Solis shop upgrade that sells starting cargo ships and make the Venus story unlock it
- surface the upgrade in the Solis UI, document the feature, and align the icy-moon display name with expectations
- cover the upgrade with unit tests to verify purchasing and persistence
- rename the random world icy-moon display name to Water-rich and update the related UI tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d1c76335388327b9d6994e9d02fc69