### PR TITLE
Fix special project alert clearing

### DIFF
--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -946,7 +946,7 @@ function registerProjectUnlockAlert(subtabId) {
   updateProjectAlert();
   const activeTab = document.getElementById('special-projects-tab');
   const activeId = projectsSubtabManager
-    ? projectsSubtabManager.activeId
+    ? projectsSubtabManager.getActiveId()
     : (document.querySelector('.projects-subtab.active') || {}).dataset?.subtab;
   if (activeTab && activeTab.classList.contains('active') && activeId === subtabId) {
     markProjectSubtabViewed(subtabId);
@@ -970,7 +970,7 @@ function updateProjectAlert() {
 
 function markProjectsViewed() {
   const activeId = projectsSubtabManager
-    ? projectsSubtabManager.activeId
+    ? projectsSubtabManager.getActiveId()
     : (document.querySelector('.projects-subtab.active') || {}).dataset?.subtab;
   if (activeId && typeof markProjectSubtabViewed === 'function') {
     markProjectSubtabViewed(activeId);

--- a/tests/projectTabClearsSubtabAlert.test.js
+++ b/tests/projectTabClearsSubtabAlert.test.js
@@ -15,9 +15,37 @@ describe('project subtab alert clears on tab view', () => {
     const dom = new JSDOM(html, { runScripts: 'outside-only' });
     const ctx = dom.getInternalVMContext();
     ctx.gameSettings = { silenceUnlockAlert: false };
-    ctx.projectManager = { projects: { probe: { category: 'resources', unlocked: true, alertedWhenUnlocked: false } } };
+    ctx.projectManager = { projects: { probe: { category: 'resources', unlocked: true, alertedWhenUnlocked: false, attributes: {} } } };
     const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
     vm.runInContext(code, ctx);
+
+    ctx.registerProjectUnlockAlert('resources-projects');
+    expect(dom.window.document.getElementById('resources-projects-alert').style.display).toBe('inline');
+
+    ctx.markProjectsViewed();
+    expect(dom.window.document.getElementById('resources-projects-alert').style.display).toBe('none');
+  });
+
+  test('clears alert when subtab manager infers active subtab', () => {
+    const html = `<!DOCTYPE html>
+      <div id="buildings-tab" class="tab active"></div>
+      <div id="special-projects-tab" class="tab"></div>
+      <div class="projects-subtabs">
+        <div id="resources-projects-tab" class="projects-subtab active" data-subtab="resources-projects">Resources<span id="resources-projects-alert" class="unlock-alert">!</span></div>
+      </div>
+      <div class="projects-subtab-content-wrapper"><div id="resources-projects" class="projects-subtab-content active"></div></div>`;
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.gameSettings = { silenceUnlockAlert: false };
+    ctx.projectManager = { projects: { probe: { category: 'resources', unlocked: true, alertedWhenUnlocked: false, attributes: {} } } };
+
+    const uiUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'ui-utils.js'), 'utf8');
+    const subtabCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'subtab-manager.js'), 'utf8');
+    vm.runInContext(uiUtilsCode + subtabCode, ctx);
+    const projectsUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projectsUI.js'), 'utf8');
+    vm.runInContext(projectsUICode, ctx);
+
+    ctx.initializeProjectTabs();
 
     ctx.registerProjectUnlockAlert('resources-projects');
     expect(dom.window.document.getElementById('resources-projects-alert').style.display).toBe('inline');


### PR DESCRIPTION
## Summary
- ensure the special project alert clearing logic consults the subtab manager for the current active id
- add a regression test that covers the scenario where the manager has to infer the active subtab from the DOM

## Testing
- CI=true npm test *(fails: tests/boschReactorResearch.test.js, tests/massDriverResearch.test.js expect historical research costs)*

------
https://chatgpt.com/codex/tasks/task_b_68d20bf1fa6083279538c70ddd9b7dad