### PR TITLE
Align orbital ring tracking with SpaceManager state

### DIFF
--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -80,3 +80,9 @@ let galaxyManager;
 let playTimeSeconds = 0;
 let totalPlayTimeSeconds = 0;
 let gameSpeed = 1;
+
+Object.defineProperty(globalThis, 'galaxyManager', {
+  get: () => galaxyManager,
+  set: (value) => { galaxyManager = value; },
+  configurable: true,
+});

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -870,6 +870,21 @@ class ProjectManager extends EffectableEntity {
       }
     }
 
+    const manager = typeof globalThis !== 'undefined' ? globalThis.spaceManager : (typeof spaceManager !== 'undefined' ? spaceManager : null);
+    const ringProject = this.projects?.orbitalRing;
+    if (ringProject && manager) {
+      const expected = ringProject.ringCount || 0;
+      if (typeof manager.countOrbitalRings === 'function' && typeof manager.assignOrbitalRings === 'function') {
+        const existing = manager.countOrbitalRings();
+        if (existing !== expected) {
+          manager.assignOrbitalRings(expected);
+        }
+      }
+      if (typeof manager.currentWorldHasOrbitalRing === 'function') {
+        ringProject.currentWorldHasRing = manager.currentWorldHasOrbitalRing();
+      }
+    }
+
     if (typeof initializeProjectsUI === 'function') {
       initializeProjectsUI();
     }

