### PR TITLE
Show quick build costs for space mirror facility

### DIFF
--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -203,8 +203,8 @@
 /* Quick Build controls (used inside info cards) */
 .quick-build-row {
     display: grid;
-    /* label | build (fixed) | spacer | x10 | /10 | filler */
-    grid-template-columns: auto 220px 8px 50px 50px 1fr;
+    /* label | build (fixed) | spacer | x10 | /10 | cost */
+    grid-template-columns: auto 220px 8px 50px 50px minmax(0, 1fr);
     align-items: center;
     gap: 8px;
     margin-top: 8px;
@@ -236,11 +236,20 @@
 /* Fixed width for quick-build increment buttons only */
 .qb-inc { width: 50px; }
 
-/* Invisible filler to consume remaining row space */
-.qb-fill { width: 100%; height: 1px; }
+
+.quick-build-cost {
+    font-size: 12px;
+    color: #495057;
+    display: inline-flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 4px;
+}
 
 /* Dark mode: make the label white for readability */
 .dark-mode .quick-build-label { color: #ffffff; }
+
+.dark-mode .quick-build-cost { color: #ffffff; }
 
 /* Display parent orbit text in a single line */
 #motion-parent-container .stat-label {


### PR DESCRIPTION
## Summary
- show quick build cost summaries for mirrors and lanterns inside the space mirror facility
- reuse cached DOM nodes when updating cost displays and ensure they clear gracefully when locked
- update quick build layout styling so the new cost column aligns with existing controls

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d1f41fa0f48327a7bdc8fa2f3e4e5d