### PR TITLE
Add antimatter production helpers and storage cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,5 +203,7 @@ If trying to take a screenshot, you should set debugMode to true first, to skip 
   lly without mutating base data.
 - Introduced a Water Tank storage structure that specializes in water capacity, includes an Empty action to dump reserves onto the surface, and moved water capacity off the general Storage Depot.
 
+- Antimatter is now produced automatically based on terraformed worlds and capped at ten hours of output.
+
 - Added a Galaxy subtab beneath Space, unlocked in Venus chapter 20.13 with a persistent GalaxyManager and placeholder UI.
 - Galaxy sectors now track faction control through dedicated GalaxyFaction and GalaxySector classes, coloring the map by the dominant controller.

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
     <script src="src/js/advanced-research/self-replicating-ships.js"></script>
     <script src="src/js/advanced-research/hive-mind-androids.js"></script>
     <script src="src/js/advanced-research/ecumenopolis.js"></script>
+    <script src="src/js/special/antimatter.js"></script>
     <script src="src/js/resource.js"></script>
     <script src="src/js/resourceUI.js"></script>
     <script src="src/js/building.js"></script>

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -80,7 +80,7 @@ const defaultPlanetParameters = {
       whiteDust: { name: 'White Dust', hasCap: true, baseCap: 144800000000000, initialValue: 0, unlocked: false, hideWhenSmall: true },
       spaceships: {name : 'Spaceships', hasCap: false, initialValue: 0, unlocked: false},
       alienArtifact: { name: 'Alien artifact', hasCap: false, initialValue: 0, unlocked: false },
-      antimatter: { name: 'Antimatter', hasCap: false, initialValue: 0, unlocked: false }
+      antimatter: { name: 'Antimatter', hasCap: true, baseCap: 0, initialValue: 0, unlocked: false }
     }
   },
   zonalCO2: {

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -1,3 +1,13 @@
+let produceAntimatterHelper = globalThis.produceAntimatter || null;
+let updateAntimatterStorageCapHelper = globalThis.updateAntimatterStorageCap || null;
+
+if (typeof module !== 'undefined' && module.exports) {
+  ({
+    produceAntimatter: produceAntimatterHelper,
+    updateAntimatterStorageCap: updateAntimatterStorageCapHelper,
+  } = require('./special/antimatter.js'));
+}
+
 // Resource Class and Core Logic
 class Resource extends EffectableEntity {
   constructor(resourceData) {
@@ -351,6 +361,10 @@ function produceResources(deltaTime, buildings) {
 
   calculateProductionRates(deltaTime, buildings);
 
+  if (updateAntimatterStorageCapHelper) {
+    updateAntimatterStorageCapHelper(resources);
+  }
+
   // Update storage cap for all resources except workers
   for (const category in resources) {
     for (const resourceName in resources[category]) {
@@ -466,6 +480,10 @@ function produceResources(deltaTime, buildings) {
 
   if (typeof updateAndroidResearch === 'function') {
     updateAndroidResearch(deltaTime, resources, globalEffects, accumulatedChanges);
+  }
+
+  if (produceAntimatterHelper) {
+    produceAntimatterHelper(deltaTime, resources, accumulatedChanges);
   }
 
   if (projectManager) {

--- a/src/js/special/antimatter.js
+++ b/src/js/special/antimatter.js
@@ -1,0 +1,64 @@
+const ANTIMATTER_PER_TERRAFORMED_WORLD = 10;
+const STORAGE_DURATION_SECONDS = 10 * 3600;
+
+function getAntimatterResource(resources) {
+  return resources?.special?.antimatter || null;
+}
+
+function getTerraformedWorldCount() {
+  return globalThis.spaceManager?.getTerraformedPlanetCount?.() ?? 0;
+}
+
+function produceAntimatter(deltaTime, resources, accumulatedChanges) {
+  const antimatter = getAntimatterResource(resources);
+  if (!antimatter || (!antimatter.unlocked && !antimatter.enabled)) {
+    return;
+  }
+
+  const terraformedWorlds = getTerraformedWorldCount();
+  if (terraformedWorlds <= 0) {
+    return;
+  }
+
+  const rate = terraformedWorlds * ANTIMATTER_PER_TERRAFORMED_WORLD;
+  const seconds = deltaTime / 1000;
+  const change = rate * seconds;
+
+  const storage = accumulatedChanges?.special;
+  if (storage && Object.prototype.hasOwnProperty.call(storage, 'antimatter')) {
+    storage.antimatter += change;
+  } else {
+    antimatter.value += change;
+  }
+
+  antimatter.modifyRate?.(rate, 'Terraformed Worlds', 'global');
+}
+
+function updateAntimatterStorageCap(resources) {
+  const antimatter = getAntimatterResource(resources);
+  if (!antimatter || (!antimatter.unlocked && !antimatter.enabled)) {
+    return;
+  }
+
+  const terraformedWorlds = getTerraformedWorldCount();
+  const productionRate = terraformedWorlds * ANTIMATTER_PER_TERRAFORMED_WORLD;
+  const baseCap = Math.max(0, productionRate * STORAGE_DURATION_SECONDS);
+
+  antimatter.hasCap = true;
+  antimatter.baseCap = baseCap;
+  antimatter.cap = baseCap;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    ANTIMATTER_PER_TERRAFORMED_WORLD,
+    STORAGE_DURATION_SECONDS,
+    produceAntimatter,
+    updateAntimatterStorageCap,
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.produceAntimatter = produceAntimatter;
+  window.updateAntimatterStorageCap = updateAntimatterStorageCap;
+}

--- a/tests/antimatterFarm.test.js
+++ b/tests/antimatterFarm.test.js
@@ -19,7 +19,8 @@ describe('Antimatter Farm integrations', () => {
 
     expect(antimatter).toBeDefined();
     expect(antimatter.unlocked).toBe(false);
-    expect(antimatter.hasCap).toBe(false);
+    expect(antimatter.hasCap).toBe(true);
+    expect(antimatter.baseCap).toBe(0);
     expect(antimatter.initialValue).toBe(0);
   });
 

--- a/tests/antimatterResource.test.js
+++ b/tests/antimatterResource.test.js
@@ -1,0 +1,97 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+const { Resource } = require('../src/js/resource.js');
+const {
+  ANTIMATTER_PER_TERRAFORMED_WORLD,
+  STORAGE_DURATION_SECONDS,
+  produceAntimatter,
+  updateAntimatterStorageCap,
+} = require('../src/js/special/antimatter.js');
+
+describe('antimatter special resource helpers', () => {
+  let previousSpaceManager;
+  let previousStructures;
+  let resources;
+  let accumulatedChanges;
+
+  beforeEach(() => {
+    previousSpaceManager = global.spaceManager;
+    previousStructures = global.structures;
+    global.structures = {};
+
+    resources = {
+      special: {
+        antimatter: new Resource({
+          name: 'antimatter',
+          category: 'special',
+          hasCap: true,
+          baseCap: 0,
+          initialValue: 0,
+          unlocked: false,
+        }),
+      },
+    };
+
+    accumulatedChanges = { special: { antimatter: 0 } };
+  });
+
+  afterEach(() => {
+    global.spaceManager = previousSpaceManager;
+    global.structures = previousStructures;
+  });
+
+  test('produceAntimatter adds production based on terraformed worlds', () => {
+    global.spaceManager = {
+      getTerraformedPlanetCount: () => 4,
+    };
+
+    resources.special.antimatter.unlocked = true;
+    produceAntimatter(1500, resources, accumulatedChanges);
+
+    const expectedChange = 4 * ANTIMATTER_PER_TERRAFORMED_WORLD * 1.5;
+    expect(accumulatedChanges.special.antimatter).toBeCloseTo(expectedChange);
+    expect(resources.special.antimatter.productionRate).toBeCloseTo(
+      4 * ANTIMATTER_PER_TERRAFORMED_WORLD
+    );
+  });
+
+  test('updateAntimatterStorageCap scales with ten hours of production', () => {
+    global.spaceManager = {
+      getTerraformedPlanetCount: () => 2,
+    };
+
+    resources.special.antimatter.unlocked = true;
+    updateAntimatterStorageCap(resources);
+
+    const expectedBaseCap =
+      2 * ANTIMATTER_PER_TERRAFORMED_WORLD * STORAGE_DURATION_SECONDS;
+    expect(resources.special.antimatter.hasCap).toBe(true);
+    expect(resources.special.antimatter.baseCap).toBe(expectedBaseCap);
+
+    resources.special.antimatter.updateStorageCap();
+    expect(resources.special.antimatter.cap).toBe(expectedBaseCap);
+  });
+
+  test('produceAntimatter does nothing when the resource is locked and disabled', () => {
+    global.spaceManager = {
+      getTerraformedPlanetCount: () => 3,
+    };
+
+    produceAntimatter(1000, resources, accumulatedChanges);
+
+    expect(accumulatedChanges.special.antimatter).toBe(0);
+    expect(resources.special.antimatter.productionRate).toBe(0);
+  });
+
+  test('updateAntimatterStorageCap does nothing when the resource is locked and disabled', () => {
+    global.spaceManager = {
+      getTerraformedPlanetCount: () => 5,
+    };
+
+    updateAntimatterStorageCap(resources);
+
+    expect(resources.special.antimatter.baseCap).toBe(0);
+    expect(resources.special.antimatter.cap).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated special/antimatter helper that produces antimatter per terraformed world and enforces a ten-hour cap
- integrate the helper into the resource loop, update default parameters, and load the new script
- document the feature and expand the antimatter tests to cover production and storage logic
- ensure antimatter production and storage updates only run when the resource is unlocked or enabled, with coverage for locked scenarios

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68da9a0e02508327a32a9cd8f101aea4