### PR TITLE
Add Colony comfort accessor method

### DIFF
--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -132,6 +132,10 @@ class Colony extends Building {
     this.rebuildFilledNeeds();
   }
 
+  getComfort() {
+    return this.baseComfort;
+  }
+
   getConsumptionRatio(){
     // Calculate minRatio based on colonist availability
     const colonists = resources.colony.colonists.value;
@@ -270,7 +274,7 @@ class Colony extends Building {
     const nonLuxuryHappiness = Math.min(foodNeed, energyNeed) * 50;
   
     // Calculate happiness from comfort
-    const comfortHappiness = this.baseComfort * 20;
+    const comfortHappiness = this.getComfort() * 20;
   
     // Calculate total luxury happiness
     let totalLuxuryHappiness = 0;

--- a/src/js/colonyUI.js
+++ b/src/js/colonyUI.js
@@ -148,7 +148,7 @@ function createColonyDetails(structure) {
 
   // Add comfort and happiness boxes
   const happinessBox = createNeedBox('happiness', 'Happiness', structure.happiness, false, structure);
-  const comfortBox = createNeedBox('comfort', 'Comfort', structure.baseComfort, false, structure);
+  const comfortBox = createNeedBox('comfort', 'Comfort', structure.getComfort(), false, structure);
 
   colonyDetails.appendChild(happinessBox);
   colonyDetails.appendChild(comfortBox);
@@ -178,7 +178,7 @@ function updateColonyDetailsDisplay(structureRow, structure) {
 
   // Update comfort and happiness boxes
   updateNeedBox(structure.needBoxCache.happiness, 'Happiness', 'happiness', structure.happiness, false, structure);
-  updateNeedBox(structure.needBoxCache.comfort, 'Comfort', 'comfort', structure.baseComfort, false, structure);
+  updateNeedBox(structure.needBoxCache.comfort, 'Comfort', 'comfort', structure.getComfort(), false, structure);
 
   // Update need boxes dynamically based on structure.filledNeeds
   for (const need in structure.filledNeeds) {

--- a/tests/colonyNeedBoxCache.test.js
+++ b/tests/colonyNeedBoxCache.test.js
@@ -22,7 +22,10 @@ describe('colony need box cache', () => {
       happiness: 0.5,
       baseComfort: 0.6,
       filledNeeds: { energy: 0.8 },
-      luxuryResourcesEnabled: { electronics: true }
+      luxuryResourcesEnabled: { electronics: true },
+      getComfort() {
+        return this.baseComfort;
+      }
     };
 
     const row = dom.window.document.createElement('div');


### PR DESCRIPTION
## Summary
- add a getComfort method to Colony for retrieving the current comfort value
- switch colony UI and happiness calculations to use the accessor
- update the colony need box cache test to provide the new method

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d29c899c808327968364c73f71e7eb