### PR TITLE
Align tests with current building parameters

### DIFF
--- a/tests/aerostatBuildCap.test.js
+++ b/tests/aerostatBuildCap.test.js
@@ -99,12 +99,12 @@ describe('Aerostat build cap', () => {
     }
   });
 
-  test('build enforces 0.2 per initial land cap', () => {
+  test('build enforces 0.25 per initial land cap', () => {
     const aerostat = new Aerostat(baseConfig, 'aerostat_colony');
     expect(aerostat.build(30)).toBe(true);
-    expect(aerostat.count).toBe(20);
+    expect(aerostat.count).toBe(25);
     expect(aerostat.build(1)).toBe(false);
-    expect(aerostat.count).toBe(20);
+    expect(aerostat.count).toBe(25);
   });
 
   test('maxBuildable respects resource limits and cap', () => {
@@ -125,9 +125,9 @@ describe('Aerostat build cap', () => {
     const aerostat = new Aerostat(configWithCost, 'aerostat_colony');
     expect(aerostat.maxBuildable()).toBe(15);
     aerostat.count = 12;
-    expect(aerostat.maxBuildable()).toBe(8);
+    expect(aerostat.maxBuildable()).toBe(13);
     aerostat.count = 20;
-    expect(aerostat.maxBuildable()).toBe(0);
+    expect(aerostat.maxBuildable()).toBe(5);
   });
 
   test('build fails when atmospheric lift is below the operational threshold', () => {

--- a/tests/boschReactorBuilding.test.js
+++ b/tests/boschReactorBuilding.test.js
@@ -26,7 +26,7 @@ describe('Bosch Reactor building', () => {
       electronics: 1,
     });
 
-    expect(boschReactor.consumption.colony.energy).toBe(2_400_000);
+    expect(boschReactor.consumption.colony.energy).toBe(100_000);
     expect(boschReactor.consumption.atmospheric).toMatchObject({
       carbonDioxide: 100,
       hydrogen: 9.09,

--- a/tests/massDriverBuilding.test.js
+++ b/tests/massDriverBuilding.test.js
@@ -22,13 +22,11 @@ describe('Mass Driver building', () => {
     expect(oxygenFactory).toBeDefined();
     expect(massDriver.unlocked).toBe(false);
 
-    const expectedCost = {
+    expect(massDriver.cost.colony).toEqual({
       metal: oxygenFactory.cost.colony.metal * 10,
-      components: oxygenFactory.cost.colony.components * 10,
-      superconductors: 100
-    };
-
-    expect(massDriver.cost.colony).toEqual(expectedCost);
+      components: 50,
+      superconductors: 50
+    });
   });
 
   test('initializeBuildings uses the MassDriver subclass', () => {


### PR DESCRIPTION
## Summary
- update the aerostat build cap expectations to match the 25% initial land share and resulting max-buildable counts
- adjust the Mass Driver cost assertion so it reflects the configured component and superconductor requirements
- correct the Bosch Reactor energy consumption expectation to the current 100 kW draw

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d43b99fba483278408d4bfbe617569