### PR TITLE
Add Venus worker reduction text to RWG effects UI

### DIFF
--- a/src/js/rwgEffectsUI.js
+++ b/src/js/rwgEffectsUI.js
@@ -105,9 +105,15 @@ function _computeRWGEffectsSummary() {
         display = `/${divisor.toFixed(1)}`;
       } else if (eff.type === 'globalPopulationGrowth') {
         const percent = raw * 100;
-        const fEach = (typeof eff.factor === 'number' ? eff.factor : 0.01) * 100;
+        const fEach = (eff.factor ?? 0.01) * 100;
         descr = descr || `Population growth rate increased (+${fEach.toFixed(0)}% each)`;
         display = `${percent >= 0 ? '+' : ''}${percent.toFixed(0)}%`;
+      } else if (eff.type === 'globalWorkerReduction') {
+        const percent = raw * 100;
+        const decimals = percent >= 10 ? 0 : 1;
+        const eachPercent = (eff.factor ?? 0.01) * 100;
+        descr = descr || `Worker requirements reduced (~${eachPercent.toFixed(0)}% each)`;
+        display = percent > 0 ? `-${percent.toFixed(decimals)}%` : '0%';
       } else if (eff.type === 'extraTerraformedWorlds') {
         // Super-Earth: counts as extra worlds; display +N not xN
         descr = descr || 'Counts as an extra world';

--- a/tests/rwgEffectsUIWorkerReduction.test.js
+++ b/tests/rwgEffectsUIWorkerReduction.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+
+describe('Random World Generator worker reduction effect UI', () => {
+  test('shows description and value for Venus-like worlds', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="space-random"><div id="rwg-history"></div></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    vm.createContext(ctx);
+
+    const read = file => fs.readFileSync(path.join(__dirname, '..', 'src/js', file), 'utf8');
+    vm.runInContext(`
+      ${read('rwg.js')}
+      ${read('rwgEffects.js')}
+      ${read('rwgEffectsUI.js')}
+    `, ctx);
+
+    ctx.rwgManager.unlockType('venus-like');
+
+    ctx.spaceManager = {
+      randomWorldStatuses: {
+        venus: {
+          terraformed: true,
+          original: { override: { classification: { archetype: 'venus-like' } } },
+        },
+      },
+    };
+
+    vm.runInContext('updateRWGEffectsUI();', ctx);
+
+    const desc = dom.window.document.querySelector('[data-effect="rwg-venus-workers"] .col-desc small');
+    const value = dom.window.document.querySelector('[data-effect="rwg-venus-workers"] .col-effect');
+
+    expect(desc.textContent).toBe('Worker requirements reduced (~1% each)');
+    expect(value.textContent).toBe('-1.0%');
+  });
+});
+


### PR DESCRIPTION
## Summary
- show the Venus-like worker reduction effect description and percentage in the Random World Generator effects card
- fall back to the configured factor via nullish coalescing when rendering population growth and worker reductions
- cover the Venus effect UI output with a regression test

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d73c3de8dc8327832a1503dc1e4fb4