### PR TITLE
Add prioritized reserve tracking to autobuild

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,7 @@ The planet visualiser has been modularised into files covering core setup, light
 - Random World Generator honours per-archetype orbit lock lists, keeping Venus-like worlds in the hot band while preserving their sulfuric haze and parched atmosphere.
 - High-gravity worlds now apply compounded building and colony cost multipliers, and the Terraforming Others panel shows the current gravity alongside any active gravity penalty.
 - Autobuild now highlights resources that stalled construction with an orange exclamation mark in the resource list.
+- Autobuild now tracks a prioritized reserve that protects resources earmarked for priority construction targets.
 - Added a fullscreen loading overlay that displays while the game or a save file is loading.
 - Milestones subtab remains hidden until Terraforming measurements research is completed.
 - Added a Mass Driver building that is locked by default and costs ten times an oxygen factory.

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -486,7 +486,7 @@ class Building extends EffectableEntity {
   }
 
   // Adjusted canAfford method to use effective cost and an optional strategic reserve
-  canAfford(buildCount = 1, reservePercent = 0) {
+  canAfford(buildCount = 1, reservePercent = 0, additionalReserves = null) {
     const effectiveCost = this.getEffectiveCost(buildCount);
 
     for (const category in effectiveCost) {
@@ -494,7 +494,8 @@ class Building extends EffectableEntity {
         const resObj = resources[category][resource];
         const cap = resObj.cap || 0;
         const reserve = (reservePercent / 100) * cap;
-        if (resObj.value - reserve < effectiveCost[category][resource]) {
+        const prioritizedReserve = additionalReserves?.[category]?.[resource] || 0;
+        if (resObj.value - reserve - prioritizedReserve < effectiveCost[category][resource]) {
           return false;
         }
       }
@@ -540,7 +541,7 @@ class Building extends EffectableEntity {
     }
   }
 
-  maxBuildable(reservePercent = 0) {
+  maxBuildable(reservePercent = 0, additionalReserves = null) {
     let maxByResource = Infinity;
 
     // Check effective cost resources
@@ -550,7 +551,8 @@ class Building extends EffectableEntity {
         const resObj = resources[category][resource];
         const cap = resObj.cap || 0;
         const reserve = (reservePercent / 100) * cap;
-        const available = Math.max(resObj.value - reserve, 0);
+        const prioritizedReserve = additionalReserves?.[category]?.[resource] || 0;
+        const available = Math.max(resObj.value - reserve - prioritizedReserve, 0);
         const costPerUnit = costObj[category][resource];
 
         if (costPerUnit > 0) {


### PR DESCRIPTION
## Summary
- add prioritized reserve tracking so prioritized autobuild targets reserve their remaining costs and release them after construction
- extend building affordability helpers to respect additional reserved resources while leaving prioritized projects unaffected
- document the new prioritized reserve behavior in the project instructions

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dab43175b4832793245b7d55e63b09