### PR TITLE
Remove sector detail raw control values

### DIFF
--- a/src/js/galaxy/galaxyUI.js
+++ b/src/js/galaxy/galaxyUI.js
@@ -375,9 +375,7 @@ function renderSelectedSectorDetails() {
             const value = doc.createElement('span');
             value.className = 'galaxy-sector-panel__control-value';
             const percent = total > 0 ? Math.round((entry.value / total) * 100) : 0;
-            value.textContent = total > 0
-                ? `${percent}% (${entry.value.toLocaleString()})`
-                : entry.value.toLocaleString();
+            value.textContent = `${percent}%`;
             item.appendChild(value);
 
             list.appendChild(item);


### PR DESCRIPTION
## Summary
- remove raw control totals from the galaxy sector detail list so only percentages remain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68daa1e3d9008327836e8b815bc7eca7