### PR TITLE
Rename Bosch reactor references to chemical reactor

### DIFF
--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -554,7 +554,7 @@ const buildingsParameters = {
     defaultRecipe: 'recipe1',
     recipes: {
       recipe1: {
-        shortName: 'Bosch Reaction',
+        shortName: 'Chemical Reactor',
         consumption: {
           atmospheric: { carbonDioxide: 100, hydrogen: 9.09 }
         },

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1168,8 +1168,8 @@ const researchParameters = {
       },
       {
         id: 'bosch_reactor',
-        name: 'Bosch Reactor',
-        description: 'Unlocks reactors that combine carbon dioxide and hydrogen into water via the Bosch reaction.',
+        name: 'Chemical Reactor',
+        description: 'Unlocks configurable reactors that combine imported hydrogen with atmospheric feedstocks to synthesize vital compounds.',
         cost: { research: 500_000 },
         prerequisites: [],
         requiredFlags: ['boschReactorUnlocked'],

--- a/src/js/story/venus.js
+++ b/src/js/story/venus.js
@@ -366,7 +366,7 @@ progressVenus.chapters.push(
     id: "chapter19.4",
     type: "journal",
     chapter: 19,
-    narrative: "Dr. Evelyn Hart: 'You have probably been wondering how you are going to cool Venus.  If you block the entire Sun - and you should - it will take hundreds of years to cool it.  No, you need to get rid of all the CO2.  Mass drivers have always been off the table since that would count as a weapon.  There is an interesting solution : what happens if we import hydrogen instead of water? The Bosch process lets us feed hydrogen into Venusian CO2. The reaction strips out solid carbon, gives us colony water as a bonus. Hydrogen shipments are lighter than water, and each tonne imported removes 11 tons of CO2. If we lean into it, we accelerate climate control and make glass without hauling sand.'",
+    narrative: "Dr. Evelyn Hart: 'You have probably been wondering how you are going to cool Venus.  If you block the entire Sun - and you should - it will take hundreds of years to cool it.  No, you need to get rid of all the CO2.  Mass drivers have always been off the table since that would count as a weapon.  There is an interesting solution : what happens if we import hydrogen instead of water? Chemical reactors let us feed hydrogen into Venusian CO2. The reaction strips out solid carbon, gives us colony water as a bonus. Hydrogen shipments are lighter than water, and each tonne imported removes 11 tons of CO2. If we lean into it, we accelerate climate control and make glass without hauling sand.'",
     prerequisites: ["chapter19.3"],
     reward: [
       {
@@ -387,7 +387,7 @@ progressVenus.chapters.push(
     id: "chapter19.4a",
     type: "journal",
     chapter: 19,
-    narrative: "Import Hydrogen special project available for research.  Unpacking boschReactor.btb...",
+    narrative: "Import Hydrogen special project available for research.  Unpacking chemicalReactor.btb...",
     prerequisites: ["chapter19.3"],
     objectives: [      { type: 'collection', resourceType: 'colony', resource: 'colonists', quantity: 5000000 }],
     reward: []

--- a/tests/chemicalReactorBuilding.test.js
+++ b/tests/chemicalReactorBuilding.test.js
@@ -31,13 +31,13 @@ describe('Chemical Reactor building', () => {
     const { recipes } = chemicalReactor;
     expect(recipes).toBeDefined();
 
-    const bosch = recipes.recipe1;
-    expect(bosch.shortName).toBe('Bosch Reaction');
-    expect(bosch.consumption.atmospheric).toMatchObject({
+    const primaryRecipe = recipes.recipe1;
+    expect(primaryRecipe.shortName).toBe('Chemical Reactor');
+    expect(primaryRecipe.consumption.atmospheric).toMatchObject({
       carbonDioxide: 100,
       hydrogen: 9.09,
     });
-    expect(bosch.production.colony).toMatchObject({ water: 81.82 });
+    expect(primaryRecipe.production.colony).toMatchObject({ water: 81.82 });
 
     const waterSynthesis = recipes.recipe2;
     expect(waterSynthesis.shortName).toBe('Water Synthesis');
@@ -53,7 +53,7 @@ describe('Chemical Reactor building', () => {
       carbonDioxide: 100,
       hydrogen: 18.18,
     });
-    expect(methane.production.atmospheric).toMatchObject({ methane: 36.36 });
+    expect(methane.production.atmospheric).toMatchObject({ atmosphericMethane: 36.36 });
     expect(methane.production.colony).toMatchObject({ water: 81.82 });
   });
 });

--- a/tests/multiRecipesBuilding.test.js
+++ b/tests/multiRecipesBuilding.test.js
@@ -102,7 +102,7 @@ describe('MultiRecipesBuilding', () => {
     defaultRecipe: 'recipe1',
     recipes: {
       recipe1: {
-        shortName: 'Bosch Reaction',
+        shortName: 'Chemical Reactor',
         consumption: {
           atmospheric: { carbonDioxide: 100, hydrogen: 9.09 },
         },


### PR DESCRIPTION
## Summary
- rename the Bosch reactor recipe label and research entry to "Chemical Reactor"
- update the Venus story text to reference the Chemical Reactor terminology
- adjust unit tests to reflect the new naming and methane output key

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d46355bb0c8327b5895be463d81754