### PR TITLE
Allow all factions to perform galaxy operations

### DIFF
--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -174,7 +174,11 @@ class GalaxyFaction {
             return 0;
         }
         if (this.id !== UHF_FACTION_ID) {
-            return 0;
+            const baseValue = sector?.getValue?.();
+            if (Number.isFinite(baseValue) && baseValue > 0) {
+                return baseValue;
+            }
+            return DEFAULT_SECTOR_VALUE;
         }
         const worldCount = manager?.getTerraformedWorldCountForSector?.(sector) ?? 0;
         const baseDefense = worldCount > 0 ? 100 * worldCount : 0;

--- a/tests/galaxyFactionDefense.test.js
+++ b/tests/galaxyFactionDefense.test.js
@@ -69,7 +69,7 @@ describe('GalaxyFaction defense calculations', () => {
         expect(neutralDefense).toBe(0);
     });
 
-    it('returns zero defense for non-UHF factions even with control', () => {
+    it('uses sector base value as defense for non-UHF factions', () => {
         const faction = new GalaxyFaction({ id: 'ally', name: 'Ally Fleet' });
         const contested = new GalaxySector({ q: 2, r: -2 });
         contested.setControl('ally', 40);
@@ -82,6 +82,7 @@ describe('GalaxyFaction defense calculations', () => {
 
         faction.markControlDirty();
 
-        expect(faction.getSectorDefense(contested, manager)).toBe(0);
+        const baseValue = contested.getValue();
+        expect(faction.getSectorDefense(contested, manager)).toBe(baseValue);
     });
 });


### PR DESCRIPTION
## Summary
- allow any faction to launch galaxy operations while reserving and refunding fleet power based on the new offense/defense calculation
- compute sector defense from control share and faction defenses, applying the new loss formula on success or failure
- refresh the operations UI and faction defense tests to reflect faction-agnostic success odds and losses

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dbd253d42c8327996c8d5e9176cf84