### PR TITLE
Adjust galaxy reset to keep manager enabled

### DIFF
--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -177,6 +177,15 @@ class GalaxyManager extends EffectableEntity {
         this.refreshUIVisibility();
     }
 
+    resetGalaxy() {
+        this.initialized = false;
+        this.radius = GALAXY_RADIUS;
+        this.factions.clear();
+        this.sectors.clear();
+        this.initialize();
+        this.enable();
+    }
+
     getSector(q, r) {
         return this.sectors.get(GalaxySectorClass.createKey(q, r)) || null;
     }


### PR DESCRIPTION
## Summary
- update `resetGalaxy` so it rebuilds sectors and factions before re-enabling the GalaxyManager

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68daa3cbd8548327be2aa116c8e7f4e0