### PR TITLE
Add Water Tank building with empty action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,3 +197,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Added an Antimatter Farm energy building that converts 2 quadrillion energy into the new locked Antimatter special resource.
 - Building and colony consumption now derive from a shared `getConsumption` helper so effect-driven upkeep is computed dynamica
   lly without mutating base data.
+- Introduced a Water Tank storage structure that specializes in water capacity, includes an Empty action to dump reserves onto the surface, and moved water capacity off the general Storage Depot.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -896,7 +896,8 @@ const constructors = {
   biodome: 'Biodome',
   dysonReceiver: 'dysonReceiver',
   solarPanel: 'solarPanel',
-  boschReactor: 'MultiRecipesBuilding'
+  boschReactor: 'MultiRecipesBuilding',
+  waterTank: 'WaterTank'
 };
 
 function loadConstructor(name) {

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -394,7 +394,6 @@ const buildingsParameters = {
         metal: 5000,
         silicon: 5000,
         glass: 5000,
-        water: 5000,
         food: 5000,
         components: 500,
         electronics: 200,
@@ -408,6 +407,22 @@ const buildingsParameters = {
     requiresProductivity: false,
     requiresWorker: 0,
     maintenanceFactor: 0.1,
+    unlocked: false
+  },
+  waterTank: {
+    name: 'Water Tank',
+    category: 'storage',
+    description: 'Dedicated reservoir that preserves large water reserves with minimal upkeep.',
+    cost: { colony: { metal: 100 } },
+    consumption: {},
+    production: {},
+    storage: { colony: { water: 5000 } },
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: true,
+    requiresProductivity: false,
+    requiresWorker: 0,
+    maintenanceFactor: 0.05,
     unlocked: false
   },
   hydrogenBattery: {

--- a/src/js/buildings/WaterTank.js
+++ b/src/js/buildings/WaterTank.js
@@ -1,0 +1,100 @@
+class WaterTank extends Building {
+  constructor(config, buildingName) {
+    super(config, buildingName);
+    this._cachedUI = null;
+  }
+
+  initializeCustomUI(context = {}) {
+    const { leftContainer, hideButton } = context;
+    if (!leftContainer || !hideButton || !globalThis.document) {
+      return;
+    }
+
+    const cache = context.cachedElements || {};
+    const emptyButton = globalThis.document.createElement('button');
+    emptyButton.textContent = 'Empty';
+    emptyButton.classList.add('empty-button');
+    emptyButton.addEventListener('click', event => {
+      event.stopPropagation();
+      this.emptyToSurface();
+    });
+
+    hideButton.insertAdjacentElement('afterend', emptyButton);
+
+    cache.emptyButton = emptyButton;
+    this._cachedUI = cache;
+    this.updateUI(cache);
+  }
+
+  updateUI(elements = {}) {
+    if (elements !== this._cachedUI && elements.emptyButton) {
+      this._cachedUI = elements;
+    }
+
+    const button = elements.emptyButton || this._cachedUI?.emptyButton;
+    if (!button) {
+      return;
+    }
+
+    const availableWater = resources?.colony?.water?.value ?? 0;
+    button.disabled = availableWater <= 0;
+    button.style.display = this.unlocked && !this.isHidden ? 'inline-block' : 'none';
+  }
+
+  emptyToSurface() {
+    const colonyWater = resources?.colony?.water;
+    const surfaceWater = resources?.surface?.liquidWater;
+    if (!colonyWater || !surfaceWater) {
+      return;
+    }
+
+    const amount = colonyWater.value;
+    if (amount <= 0) {
+      return;
+    }
+
+    colonyWater.decrease(amount);
+    surfaceWater.increase(amount);
+    surfaceWater.enable?.();
+
+    if (terraforming?.zonalWater) {
+      this.distributeToZones(amount);
+    }
+
+    globalThis.updateResourceDisplay?.(resources);
+    globalThis.updateStructureDisplay?.(structures);
+    this.updateUI(this._cachedUI || {});
+  }
+
+  distributeToZones(totalAmount) {
+    const zoneList = Array.isArray(globalThis.ZONES) && globalThis.ZONES.length > 0
+      ? globalThis.ZONES
+      : ['tropical', 'temperate', 'polar'];
+    const weights = zoneList.map(zone => {
+      if (globalThis.getZonePercentage) {
+        const weight = globalThis.getZonePercentage(zone);
+        return Number.isFinite(weight) && weight > 0 ? weight : 0;
+      }
+      return 1;
+    });
+    const totalWeight = weights.reduce((sum, value) => sum + value, 0) || zoneList.length;
+
+    zoneList.forEach((zone, index) => {
+      if (!terraforming.zonalWater[zone]) {
+        terraforming.zonalWater[zone] = { liquid: 0, ice: 0, buriedIce: 0 };
+      }
+      const entry = terraforming.zonalWater[zone];
+      if (entry.liquid === undefined) {
+        entry.liquid = 0;
+      }
+      const portion = totalAmount * (weights[index] / totalWeight);
+      entry.liquid += portion;
+    });
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { WaterTank };
+} else {
+  globalThis.WaterTank = WaterTank;
+}

--- a/src/js/story/mars.js
+++ b/src/js/story/mars.js
@@ -225,6 +225,21 @@ var progressMars = {
         ]
       },
       {
+        id: "chapter1.10",
+        type: "journal",
+        chapter: 0,
+        narrative: "Processing blueprint: waterTank.btb...",
+        prerequisites: ["chapter1.9"],
+        objectives: [
+        ],
+        reward: [{
+            target: 'building',
+            targetId: 'waterTank',
+            type: 'enable'
+        }
+        ]
+      },
+      {
         id: "chapter1.11",
         type: "journal",
         chapter: 0,

--- a/tests/waterTank.test.js
+++ b/tests/waterTank.test.js
@@ -1,0 +1,122 @@
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+const { Resource } = require('../src/js/resource.js');
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+
+const { WaterTank } = require('../src/js/buildings/WaterTank.js');
+const { getZonePercentage, ZONES } = require('../src/js/terraforming/zones.js');
+
+global.getZonePercentage = getZonePercentage;
+global.ZONES = ZONES;
+
+describe('WaterTank', () => {
+  let dom;
+  let tank;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    global.resources = {
+      colony: {
+        water: new Resource({ name: 'water', category: 'colony', hasCap: true, baseCap: 0, unlocked: true })
+      },
+      surface: {
+        liquidWater: new Resource({ name: 'liquidWater', category: 'surface', hasCap: false, baseCap: 0, unlocked: true })
+      }
+    };
+
+    global.resources.colony.water.value = 200;
+    global.resources.surface.liquidWater.value = 0;
+
+    global.terraforming = {
+      zonalWater: {
+        tropical: { liquid: 0, ice: 0, buriedIce: 0 },
+        temperate: { liquid: 0, ice: 0, buriedIce: 0 },
+        polar: { liquid: 0, ice: 0, buriedIce: 0 }
+      }
+    };
+
+    global.structures = {};
+    global.buildings = {};
+    global.maintenanceFraction = 0.001;
+    global.unlockResource = () => {};
+
+    const config = {
+      name: 'Water Tank',
+      category: 'storage',
+      description: '',
+      cost: { colony: { metal: 100 } },
+      consumption: {},
+      production: {},
+      storage: { colony: { water: 5000 } },
+      dayNightActivity: false,
+      canBeToggled: true,
+      requiresMaintenance: true,
+      requiresProductivity: false,
+      requiresWorker: 0,
+      maintenanceFactor: 0.05,
+      unlocked: true
+    };
+
+    tank = new WaterTank(config, 'waterTank');
+    global.structures.waterTank = tank;
+    global.buildings.waterTank = tank;
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    delete global.window;
+    delete global.document;
+    delete global.resources;
+    delete global.structures;
+    delete global.buildings;
+    delete global.terraforming;
+    delete global.maintenanceFraction;
+    delete global.unlockResource;
+  });
+
+  test('emptyToSurface transfers stored water to surface reservoirs and zonal pools', () => {
+    global.resources.colony.water.value = 300;
+    tank.emptyToSurface();
+
+    expect(global.resources.colony.water.value).toBe(0);
+    expect(global.resources.surface.liquidWater.value).toBeCloseTo(300);
+
+    const totalLiquid = Object.values(global.terraforming.zonalWater)
+      .reduce((sum, zone) => sum + (zone.liquid || 0), 0);
+    expect(totalLiquid).toBeCloseTo(300);
+  });
+
+  test('initializeCustomUI creates empty button that empties tanks when pressed', () => {
+    const leftContainer = global.document.createElement('div');
+    const hideButton = global.document.createElement('button');
+    leftContainer.appendChild(hideButton);
+    const cachedElements = {};
+
+    tank.initializeCustomUI({ leftContainer, hideButton, cachedElements });
+
+    const emptyButton = cachedElements.emptyButton;
+    expect(emptyButton).toBeDefined();
+    expect(hideButton.nextSibling).toBe(emptyButton);
+
+    global.resources.colony.water.value = 0;
+    tank.updateUI(cachedElements);
+    expect(emptyButton.disabled).toBe(true);
+
+    global.resources.colony.water.value = 40;
+    tank.updateUI(cachedElements);
+    expect(emptyButton.disabled).toBe(false);
+
+    emptyButton.click();
+    expect(global.resources.colony.water.value).toBe(0);
+    expect(global.resources.surface.liquidWater.value).toBeCloseTo(40);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Water Tank building that offers focused water storage with a surface dump control
- remove water capacity from the general Storage Depot and unlock the new structure in the Mars intro storyline
- cover the new building and UI behaviour with automated tests

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5cb04e3b083279a6762387fb9d399