### PR TITLE
Render tabs immediately on activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,3 +191,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Solis Upgrade Two unlocks a Solis shop option to pre-purchase starting cargo ships for 100 points each.
 - Oxygen factories now vent hydrogen alongside oxygen to reflect electrolysis byproducts.
 - Colony research tiers two through six now grant aerostat colonies +10 comfort each via a new `addComfort` effect type.
+- Clicking a tab immediately rerenders that tab and its active subtabs so freshly unlocked data appears right away.

--- a/index.html
+++ b/index.html
@@ -654,6 +654,7 @@
             } else {
                 console.error(`Tab content with id "${tabId}" not found.`);
             }
+            renderTabImmediately?.(tabId);
         } else if (!tabButton) {
              console.error(`Tab button with data-tab="${tabId}" not found.`);
         } else {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -540,6 +540,37 @@ function updateRender(force = false) {
   updateMilestonesUI();
 }
 
+const tabSubtabGetters = {
+  buildings: () => globalThis.buildingSubtabManager?.(),
+  'special-projects': () => globalThis.projectsSubtabManager?.(),
+  research: () => globalThis.researchSubtabManager?.(),
+  terraforming: () => globalThis.getTerraformingSubtabManager?.(),
+  space: () => globalThis.getSpaceSubtabManager?.(),
+  hope: () => globalThis.hopeSubtabManager?.()
+};
+
+const defaultSubtabs = {
+  buildings: 'resource-buildings',
+  'special-projects': 'resources-projects',
+  research: 'energy-research',
+  terraforming: 'world-terraforming',
+  space: 'space-story',
+  hope: 'awakening-hope'
+};
+
+function renderTabImmediately(tabId) {
+  const suffix = '-tab';
+  const normalizedId = tabId && tabId.endsWith(suffix) ? tabId.slice(0, -suffix.length) : tabId;
+  updateRender();
+  const managerGetter = normalizedId ? tabSubtabGetters[normalizedId] : null;
+  const manager = managerGetter?.();
+  const activeId = manager?.getActiveId?.() || manager?.activeId || null;
+  const targetId = activeId || (normalizedId ? defaultSubtabs[normalizedId] : null);
+  targetId && manager?.activate?.(targetId);
+}
+
+globalThis.renderTabImmediately = renderTabImmediately;
+
 function update(time, delta) {
   const speed = (typeof gameSpeed !== 'undefined') ? gameSpeed : 1;
   const scaledDelta = delta * speed;

--- a/src/js/hopeUI.js
+++ b/src/js/hopeUI.js
@@ -7,6 +7,10 @@ if (typeof SubtabManager === 'undefined') {
 }
 let hopeSubtabManager = null;
 
+function getHopeSubtabManager() {
+    return hopeSubtabManager;
+}
+
 function initializeHopeTabs() {
     if (typeof SubtabManager !== 'function') return;
     hopeSubtabManager = new SubtabManager('.hope-subtab', '.hope-subtab-content', true);
@@ -73,4 +77,6 @@ function updateHopeUI() {
     }
     updateHopeAlert();
 }
+
+globalThis.window && (globalThis.window.hopeSubtabManager = getHopeSubtabManager);
 

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -1022,6 +1022,8 @@ if (typeof module !== 'undefined' && module.exports) {
   };
 }
 
+globalThis.window && (globalThis.window.projectsSubtabManager = () => projectsSubtabManager);
+
 
 function toggleProjectCollapse(projectCard) {
   projectCard.classList.toggle('collapsed');

--- a/src/js/researchUI.js
+++ b/src/js/researchUI.js
@@ -375,3 +375,5 @@ if (typeof module !== 'undefined' && module.exports) {
         researchSubtabManager: () => researchSubtabManager
     };
 }
+
+globalThis.window && (globalThis.window.researchSubtabManager = () => researchSubtabManager);

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -20,6 +20,10 @@ let spaceSubtabManager = null;
 let lastWorldKey = null;
 let lastWorldSeed = null;
 
+function getSpaceSubtabManager() {
+    return spaceSubtabManager;
+}
+
 // Cached travel warning popup elements
 let travelWarningOverlay = null;
 let travelWarningMessageEl = null;
@@ -399,3 +403,5 @@ function updateCurrentWorldUI() {
         }
     }
 }
