### PR TITLE
Add sector lock toggle and per-sector terraformation counts

### DIFF
--- a/src/js/galaxy/galaxyUI.js
+++ b/src/js/galaxy/galaxyUI.js
@@ -739,6 +739,68 @@ function renderSelectedSectorDetails() {
 
     fragment.appendChild(powerContainer);
 
+    const spaceManagerInstance = globalThis.spaceManager;
+    const worldCountContainer = doc.createElement('div');
+    worldCountContainer.className = 'galaxy-sector-panel__stat';
+
+    const worldCountLabel = doc.createElement('span');
+    worldCountLabel.className = 'galaxy-sector-panel__stat-label';
+    worldCountLabel.textContent = 'Terraformations';
+    worldCountContainer.appendChild(worldCountLabel);
+
+    const worldCountValue = doc.createElement('span');
+    worldCountValue.className = 'galaxy-sector-panel__stat-value';
+    const selectionLabel = String(selection.displayName || '').trim();
+    const worldCount = spaceManagerInstance?.getWorldCountPerSector
+        ? spaceManagerInstance.getWorldCountPerSector(selectionLabel)
+        : 0;
+    worldCountValue.textContent = numberFormatter(worldCount, true, 0);
+    worldCountContainer.appendChild(worldCountValue);
+
+    fragment.appendChild(worldCountContainer);
+
+    if (spaceManagerInstance?.setRwgSectorLock) {
+        const lockLabel = doc.createElement('label');
+        lockLabel.className = 'galaxy-sector-panel__lock-option';
+
+        const lockInput = doc.createElement('input');
+        lockInput.type = 'checkbox';
+        lockInput.className = 'galaxy-sector-panel__lock-checkbox';
+        const lockedValue = spaceManagerInstance.getRwgSectorLock?.() || '';
+        const normalizedLocked = String(lockedValue).trim();
+        lockInput.checked = normalizedLocked !== '' && normalizedLocked === selectionLabel;
+
+        lockInput.addEventListener('change', () => {
+            const managerRef = globalThis.spaceManager;
+            const currentSelection = galaxyUICache?.selectedSector?.displayName || '';
+            const label = String(currentSelection).trim();
+            if (!managerRef || !label) {
+                managerRef?.clearRwgSectorLock?.();
+                renderSelectedSectorDetails();
+                return;
+            }
+            if (lockInput.checked) {
+                managerRef.setRwgSectorLock?.(label);
+            } else if (managerRef.getRwgSectorLock?.() === label) {
+                if (managerRef.clearRwgSectorLock) {
+                    managerRef.clearRwgSectorLock();
+                } else {
+                    managerRef.setRwgSectorLock?.(null);
+                }
+            }
+            renderSelectedSectorDetails();
+        });
+
+        const lockText = doc.createElement('span');
+        lockText.className = 'galaxy-sector-panel__lock-label';
+        lockText.textContent = 'Limit RWG to this sector';
+
+        lockLabel.appendChild(lockInput);
+        lockLabel.appendChild(lockText);
+
+        fragment.appendChild(lockLabel);
+    }
+
     if (breakdown.length === 0) {
         const empty = doc.createElement('p');
         empty.className = 'galaxy-sector-panel__empty';

--- a/src/js/rwg.js
+++ b/src/js/rwg.js
@@ -116,6 +116,14 @@ function pickLabelFromRadius(rng, radius) {
 function selectSectorLabel(seed) {
   const numericSeed = Number.isFinite(seed) ? (seed >>> 0) : hashStringToInt(String(seed ?? ''));
   const rng = mulberry32(numericSeed ^ 0x5EC7);
+  const spaceManagerInstance = globalThis?.spaceManager;
+  const lockedSector = spaceManagerInstance?.getRwgSectorLock?.();
+  if (lockedSector) {
+    const text = String(lockedSector).trim();
+    if (text) {
+      return text;
+    }
+  }
   const manager = globalThis?.galaxyManager;
   const sectors = manager?.getSectors?.();
   if (Array.isArray(sectors) && sectors.length > 0) {
@@ -126,7 +134,9 @@ function selectSectorLabel(seed) {
       return display;
     }
   }
-  return pickLabelFromRadius(rng, manager?.radius);
+  return Array.isArray(sectors) && sectors.length > 0
+    ? pickLabelFromRadius(rng, manager?.radius)
+    : DEFAULT_SECTOR_LABEL;
 }
 
 // Deep merge shim

--- a/tests/rwgSectorAssignment.test.js
+++ b/tests/rwgSectorAssignment.test.js
@@ -5,16 +5,18 @@ const { generateRandomPlanet } = require('../src/js/rwg.js');
 describe('Random world generator sector assignment', () => {
   afterEach(() => {
     delete global.galaxyManager;
+    delete global.spaceManager;
   });
 
   afterAll(() => {
     delete global.EffectableEntity;
   });
 
-  test('assigns a deterministic fallback sector when galaxy manager is unavailable', () => {
+  test('assigns the default sector when no managers are available', () => {
     delete global.galaxyManager;
+    delete global.spaceManager;
     const result = generateRandomPlanet(12345);
-    expect(result?.merged?.celestialParameters?.sector).toBe('R4-10');
+    expect(result?.merged?.celestialParameters?.sector).toBe('R5-07');
   });
 
   test('uses galaxy manager sector display names when available', () => {
@@ -25,5 +27,14 @@ describe('Random world generator sector assignment', () => {
     };
     const result = generateRandomPlanet(67890);
     expect(result?.merged?.celestialParameters?.sector).toBe('R2-03');
+  });
+
+  test('honors a locked sector provided by the space manager', () => {
+    global.spaceManager = {
+      getRwgSectorLock: () => 'Core'
+    };
+    delete global.galaxyManager;
+    const result = generateRandomPlanet(98765);
+    expect(result?.merged?.celestialParameters?.sector).toBe('Core');
   });
 });

--- a/tests/spaceManagerWorldCountPerSector.test.js
+++ b/tests/spaceManagerWorldCountPerSector.test.js
@@ -1,0 +1,44 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const SpaceManager = require('../src/js/space.js');
+
+describe('SpaceManager world counts per sector', () => {
+  afterAll(() => {
+    delete global.EffectableEntity;
+  });
+
+  test('defaults to R5-07 and counts orbital rings as extra worlds', () => {
+    const manager = new SpaceManager({
+      mars: { name: 'Mars', celestialParameters: {} }
+    });
+
+    manager.planetStatuses.mars.terraformed = true;
+    manager.planetStatuses.mars.orbitalRing = true;
+
+    expect(manager.getWorldCountPerSector()).toBe(2);
+    expect(manager.getWorldCountPerSector('R5-07')).toBe(2);
+  });
+
+  test('counts random worlds and super-earth bonuses for matching sectors', () => {
+    const manager = new SpaceManager({
+      mars: { name: 'Mars', celestialParameters: {} },
+      titan: { name: 'Titan', celestialParameters: { sector: 'R5-08' } }
+    });
+
+    manager.planetStatuses.titan.terraformed = true;
+
+    manager.randomWorldStatuses.alpha = {
+      terraformed: true,
+      orbitalRing: false,
+      original: {
+        override: {
+          celestialParameters: { sector: 'R5-08' },
+          classification: { archetype: 'super-earth' }
+        }
+      }
+    };
+
+    expect(manager.getWorldCountPerSector('R5-07')).toBe(0);
+    expect(manager.getWorldCountPerSector('R5-08')).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add a default RWG sector lock in `SpaceManager`, persist it across saves, and expose per-sector terraformed world counts
- honour the locked sector during random world generation and surface the data in the Galaxy sector panel with a checkbox toggle
- cover the new logic with focused unit tests for `SpaceManager` and `selectSectorLabel`

## Testing
- CI=true npm test -- spaceManagerWorldCountPerSector rwgSectorAssignment

------
https://chatgpt.com/codex/tasks/task_b_68dae3bdbac08327a590a1b0e4477019