### PR TITLE
Add hydrogen production to oxygen factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,3 +189,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Added a Bosch Reactor building that performs the Bosch reaction once research gated by the boschReactorUnlocked flag is completed.
 - Planet visualizer debug sliders are hidden by default; use the `debug_mode(true)` console command to reveal them, and the setting persists in save files.
 - Solis Upgrade Two unlocks a Solis shop option to pre-purchase starting cargo ships for 100 points each.
+- Oxygen factories now vent hydrogen alongside oxygen to reflect electrolysis byproducts.

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -523,10 +523,10 @@ const buildingsParameters = {
   oxygenFactory: {
     name: 'Oxygen Factory',
     category: 'terraforming',
-    description: 'Extracts oxygen from liquid water via electrolysis.',
+    description: 'Extracts oxygen from liquid water via electrolysis, venting hydrogen as a byproduct.',
     cost: { colony: { metal: 1000, glass : 10, components: 10, electronics: 10} },
     consumption: { colony: { energy: 24000000, water: 100} },
-    production: { atmospheric: { oxygen: 88.89} },
+    production: { atmospheric: { oxygen: 88.89, hydrogen: 11.11 } },
     storage: {},
     dayNightActivity: false,
     canBeToggled: true,

--- a/tests/oxygenFactoryHydrogenOutput.test.js
+++ b/tests/oxygenFactoryHydrogenOutput.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Oxygen Factory electrolysis outputs', () => {
+  function loadOxygenFactoryParameters() {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildings-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.buildingsParameters = buildingsParameters;', ctx);
+    return ctx.buildingsParameters.oxygenFactory;
+  }
+
+  test('produces hydrogen alongside oxygen', () => {
+    const oxygenFactory = loadOxygenFactoryParameters();
+    const atmospheric = oxygenFactory.production.atmospheric;
+
+    expect(atmospheric).toHaveProperty('oxygen');
+    expect(atmospheric).toHaveProperty('hydrogen');
+    expect(atmospheric.oxygen).toBeCloseTo(88.89, 2);
+    expect(atmospheric.hydrogen).toBeCloseTo(11.11, 2);
+  });
+
+  test('maintains mass balance between input water and output gases', () => {
+    const oxygenFactory = loadOxygenFactoryParameters();
+    const waterConsumption = oxygenFactory.consumption.colony.water;
+    const atmospheric = oxygenFactory.production.atmospheric;
+    const totalGasOutput = atmospheric.oxygen + atmospheric.hydrogen;
+
+    expect(totalGasOutput).toBeCloseTo(waterConsumption, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add hydrogen as a byproduct of the oxygen factory's electrolysis process
- document the change in AGENTS.md and cover it with automated tests ensuring mass balance

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d1e74651cc8327a5d3c1065eb068a1