### PR TITLE
Recalculate galaxy operation outcomes on completion

### DIFF
--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -924,8 +924,13 @@ class GalaxyManager extends EffectableEntity {
         if (operation.status !== 'running') {
             operation.status = 'completed';
         }
+        const sector = this.sectors.get(operation.sectorKey);
+        const attackerId = operation.factionId || galaxyUhfId;
         const offensePower = Math.max(0, Math.min(operation.offensePower ?? operation.reservedPower, operation.reservedPower));
-        const defensePower = Math.max(0, operation.defensePower ?? 0);
+        let defensePower = this.#computeDefensePower(sector, attackerId);
+        if (!Number.isFinite(defensePower) || defensePower < 0) {
+            defensePower = Math.max(0, operation.defensePower ?? 0);
+        }
         const successChance = this.#calculateSuccessChance(offensePower, defensePower);
         const failureChance = Math.max(0, Math.min(1, 1 - successChance));
         let losses;


### PR DESCRIPTION
## Summary
- recompute a sector's defense power when a galaxy operation finishes
- derive the final success chance using the refreshed defense value before calculating losses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbd65d3ea0832782519e33e0b66d60