### PR TITLE
Reset colony base comfort on load

### DIFF
--- a/tests/buildingSaveLoadMethods.test.js
+++ b/tests/buildingSaveLoadMethods.test.js
@@ -184,13 +184,14 @@ describe('Building save/load methods', () => {
     colony.luxuryResourcesEnabled.electronics = false;
 
     const saved = colony.saveState();
+    expect(saved.baseComfort).toBeUndefined();
     const restored = new ctx.Colony(config, 'settlement');
     restored.loadState(saved);
 
     expect(restored.count).toBe(4);
     expect(restored.active).toBe(2);
     expect(restored.productivity).toBeCloseTo(0.6);
-    expect(restored.baseComfort).toBe(12);
+    expect(restored.baseComfort).toBe(config.baseComfort);
     expect(restored.happiness).toBeCloseTo(0.8);
     expect(restored.obsolete).toBe(true);
     expect(restored.filledNeeds.energy).toBeCloseTo(0.5);


### PR DESCRIPTION
## Summary
- remove colony base comfort from the saved state so loads reapply the configuration value
- update the building save/load test to assert base comfort is not persisted

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d2fa8ad9f083278f642e84741ea74c