### PR TITLE
Remove unused toxicity tolerance from life designer

### DIFF
--- a/src/js/life.js
+++ b/src/js/life.js
@@ -51,8 +51,6 @@ class LifeAttribute {
         return (0.00008*this.value).toFixed(5); // Adjust as needed
       case 'radiationTolerance':
         return this.value * 4 + '%';
-      case 'toxicityTolerance':
-        return this.value * 10 + '%';
       case 'invasiveness':
         return this.value;
       case 'spaceEfficiency':
@@ -71,11 +69,11 @@ class LifeAttribute {
 }
 
 class LifeDesign {
-  constructor(minTemperatureTolerance,
+  constructor(
+    minTemperatureTolerance,
     maxTemperatureTolerance,
     photosynthesisEfficiency,
     radiationTolerance,
-    toxicityTolerance,
     invasiveness,
     spaceEfficiency, // Added new attribute
     geologicalBurial, // Added Geological Burial
@@ -93,7 +91,6 @@ class LifeDesign {
     this.growthTemperatureTolerance = new LifeAttribute('growthTemperatureTolerance', growthTemperatureTolerance, 'Growth Temperature Tolerance', 'Controls how quickly growth falls off from the optimal temperature.', 40);
     this.photosynthesisEfficiency = new LifeAttribute('photosynthesisEfficiency', photosynthesisEfficiency, 'Photosynthesis Efficiency', 'Efficiency of converting light to energy; affects growth rate.', 500);
     this.radiationTolerance = new LifeAttribute('radiationTolerance', radiationTolerance, 'Radiation Tolerance', 'Resistance to radiation; vital without a magnetosphere.', 25);
-    this.toxicityTolerance = new LifeAttribute('toxicityTolerance', toxicityTolerance, 'Toxicity Tolerance', 'Resistance to environmental toxins.', 10);
     this.invasiveness = new LifeAttribute('invasiveness', invasiveness, 'Invasiveness', 'Speed of spreading/replacing existing life; reduces deployment time.', 50);
     this.spaceEfficiency = new LifeAttribute('spaceEfficiency', spaceEfficiency, 'Space Efficiency', 'Increases maximum biomass density per unit area.', 100);
     this.geologicalBurial = new LifeAttribute('geologicalBurial', geologicalBurial, 'Geological Burial', 'Removes existing biomass into inert storage.', 50);
@@ -149,7 +146,6 @@ class LifeDesign {
       growthTemperatureTolerance: this.growthTemperatureTolerance.value,
       photosynthesisEfficiency: this.photosynthesisEfficiency.value,
       radiationTolerance: this.radiationTolerance.value,
-      toxicityTolerance: this.toxicityTolerance.value,
       invasiveness: this.invasiveness.value,
       spaceEfficiency: this.spaceEfficiency.value, // Added for saving
       geologicalBurial: this.geologicalBurial.value // Added Geological Burial
@@ -163,7 +159,6 @@ class LifeDesign {
       data.maxTemperatureTolerance,
       data.photosynthesisEfficiency,
       data.radiationTolerance,
-      data.toxicityTolerance,
       data.invasiveness,
       data.spaceEfficiency ?? 0, // Added for loading, default to 0 if missing in save
       data.geologicalBurial ?? 0, // Added Geological Burial, default 0
@@ -294,14 +289,6 @@ class LifeDesign {
       return Math.max(dayPen, nightPen);
   }
 
-  // Checks toxicity tolerance (currently a simple global check)
-  toxicityCheck() {
-      // Placeholder - Add actual toxicity check logic if/when implemented
-      const isToxic = false; // Assume not toxic for now
-      const pass = !isToxic || this.toxicityTolerance.value >= 5; // Example threshold
-      return { pass: pass, reason: pass ? null : "High toxicity" };
-  }
-
     // Checks radiation tolerance against magnetosphere status
     radiationCheck() {
         const hasShield = terraforming.getMagnetosphereStatus();
@@ -322,7 +309,7 @@ class LifeDesign {
     }
 
   // Checks if the lifeform can survive in at least one zone based on temperature
-  // TODO: Incorporate global radiation/toxicity checks?
+  // TODO: Incorporate global radiation checks?
   canSurviveAnywhere() {
       const tempResults = this.temperatureSurvivalCheck();
       // Check if any zone passed the temperature check
@@ -469,8 +456,8 @@ class LifeDesigner extends EffectableEntity {
     maxTemperatureTolerance,
     photosynthesisEfficiency,
     radiationTolerance,
-    toxicityTolerance,
     invasiveness,
+    spaceEfficiency,
     geologicalBurial,
     growthTemperatureTolerance = 0
   ) {
@@ -479,9 +466,8 @@ class LifeDesigner extends EffectableEntity {
       maxTemperatureTolerance,
       photosynthesisEfficiency,
       radiationTolerance,
-      toxicityTolerance,
       invasiveness,
-      0, // Default spaceEfficiency for new design
+      spaceEfficiency,
       geologicalBurial, // Pass geologicalBurial
       growthTemperatureTolerance
     );

--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -55,7 +55,6 @@ const lifeUICache = {
     tempMultiplier: {},
     moisture: {},
     radiation: {},
-    toxicity: {},
     maxDensity: {},
     biomassAmount: {},
     biomassDensity: {},
@@ -86,7 +85,6 @@ function cacheLifeStatusTableElements() {
     lifeUICache.cells.tempMultiplier[zone] = document.getElementById(`temp-multiplier-${zone}-status`);
     lifeUICache.cells.moisture[zone] = document.getElementById(`moisture-${zone}-status`);
     lifeUICache.cells.radiation[zone] = document.getElementById(`radiation-${zone}-status`);
-    lifeUICache.cells.toxicity[zone] = document.getElementById(`toxicity-${zone}-status`);
     lifeUICache.cells.maxDensity[zone] = document.getElementById(`max-density-${zone}-status`);
     lifeUICache.cells.biomassAmount[zone] = document.getElementById(`biomass-amount-${zone}-status`);
     lifeUICache.cells.biomassDensity[zone] = document.getElementById(`biomass-density-${zone}-status`);
@@ -130,7 +128,7 @@ function cacheLifeAttributeCells() {
     'minTemperatureTolerance', 'maxTemperatureTolerance',
     'optimalGrowthTemperature', 'growthTemperatureTolerance',
     'photosynthesisEfficiency',
-    'radiationTolerance', 'toxicityTolerance',
+    'radiationTolerance',
     'invasiveness', 'spaceEfficiency', 'geologicalBurial'
   ];
   lifeUICache.attributeCells = {};
@@ -258,13 +256,6 @@ function initializeLifeTerraformingDesignerUI() {
                         <td id="radiation-temperate-status" style="border: 1px solid #ccc; padding: 5px; text-align: center;">-</td>
                         <td id="radiation-polar-status" style="border: 1px solid #ccc; padding: 5px; text-align: center;">-</td>
                     </tr>
-                     <tr>
-                        <td style="border: 1px solid #ccc; padding: 5px;">Toxicity</td>
-                        <td id="toxicity-global-status" style="border: 1px solid #ccc; padding: 5px; text-align: center;">-</td>
-                        <td id="toxicity-tropical-status" style="border: 1px solid #ccc; padding: 5px; text-align: center;">-</td>
-                        <td id="toxicity-temperate-status" style="border: 1px solid #ccc; padding: 5px; text-align: center;">-</td>
-                        <td id="toxicity-polar-status" style="border: 1px solid #ccc; padding: 5px; text-align: center;">-</td>
-                    </tr>
                     <tr>
                         <td style="border: 1px solid #ccc; padding: 5px;">Biomass Amount (tons)</td>
                         <td id="biomass-amount-global-status" style="border: 1px solid #ccc; padding: 5px; text-align: center;">-</td>
@@ -325,7 +316,7 @@ function initializeLifeTerraformingDesignerUI() {
           'minTemperatureTolerance', 'maxTemperatureTolerance',
           'optimalGrowthTemperature', 'growthTemperatureTolerance',
           'photosynthesisEfficiency',
-          'radiationTolerance', 'toxicityTolerance',
+          'radiationTolerance',
           'invasiveness', 'spaceEfficiency', 'geologicalBurial' // Added geologicalBurial
       ];
 
@@ -361,7 +352,7 @@ function initializeLifeTerraformingDesignerUI() {
     }
     // Event listener for the "Create New Design" button
     newDesignBtn.addEventListener('click', () => {
-      lifeDesigner.createNewDesign(0, 0, 0, 0, 0, 0, 0, 0, 0);
+      lifeDesigner.createNewDesign(0, 0, 0, 0, 0, 0, 0, 0);
       lifeDesigner.tentativeDesign.copyFrom(lifeDesigner.currentDesign);
       document.dispatchEvent(new Event('lifeTentativeDesignCreated'));
       updateLifeUI();
@@ -624,7 +615,7 @@ function updateLifeUI() {
            'minTemperatureTolerance', 'maxTemperatureTolerance',
            'optimalGrowthTemperature', 'growthTemperatureTolerance',
            'photosynthesisEfficiency',
-           'radiationTolerance', 'toxicityTolerance',
+           'radiationTolerance',
            'invasiveness', 'spaceEfficiency', 'geologicalBurial' // Added geologicalBurial
         ];
 
@@ -721,7 +712,6 @@ function updateLifeStatusTable() {
     const survivalTempResults = designToCheck.temperatureSurvivalCheck();
     const moistureResults = designToCheck.moistureCheckAllZones(); // Use the aggregate function
     const radiationResult = designToCheck.radiationCheck(); // Global check
-    const toxicityResult = designToCheck.toxicityCheck();   // Global check
     // Calculate max density based on space efficiency
     const spaceEfficiencyAttr = designToCheck.spaceEfficiency;
     const densityMultiplier = 1 + (spaceEfficiencyAttr?.value || 0);
@@ -839,7 +829,6 @@ function updateLifeStatusTable() {
 
         updateStatusCell(lifeUICache.cells.moisture[zone], moistureResults[zone]);
         updateStatusCell(lifeUICache.cells.radiation[zone], radiationResult, zone === 'global');
-        updateStatusCell(lifeUICache.cells.toxicity[zone], toxicityResult);
 
         const maxDensityCell = lifeUICache.cells.maxDensity[zone];
         if (maxDensityCell) {


### PR DESCRIPTION
## Summary
- remove the unused toxicity tolerance attribute from life designs and align creation/loading helpers
- clean the life designer UI caches and status table so only supported requirements are shown

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d2ff03f2a48327b0e7543411713646