### PR TITLE
Add Venus travel warning with collapsible hint

### DIFF
--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -616,7 +616,9 @@ const ganymedeOverrides = {
 // A completely dry, Venus-sized world with a pure inert atmosphere (>0.5 atm)
 const vega2Overrides = {
   name: 'Vega-2',
-  travelWarning: 'This world has no water.  Solis can help.',
+  travelWarning: {
+    message: 'This world has no water.  Solis can help.'
+  },
 
   resources: {
     surface: {
@@ -700,6 +702,13 @@ const vega2Overrides = {
 /* ---------- VENUS OVERRIDES ---------- */
 const venusOverrides = {
   name: 'Venus',
+  travelWarning: {
+    message: 'Venus begins with crushing pressure and furnace-like heat.',
+    hint: {
+      title: 'Terraforming Hint',
+      body: 'Deploy solar shades early to ease cooling and scrub sulfuric acid so condensers survive the opening years.'
+    }
+  },
 
   resources: {
     surface: {

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -25,6 +25,22 @@ let travelWarningOverlay = null;
 let travelWarningMessageEl = null;
 let travelWarningConfirmBtn = null;
 let travelWarningCancelBtn = null;
+let travelWarningHintContainer = null;
+let travelWarningHintToggle = null;
+let travelWarningHintTitleEl = null;
+let travelWarningHintBodyEl = null;
+
+function setTravelWarningHintVisibility(isOpen) {
+    if (!travelWarningHintContainer) return;
+    travelWarningHintContainer.dataset.open = isOpen ? 'true' : 'false';
+    if (travelWarningHintBodyEl) {
+        travelWarningHintBodyEl.style.display = isOpen ? 'block' : 'none';
+    }
+    if (travelWarningHintToggle) {
+        travelWarningHintToggle.textContent = isOpen ? 'Hide Hint' : 'Show Hint';
+        travelWarningHintToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    }
+}
 
 function showSpaceRandomTab() {
     spaceRandomTabVisible = true;
@@ -50,7 +66,7 @@ function hideSpaceRandomTab() {
     }
 }
 
-function showTravelWarningPopup(message, onConfirm) {
+function showTravelWarningPopup(warningData, onConfirm) {
     if (!travelWarningOverlay) {
         travelWarningOverlay = document.createElement('div');
         travelWarningOverlay.id = 'travel-warning-popup';
@@ -77,6 +93,45 @@ function showTravelWarningPopup(message, onConfirm) {
         travelWarningMessageEl.style.marginBottom = '12px';
         win.appendChild(travelWarningMessageEl);
 
+        travelWarningHintContainer = document.createElement('div');
+        travelWarningHintContainer.className = 'travel-warning-hint';
+        travelWarningHintContainer.style.marginBottom = '12px';
+        travelWarningHintContainer.style.textAlign = 'left';
+        travelWarningHintContainer.style.display = 'none';
+
+        const hintHeader = document.createElement('div');
+        hintHeader.style.display = 'flex';
+        hintHeader.style.justifyContent = 'space-between';
+        hintHeader.style.alignItems = 'center';
+
+        travelWarningHintTitleEl = document.createElement('span');
+        travelWarningHintTitleEl.className = 'travel-warning-hint-title';
+        travelWarningHintTitleEl.textContent = 'Hint';
+        hintHeader.appendChild(travelWarningHintTitleEl);
+
+        travelWarningHintToggle = document.createElement('button');
+        travelWarningHintToggle.type = 'button';
+        travelWarningHintToggle.className = 'travel-warning-hint-toggle';
+        travelWarningHintToggle.textContent = 'Show Hint';
+
+        travelWarningHintBodyEl = document.createElement('div');
+        travelWarningHintBodyEl.id = 'travel-warning-hint-body';
+        travelWarningHintBodyEl.className = 'travel-warning-hint-body';
+        travelWarningHintBodyEl.style.marginTop = '8px';
+        travelWarningHintBodyEl.style.display = 'none';
+
+        travelWarningHintToggle.setAttribute('aria-expanded', 'false');
+        travelWarningHintToggle.setAttribute('aria-controls', travelWarningHintBodyEl.id);
+        travelWarningHintToggle.addEventListener('click', () => {
+            const currentState = travelWarningHintContainer.dataset.open === 'true';
+            setTravelWarningHintVisibility(!currentState);
+        });
+
+        hintHeader.appendChild(travelWarningHintToggle);
+        travelWarningHintContainer.appendChild(hintHeader);
+        travelWarningHintContainer.appendChild(travelWarningHintBodyEl);
+        win.appendChild(travelWarningHintContainer);
+
         const btnRow = document.createElement('div');
         btnRow.style.display = 'flex';
         btnRow.style.gap = '8px';
@@ -96,7 +151,19 @@ function showTravelWarningPopup(message, onConfirm) {
         travelWarningOverlay.appendChild(win);
         document.body.appendChild(travelWarningOverlay);
     }
-    travelWarningMessageEl.textContent = message;
+    const warning = warningData || { message: '' };
+    travelWarningMessageEl.textContent = warning.message || '';
+
+    if (warning.hint && warning.hint.body) {
+        travelWarningHintContainer.style.display = 'block';
+        travelWarningHintTitleEl.textContent = warning.hint.title || 'Hint';
+        travelWarningHintBodyEl.textContent = warning.hint.body;
+        setTravelWarningHintVisibility(false);
+    } else if (travelWarningHintContainer) {
+        travelWarningHintContainer.style.display = 'none';
+        travelWarningHintBodyEl.textContent = '';
+        travelWarningHintContainer.dataset.open = 'false';
+    }
     travelWarningConfirmBtn.onclick = () => {
         travelWarningOverlay.style.display = 'none';
         onConfirm();

--- a/tests/chemicalReactorResearch.test.js
+++ b/tests/chemicalReactorResearch.test.js
@@ -12,7 +12,7 @@ describe('Chemical Reactor research', () => {
     vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
 
     const terraformingResearch = ctx.researchParameters.terraforming;
-    const research = terraformingResearch.find((entry) => entry.id === 'bosch_reactor');
+    const research = terraformingResearch.find((entry) => entry.id === 'chemical_reactor');
 
     expect(research).toBeDefined();
     expect(research.cost.research).toBe(500000);

--- a/tests/spaceTravelWarningPopup.test.js
+++ b/tests/spaceTravelWarningPopup.test.js
@@ -49,10 +49,54 @@ describe('travel warning popup', () => {
     const popup = dom.window.document.getElementById('travel-warning-popup');
     expect(popup).not.toBeNull();
     const message = popup.querySelector('.travel-warning-message');
-    expect(message.textContent).toBe(ctx.planetParameters.vega2.travelWarning);
+    expect(message.textContent).toBe(ctx.planetParameters.vega2.travelWarning.message);
     expect(ctx.spaceManager.changeCurrentPlanet).not.toHaveBeenCalled();
 
     popup.querySelector('#travel-warning-confirm').click();
     expect(ctx.spaceManager.changeCurrentPlanet).toHaveBeenCalledWith('vega2');
+  });
+
+  test('displays collapsible hint for Venus travel warning', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="planet-selection-options"></div><div id="travel-status"></div>', { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.window = dom.window;
+    ctx.formatNumber = numbers.formatNumber;
+    ctx.console = console;
+    ctx.planetParameters = planetParameters;
+    ctx.saveGameToSlot = () => {};
+    ctx.projectManager = { projects: { spaceStorage: { saveTravelState: () => null, loadTravelState: () => {} } } };
+    ctx.nanotechManager = { prepareForTravel: () => {} };
+    ctx.initializeGameState = () => {};
+    ctx.updateProjectUI = () => {};
+    ctx.skillManager = { skillPoints: 0 };
+
+    vm.runInContext(`${effectCode}\n${spaceCode}; this.EffectableEntity = EffectableEntity; this.SpaceManager = SpaceManager;`, ctx);
+    loadScript('spaceUI.js', ctx);
+
+    ctx.spaceManager = new ctx.SpaceManager(planetParameters);
+    ctx.initializeSpaceUI(ctx.spaceManager);
+
+    ctx.spaceManager.planetStatuses.venus.enabled = true;
+    ctx.spaceManager.updateCurrentPlanetTerraformedStatus(true);
+    ctx.updateSpaceUI();
+
+    const btn = dom.window.document.querySelector('.select-planet-button[data-planet-key="venus"]');
+    btn.click();
+
+    const popup = dom.window.document.getElementById('travel-warning-popup');
+    const message = popup.querySelector('.travel-warning-message');
+    expect(message.textContent).toBe(ctx.planetParameters.venus.travelWarning.message);
+
+    const hintContainer = popup.querySelector('.travel-warning-hint');
+    expect(hintContainer.style.display).toBe('block');
+    const toggle = hintContainer.querySelector('.travel-warning-hint-toggle');
+    const hintBody = hintContainer.querySelector('.travel-warning-hint-body');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(hintBody.style.display).toBe('none');
+
+    toggle.click();
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(hintBody.style.display).toBe('block');
   });
 });


### PR DESCRIPTION
## Summary
- define travel warning metadata for Vega-2 and Venus, including a collapsible hint on Venus
- implement a reusable hint toggle inside the travel warning popup UI
- rename the travel research id to `chemical_reactor` and keep its test coverage in sync

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d466a4ecf88327a788ecda7173a153