### PR TITLE
Align research tests with updated Bosch reactor and mass driver costs

### DIFF
--- a/tests/boschReactorBuilding.test.js
+++ b/tests/boschReactorBuilding.test.js
@@ -19,9 +19,14 @@ describe('Bosch Reactor building', () => {
 
     expect(boschReactor.unlocked).toBe(false);
     expect(boschReactor.category).toBe('terraforming');
-    expect(boschReactor.cost.colony).toEqual(oxygenFactory.cost.colony);
+    expect(boschReactor.cost.colony).toEqual({
+      metal: 100,
+      glass: 10,
+      components: 2,
+      electronics: 1,
+    });
 
-    expect(boschReactor.consumption.colony.energy).toBe(24000000);
+    expect(boschReactor.consumption.colony.energy).toBe(2_400_000);
     expect(boschReactor.consumption.atmospheric).toMatchObject({
       carbonDioxide: 100,
       hydrogen: 9.09,

--- a/tests/boschReactorResearch.test.js
+++ b/tests/boschReactorResearch.test.js
@@ -15,7 +15,7 @@ describe('Bosch Reactor research', () => {
     const research = terraformingResearch.find((entry) => entry.id === 'bosch_reactor');
 
     expect(research).toBeDefined();
-    expect(research.cost.research).toBe(150000);
+    expect(research.cost.research).toBe(500000);
     expect(research.prerequisites).toEqual([]);
     expect(research.requiredFlags).toContain('boschReactorUnlocked');
 

--- a/tests/massDriverResearch.test.js
+++ b/tests/massDriverResearch.test.js
@@ -15,7 +15,7 @@ describe('Mass Driver research', () => {
     const research = terraformingResearch.find(entry => entry.id === 'mass_driver');
 
     expect(research).toBeDefined();
-    expect(research.cost.research).toBe(5000000);
+    expect(research.cost.research).toBe(1_000_000_000);
     expect(research.prerequisites).not.toContain('water_electrolysis');
     expect(research.requiredFlags).toContain('massDriverUnlocked');
 


### PR DESCRIPTION
## Summary
- update the mass driver research test to expect the new 1,000,000,000 research cost
- adjust the Bosch Reactor building test to match its revised construction inputs and energy draw
- reflect the increased research cost for unlocking the Bosch Reactor in its unit test

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d20efa86288327bf61fc828fe082e1