### PR TITLE
Add fleet capacity tracking to galaxy factions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,3 +214,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Added a Galaxy subtab beneath Space, unlocked in Venus chapter 20.13 with a persistent GalaxyManager and placeholder UI.
 - Galaxy sectors now track faction control through dedicated GalaxyFaction and GalaxySector classes, coloring the map by the dominant controller.
 - Galaxy map hexes now display zebra stripes combining the top two factions, scaling stripe width with the runner-up's control share.
+- Galaxy factions now track fleet capacity and power, with the UHF scaling from terraformed worlds and other factions drawing capacity from sector control.

--- a/src/js/galaxy/sector.js
+++ b/src/js/galaxy/sector.js
@@ -1,9 +1,10 @@
 class GalaxySector {
-    constructor({ q, r, control } = {}) {
+    constructor({ q, r, control, value } = {}) {
         this.q = Number.isFinite(q) ? q : 0;
         this.r = Number.isFinite(r) ? r : 0;
         this.key = GalaxySector.createKey(this.q, this.r);
         this.ring = GalaxySector.computeRing(this.q, this.r);
+        this.value = this.#sanitizeValue(value);
         this.control = {};
         if (control) {
             this.replaceControl(control);
@@ -27,6 +28,14 @@ class GalaxySector {
         Object.entries(controlMap).forEach(([factionId, value]) => {
             this.setControl(factionId, value);
         });
+    }
+
+    setValue(rawValue) {
+        this.value = this.#sanitizeValue(rawValue);
+    }
+
+    getValue() {
+        return this.value;
     }
 
     setControl(factionId, rawValue) {
@@ -115,11 +124,30 @@ class GalaxySector {
         return breakdown.slice(0, numericLimit);
     }
 
+    getTotalControlValue() {
+        return Object.values(this.control).reduce((total, value) => {
+            const numericValue = Number(value);
+            if (!Number.isFinite(numericValue) || numericValue <= 0) {
+                return total;
+            }
+            return total + numericValue;
+        }, 0);
+    }
+
+    #sanitizeValue(rawValue) {
+        const numericValue = Number(rawValue);
+        if (!Number.isFinite(numericValue) || numericValue <= 0) {
+            return 100;
+        }
+        return numericValue;
+    }
+
     toJSON() {
         return {
             q: this.q,
             r: this.r,
-            control: { ...this.control }
+            control: { ...this.control },
+            value: this.value
         };
     }
 }

--- a/tests/galaxyFactionFleetPower.test.js
+++ b/tests/galaxyFactionFleetPower.test.js
@@ -1,0 +1,80 @@
+const { GalaxyFaction } = require('../src/js/galaxy/faction');
+const { GalaxySector } = require('../src/js/galaxy/sector');
+
+function createManager({ sectors = [], terraformedWorlds = 0 } = {}) {
+    return {
+        getSectors: () => sectors,
+        getTerraformedWorldCount: () => terraformedWorlds
+    };
+}
+
+describe('GalaxyFaction fleet power and capacity', () => {
+    beforeEach(() => {
+        global.spaceManager = undefined;
+    });
+
+    it('initializes non-UHF factions at full fleet power based on sector control', () => {
+        const primarySector = new GalaxySector({ q: 0, r: 0 });
+        primarySector.setValue(150);
+        primarySector.setControl('test', 60);
+        primarySector.setControl('rival', 40);
+
+        const frontierSector = new GalaxySector({ q: 1, r: -1 });
+        frontierSector.setValue(80);
+        frontierSector.setControl('test', 20);
+        frontierSector.setControl('rival', 80);
+
+        const faction = new GalaxyFaction({ id: 'test', name: 'Test Collective' });
+        const manager = createManager({ sectors: [primarySector, frontierSector] });
+
+        faction.initializeFleetPower(manager);
+
+        const expectedCapacity = (150 * (60 / 100)) + (80 * (20 / 100));
+        expect(faction.fleetCapacity).toBeCloseTo(expectedCapacity);
+        expect(faction.fleetPower).toBeCloseTo(expectedCapacity);
+    });
+
+    it('calculates UHF capacity from terraformed worlds and regrows with replacement time', () => {
+        const faction = new GalaxyFaction({ id: 'uhf', name: 'UHF' });
+        const manager = createManager({ terraformedWorlds: 4 });
+
+        faction.initializeFleetPower(manager);
+
+        expect(faction.fleetCapacity).toBe(400);
+        expect(faction.fleetPower).toBe(0);
+
+        faction.update(600000, manager);
+
+        expect(faction.fleetPower).toBeCloseTo(400 * (600 / 3600));
+    });
+
+    it('applies an asymptotic penalty above half capacity', () => {
+        const faction = new GalaxyFaction({ id: 'uhf', name: 'UHF' });
+        const manager = createManager({ terraformedWorlds: 5 });
+
+        faction.initializeFleetPower(manager);
+        faction.setFleetPower(375);
+
+        faction.update(3600000, manager);
+
+        expect(faction.fleetPower).toBeCloseTo(437.5);
+    });
+
+    it('clamps fleet power when capacity drops', () => {
+        const contestedSector = new GalaxySector({ q: 2, r: -1 });
+        contestedSector.setControl('ally', 100);
+
+        const faction = new GalaxyFaction({ id: 'ally', name: 'Ally Faction' });
+        const manager = createManager({ sectors: [contestedSector] });
+
+        faction.initializeFleetPower(manager);
+        expect(faction.fleetPower).toBeGreaterThan(0);
+
+        contestedSector.clearControl('ally');
+
+        faction.update(1000, manager);
+
+        expect(faction.fleetCapacity).toBe(0);
+        expect(faction.fleetPower).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- add fleet capacity and regeneration tracking to galaxy factions with unique UHF scaling
- extend the galaxy manager and sector models to expose sector values, fleet persistence, and terraformed world counts
- cover the new behaviour with dedicated galaxy faction fleet power tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68daa48ab19c83278b539b5dde44f3ac