### PR TITLE
Add fallback to debug save when no recent save is available

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -126,13 +126,46 @@ function create() {
   }
 
   if(!loadMostRecentSave()){  // Handle initial game state (building counts, etc.)
-    initializeGameState();
-    if (typeof openTerraformingWorldTab === 'function') {
-      openTerraformingWorldTab();
-    }
+    loadDebugSave().then((loadedDebug) => {
+      if (loadedDebug) {
+        return;
+      }
+      initializeGameState();
+      if (typeof openTerraformingWorldTab === 'function') {
+        openTerraformingWorldTab();
+      }
+      if (typeof hideLoadingOverlay === 'function') {
+        hideLoadingOverlay();
+      }
+    });
+    return;
   }
   if (typeof hideLoadingOverlay === 'function') {
     hideLoadingOverlay();
+  }
+}
+
+function loadDebugSave() {
+  try {
+    return fetch('debug_save/debug1.json', { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch debug save: ${response.status}`);
+        }
+        return response.text();
+      })
+      .then((saveData) => {
+        console.log('Loaded debug save from debug_save/debug1.json.');
+        loadGame(saveData);
+        return true;
+      })
+      .catch((error) => {
+        console.warn('Unable to load debug save debug1.json.', error);
+        return false;
+      });
+  } catch (error) {
+    console.warn('Failed to initiate debug save load for debug1.json.', error);
+    return Promise.resolve(false);
   }
 }
 


### PR DESCRIPTION
## Summary
- attempt to load `debug_save/debug1.json` if no recent save is found when starting the game
- only initialize a fresh game state when both the recent save and debug fallback are unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da839ab59c832797833e00d3cd89a7