### PR TITLE
Add Galaxy subtab unlocked by chapter 20.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,3 +199,5 @@ The planet visualiser has been modularised into files covering core setup, light
 - Building and colony consumption now derive from a shared `getConsumption` helper so effect-driven upkeep is computed dynamica
   lly without mutating base data.
 - Introduced a Water Tank storage structure that specializes in water capacity, includes an Empty action to dump reserves onto the surface, and moved water capacity off the general Storage Depot.
+
+- Added a Galaxy subtab beneath Space, unlocked in Venus chapter 20.13 with a persistent GalaxyManager and placeholder UI.

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     <link rel="stylesheet" href="src/css/milestones.css">
     <!-- Add CSS for the new Space tab if needed -->
     <link rel="stylesheet" href="src/css/space.css">
+    <link rel="stylesheet" href="src/css/galaxy.css">
     <link rel="stylesheet" href="src/css/rwg.css">
     <!-- Add CSS for the new HOPE tab -->
     <link rel="stylesheet" href="src/css/skillsUI.css">
@@ -152,6 +153,8 @@
     <script src="src/js/gold-asteroid.js"></script>
     <script src="src/js/space.js"></script>
     <script src="src/js/spaceUI.js"></script>
+    <script src="src/js/galaxy/galaxy.js"></script>
+    <script src="src/js/galaxy/galaxyUI.js"></script>
     <script src="src/js/rwgUI.js"></script>
     <script src="src/js/warning.js"></script>
     <script src="src/js/game-effects.js"></script>
@@ -412,6 +415,7 @@
             <div class="space-subtabs">
                 <div class="space-subtab active" data-subtab="space-story">Story</div>
                 <div class="space-subtab hidden" data-subtab="space-random">Random</div>
+                <div class="space-subtab hidden" data-subtab="space-galaxy">Galaxy</div>
             </div>
             <div class="space-subtab-content-wrapper">
                 <div id="space-story" class="space-subtab-content active">
@@ -432,6 +436,9 @@
                 </div>
                 <div id="space-random" class="space-subtab-content hidden">
                     <!-- Random events will appear here -->
+                </div>
+                <div id="space-galaxy" class="space-subtab-content hidden">
+                    <!-- Galaxy overview placeholder -->
                 </div>
             </div>
         </div>

--- a/src/css/galaxy.css
+++ b/src/css/galaxy.css
@@ -1,0 +1,20 @@
+#space-galaxy {
+  padding: 16px;
+}
+
+.galaxy-placeholder-message {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: #d0e4ff;
+  background: rgba(24, 32, 48, 0.6);
+  border: 1px solid rgba(64, 128, 192, 0.4);
+  border-radius: 8px;
+  padding: 16px;
+  max-width: 420px;
+}
+
+.dark-mode .galaxy-placeholder-message {
+  color: #f0f6ff;
+  background: rgba(12, 20, 32, 0.7);
+  border-color: rgba(96, 160, 224, 0.6);
+}

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -614,6 +614,7 @@ function addOrRemoveEffect(effect, action) {
     'warpGateCommand' : warpGateCommand,
     'rwgManager': typeof rwgManager !== 'undefined' ? rwgManager : undefined,
     'nanotechManager': typeof nanotechManager !== 'undefined' ? nanotechManager : undefined,
+    'galaxyManager': typeof galaxyManager !== 'undefined' ? galaxyManager : undefined,
     'colonySliders': typeof colonySliderSettings !== 'undefined' ? colonySliderSettings : undefined
   };
 

