### PR TITLE
Clamp night temperature to quarter mean

### DIFF
--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -976,7 +976,9 @@ class Terraforming extends EffectableEntity{
 
         this.temperature.zones[zone].value = newTemp;
         this.temperature.zones[zone].day = newTemp + dMean;
-        this.temperature.zones[zone].night = newTemp - dMean;
+        const nightTemperature = newTemp - dMean;
+        const minimumNightTemperature = newTemp / 4;
+        this.temperature.zones[zone].night = Math.max(nightTemperature, minimumNightTemperature);
 
         weightedTemp += newTemp*pct;
     }


### PR DESCRIPTION
## Summary
- ensure zonal night temperatures are not allowed to drop below a quarter of the current mean when updating surface temperatures

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d2a306f4108327bf5edff09c236a4d