### PR TITLE
Update WGC healing tests for new regeneration rate

### DIFF
--- a/tests/wgcFacilityUpgrade.test.js
+++ b/tests/wgcFacilityUpgrade.test.js
@@ -18,10 +18,10 @@ describe('WGC facility upgrades', () => {
   test('infirmary boosts healing rate', () => {
     const wgc = new WarpGateCommand();
     const mem = WGCTeamMember.create('A', '', 'Soldier', {});
-    mem.health = 50;
+    mem.health = 5;
     wgc.recruitMember(0,0,mem);
     wgc.facilities.infirmary = 10;
     wgc.update(60000);
-    expect(mem.health).toBeCloseTo(55.5);
+    expect(mem.health).toBeCloseTo(60);
   });
 });

--- a/tests/wgcHealthRegen.test.js
+++ b/tests/wgcHealthRegen.test.js
@@ -4,13 +4,13 @@ const { WGCTeamMember } = require('../src/js/team-member.js');
 const { WarpGateCommand } = require('../src/js/wgc.js');
 
 describe('WGC team health regeneration', () => {
-  test('members heal 5 HP per step when not active', () => {
+  test('members heal 50 HP per step when not active', () => {
     const wgc = new WarpGateCommand();
     const m = WGCTeamMember.create('Bob', '', 'Soldier', {});
-    m.health = 90;
+    m.health = 40;
     wgc.recruitMember(0, 0, m);
     wgc.update(60000); // one minute
-    expect(m.health).toBeCloseTo(95);
+    expect(m.health).toBeCloseTo(90);
   });
 
   test('members heal 1 HP per step during operations', () => {


### PR DESCRIPTION
## Summary
- update Warp Gate Command health regeneration test to reflect the new 50 HP per minute idle heal rate
- adjust infirmary upgrade test expectations to match the faster baseline healing and avoid max-health capping

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d734d720288327b6f821cdcd6cc391