### PR TITLE
Skip story pop-ups in debug mode

### DIFF
--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -796,6 +796,12 @@ class StoryEvent {
     trigger() { // Modified to skip journal entries for outdated chapters
         switch (this.type) {
             case "pop-up":
+                if (globalThis.debugMode) {
+                    if (window.storyManager && window.storyManager.activeEventIds.has(this.id)) {
+                        window.storyManager.processEventCompletion(this.id);
+                    }
+                    break;
+                }
                 createPopup(
                     this.parameters.title,
                     joinLines(this.parameters.text),
@@ -803,6 +809,12 @@ class StoryEvent {
                 );
                 break;
             case "system-pop-up":
+                if (globalThis.debugMode) {
+                    if (window.storyManager && window.storyManager.activeEventIds.has(this.id)) {
+                        window.storyManager.processEventCompletion(this.id);
+                    }
+                    break;
+                }
                 createSystemPopup(
                     this.parameters.title,
                     joinLines(this.parameters.text),


### PR DESCRIPTION
## Summary
- bypass story pop-up and system pop-up displays when debug mode is enabled
- immediately complete the associated story events so progression continues uninterrupted during debugging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da8a00d34483278cff2160b1f47561