### PR TITLE
Track original galaxy sector control and faction holdings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,3 +215,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Galaxy sectors now track faction control through dedicated GalaxyFaction and GalaxySector classes, coloring the map by the dominant controller.
 - Galaxy map hexes now display zebra stripes combining the top two factions, scaling stripe width with the runner-up's control share.
 - Galaxy factions now track fleet capacity and power, with the UHF scaling from terraformed worlds and other factions drawing capacity from sector control.
+- Galaxy sectors now store their original controller and factions keep running counts of controlled and original sectors.

--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -17,6 +17,9 @@ class GalaxyFaction {
         }
         this.fleetCapacity = 0;
         this.fleetPower = 0;
+        this.controlledSectorCount = 0;
+        this.originalControlledSectorCount = 0;
+        this.originalSectorCount = 0;
     }
 
     getStartingSectors() {
@@ -138,7 +141,10 @@ class GalaxyFaction {
     toJSON() {
         return {
             id: this.id,
-            fleetPower: this.fleetPower
+            fleetPower: this.fleetPower,
+            controlledSectorCount: this.controlledSectorCount,
+            originalControlledSectorCount: this.originalControlledSectorCount,
+            originalSectorCount: this.originalSectorCount
         };
     }
 

--- a/src/js/galaxy/sector.js
+++ b/src/js/galaxy/sector.js
@@ -1,13 +1,23 @@
 class GalaxySector {
-    constructor({ q, r, control, value } = {}) {
+    constructor({ q, r, control, value, originalController } = {}) {
         this.q = Number.isFinite(q) ? q : 0;
         this.r = Number.isFinite(r) ? r : 0;
         this.key = GalaxySector.createKey(this.q, this.r);
         this.ring = GalaxySector.computeRing(this.q, this.r);
         this.value = this.#sanitizeValue(value);
         this.control = {};
+        this.originalController = typeof originalController === 'string' && originalController
+            ? originalController
+            : null;
+        this.controlChangeHandler = null;
         if (control) {
-            this.replaceControl(control);
+            this.replaceControl(control, { suppressNotification: true });
+        }
+        if (!this.originalController) {
+            const dominant = this.getDominantController();
+            if (dominant) {
+                this.originalController = dominant.factionId;
+            }
         }
     }
 
@@ -20,14 +30,26 @@ class GalaxySector {
         return Math.max(Math.abs(q), Math.abs(r), Math.abs(s));
     }
 
-    replaceControl(controlMap) {
+    replaceControl(controlMap, options = {}) {
+        const before = this.getControlBreakdown();
         this.control = {};
-        if (!controlMap) {
-            return;
+        if (controlMap) {
+            Object.entries(controlMap).forEach(([factionId, value]) => {
+                this.setControl(factionId, value, { suppressNotification: true });
+            });
         }
-        Object.entries(controlMap).forEach(([factionId, value]) => {
-            this.setControl(factionId, value);
-        });
+        const after = this.getControlBreakdown();
+        const changed = before.length !== after.length
+            || before.some((entry, index) => {
+                const next = after[index];
+                if (!next) {
+                    return true;
+                }
+                return entry.factionId !== next.factionId || entry.value !== next.value;
+            });
+        if (changed && !options.suppressNotification) {
+            this.#notifyControlChange();
+        }
     }
 
     setValue(rawValue) {
@@ -38,23 +60,35 @@ class GalaxySector {
         return this.value;
     }
 
-    setControl(factionId, rawValue) {
+    setControl(factionId, rawValue, options = {}) {
         if (!factionId) {
             return;
         }
+        const existing = this.control[factionId];
+        const hadEntry = Object.prototype.hasOwnProperty.call(this.control, factionId);
         const value = Number(rawValue);
         if (!Number.isFinite(value) || value <= 0) {
-            delete this.control[factionId];
+            if (hadEntry) {
+                delete this.control[factionId];
+                if (!options.suppressNotification) {
+                    this.#notifyControlChange();
+                }
+            }
             return;
         }
+        const numericExisting = Number(existing);
+        const unchanged = hadEntry && Number.isFinite(numericExisting) && numericExisting === value;
         this.control[factionId] = value;
+        if (!this.originalController) {
+            this.originalController = factionId;
+        }
+        if (!unchanged && !options.suppressNotification) {
+            this.#notifyControlChange();
+        }
     }
 
     clearControl(factionId) {
-        if (!factionId) {
-            return;
-        }
-        delete this.control[factionId];
+        this.setControl(factionId, 0);
     }
 
     getControlValue(factionId) {
@@ -134,6 +168,32 @@ class GalaxySector {
         }, 0);
     }
 
+    setControlChangeHandler(handler) {
+        if (handler && handler.call) {
+            this.controlChangeHandler = handler;
+            return;
+        }
+        this.controlChangeHandler = null;
+    }
+
+    setOriginalController(factionId, { overwrite = false } = {}) {
+        if (!overwrite && this.originalController) {
+            return;
+        }
+        const candidate = typeof factionId === 'string' ? factionId.trim() : '';
+        if (!candidate) {
+            if (overwrite) {
+                this.originalController = null;
+            }
+            return;
+        }
+        this.originalController = candidate;
+    }
+
+    getOriginalController() {
+        return this.originalController;
+    }
+
     #sanitizeValue(rawValue) {
         const numericValue = Number(rawValue);
         if (!Number.isFinite(numericValue) || numericValue <= 0) {
@@ -142,12 +202,20 @@ class GalaxySector {
         return numericValue;
     }
 
+    #notifyControlChange() {
+        const handler = this.controlChangeHandler;
+        if (handler && handler.call) {
+            handler(this);
+        }
+    }
+
     toJSON() {
         return {
             q: this.q,
             r: this.r,
             control: { ...this.control },
-            value: this.value
+            value: this.value,
+            originalController: this.originalController
         };
     }
 }

--- a/tests/galaxyFactionControlStats.test.js
+++ b/tests/galaxyFactionControlStats.test.js
@@ -1,0 +1,86 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+
+jest.mock('../src/js/galaxy/factions-parameters', () => {
+    const { GalaxySector } = require('../src/js/galaxy/sector');
+    return {
+        galaxyFactionParameters: [
+            {
+                id: 'alpha',
+                name: 'Alpha Concordat',
+                color: '#ffffff',
+                startingSectors: [GalaxySector.createKey(0, 0)]
+            },
+            {
+                id: 'beta',
+                name: 'Beta Accord',
+                color: '#000000',
+                startingSectors: [GalaxySector.createKey(1, 0)]
+            }
+        ],
+        galaxySectorControlOverrides: {}
+    };
+});
+
+const { GalaxyManager } = require('../src/js/galaxy/galaxy');
+const { GalaxySector } = require('../src/js/galaxy/sector');
+
+describe('Galaxy sector original controller tracking', () => {
+    it('retains the first controlling faction as the original controller', () => {
+        const sector = new GalaxySector({ q: 0, r: 0 });
+
+        expect(sector.getOriginalController()).toBeNull();
+
+        sector.setControl('alpha', 80);
+        expect(sector.getOriginalController()).toBe('alpha');
+
+        sector.setControl('beta', 40);
+        expect(sector.getOriginalController()).toBe('alpha');
+
+        sector.clearControl('alpha');
+        expect(sector.getOriginalController()).toBe('alpha');
+
+        const serialized = sector.toJSON();
+        expect(serialized.originalController).toBe('alpha');
+    });
+});
+
+describe('GalaxyManager faction control statistics', () => {
+    let manager;
+
+    beforeEach(() => {
+        manager = new GalaxyManager();
+        manager.initialize();
+    });
+
+    it('updates faction counts when sector control changes', () => {
+        const alphaFaction = manager.getFaction('alpha');
+        const betaFaction = manager.getFaction('beta');
+        const alphaSector = manager.getSector(0, 0);
+        const betaSector = manager.getSector(1, 0);
+
+        expect(alphaSector.getOriginalController()).toBe('alpha');
+        expect(betaSector.getOriginalController()).toBe('beta');
+
+        expect(alphaFaction.originalSectorCount).toBe(1);
+        expect(alphaFaction.originalControlledSectorCount).toBe(1);
+        expect(alphaFaction.controlledSectorCount).toBe(1);
+
+        expect(betaFaction.originalSectorCount).toBe(1);
+        expect(betaFaction.originalControlledSectorCount).toBe(1);
+        expect(betaFaction.controlledSectorCount).toBe(1);
+
+        alphaSector.setControl('beta', 120);
+        alphaSector.clearControl('alpha');
+
+        expect(alphaFaction.controlledSectorCount).toBe(0);
+        expect(alphaFaction.originalControlledSectorCount).toBe(0);
+        expect(alphaFaction.originalSectorCount).toBe(1);
+
+        expect(betaFaction.controlledSectorCount).toBe(2);
+        expect(betaFaction.originalControlledSectorCount).toBe(1);
+        expect(betaFaction.originalSectorCount).toBe(1);
+
+        expect(alphaSector.getOriginalController()).toBe('alpha');
+    });
+});


### PR DESCRIPTION
## Summary
- capture each sector's original controller and centralize control-change notifications
- maintain per-faction controlled/original sector counts with save/load support and UI documentation
- cover the new tracking logic with focused galaxy sector and manager tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68daaa23e794832790d97a2747c39fa8