### PR TITLE
Restrict orbital ring assignments to terraformed worlds

### DIFF
--- a/src/js/space.js
+++ b/src/js/space.js
@@ -340,7 +340,10 @@ class SpaceManager extends EffectableEntity {
             if (seen.has(id)) {
                 return;
             }
-            if (!force && !status.terraformed) {
+            if (!status.terraformed) {
+                if (force && status.orbitalRing) {
+                    status.orbitalRing = false;
+                }
                 return;
             }
             ordered.push({ type, key, status });


### PR DESCRIPTION
## Summary
- ensure assignOrbitalRings only considers planets and random worlds that are terraformed
- clear any existing orbital ring flag when forcing a non-terraformed world

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dc02e9402c8327b7aef375b4523cf6