### PR TITLE
Add venus-like RWG worker reduction effect

### DIFF
--- a/src/js/rwgEffects.js
+++ b/src/js/rwgEffects.js
@@ -76,6 +76,17 @@ const RWG_EFFECTS = {
         return 1 + f * count;
       }
     }],
+  "venus-like": [
+    {
+      effectId: "rwg-venus-workers",
+      target: "global",
+      type: "globalWorkerReduction",
+      computeValue(count) {
+        const divisor = 1 + 0.01 * count;
+        return 1 - 1 / divisor;
+      },
+    },
+  ],
   "mars-like": [
     {
       effectId: "rwg-mars-pop",

--- a/tests/rwgEffects.test.js
+++ b/tests/rwgEffects.test.js
@@ -144,3 +144,23 @@ describe('rwgEffects mars-like population bonus', () => {
     );
   });
 });
+
+describe('rwgEffects venus-like worker reduction', () => {
+  let context;
+  beforeEach(() => {
+    context = initContext('nitrogenSpaceMining', 'venus-like');
+    context.globalEffects = new context.EffectableEntity({ description: 'global' });
+    context.buildings = {
+      factory: new context.EffectableEntity({ description: 'factory' }),
+    };
+  });
+
+  test('applies global worker reduction based on venus-like count', () => {
+    const building = context.buildings.factory;
+    expect(building.activeEffects.filter((e) => e.type === 'workerMultiplier')).toHaveLength(0);
+    context.applyRWGEffects();
+    const workerEffect = building.activeEffects.find((e) => e.type === 'workerMultiplier');
+    expect(workerEffect).toBeDefined();
+    expect(workerEffect.value).toBeCloseTo(1 / (1 + 0.01 * 2));
+  });
+});


### PR DESCRIPTION
## Summary
- add a venus-like random world reward that scales global worker requirements by terraformed count
- cover the venus-like reward with a focused unit test that validates the worker multiplier effect

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d739cd86388327aaad37fa8f6230af