### PR TITLE
Cache galaxy border sectors for UHF defense distribution

### DIFF
--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -603,6 +603,12 @@ class GalaxyManager extends EffectableEntity {
         faction?.markControlDirty?.();
     }
 
+    #markAllFactionBorderCachesDirty() {
+        this.factions.forEach((faction) => {
+            faction?.markBorderDirty?.();
+        });
+    }
+
     #setSectorControlValue(sector, factionId, value) {
         if (!sector || !factionId) {
             return;
@@ -616,6 +622,7 @@ class GalaxyManager extends EffectableEntity {
         sector.setControl(factionId, numericValue);
         if (previous !== numericValue) {
             this.#markFactionControlDirty(factionId);
+            this.#markAllFactionBorderCachesDirty();
         }
     }
 
@@ -627,6 +634,7 @@ class GalaxyManager extends EffectableEntity {
         sector.clearControl(factionId);
         if (previous > 0) {
             this.#markFactionControlDirty(factionId);
+            this.#markAllFactionBorderCachesDirty();
         }
     }
 


### PR DESCRIPTION
## Summary
- cache galaxy border sector keys per faction and invalidate them when sector control changes
- update UHF defense calculations to allocate fleet power only to cached border sectors
- refresh galaxy defense tests to cover new border behavior and expectations

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68dbd6d8001c8327885dc55c64d7136b