### PR TITLE
Adjust tests for Solis shop and mass driver updates

### DIFF
--- a/tests/massDriverBuilding.test.js
+++ b/tests/massDriverBuilding.test.js
@@ -10,7 +10,7 @@ const { MassDriver } = require('../src/js/buildings/MassDriver.js');
 global.initializeBuildingTabs = () => {};
 
 describe('Mass Driver building', () => {
-  test('Mass Driver costs 10x an oxygen factory and is locked by default', () => {
+  test('Mass Driver requires superconductors and is locked by default', () => {
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildings-parameters.js'), 'utf8');
     const ctx = {};
     vm.createContext(ctx);
@@ -22,10 +22,12 @@ describe('Mass Driver building', () => {
     expect(oxygenFactory).toBeDefined();
     expect(massDriver.unlocked).toBe(false);
 
-    const expectedCost = {};
-    for (const [resource, amount] of Object.entries(oxygenFactory.cost.colony)) {
-      expectedCost[resource] = amount * 10;
-    }
+    const expectedCost = {
+      metal: oxygenFactory.cost.colony.metal * 10,
+      components: oxygenFactory.cost.colony.components * 10,
+      superconductors: 100
+    };
+
     expect(massDriver.cost.colony).toEqual(expectedCost);
   });
 

--- a/tests/solisStartingShipsUpgrade.test.js
+++ b/tests/solisStartingShipsUpgrade.test.js
@@ -31,13 +31,13 @@ describe('Solis starting ships upgrade', () => {
     delete global.globalGameIsLoadingFromSave;
   });
 
-  test('purchase adds ships and deducts Solis points', () => {
+  test('purchase unlocks ships without immediately granting any and deducts Solis points', () => {
     manager.solisPoints = 150;
     expect(manager.getUpgradeCost('startingShips')).toBe(100);
 
     expect(manager.purchaseUpgrade('startingShips')).toBe(true);
     expect(manager.shopUpgrades.startingShips.purchases).toBe(1);
-    expect(global.resources.special.spaceships.value).toBe(1);
+    expect(global.resources.special.spaceships.value).toBe(0);
     expect(global.resources.special.spaceships.unlocked).toBe(true);
     expect(manager.solisPoints).toBe(50);
 
@@ -46,7 +46,7 @@ describe('Solis starting ships upgrade', () => {
 
     expect(manager.purchaseUpgrade('startingShips')).toBe(true);
     expect(manager.shopUpgrades.startingShips.purchases).toBe(2);
-    expect(global.resources.special.spaceships.value).toBe(2);
+    expect(global.resources.special.spaceships.value).toBe(0);
     expect(manager.solisPoints).toBe(50);
   });
 


### PR DESCRIPTION
## Summary
- update the Solis starting ships test to match the new behavior where purchases only unlock ships immediately
- refresh the mass driver building test to expect the revised resource cost

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d1e407a714832785072f626b00f3db