+
+globalThis.window && (globalThis.window.getSpaceSubtabManager = getSpaceSubtabManager);

--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -129,8 +129,9 @@ const tabParameters = {
   
     // Activate a tab
     activateTab(tabId) {
-      const tabElement = document.querySelector(`[data-tab="${tabId}"]`);
-      const tabContentElement = document.getElementById(tabId);
+      const normalizedId = extractTabId(tabId);
+      const tabElement = document.querySelector(`[data-tab="${normalizedId}"]`);
+      const tabContentElement = document.getElementById(normalizedId);
 
       if (tabElement && tabContentElement) {
         document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
@@ -138,6 +139,7 @@ const tabParameters = {
 
         tabElement.classList.add('active');
         tabContentElement.classList.add('active');
+        globalThis.renderTabImmediately?.(normalizedId);
       }
     }
   }

--- a/tests/tabImmediateRender.test.js
+++ b/tests/tabImmediateRender.test.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+function createContext() {
+  const dom = new JSDOM('<!DOCTYPE html>', { runScripts: 'outside-only' });
+  const ctx = dom.getInternalVMContext();
+  ctx.document = dom.window.document;
+  ctx.globalThis = ctx;
+  ctx.updateDayNightDisplay = () => {};
+  ctx.updateResourceDisplay = () => {};
+  ctx.updateWarnings = () => {};
+  ctx.updateBuildingAlert = () => {};
+  ctx.updateProjectAlert = () => {};
+  ctx.updateResearchAlert = () => {};
+  ctx.updateHopeAlert = () => {};
+  ctx.updateColonyDisplay = () => {};
+  ctx.updateGrowthRateDisplay = () => {};
+  ctx.updateColonySlidersUI = () => {};
+  ctx.renderProjects = () => {};
+  ctx.updateResearchUI = () => {};
+  ctx.updateTerraformingUI = () => {};
+  ctx.updateSpaceUI = () => {};
+  ctx.updateRWGEffectsUI = () => {};
+  ctx.updateHopeUI = () => {};
+  ctx.updateStatisticsDisplay = () => {};
+  ctx.updateMilestonesUI = () => {};
+  ctx.resources = {};
+  ctx.buildings = {};
+  ctx.colonies = {};
+  ctx.Phaser = { AUTO: 0, Game: function GameStub() { this.scene = {}; } };
+  return { ctx, dom };
+}
+
+function loadGameIntoContext(ctx) {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'game.js'), 'utf8');
+  vm.runInContext(code + '; this.renderTabImmediately = renderTabImmediately;', ctx);
+}
+
+test('renderTabImmediately triggers a render and reactivates the current subtab', () => {
+  const { ctx, dom } = createContext();
+  loadGameIntoContext(ctx);
+
+  let renderCalls = 0;
+  ctx.updateRender = () => { renderCalls += 1; };
+
+  const activated = [];
+  const manager = {
+    getActiveId: () => 'resource-buildings',
+    activate: (id) => activated.push(id)
+  };
+  ctx.buildingSubtabManager = () => manager;
+
+  ctx.renderTabImmediately('buildings');
+
+  expect(renderCalls).toBe(1);
+  expect(activated).toEqual(['resource-buildings']);
+
+  dom.window.close();
+});
+
+test('renderTabImmediately falls back to default subtab when none is active', () => {
+  const { ctx, dom } = createContext();
+  loadGameIntoContext(ctx);
+
+  let renderCalls = 0;
+  ctx.updateRender = () => { renderCalls += 1; };
+
+  const activated = [];
+  const manager = {
+    getActiveId: () => undefined,
+    activate: (id) => activated.push(id)
+  };
+  ctx.buildingSubtabManager = () => manager;
+
+  ctx.renderTabImmediately('buildings-tab');
+
+  expect(renderCalls).toBe(1);
+  expect(activated).toEqual(['resource-buildings']);
+
+  dom.window.close();
+});


### PR DESCRIPTION
## Summary
- ensure activating a tab requests an immediate render for that view and its active subtab
- expose subtab manager getters for space, hope, projects, and research so the renderer can reapply current subtabs
- add regression coverage for the new renderTabImmediately helper

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d33a302cfc8327bac581031b53b2cf