--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -1,0 +1,91 @@
+class GalaxyManager extends EffectableEntity {
+    constructor() {
+        super({ description: 'Manages the galactic view.' });
+        this.enabled = false;
+        this.initialized = false;
+    }
+
+    initialize() {
+        if (this.initialized) {
+            this.refreshUIVisibility();
+            return;
+        }
+        this.initialized = true;
+        this.refreshUIVisibility();
+    }
+
+    update(deltaMs) { // Placeholder for future logic
+        void deltaMs;
+    }
+
+    enable(targetId, { autoSwitch = true } = {}) {
+        if (targetId && targetId !== 'space-galaxy' && targetId !== 'galaxy') {
+            return;
+        }
+        this.enabled = true;
+        this.refreshUIVisibility();
+        if (autoSwitch) {
+            this.focusOnGalaxy();
+        }
+    }
+
+    refreshUIVisibility() {
+        if (this.enabled) {
+            if (typeof showSpaceGalaxyTab === 'function') {
+                showSpaceGalaxyTab();
+            }
+            if (typeof initializeGalaxyUI === 'function') {
+                initializeGalaxyUI();
+            }
+            if (typeof updateGalaxyUI === 'function') {
+                updateGalaxyUI();
+            }
+        } else if (typeof hideSpaceGalaxyTab === 'function') {
+            hideSpaceGalaxyTab();
+        }
+    }
+
+    focusOnGalaxy() {
+        if (typeof tabManager !== 'undefined' && tabManager && typeof tabManager.activateTab === 'function') {
+            tabManager.activateTab('space');
+        }
+        if (typeof activateSpaceSubtab === 'function') {
+            activateSpaceSubtab('space-galaxy');
+        }
+    }
+
+    applyEffect(effect) {
+        if (!effect) {
+            return;
+        }
+        if (effect.type === 'unlockGalaxy') {
+            const autoSwitch = effect.autoSwitch !== false;
+            this.enable(effect.targetId || 'space-galaxy', { autoSwitch });
+            return;
+        }
+        if (effect.type === 'enable') {
+            this.enable(effect.targetId, { autoSwitch: effect.autoSwitch !== false });
+            return;
+        }
+        super.applyEffect(effect);
+    }
+
+    saveState() {
+        return { enabled: this.enabled };
+    }
+
+    loadState(state) {
+        this.initialize();
+        if (state && typeof state.enabled === 'boolean') {
+            this.enabled = state.enabled;
+        }
+        this.refreshUIVisibility();
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.GalaxyManager = GalaxyManager;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { GalaxyManager };
+}

--- a/src/js/galaxy/galaxyUI.js
+++ b/src/js/galaxy/galaxyUI.js
@@ -1,0 +1,51 @@
+let galaxyUICache = null;
+
+function cacheGalaxyElements() {
+    if (galaxyUICache) {
+        return galaxyUICache;
+    }
+    if (typeof document === 'undefined') {
+        return null;
+    }
+    const container = document.getElementById('space-galaxy');
+    if (!container) {
+        return null;
+    }
+    const placeholder = document.createElement('div');
+    placeholder.className = 'galaxy-placeholder-message';
+    placeholder.textContent = 'The galaxy awaits further updates.';
+    container.appendChild(placeholder);
+    galaxyUICache = { container, placeholder };
+    return galaxyUICache;
+}
+
+function initializeGalaxyUI() {
+    const cache = galaxyUICache || cacheGalaxyElements();
+    if (!cache) {
+        return;
+    }
+    updateGalaxyUI();
+}
+
+function updateGalaxyUI() {
+    if (!galaxyUICache) {
+        if (!cacheGalaxyElements()) {
+            return;
+        }
+    }
+    const manager = typeof galaxyManager !== 'undefined' ? galaxyManager : null;
+    const enabled = !!(manager && manager.enabled);
+    if (galaxyUICache && galaxyUICache.placeholder) {
+        galaxyUICache.placeholder.textContent = enabled
+            ? 'Starlanes calibrating. Future missions will chart this expanse.'
+            : 'The galaxy awaits further updates.';
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.initializeGalaxyUI = initializeGalaxyUI;
+    window.updateGalaxyUI = updateGalaxyUI;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initializeGalaxyUI, updateGalaxyUI };
+}

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -118,8 +118,12 @@ function create() {
   createMilestonesUI();
 
   spaceManager = new SpaceManager(planetParameters);
+  galaxyManager = new GalaxyManager();
   initializeHopeUI();
   initializeSpaceUI(spaceManager);
+  if (typeof galaxyManager.initialize === 'function') {
+    galaxyManager.initialize();
+  }
 
   if(!loadMostRecentSave()){  // Handle initial game state (building counts, etc.)
     initializeGameState();
@@ -315,6 +319,12 @@ function initializeGameState(options = {}) {
   lifeManager = new LifeManager();
 
   milestonesManager = new MilestonesManager();
+  if (!preserveManagers || !galaxyManager) {
+    galaxyManager = new GalaxyManager();
+  }
+  if (typeof galaxyManager.initialize === 'function') {
+    galaxyManager.initialize();
+  }
   if (!preserveManagers) {
     storyManager = new StoryManager(progressData);  // Pass the progressData object
     if (!skipStoryInitialization) {
@@ -349,6 +359,11 @@ function initializeGameState(options = {}) {
   } else if (!preserveManagers && typeof initializeSpaceUI === 'function') {
     initializeSpaceUI(spaceManager);
   }
+  if (typeof galaxyManager?.refreshUIVisibility === 'function') {
+    galaxyManager.refreshUIVisibility();
+  } else if (typeof updateGalaxyUI === 'function') {
+    updateGalaxyUI();
+  }
 
   // When keeping existing managers, reapplied story effects need to
   // target the newly created game objects for this planet.
@@ -377,6 +392,10 @@ function updateLogic(delta) {
   dayNightCycle.update(delta);
 
   colonySliderSettings.updateColonySlidersEffect();
+
+  if (galaxyManager && typeof galaxyManager.update === 'function') {
+    galaxyManager.update(delta);
+  }
 
   const allStructures = {...buildings, ...colonies};
 
@@ -512,6 +531,7 @@ function updateRender(force = false) {
 
     if (isActive('space') && typeof updateSpaceUI === 'function') {
       updateSpaceUI();
+      if (typeof updateGalaxyUI === 'function') updateGalaxyUI();
       if (typeof updateRWGEffectsUI === 'function') updateRWGEffectsUI();
     }
 
@@ -534,6 +554,7 @@ function updateRender(force = false) {
     updateStatisticsDisplay();
     updateHopeUI();
     if (typeof updateSpaceUI === 'function') updateSpaceUI();
+    if (typeof updateGalaxyUI === 'function') updateGalaxyUI();
   }
 
   // Milestones often affect multiple views; keep updated

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -68,6 +68,7 @@ let globalEffects = new EffectableEntity({description : 'Manages global effects'
 let skillManager;
 let solisManager;
 let warpGateCommand;
+let galaxyManager;
 let playTimeSeconds = 0;
 let totalPlayTimeSeconds = 0;
 let gameSpeed = 1;

--- a/src/js/save.js
+++ b/src/js/save.js
@@ -155,6 +155,7 @@ function getGameState() {
     milestonesManager: (typeof milestonesManager !== 'undefined' && typeof milestonesManager.saveState === 'function') ? milestonesManager.saveState() : undefined,
     skills: (typeof skillManager !== 'undefined' && typeof skillManager.saveState === 'function') ? skillManager.saveState() : undefined,
     spaceManager: (typeof spaceManager !== 'undefined' && typeof spaceManager.saveState === 'function') ? spaceManager.saveState() : undefined,
+    galaxyManager: (typeof galaxyManager !== 'undefined' && typeof galaxyManager.saveState === 'function') ? galaxyManager.saveState() : undefined,
     selectedBuildCounts: typeof selectedBuildCounts !== 'undefined' ? selectedBuildCounts : undefined,
     settings: typeof gameSettings !== 'undefined' ? gameSettings : undefined,
     colonySliderSettings: (typeof colonySliderSettings !== 'undefined' && typeof colonySliderSettings.saveState === 'function') ? colonySliderSettings.saveState() : undefined,
@@ -476,6 +477,10 @@ function loadGame(slotOrCustomString) {
 
     if(gameState.nanotechManager){
       nanotechManager.loadState(gameState.nanotechManager);
+    }
+
+    if (gameState.galaxyManager && typeof galaxyManager !== 'undefined' && galaxyManager) {
+      galaxyManager.loadState(gameState.galaxyManager);
     }
 
     if(gameState.solisManager){

--- a/src/js/spaceUI.js
+++ b/src/js/spaceUI.js
@@ -15,10 +15,13 @@ if (typeof SubtabManager === 'undefined') {
 let spaceUIInitialized = false;
 // Track visibility of the Random subtab
 let spaceRandomTabVisible = false;
+let spaceGalaxyTabVisible = false;
 let spaceSubtabManager = null;
 // Cache the last rendered world so we can skip redundant updates
 let lastWorldKey = null;
 let lastWorldSeed = null;
+
+const galaxyTabElements = { button: null, content: null };
 
 // Cached travel warning popup elements
 let travelWarningOverlay = null;
@@ -62,6 +65,53 @@ function hideSpaceRandomTab() {
         const tab = document.querySelector('[data-subtab="space-random"]');
         const content = document.getElementById('space-random');
         if (tab) tab.classList.add('hidden');
+        if (content) content.classList.add('hidden');
+    }
+}
+
+function cacheGalaxyTabElements() {
+    if (typeof document === 'undefined') {
+        return galaxyTabElements;
+    }
+    if (!galaxyTabElements.button || !galaxyTabElements.button.isConnected) {
+        const button = document.querySelector('[data-subtab="space-galaxy"]');
+        if (button) {
+            galaxyTabElements.button = button;
+        }
+    }
+    if (!galaxyTabElements.content || !galaxyTabElements.content.isConnected) {
+        const content = document.getElementById('space-galaxy');
+        if (content) {
+            galaxyTabElements.content = content;
+        }
+    }
+    return galaxyTabElements;
+}
+
+function showSpaceGalaxyTab() {
+    spaceGalaxyTabVisible = true;
+    const { button, content } = cacheGalaxyTabElements();
+    if (spaceSubtabManager) {
+        spaceSubtabManager.show('space-galaxy');
+    } else {
+        if (button) button.classList.remove('hidden');
+        if (content) content.classList.remove('hidden');
+    }
+    if (typeof initializeGalaxyUI === 'function') {
+        initializeGalaxyUI();
+    }
+    if (typeof updateGalaxyUI === 'function') {
+        updateGalaxyUI();
+    }
+}
+
+function hideSpaceGalaxyTab() {
+    spaceGalaxyTabVisible = false;
+    const { button, content } = cacheGalaxyTabElements();
+    if (spaceSubtabManager) {
+        spaceSubtabManager.hide('space-galaxy');
+    } else {
+        if (button) button.classList.add('hidden');
         if (content) content.classList.add('hidden');
     }
 }
@@ -218,6 +268,12 @@ function initializeSpaceUI(spaceManager) {
     console.log("Initializing Space UI with SpaceManager reference.");
     initializeSpaceTabs();
     hideSpaceRandomTab();
+    cacheGalaxyTabElements();
+    if (typeof galaxyManager !== 'undefined' && galaxyManager && galaxyManager.enabled) {
+        showSpaceGalaxyTab();
+    } else {
+        hideSpaceGalaxyTab();
+    }
 
     // If the UI has already been generated, just update with the new instance
     if (spaceUIInitialized) {

--- a/src/js/story/venus.js
+++ b/src/js/story/venus.js
@@ -657,7 +657,19 @@ progressVenus.chapters.push(
     narrative: "System Message: Galactic map unlocked.",
     prerequisites: ["chapter20.12"],
     objectives: [],
-    reward: []
+    reward: [
+      { target: 'galaxyManager', type: 'enable', targetId: 'space-galaxy', onLoad: false },
+      { target: 'tab', targetId: 'space', type: 'activateTab', onLoad: false },
+      {
+        target: 'global',
+        type: 'activateSubtab',
+        subtabClass: 'space-subtab',
+        contentClass: 'space-subtab-content',
+        targetId: 'space-galaxy',
+        unhide: true,
+        onLoad: false
+      }
+    ]
   },
   {
     id: "chapter20.14",

--- a/tests/enableGalaxyTabEffect.test.js
+++ b/tests/enableGalaxyTabEffect.test.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+describe('Galaxy tab unlock', () => {
+  test('enabling the galaxy manager reveals and focuses the subtab', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div class="tab" data-tab="settings"></div>
+      <div class="tab" data-tab="space"></div>
+      <div id="settings" class="tab-content active"></div>
+      <div id="space" class="tab-content"></div>
+      <div class="space-subtab" data-subtab="space-story"></div>
+      <div class="space-subtab hidden" data-subtab="space-random"></div>
+      <div class="space-subtab hidden" data-subtab="space-galaxy"></div>
+      <div id="space-story" class="space-subtab-content active">
+        <div id="planet-selection-options"></div>
+        <div id="travel-status"></div>
+      </div>
+      <div id="space-random" class="space-subtab-content hidden"></div>
+      <div id="space-galaxy" class="space-subtab-content hidden"></div>`, { runScripts: 'outside-only' });
+
+    const ctx = dom.getInternalVMContext();
+    ctx.window = dom.window;
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.planetParameters = {
+      mars: {
+        name: 'Mars',
+        celestialParameters: { distanceFromSun: 1, gravity: 3.7, radius: 3389, albedo: 0.25 },
+      },
+    };
+    vm.createContext(ctx);
+
+    const scripts = [
+      'ui-utils.js',
+      'subtab-manager.js',
+      'effectable-entity.js',
+      'tab.js',
+      'space.js',
+      'spaceUI.js',
+      'galaxy/galaxy.js',
+      'galaxy/galaxyUI.js',
+    ].map(file => fs.readFileSync(path.join(__dirname, '..', 'src/js', file), 'utf8'));
+    vm.runInContext(`${scripts.join('\n')}; this.SpaceManager = SpaceManager; this.GalaxyManager = GalaxyManager; this.TabManager = TabManager;`, ctx);
+
+    ctx.spaceManager = new ctx.SpaceManager(ctx.planetParameters);
+    ctx.galaxyManager = new ctx.GalaxyManager();
+    ctx.tabManager = { activateTab(id) { this.lastActivated = id; } };
+    ctx.initializeSpaceUI(ctx.spaceManager);
+    ctx.galaxyManager.initialize();
+
+    const galaxyTab = dom.window.document.querySelector('[data-subtab="space-galaxy"]');
+    const galaxyContent = dom.window.document.getElementById('space-galaxy');
+    expect(galaxyTab.classList.contains('hidden')).toBe(true);
+    expect(galaxyContent.classList.contains('hidden')).toBe(true);
+
+    ctx.galaxyManager.addAndReplace({
+      target: 'galaxyManager',
+      type: 'enable',
+      targetId: 'space-galaxy',
+      effectId: 'galaxyUnlock',
+      sourceId: 'story',
+    });
+
+    expect(galaxyTab.classList.contains('hidden')).toBe(false);
+    expect(galaxyContent.classList.contains('hidden')).toBe(false);
+    const activeId = vm.runInContext('spaceSubtabManager.getActiveId()', ctx);
+    expect(activeId).toBe('space-galaxy');
+    expect(ctx.tabManager.lastActivated).toBe('space');
+  });
+});

--- a/tests/spaceRandomTabHiddenMarkup.test.js
+++ b/tests/spaceRandomTabHiddenMarkup.test.js
@@ -7,5 +7,7 @@ describe('Space Random subtab markup', () => {
     const html = fs.readFileSync(htmlPath, 'utf8');
     expect(html).toMatch(/<div class="space-subtab hidden" data-subtab="space-random">/);
     expect(html).toMatch(/<div id="space-random" class="space-subtab-content hidden">/);
+    expect(html).toMatch(/<div class="space-subtab hidden" data-subtab="space-galaxy">/);
+    expect(html).toMatch(/<div id="space-galaxy" class="space-subtab-content hidden">/);
   });
 });


### PR DESCRIPTION
## Summary
- add a GalaxyManager with placeholder UI hooks that persists through travel and saving
- expose a hidden Galaxy subtab on the Space screen and unlock it via Venus chapter 20.13
- style the new view and cover the feature with unit tests for markup and unlock behavior
- organize the Galaxy scripts into src/js/galaxy/ for clarity

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68d98f71dce083278713c29e194abdc2