### PR TITLE
Rebuild colony needs UI when consumption changes

### DIFF
--- a/src/js/colonyUI.js
+++ b/src/js/colonyUI.js
@@ -171,9 +171,20 @@ function createColonyDetails(structure) {
 function updateColonyDetailsDisplay(structureRow, structure) {
   updateUnhideButtons();
 
-  if (!structure.needBoxCache) {
-    structureRow.querySelector('.colony-details')?.remove();
-    structureRow.appendChild(createColonyDetails(structure));
+  const colonyConsumption = structure.consumption?.colony || {};
+  let needsMissing = false;
+  if (structure.needBoxCache) {
+    for (const need in colonyConsumption) {
+      if (!shouldDisplayNeedBox(need, structure)) continue;
+      if (!structure.needBoxCache[need]) {
+        needsMissing = true;
+        break;
+      }
+    }
+  }
+
+  if (!structure.needBoxCache || needsMissing) {
+    rebuildColonyNeedCache(structureRow, structure);
   }
 
   // Update comfort and happiness boxes

--- a/tests/colonyNeedBoxCache.test.js
+++ b/tests/colonyNeedBoxCache.test.js
@@ -22,9 +22,13 @@ describe('colony need box cache', () => {
       happiness: 0.5,
       baseComfort: 0.6,
       filledNeeds: { energy: 0.8 },
+      consumption: { colony: { energy: { amount: 1 } } },
       luxuryResourcesEnabled: { electronics: true },
       getComfort() {
         return this.baseComfort;
+      },
+      getConsumptionResource(category, resource) {
+        return this.consumption?.[category]?.[resource] || { amount: 0 };
       }
     };
 
@@ -41,8 +45,10 @@ describe('colony need box cache', () => {
     expect(cached.fill.style.width).toBe('40%');
 
     structure.filledNeeds.electronics = 1;
-    ctx.rebuildColonyNeedCache(row, structure);
+    structure.consumption.colony.electronics = { amount: 1 };
+    ctx.updateColonyDetailsDisplay(row, structure);
     expect(structure.needBoxCache.electronics).toBeDefined();
+    expect(structure.needBoxCache.energy.fill.style.width).toBe('40%');
     expect(row.textContent).toContain('Electronics');
   });
 });


### PR DESCRIPTION
## Summary
- ensure the colony needs display rebuilds when consumption gains a resource without a cached box
- keep need fill updates intact while adding coverage for the new electronics/androids consumption path
- extend the colony need box cache test to cover automatic rebuilding on update

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d29f9ac1948327823c4ab0b2858ed2