### PR TITLE
Simplify Antimatter Farm building implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,3 +194,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Colony research tiers two through six now grant aerostat colonies +10 comfort each via a new `addComfort` effect type.
 - Adrien Solis now offers a permanent Terraforming measurements research unlock in his shop once chapter 18.4d is completed.
 - Introduced an Antimatter Battery structure that stores a quadrillion units of energy for 1000 metal and 100 superconductors.
+- Added an Antimatter Farm energy building that converts 2 quadrillion energy into the new locked Antimatter special resource.

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -350,6 +350,22 @@ const buildingsParameters = {
     maintenanceFactor: 1,
     unlocked: false
   },
+  antimatterFarm: {
+    name: 'Antimatter Farm',
+    category: 'energy',
+    description: 'Harvests microscopic antimatter using staggering amounts of power.',
+    cost: { colony: { metal: 10000, components: 1000, superconductors: 1000, electronics: 100 } },
+    consumption: { colony: { energy: 2_000_000_000_000_000 } },
+    production: { special: { antimatter: 1 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: true,
+    requiresProductivity: false,
+    requiresWorker: 0,
+    maintenanceFactor: 1,
+    unlocked: false
+  },
   battery: {
     name: 'Battery',
     category: 'storage',

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -79,7 +79,8 @@ const defaultPlanetParameters = {
       albedoUpgrades: {name : 'Black Dust', hasCap: true, baseCap: 144800000000000,initialValue: 0, unlocked: false, hideWhenSmall: true}, // Default (Mars)
       whiteDust: { name: 'White Dust', hasCap: true, baseCap: 144800000000000, initialValue: 0, unlocked: false, hideWhenSmall: true },
       spaceships: {name : 'Spaceships', hasCap: false, initialValue: 0, unlocked: false},
-      alienArtifact: { name: 'Alien artifact', hasCap: false, initialValue: 0, unlocked: false }
+      alienArtifact: { name: 'Alien artifact', hasCap: false, initialValue: 0, unlocked: false },
+      antimatter: { name: 'Antimatter', hasCap: false, initialValue: 0, unlocked: false }
     }
   },
   zonalCO2: {

--- a/tests/antimatterFarm.test.js
+++ b/tests/antimatterFarm.test.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { initializeBuildings, Building } = require('../src/js/building.js');
+global.Building = Building;
+global.initializeBuildingTabs = () => {};
+
+describe('Antimatter Farm integrations', () => {
+  test('default planet parameters include a locked antimatter resource', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'planet-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.defaultPlanetParameters = defaultPlanetParameters;', ctx);
+
+    const antimatter = ctx.defaultPlanetParameters.resources.special.antimatter;
+
+    expect(antimatter).toBeDefined();
+    expect(antimatter.unlocked).toBe(false);
+    expect(antimatter.hasCap).toBe(false);
+    expect(antimatter.initialValue).toBe(0);
+  });
+
+  test('antimatter farm parameters consume energy and produce antimatter', () => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'buildings-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.buildingsParameters = buildingsParameters;', ctx);
+
+    const antimatterFarm = ctx.buildingsParameters.antimatterFarm;
+
+    expect(antimatterFarm).toBeDefined();
+    expect(antimatterFarm.unlocked).toBe(false);
+    expect(antimatterFarm.category).toBe('energy');
+    expect(antimatterFarm.cost.colony).toEqual({
+      metal: 10000,
+      components: 1000,
+      superconductors: 1000,
+      electronics: 100
+    });
+    expect(antimatterFarm.consumption.colony.energy).toBe(2_000_000_000_000_000);
+    expect(antimatterFarm.production.special.antimatter).toBe(1);
+  });
+
+  test('initializeBuildings returns a Building instance for the antimatter farm', () => {
+    const previousResources = global.resources;
+    const previousBuildings = global.buildings;
+    const previousMaintenanceFraction = global.maintenanceFraction;
+
+    global.resources = { colony: {}, special: {} };
+    global.buildings = {};
+    global.maintenanceFraction = 1;
+
+    try {
+      const params = {
+        antimatterFarm: {
+          name: 'Antimatter Farm',
+          category: 'energy',
+          description: '',
+          cost: { colony: { metal: 1 } },
+          consumption: { colony: { energy: 1 } },
+          production: { special: { antimatter: 1 } },
+          storage: {},
+          dayNightActivity: false,
+          canBeToggled: true,
+          requiresMaintenance: true,
+          requiresProductivity: false,
+          requiresWorker: 0,
+          maintenanceFactor: 1,
+          unlocked: false
+        }
+      };
+
+      const buildings = initializeBuildings(params);
+      expect(buildings.antimatterFarm).toBeInstanceOf(Building);
+    } finally {
+      global.resources = previousResources;
+      global.buildings = previousBuildings;
+      global.maintenanceFraction = previousMaintenanceFraction;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- stop registering a dedicated Antimatter Farm subclass so the building uses the base Building implementation
- update the Antimatter Farm integration test to expect the default Building type instead of a removed subclass

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d4acb83b048327a7f6aaf82180da53