### PR TITLE
Add original controller tracking to galaxy sectors

### DIFF
--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -172,6 +172,15 @@ class GalaxyManager extends EffectableEntity {
                     return;
                 }
                 sector.replaceControl(sectorData.control);
+                if (Object.prototype.hasOwnProperty.call(sectorData, 'originalController')) {
+                    const stored = sectorData.originalController;
+                    if (stored === null || stored === undefined) {
+                        sector.originalController = null;
+                    } else {
+                        const value = `${stored}`;
+                        sector.originalController = value ? value : null;
+                    }
+                }
             });
         }
         this.refreshUIVisibility();

--- a/src/js/galaxy/sector.js
+++ b/src/js/galaxy/sector.js
@@ -1,9 +1,14 @@
 class GalaxySector {
-    constructor({ q, r, control } = {}) {
+    constructor({ q, r, control, originalController } = {}) {
         this.q = Number.isFinite(q) ? q : 0;
         this.r = Number.isFinite(r) ? r : 0;
         this.key = GalaxySector.createKey(this.q, this.r);
         this.ring = GalaxySector.computeRing(this.q, this.r);
+        this.originalController = null;
+        if (originalController || originalController === 0) {
+            const value = `${originalController}`;
+            this.originalController = value ? value : null;
+        }
         this.control = {};
         if (control) {
             this.replaceControl(control);
@@ -39,6 +44,9 @@ class GalaxySector {
             return;
         }
         this.control[factionId] = value;
+        if (!this.originalController) {
+            this.originalController = `${factionId}`;
+        }
     }
 
     clearControl(factionId) {
@@ -119,7 +127,8 @@ class GalaxySector {
         return {
             q: this.q,
             r: this.r,
-            control: { ...this.control }
+            control: { ...this.control },
+            originalController: this.originalController
         };
     }
 }

--- a/tests/galaxySectorOriginalController.test.js
+++ b/tests/galaxySectorOriginalController.test.js
@@ -1,0 +1,39 @@
+const { GalaxySector } = require('../src/js/galaxy/sector');
+
+describe('GalaxySector original controller tracking', () => {
+    test('records the first faction that gains control', () => {
+        const sector = new GalaxySector({ q: 1, r: -2 });
+
+        sector.setControl('alpha', 75);
+        expect(sector.originalController).toBe('alpha');
+
+        sector.setControl('beta', 120);
+        expect(sector.originalController).toBe('alpha');
+
+        sector.setControl('alpha', 0);
+        expect(sector.originalController).toBe('alpha');
+    });
+
+    test('persists original controller through serialization', () => {
+        const sector = new GalaxySector({ q: 0, r: 0 });
+        sector.setControl('gamma', 55);
+
+        const saved = sector.toJSON();
+        expect(saved.originalController).toBe('gamma');
+
+        const restored = new GalaxySector(saved);
+        expect(restored.originalController).toBe('gamma');
+        expect(restored.getControlValue('gamma')).toBe(55);
+
+        restored.setControl('delta', 40);
+        expect(restored.originalController).toBe('gamma');
+    });
+
+    test('respects provided original controller when present', () => {
+        const sector = new GalaxySector({ q: -1, r: 2, originalController: 'omega' });
+        expect(sector.originalController).toBe('omega');
+
+        sector.setControl('sigma', 100);
+        expect(sector.originalController).toBe('omega');
+    });
+});


### PR DESCRIPTION
## Summary
- add an `originalController` field to `GalaxySector` that records the first faction controlling a sector and persists through serialization
- restore stored original controllers when loading galaxy state data
- cover the new behavior with unit tests for `GalaxySector`

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68daa660bd64832795b81de6b4f2450a