### PR TITLE
Fix resource disposal energy tooltip label

### DIFF
--- a/src/js/projects/SpaceDisposalProject.js
+++ b/src/js/projects/SpaceDisposalProject.js
@@ -9,6 +9,10 @@ class SpaceDisposalProject extends SpaceExportBaseProject {
     return 'Resource Disposal';
   }
 
+  getCostRateLabel() {
+    return 'Resource Disposal';
+  }
+
   createResourceDisposalUI() {
     const section = super.createResourceDisposalUI();
     const detailsGrid = section.querySelector('.project-details-grid');

--- a/src/js/projects/SpaceshipProject.js
+++ b/src/js/projects/SpaceshipProject.js
@@ -24,6 +24,10 @@ class SpaceshipProject extends Project {
     return baseLabel;
   }
 
+  getCostRateLabel() {
+    return 'Spaceship Cost';
+  }
+
  assignSpaceships(count) {
     const wasContinuous = this.isContinuous();
     const availableSpaceships = Math.floor(resources.special.spaceships.value);
@@ -652,7 +656,7 @@ class SpaceshipProject extends Project {
               if (applyRates) {
                 resources[category][resource].modifyRate(
                   -rateValue,
-                  'Spaceship Cost',
+                  this.getCostRateLabel(),
                   'project'
                 );
               }
@@ -733,7 +737,7 @@ class SpaceshipProject extends Project {
             if (applyRates) {
               resources[category][resource].modifyRate(
                 -rateValue,
-                'Spaceship Cost',
+                this.getCostRateLabel(),
                 'project'
               );
             }


### PR DESCRIPTION
## Summary
- allow spaceship projects to customize the tooltip label used for their energy costs
- make the resource disposal project report energy usage under the Resource Disposal label

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d34b66915c8327b9b5991b2570ae77