### PR TITLE
Expose SpaceManager globally for galaxy UI

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -118,6 +118,7 @@ function create() {
   createMilestonesUI();
 
   spaceManager = new SpaceManager(planetParameters);
+  globalThis.spaceManager = spaceManager;
   galaxyManager = new GalaxyManager();
   initializeHopeUI();
   initializeSpaceUI(spaceManager);
@@ -331,6 +332,7 @@ function initializeGameState(options = {}) {
     if (!skipStoryInitialization) {
       storyManager.initializeStory();
       spaceManager = new SpaceManager(planetParameters);
+      globalThis.spaceManager = spaceManager;
     }
   }
 


### PR DESCRIPTION
## Summary
- assign the SpaceManager instance to `globalThis` when it is created so galaxy UI elements, including the sector lock checkbox, can access it
- refresh the global reference whenever a new SpaceManager is constructed during game state reinitialization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dae7ea5d348327bb824a1235a9c6d9