### PR TITLE
Apply project duration modifiers to Dyson swarm collectors

### DIFF
--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -17,7 +17,8 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
   }
 
   get collectorDuration() {
-    return this.getDurationWithTerraformBonus(this.baseCollectorDuration);
+    const duration = this.getDurationWithTerraformBonus(this.baseCollectorDuration);
+    return this.applyDurationEffects(duration);
   }
 
   renderUI(container) {


### PR DESCRIPTION
## Summary
- apply the standard project duration multipliers when calculating Dyson Swarm collector build time so global modifiers, including skill bonuses, affect collectors

## Testing
- CI=true npm test *(fails: tests/aerostatBuildCap.test.js, tests/massDriverBuilding.test.js, tests/boschReactorBuilding.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68d43994010083279d1bd2c13174f37b