### PR TITLE
Unlock Venus-like RWG type after terraforming Venus

### DIFF
--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -701,6 +701,10 @@ class RwgManager extends EffectableEntity {
       this.unlockOrbit(effect.targetId);
     } else if (effect.type === 'lockOrbit') {
       this.lockOrbit(effect.targetId);
+    } else if (effect.type === 'unlockType') {
+      this.unlockType(effect.targetId);
+    } else if (effect.type === 'lockType') {
+      this.lockType(effect.targetId);
     } else if (effect.type === 'enable' && effect.type2 === 'orbit') {
       // Backward compatibility for older save effects
       this.unlockOrbit(effect.targetId);

--- a/src/js/story/venus.js
+++ b/src/js/story/venus.js
@@ -705,7 +705,8 @@ progressVenus.chapters.push(
       { type: 'terraforming', terraformingParameter: 'complete' }
     ],
     reward: [
-      { target: 'spaceManager', type: 'setRwgLock', targetId: 'venus', value: true }
+      { target: 'spaceManager', type: 'setRwgLock', targetId: 'venus', value: true },
+      { target: 'rwgManager', type: 'unlockType', targetId: 'venus-like' }
     ]
   },
 );

--- a/tests/rwgVenusLikeUnlockReward.test.js
+++ b/tests/rwgVenusLikeUnlockReward.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Chapter20.17 reward unlocks venus-like type', () => {
+  test('addEffect reward unlocks venus-like type', () => {
+    const ctx = {
+      console,
+      fundingModule: {},
+      populationModule: {},
+      projectManager: {},
+      tabManager: {},
+      globalEffects: {},
+      terraforming: {},
+      lifeDesigner: {},
+      lifeManager: {},
+      oreScanner: {},
+      researchManager: {},
+      solisManager: {},
+      spaceManager: {},
+      warpGateCommand: {}
+    };
+    vm.createContext(ctx);
+    const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+    const rwgCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'rwg.js'), 'utf8');
+    vm.runInContext(`${effectCode}\n${rwgCode}`, ctx);
+    expect(vm.runInContext('rwgManager.isTypeLocked("venus-like");', ctx)).toBe(true);
+    vm.runInContext('addEffect({ target: "rwgManager", type: "unlockType", targetId: "venus-like" });', ctx);
+    expect(vm.runInContext('rwgManager.isTypeLocked("venus-like");', ctx)).toBe(false);
+  });
+
+  test('story chapter20.17 includes unlockType reward', () => {
+    const direct = require('../src/js/story/venus.js');
+    let chapters = Array.isArray(direct.chapters) ? direct.chapters : undefined;
+    if (!chapters || chapters.length === 0) {
+      const storyCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/story', 'venus.js'), 'utf8');
+      const ctx = { console };
+      ctx.globalThis = ctx;
+      vm.createContext(ctx);
+      vm.runInContext(storyCode, ctx);
+      chapters = ctx.progressVenus.chapters;
+    }
+    const chapter = chapters.find(ch => ch.id === 'chapter20.17');
+    const hasReward = chapter.reward.some(r => r.target === 'rwgManager' && r.type === 'unlockType' && r.targetId === 'venus-like');
+    expect(hasReward).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- allow random world generator effects to unlock or lock planet types
- award chapter 20.17 with a venus-like world unlock in the random world generator
- cover the new reward with targeted Jest tests

## Testing
- CI=true npm test -- rwgVenusLikeUnlockReward.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d738b1a1388327a2dda357243ed8d3