### PR TITLE
Add addComfort colony effect for aerostat research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,3 +190,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Planet visualizer debug sliders are hidden by default; use the `debug_mode(true)` console command to reveal them, and the setting persists in save files.
 - Solis Upgrade Two unlocks a Solis shop option to pre-purchase starting cargo ships for 100 points each.
 - Oxygen factories now vent hydrogen alongside oxygen to reflect electrolysis byproducts.
+- Colony research tiers two through six now grant aerostat colonies +10 comfort each via a new `addComfort` effect type.

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -85,6 +85,10 @@ class Colony extends Building {
     }
   }
 
+  applyAddComfort() {
+    globalThis.invalidateColonyNeedCache?.();
+  }
+
   initializeFromConfig(config, colonyName) {
     super.initializeFromConfig(config, colonyName);
     this.baseComfort = config.baseComfort;
@@ -132,8 +136,23 @@ class Colony extends Building {
     this.rebuildFilledNeeds();
   }
 
+  calculateEffectiveComfort() {
+    const baseComfort = Number.isFinite(this.baseComfort) ? this.baseComfort : 0;
+    let totalComfort = baseComfort;
+    const comfortEffects = Array.isArray(this.activeEffects) ? this.activeEffects : [];
+
+    comfortEffects.forEach((effect) => {
+      if (effect.type === 'addComfort') {
+        const bonus = Number.isFinite(effect.value) ? effect.value : 0;
+        totalComfort += bonus;
+      }
+    });
+
+    return totalComfort;
+  }
+
   getComfort() {
-    return this.baseComfort;
+    return this.calculateEffectiveComfort();
   }
 
   getConsumptionRatio(){

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -126,6 +126,9 @@ class EffectableEntity {
             this.applyAddResourceConsumption(effect);
           }
           break;
+        case 'addComfort':
+          this.applyAddComfort?.(effect);
+          break;
         case 'enable':
           this.enable(effect.targetId);
           break;

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -685,6 +685,12 @@ const researchParameters = {
             targetId: 't2_colony',
             type: 'enable',
           },
+          {
+            target: 'colony',
+            targetId: 'aerostat_colony',
+            type: 'addComfort',
+            value: 10,
+          },
         ],
       },
       {
@@ -738,6 +744,12 @@ const researchParameters = {
             resourceCategory: 'colony',
             resourceId: 'electronics',
             amount: 0.01,
+          },
+          {
+            target: 'colony',
+            targetId: 'aerostat_colony',
+            type: 'addComfort',
+            value: 10,
           },
         ],
       },
@@ -812,6 +824,12 @@ const researchParameters = {
             resourceId: 'androids',
             amount: 0.0001,
           },
+          {
+            target: 'colony',
+            targetId: 'aerostat_colony',
+            type: 'addComfort',
+            value: 10,
+          },
         ],
       },
       {
@@ -853,8 +871,14 @@ const researchParameters = {
             targetId: 't5_colony',
             type: 'enable',
           },
+          {
+            target: 'colony',
+            targetId: 'aerostat_colony',
+            type: 'addComfort',
+            value: 10,
+          },
         ],
-      },   
+      },
       {
         id: 't6_colony',
         name: 'Metropolis',
@@ -866,6 +890,12 @@ const researchParameters = {
             target: 'colony',
             targetId: 't6_colony',
             type: 'enable',
+          },
+          {
+            target: 'colony',
+            targetId: 'aerostat_colony',
+            type: 'addComfort',
+            value: 10,
           },
         ],
       },

--- a/tests/addComfortEffect.test.js
+++ b/tests/addComfortEffect.test.js
@@ -1,0 +1,76 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+require('../src/js/colony.js');
+const Colony = global.Colony;
+
+describe('addComfort effect', () => {
+  function createColony(baseComfort = 0.5) {
+    const config = {
+      name: 'Test Colony',
+      category: 'colony',
+      description: 'Test colony for comfort effects',
+      cost: { colony: {} },
+      consumption: {},
+      production: {},
+      storage: {},
+      dayNightActivity: false,
+      canBeToggled: true,
+      requiresMaintenance: false,
+      maintenanceFactor: 1,
+      requiresDeposit: null,
+      requiresWorker: 0,
+      unlocked: true,
+      baseComfort,
+      requiresLand: 0,
+    };
+
+    return new Colony(config, 'test_colony');
+  }
+
+  beforeEach(() => {
+    global.globalGameIsLoadingFromSave = false;
+    global.resources = { colony: {}, atmospheric: {} };
+    global.buildings = {};
+    global.invalidateColonyNeedCache = jest.fn();
+  });
+
+  test('calculateEffectiveComfort sums base comfort and addComfort values', () => {
+    const colony = createColony(0.5);
+    expect(colony.calculateEffectiveComfort()).toBe(0.5);
+
+    const effectA = {
+      type: 'addComfort',
+      value: 10,
+      effectId: 'comfort-1',
+      sourceId: 'research-1',
+    };
+    colony.addEffect(effectA);
+    expect(colony.calculateEffectiveComfort()).toBe(10.5);
+
+    const effectB = {
+      type: 'addComfort',
+      value: 5,
+      effectId: 'comfort-2',
+      sourceId: 'research-2',
+    };
+    colony.addEffect(effectB);
+    expect(colony.calculateEffectiveComfort()).toBe(15.5);
+
+    colony.removeEffect(effectA);
+    expect(colony.calculateEffectiveComfort()).toBe(5.5);
+  });
+
+  test('getComfort reflects addComfort effects', () => {
+    const colony = createColony(1);
+    colony.addEffect({
+      type: 'addComfort',
+      value: 10,
+      effectId: 'comfort-3',
+      sourceId: 'research-3',
+    });
+
+    expect(colony.getComfort()).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary
- add an `addComfort` effect hook for colonies and compute comfort via a shared helper
- award aerostat colonies +10 comfort from tier two through six research unlocks and document the change
- add unit coverage for the new comfort effect behaviour

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d2a2029ca48327a9de866ad2eaa306