### PR TITLE
Allow decimal strategic reserve editing

### DIFF
--- a/src/js/projects/spaceStorageUI.js
+++ b/src/js/projects/spaceStorageUI.js
@@ -431,6 +431,13 @@ function updateSpaceStorageUI(project) {
   if (els.prioritizeMegaCheckbox) {
     els.prioritizeMegaCheckbox.checked = project.prioritizeMegaProjects;
   }
+  if (els.strategicReserveInput) {
+    const activeElement = globalThis.document?.activeElement;
+    if (els.strategicReserveInput !== activeElement) {
+      const reserveValue = project.strategicReserve ?? 0;
+      els.strategicReserveInput.value = reserveValue === 0 ? '0' : reserveValue.toString();
+    }
+  }
   if (els.updateModeButtons) {
     els.updateModeButtons();
   }

--- a/tests/autobuildLandPartial.test.js
+++ b/tests/autobuildLandPartial.test.js
@@ -25,6 +25,6 @@ describe('autoBuild limited by land', () => {
 
     expect(building.build).toHaveBeenCalledWith(5, false);
     expect(building.autoBuildPartial).toBe(true);
-    expect(global.resources.surface.land.autobuildShortage).toBe(false);
+    expect(global.resources.surface.land.autobuildShortage).toBe(true);
   });
 });

--- a/tests/autobuildResourceShortageWarning.test.js
+++ b/tests/autobuildResourceShortageWarning.test.js
@@ -177,6 +177,46 @@ describe('autobuild resource shortage warnings', () => {
     autoBuild({ geoPlant: building });
 
     expect(building.autoBuildPartial).toBe(true);
+    expect(global.resources.underground.geothermal.autobuildShortage).toBe(true);
+    expect(global.resources.colony.metal.autobuildShortage).toBe(true);
+  });
+
+  test('suppresses deposit alerts when deposits are gone and nothing else is limiting', () => {
+    constructionOfficeState.strategicReserve = 0;
+    global.resources = {
+      colony: {
+        colonists: { value: 10 },
+        metal: { value: 100, cap: 100 },
+      },
+      surface: { land: { value: 100, reserved: 0 } },
+      underground: {
+        geothermal: { value: 0, reserved: 0 },
+      },
+    };
+
+    const building = {
+      displayName: 'Geo Plant',
+      autoBuildEnabled: true,
+      autoBuildPercent: 10,
+      autoBuildPriority: false,
+      autoActiveEnabled: false,
+      autoBuildBasis: 'population',
+      count: 0,
+      requiresDeposit: { underground: { geothermal: 1 } },
+      getEffectiveCost: jest.fn(count => ({
+        colony: { metal: count },
+        underground: { geothermal: count },
+      })),
+      canAfford: jest.fn(() => false),
+      canAffordDeposit: jest.fn(() => false),
+      canAffordLand: jest.fn(() => true),
+      maxBuildable: jest.fn(() => 0),
+      build: jest.fn(() => false),
+    };
+
+    autoBuild({ geoPlant: building });
+
+    expect(building.autoBuildPartial).toBe(true);
     expect(global.resources.underground.geothermal.autobuildShortage).toBe(false);
     expect(global.resources.colony.metal.autobuildShortage).toBe(false);
   });
@@ -212,7 +252,79 @@ describe('autobuild resource shortage warnings', () => {
     autoBuild({ habitat: building });
 
     expect(building.autoBuildPartial).toBe(true);
+    expect(global.resources.surface.land.autobuildShortage).toBe(true);
+    expect(global.resources.colony.metal.autobuildShortage).toBe(true);
+
+    // Metal is also fully depleted so it remains a limiting resource.
+  });
+
+  test('suppresses land alerts when not enough land remains for a single build and nothing else limits progress', () => {
+    constructionOfficeState.strategicReserve = 0;
+    global.resources = {
+      colony: {
+        colonists: { value: 10 },
+        metal: { value: 100, cap: 100 },
+      },
+      surface: {
+        land: { value: 2, reserved: 0 },
+      },
+    };
+
+    const building = {
+      displayName: 'Habitat',
+      autoBuildEnabled: true,
+      autoBuildPercent: 10,
+      autoBuildPriority: false,
+      autoActiveEnabled: false,
+      autoBuildBasis: 'population',
+      count: 0,
+      requiresLand: 5,
+      getEffectiveCost: jest.fn(count => ({ colony: { metal: count } })),
+      canAfford: jest.fn(() => false),
+      canAffordLand: jest.fn(() => false),
+      maxBuildable: jest.fn(() => 0),
+      build: jest.fn(() => false),
+    };
+
+    autoBuild({ habitat: building });
+
+    expect(building.autoBuildPartial).toBe(true);
     expect(global.resources.surface.land.autobuildShortage).toBe(false);
     expect(global.resources.colony.metal.autobuildShortage).toBe(false);
+  });
+
+  test('does not flag land when other resources constrain autobuild more severely', () => {
+    constructionOfficeState.strategicReserve = 0;
+    global.resources = {
+      colony: {
+        colonists: { value: 100 },
+        metal: { value: 10, cap: 100 },
+      },
+      surface: {
+        land: { value: 50, reserved: 0 },
+      },
+    };
+
+    const building = {
+      displayName: 'Habitat',
+      autoBuildEnabled: true,
+      autoBuildPercent: 10,
+      autoBuildPriority: false,
+      autoActiveEnabled: false,
+      autoBuildBasis: 'population',
+      count: 0,
+      requiresLand: 10,
+      getEffectiveCost: jest.fn(count => ({ colony: { metal: count * 10 } })),
+      canAfford: jest.fn(() => false),
+      canAffordLand: jest.fn(() => false),
+      maxBuildable: jest.fn(() => 0),
+      build: jest.fn(() => false),
+    };
+
+    autoBuild({ habitat: building });
+
+    expect(building.autoBuildPartial).toBe(true);
+    expect(global.resources.colony.metal.autobuildShortage).toBe(true);
+    expect(global.resources.surface.land.autobuildShortage).toBe(false);
   });
 });

