### PR TITLE
Compute consumption dynamically from effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,3 +195,5 @@ The planet visualiser has been modularised into files covering core setup, light
 - Adrien Solis now offers a permanent Terraforming measurements research unlock in his shop once chapter 18.4d is completed.
 - Introduced an Antimatter Battery structure that stores a quadrillion units of energy for 1000 metal and 100 superconductors.
 - Added an Antimatter Farm energy building that converts 2 quadrillion energy into the new locked Antimatter special resource.
+- Building and colony consumption now derive from a shared `getConsumption` helper so effect-driven upkeep is computed dynamica
+  lly without mutating base data.

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -41,8 +41,9 @@ class Colony extends Building {
     }
 
     // Initialize filledNeeds based on the consumption defined in the config
-    for (const category in this.consumption) {
-      for (const resource in this.consumption[category]) {
+    const consumption = this.getConsumption();
+    for (const category in consumption) {
+      for (const resource in consumption[category]) {
         this.filledNeeds[resource] = 1;
       }
     }
@@ -52,7 +53,8 @@ class Colony extends Building {
   rebuildFilledNeeds() {
     const previous = this.filledNeeds || {};
     const order = ['energy', 'food', 'components', 'electronics', 'androids'];
-    const colonyConsumption = this.consumption.colony || {};
+    const consumption = this.getConsumption();
+    const colonyConsumption = consumption.colony || {};
     const rebuilt = {};
 
     order.forEach(res => {
@@ -87,6 +89,10 @@ class Colony extends Building {
 
   applyAddComfort() {
     globalThis.invalidateColonyNeedCache?.();
+  }
+
+  getConsumption() {
+    return super.getConsumption();
   }
 
   initializeFromConfig(config, colonyName) {
@@ -177,14 +183,15 @@ class Colony extends Building {
     const effectiveMultiplier = this.getEffectiveConsumptionMultiplier();
     const popConsumptionRatio = this.getConsumptionRatio();
   
-    for (const category in this.consumption) {
+    const consumption = this.getConsumption();
+    for (const category in consumption) {
       if (!this.currentConsumption[category]) {
         this.currentConsumption[category] = {};
       }
-  
-      for (const resource in this.consumption[category]) {
+
+      for (const resource in consumption[category]) {
         const isLuxuryResource = luxuryResources[resource] !== undefined;
-  
+
         if (isLuxuryResource && !this.luxuryResourcesEnabled[resource]) {
           // If the luxury resource is not enabled, set the filledNeeds value to 0
           this.filledNeeds[resource] = 0;
@@ -221,12 +228,13 @@ class Colony extends Building {
     this.currentConsumption = {}; // Reset current consumption
   
     // Calculate consumption and accumulate changes
-    for (const category in this.consumption) {
+    const consumption = this.getConsumption();
+    for (const category in consumption) {
       if (!this.currentConsumption[category]) {
         this.currentConsumption[category] = {};
       }
-  
-      for (const resource in this.consumption[category]) {
+
+      for (const resource in consumption[category]) {
         const isLuxuryResource = luxuryResources[resource] !== undefined;
   
         if (isLuxuryResource && !this.luxuryResourcesEnabled[resource]) {
@@ -323,9 +331,10 @@ class Colony extends Building {
   calculateBaseMinRatio(resources, deltaTime) {
       let minRatio = Infinity;
 
-      // Calculate minRatio based on NON-LUXURY resource consumption
-      for (const category in this.consumption) {
-          for (const resource in this.consumption[category]) {
+        // Calculate minRatio based on NON-LUXURY resource consumption
+        const consumption = this.getConsumption();
+        for (const category in consumption) {
+            for (const resource in consumption[category]) {
               // Skip luxury resources
               if (luxuryResources[resource]) {
                   continue;

--- a/src/js/colonyUI.js
+++ b/src/js/colonyUI.js
@@ -134,8 +134,8 @@ function updateGrowthRateDisplay(){
 
 function shouldDisplayNeedBox(needKey, structure) {
   if (needKey !== 'components') return true;
-  const entry = structure.consumption?.colony?.[needKey];
-  return entry !== undefined && structure.getConsumptionResource('colony', needKey).amount > 0;
+  const { amount } = structure.getConsumptionResource('colony', needKey);
+  return amount > 0;
 }
 
 function createColonyDetails(structure) {
@@ -171,7 +171,7 @@ function createColonyDetails(structure) {
 function updateColonyDetailsDisplay(structureRow, structure) {
   updateUnhideButtons();
 
-  const colonyConsumption = structure.consumption?.colony || {};
+  const colonyConsumption = structure.getConsumption().colony || {};
   let needsMissing = false;
   if (structure.needBoxCache) {
     for (const need in colonyConsumption) {

--- a/tests/addResourceConsumptionEffect.test.js
+++ b/tests/addResourceConsumptionEffect.test.js
@@ -56,9 +56,11 @@ describe('addResourceConsumption effect', () => {
       sourceId: 's1'
     };
     b.addEffect(effect);
-    expect(b.consumption.colony.food).toBe(2);
+    expect(b.getConsumptionResource('colony', 'food').amount).toBe(2);
+    expect(b.getConsumption().colony.food).toBe(2);
     b.removeEffect(effect);
-    expect(b.consumption.colony && b.consumption.colony.food).toBeUndefined();
+    expect(b.getConsumptionResource('colony', 'food').amount).toBe(0);
+    expect(b.getConsumption().colony?.food).toBeUndefined();
   });
 
   test('adds and removes consumption on colony', () => {
@@ -72,10 +74,10 @@ describe('addResourceConsumption effect', () => {
       sourceId: 's2'
     };
     c.addEffect(effect);
-    expect(c.consumption.colony.food).toBe(3);
-    expect(c.consumption.colony.water).toBe(1);
+    expect(c.getConsumptionResource('colony', 'food').amount).toBe(3);
+    expect(c.getConsumptionResource('colony', 'water').amount).toBe(1);
     c.removeEffect(effect);
-    expect(c.consumption.colony.food).toBeUndefined();
-    expect(c.consumption.colony.water).toBe(1);
+    expect(c.getConsumptionResource('colony', 'food').amount).toBe(0);
+    expect(c.getConsumptionResource('colony', 'water').amount).toBe(1);
   });
 });

--- a/tests/colonyNeedBoxCache.test.js
+++ b/tests/colonyNeedBoxCache.test.js
@@ -27,6 +27,13 @@ describe('colony need box cache', () => {
       getComfort() {
         return this.baseComfort;
       },
+      getConsumption() {
+        const clone = {};
+        for (const category in this.consumption || {}) {
+          clone[category] = { ...this.consumption[category] };
+        }
+        return clone;
+      },
       getConsumptionResource(category, resource) {
         return this.consumption?.[category]?.[resource] || { amount: 0 };
       }

--- a/tests/mechanicalAssistanceMitigation.test.js
+++ b/tests/mechanicalAssistanceMitigation.test.js
@@ -16,6 +16,13 @@ describe('Mechanical Assistance mitigation', () => {
           this.happiness = 0;
         }
         initializeFromConfig() {}
+        getConsumption() {
+          const clone = {};
+          for (const category in this.consumption || {}) {
+            clone[category] = { ...this.consumption[category] };
+          }
+          return clone;
+        }
         getConsumptionResource(cat, res) { return { amount: this.consumption?.[cat]?.[res] || 0 }; }
         getEffectiveConsumptionMultiplier() { return 1; }
         getEffectiveResourceConsumptionMultiplier() { return 1; }


### PR DESCRIPTION
## Summary
- add a getConsumption helper so buildings aggregate base upkeep with effect-driven additions on demand
- switch colonies and their UI to rely on the dynamic consumption map when rebuilding needs
- update consumption-focused tests and stubs to reflect the new access pattern

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5915a77f48327ad85a92955aedab6