### PR TITLE
Fix travel hint newline rendering

### DIFF
--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -119,6 +119,7 @@ function showTravelWarningPopup(warningData, onConfirm) {
         travelWarningHintBodyEl.className = 'travel-warning-hint-body';
         travelWarningHintBodyEl.style.marginTop = '8px';
         travelWarningHintBodyEl.style.display = 'none';
+        travelWarningHintBodyEl.style.whiteSpace = 'pre-line';
 
         travelWarningHintToggle.setAttribute('aria-expanded', 'false');
         travelWarningHintToggle.setAttribute('aria-controls', travelWarningHintBodyEl.id);


### PR DESCRIPTION
## Summary
- ensure the travel warning hint body respects newline characters by rendering the text with pre-line whitespace handling

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d47a8354e083278f31dbfbc4fce290