--- a/tests/autobuildStrategicReserve.test.js
+++ b/tests/autobuildStrategicReserve.test.js
@@ -1,4 +1,4 @@
-const { autoBuild, setStrategicReserve } = require('../src/js/autobuild.js');
+const { autoBuild, setStrategicReserve, constructionOfficeState } = require('../src/js/autobuild.js');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 global.maintenanceFraction = 0;
@@ -47,5 +47,12 @@ describe('autobuild respects strategic reserve', () => {
     autoBuild({ t: b });
     expect(b.count).toBe(1);
     expect(resources.colony.metal.value).toBe(100);
+  });
+
+  test('stores decimal strategic reserve values', () => {
+    setStrategicReserve('12.5');
+    expect(constructionOfficeState.strategicReserve).toBe(12.5);
+    setStrategicReserve('105.75');
+    expect(constructionOfficeState.strategicReserve).toBe(100);
   });
 });

--- a/tests/constructionOfficeUI.test.js
+++ b/tests/constructionOfficeUI.test.js
@@ -25,6 +25,7 @@ describe('Construction Office UI', () => {
     expect(pauseBtn.textContent).toBe('Pause');
     expect(reserveInput.value).toBe('0');
     expect(reserveInput.nextSibling.textContent).toBe('%');
+    expect(reserveInput.getAttribute('step')).toBe('any');
     expect(reserveIcon).toBeTruthy();
     expect(reserveIcon.getAttribute('title')).toBe('Prevents the Construction Office from using resources from storage if spending them would drop any resource below the specified percentage of its capacity.  Does not apply to workers.');
 
@@ -50,5 +51,42 @@ describe('Construction Office UI', () => {
     // ensure the container is positioned after the sliders box
     const parentChildren = Array.from(container.parentElement.children);
     expect(parentChildren[parentChildren.length - 1]).toBe(container);
+
+    delete global.document;
+    delete global.globalEffects;
+  });
+
+  test('strategic reserve input keeps edits while focused', () => {
+    const { JSDOM } = require('jsdom');
+    const dom = new JSDOM(`<!DOCTYPE html><div id="colony-controls-container"><div id="colony-sliders-container"></div><div id="construction-office-container" class="invisible"></div></div>`, { runScripts: 'outside-only' });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.globalEffects = { isBooleanFlagSet: () => true };
+
+    initializeConstructionOfficeUI();
+
+    const reserveInput = document.getElementById('strategic-reserve-input');
+    reserveInput.value = '2.5';
+    reserveInput.focus();
+    expect(document.activeElement).toBe(reserveInput);
+    constructionOfficeState.strategicReserve = 7.5;
+    updateConstructionOfficeUI();
+    expect(reserveInput.value).toBe('2.5');
+    reserveInput.blur();
+    updateConstructionOfficeUI();
+    expect(reserveInput.value).toBe('7.5');
+
+    reserveInput.value = '';
+    reserveInput.focus();
+    reserveInput.value = '3.25';
+    reserveInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    reserveInput.blur();
+    updateConstructionOfficeUI();
+    expect(constructionOfficeState.strategicReserve).toBe(3.25);
+    expect(reserveInput.value).toBe('3.25');
+
+    delete global.document;
+    delete global.window;
+    delete global.globalEffects;
   });
 });

--- a/tests/spaceStorageScientificNotation.test.js
+++ b/tests/spaceStorageScientificNotation.test.js
@@ -9,7 +9,7 @@ class SpaceStorageProject {
 
 global.SpaceStorageProject = SpaceStorageProject;
 global.projectElements = {};
-require('../src/js/projects/spaceStorageUI.js');
+const { updateSpaceStorageUI } = require('../src/js/projects/spaceStorageUI.js');
 delete global.SpaceStorageProject;
 delete global.projectElements;
 
@@ -48,6 +48,29 @@ describe('space storage strategic reserve input', () => {
     expect(icon.title).toContain('mega project');
     expect(icon.title).toContain('transfers ignore');
     expect(icon.title).toContain('scientific notation');
+    delete global.document;
+    delete global.window;
+    delete global.projectElements;
+  });
+
+  test('does not overwrite strategic reserve while focused', () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.projectElements = {};
+    const project = new SpaceStorageProject();
+    project.strategicReserve = 7.5;
+    const container = document.getElementById('root');
+    const inputContainer = project.createStrategicReserveInput();
+    container.appendChild(inputContainer);
+    const input = projectElements[project.name].strategicReserveInput;
+    input.value = '2.';
+    input.focus();
+    updateSpaceStorageUI(project);
+    expect(input.value).toBe('2.');
+    input.blur();
+    updateSpaceStorageUI(project);
+    expect(input.value).toBe('7.5');
     delete global.document;
     delete global.window;
     delete global.projectElements;


### PR DESCRIPTION
## Summary
- allow the Construction Office strategic reserve to accept decimal values without overwriting the field while the user is editing
- prevent the space storage reserve input from refreshing while focused so partial entries are preserved
- cover the new behaviours with unit tests for both Construction Office and space storage inputs
- evaluate deposit and land limits with the same limiting-resource logic as other inputs so autobuild highlights the true bottleneck, while suppressing alerts when land or deposits are completely exhausted and no other shortages exist, backed by focused tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68d5dc00c2fc8327a31ffb3029e4dff9