### PR TITLE
Add aerostat-based temperature mitigation for select buildings

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -60,7 +60,8 @@ class Building extends EffectableEntity {
         surfaceArea,
         requiresProductivity,
         requiresLand,
-        temperatureMaintenanceImmune
+        temperatureMaintenanceImmune,
+        aerostatReduction
       } = config;
   
       this.name = buildingName;
@@ -83,6 +84,10 @@ class Building extends EffectableEntity {
       this.requiresLand = requiresLand;
       this.powerPerBuilding = config.powerPerBuilding;
       this.temperatureMaintenanceImmune = !!temperatureMaintenanceImmune;
+      this.aerostatReduction = Math.max(
+        0,
+        Number.isFinite(aerostatReduction) ? aerostatReduction : 0
+      );
 
       this.updateResourceStorage();
     }

--- a/src/js/buildings-parameters.js
+++ b/src/js/buildings-parameters.js
@@ -103,6 +103,7 @@ const buildingsParameters = {
     requiresMaintenance: true,
     requiresWorker: 0,
     maintenanceFactor: 1,
+    aerostatReduction: 1,
     unlocked: false
   },
   hydroponicFarm: {
@@ -302,6 +303,7 @@ const buildingsParameters = {
     requiresMaintenance: true,
     requiresWorker: 0,
     maintenanceFactor: 1,
+    aerostatReduction: 1,
     unlocked: false
   },
   fusionPowerPlant: {
@@ -317,6 +319,7 @@ const buildingsParameters = {
     requiresMaintenance: true,
     requiresWorker: 0,
     maintenanceFactor: 1,
+    aerostatReduction: 0.02,
     unlocked: false
   },
   dysonReceiver: {
@@ -582,6 +585,7 @@ const buildingsParameters = {
     requiresMaintenance: true,
     requiresWorker: 0,
     maintenanceFactor: 1,
+    aerostatReduction: 1,
     unlocked: false,
     defaultRecipe: 'recipe1',
     recipes: {

--- a/src/js/terraforming/terraforming.js
+++ b/src/js/terraforming/terraforming.js
@@ -35,6 +35,7 @@ const EQUILIBRIUM_CO2_PARAMETER = 1.95e-3;
 // Load utility functions when running under Node for tests
 var getZonePercentage, estimateCoverage, waterCycleInstance, methaneCycleInstance, co2CycleInstance;
 var getFactoryTemperatureMaintenancePenaltyReductionHelper;
+var getAerostatMaintenanceMitigationHelper;
 var isBuildingEligibleForFactoryMitigationHelper;
 var calculateEffectiveAtmosphericHeatCapacityHelper;
 if (typeof module !== 'undefined' && module.exports) {
@@ -98,7 +99,8 @@ if (typeof module !== 'undefined' && module.exports) {
 
     ({
       getFactoryTemperatureMaintenancePenaltyReduction: getFactoryTemperatureMaintenancePenaltyReductionHelper,
-      isBuildingEligibleForFactoryMitigation: isBuildingEligibleForFactoryMitigationHelper
+      isBuildingEligibleForFactoryMitigation: isBuildingEligibleForFactoryMitigationHelper,
+      getAerostatMaintenanceMitigation: getAerostatMaintenanceMitigationHelper
     } = require('../buildings/aerostat.js'));
 } else {
     getZonePercentage = globalThis.getZonePercentage;
@@ -114,6 +116,8 @@ if (typeof module !== 'undefined' && module.exports) {
       globalThis.getFactoryTemperatureMaintenancePenaltyReduction;
     isBuildingEligibleForFactoryMitigationHelper =
       globalThis.isBuildingEligibleForFactoryMitigation;
+    getAerostatMaintenanceMitigationHelper =
+      globalThis.getAerostatMaintenanceMitigation;
 }
 
 var getEcumenopolisLandFraction;
@@ -1482,7 +1486,17 @@ class Terraforming extends EffectableEntity{
       const colonyEnergyPenalty = this.calculateColonyEnergyPenalty();
       const colonyCostPenalty = this.calculateColonyPressureCostPenalty();
       const maintenancePenalty = this.calculateMaintenancePenalty();
-      const factoryPenaltyReduction = this.getFactoryTemperatureMaintenancePenaltyReduction();
+      const aerostatMitigationDetails =
+        typeof getAerostatMaintenanceMitigationHelper === 'function'
+          ? getAerostatMaintenanceMitigationHelper()
+          : null;
+      const factoryPenaltyReduction =
+        aerostatMitigationDetails &&
+        Number.isFinite(aerostatMitigationDetails.workerShare)
+          ? aerostatMitigationDetails.workerShare
+          : this.getFactoryTemperatureMaintenancePenaltyReduction();
+      const buildingMitigationById =
+        aerostatMitigationDetails?.buildingCoverage?.byId ?? {};
 
       for (let i = 1; i <= 7; i++) {
         const energyPenaltyEffect = {
@@ -1576,13 +1590,29 @@ class Terraforming extends EffectableEntity{
               : b.requiresWorker || 0;
 
           let penaltyValue = maintenancePenalty;
-          if (
-            maintenancePenalty > 1 &&
-            factoryPenaltyReduction > 0 &&
-            workerNeed > 0 &&
-            countsTowardFactoryMitigation
-          ) {
-            penaltyValue = 1 + (maintenancePenalty - 1) * (1 - factoryPenaltyReduction);
+
+          if (maintenancePenalty > 1) {
+            const baseIncrease = maintenancePenalty - 1;
+            let remainingFactor = 1;
+
+            if (
+              factoryPenaltyReduction > 0 &&
+              workerNeed > 0 &&
+              countsTowardFactoryMitigation
+            ) {
+              const clampedFactoryReduction = Math.max(
+                0,
+                Math.min(1, factoryPenaltyReduction)
+              );
+              remainingFactor *= 1 - clampedFactoryReduction;
+            }
+
+            const buildingMitigation = buildingMitigationById[id];
+            if (buildingMitigation) {
+              remainingFactor *= buildingMitigation.remainingFraction;
+            }
+
+            penaltyValue = 1 + baseIncrease * remainingFactor;
           }
 
           addEffect({


### PR DESCRIPTION
## Summary
- add an `aerostatReduction` rating to glass smelters, chemical reactors, nuclear plants, and fusion reactors
- expose aerostat maintenance mitigation details, update temperature penalty calculations, and refresh the mitigation tooltip copy
- extend the temperature maintenance penalty tests to cover the new aerostat-supported buildings

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d5cc06c80883278665289cd4e570f1