--- a/src/js/projects/OrbitalRingProject.js
+++ b/src/js/projects/OrbitalRingProject.js
@@ -31,11 +31,25 @@ class OrbitalRingProject extends TerraformingDurationProject {
   complete() {
     super.complete();
     this.ringCount += 1;
-    if (!this.currentWorldHasRing && spaceManager?.isPlanetTerraformed(spaceManager.getCurrentPlanetKey())) {
-      this.currentWorldHasRing = true;
-      if (typeof spaceManager !== 'undefined' && typeof spaceManager.setCurrentWorldHasOrbitalRing === 'function') {
-        spaceManager.setCurrentWorldHasOrbitalRing(true);
+    const manager = typeof spaceManager !== 'undefined' ? spaceManager : null;
+    const hadRingBefore = manager?.currentWorldHasOrbitalRing?.() || this.currentWorldHasRing;
+    const canPreferCurrent = !hadRingBefore && manager?.isCurrentWorldTerraformed?.();
+
+    if (manager?.assignOrbitalRings) {
+      manager.assignOrbitalRings(this.ringCount, { preferCurrentWorld: !!canPreferCurrent });
+    } else if (!hadRingBefore && manager?.isPlanetTerraformed && manager?.getCurrentPlanetKey) {
+      if (manager.isPlanetTerraformed(manager.getCurrentPlanetKey())) {
+        manager.setCurrentWorldHasOrbitalRing?.(true);
       }
+    }
+
+    const reportedRingState = manager?.currentWorldHasOrbitalRing?.();
+    const hasRingAfter = typeof reportedRingState === 'boolean'
+      ? reportedRingState
+      : (hadRingBefore || !!canPreferCurrent);
+    this.currentWorldHasRing = !!hasRingAfter;
+
+    if (!hadRingBefore && hasRingAfter) {
       const initialLand = terraforming.initialLand || 0;
       if (resources?.surface?.land) {
         resources.surface.land.value += initialLand;

--- a/src/js/rwgUI.js
+++ b/src/js/rwgUI.js
@@ -612,7 +612,7 @@ function renderWorldDetail(res, seedUsed, forcedType) {
   const nightTVal = (showTemps && temps)
     ? `${fmt(Math.round(toDisplayTemp(temps.night)))} ${tempUnit}`
     : '—';
-  const galaxy = galaxyManager || globalThis?.galaxyManager;
+  const galaxy = globalThis?.galaxyManager;
   const galaxyEnabled = Boolean(galaxy?.enabled);
   const sectorChip = (galaxyEnabled && c.sector)
     ? `<div class="rwg-chip"><div class="label">Sector</div><div class="value">${c.sector}</div></div>`

--- a/tests/spaceManagerOrbitalRings.test.js
+++ b/tests/spaceManagerOrbitalRings.test.js
@@ -1,0 +1,153 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+const previousEffectableEntity = global.EffectableEntity;
+global.EffectableEntity = EffectableEntity;
+
+const SpaceManager = require('../src/js/space.js');
+
+function createProjectContext(spaceManager, resources, terraforming) {
+  const ctx = {
+    console,
+    EffectableEntity,
+    resources,
+    terraforming,
+    spaceManager,
+    projectManager: { projects: {} },
+    addJournalEntry: () => {},
+  };
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+
+  const baseDir = path.join(__dirname, '..', 'src/js');
+  const projectsCode = fs.readFileSync(path.join(baseDir, 'projects.js'), 'utf8');
+  vm.runInContext(`${projectsCode}; this.Project = Project; this.ProjectManager = ProjectManager;`, ctx);
+  const tdpCode = fs.readFileSync(path.join(baseDir, 'projects', 'TerraformingDurationProject.js'), 'utf8');
+  vm.runInContext(`${tdpCode}; this.TerraformingDurationProject = TerraformingDurationProject;`, ctx);
+  const orbCode = fs.readFileSync(path.join(baseDir, 'projects', 'OrbitalRingProject.js'), 'utf8');
+  vm.runInContext(`${orbCode}; this.OrbitalRingProject = OrbitalRingProject;`, ctx);
+
+  return ctx;
+}
+
+function createSpaceManager() {
+  const planetsData = {
+    mars: { name: 'Mars' },
+    titan: { name: 'Titan' },
+    venus: { name: 'Venus' },
+  };
+  return new SpaceManager(planetsData);
+}
+
+const projectConfig = {
+  name: 'orbitalRing',
+  category: 'mega',
+  cost: {},
+  duration: 1000,
+  description: '',
+  repeatable: true,
+  unlocked: true,
+  attributes: {},
+};
+
+describe('Orbital ring assignments', () => {
+  afterAll(() => {
+    global.EffectableEntity = previousEffectableEntity;
+  });
+
+  test('assigns ring to current story world and updates land', () => {
+    const spaceManager = createSpaceManager();
+    spaceManager.planetStatuses.mars.terraformed = true;
+    spaceManager.currentPlanetKey = 'mars';
+    const resources = { surface: { land: { value: 0 } }, colony: {} };
+    const terraforming = { initialLand: 50 };
+    const ctx = createProjectContext(spaceManager, resources, terraforming);
+    const project = new ctx.OrbitalRingProject(projectConfig, 'orbitalRing');
+
+    project.complete();
+
+    expect(spaceManager.planetStatuses.mars.orbitalRing).toBe(true);
+    expect(project.ringCount).toBe(1);
+    expect(project.currentWorldHasRing).toBe(true);
+    expect(resources.surface.land.value).toBe(50);
+  });
+
+  test('assigns additional ring to other terraformed story world', () => {
+    const spaceManager = createSpaceManager();
+    spaceManager.planetStatuses.mars.terraformed = true;
+    spaceManager.planetStatuses.venus.terraformed = true;
+    spaceManager.planetStatuses.mars.orbitalRing = true;
+    spaceManager.currentPlanetKey = 'mars';
+    const resources = { surface: { land: { value: 0 } }, colony: {} };
+    const terraforming = { initialLand: 100 };
+    const ctx = createProjectContext(spaceManager, resources, terraforming);
+    const project = new ctx.OrbitalRingProject(projectConfig, 'orbitalRing');
+    project.ringCount = 1;
+    project.currentWorldHasRing = true;
+
+    project.complete();
+
+    expect(spaceManager.planetStatuses.mars.orbitalRing).toBe(true);
+    expect(spaceManager.planetStatuses.venus.orbitalRing).toBe(true);
+    expect(resources.surface.land.value).toBe(0);
+  });
+
+  test('assigns rings to random worlds after story worlds', () => {
+    const spaceManager = createSpaceManager();
+    spaceManager.planetStatuses.mars.terraformed = true;
+    spaceManager.planetStatuses.mars.orbitalRing = true;
+    spaceManager.currentPlanetKey = 'mars';
+    const seed = '12345';
+    spaceManager.randomWorldStatuses[seed] = {
+      name: 'Seed 12345',
+      terraformed: true,
+      colonists: 0,
+      original: null,
+      visited: true,
+      orbitalRing: false,
+      departedAt: null,
+      ecumenopolisPercent: 0,
+    };
+    spaceManager.currentRandomSeed = seed;
+    spaceManager.currentPlanetKey = seed;
+    const resources = { surface: { land: { value: 0 } }, colony: {} };
+    const terraforming = { initialLand: 20 };
+    const ctx = createProjectContext(spaceManager, resources, terraforming);
+    const project = new ctx.OrbitalRingProject(projectConfig, 'orbitalRing');
+    project.ringCount = 1;
+
+    project.complete();
+
+    expect(spaceManager.randomWorldStatuses[seed].orbitalRing).toBe(true);
+    expect(project.ringCount).toBe(2);
+    expect(project.currentWorldHasRing).toBe(true);
+    expect(resources.surface.land.value).toBe(20);
+  });
+
+  test('reconciles assignments when loading project state', () => {
+    const spaceManager = createSpaceManager();
+    spaceManager.planetStatuses.mars.terraformed = true;
+    spaceManager.planetStatuses.venus.terraformed = true;
+    spaceManager.currentPlanetKey = 'mars';
+    const resources = { surface: { land: { value: 0 } }, colony: {} };
+    const terraforming = { initialLand: 75 };
+    const ctx = createProjectContext(spaceManager, resources, terraforming);
+    const projectManager = new ctx.ProjectManager();
+    const orbitalProject = new ctx.OrbitalRingProject(projectConfig, 'orbitalRing');
+    projectManager.projects.orbitalRing = orbitalProject;
+    projectManager.projectOrder = ['orbitalRing'];
+    ctx.projectManager = projectManager;
+
+    const savedState = { projects: { orbitalRing: { ringCount: 2, currentWorldHasRing: false } } };
+
+    projectManager.loadState(savedState);
+
+    expect(spaceManager.countOrbitalRings()).toBe(2);
+    expect(spaceManager.planetStatuses.mars.orbitalRing).toBe(true);
+    expect(spaceManager.planetStatuses.venus.orbitalRing).toBe(true);
+    expect(orbitalProject.currentWorldHasRing).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure SpaceManager tracks orbital ring placements per world and can reassign rings when worlds change
- update OrbitalRingProject and ProjectManager to sync ring counts with world statuses
- expose galaxyManager globally for UI code and add regression tests for orbital ring assignments

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68db011013348327abd98c73c260e944