### PR TITLE
Refactor land reconciliation for ring and underground projects

### DIFF
--- a/src/js/projects/UndergroundExpansionProject.js
+++ b/src/js/projects/UndergroundExpansionProject.js
@@ -1,3 +1,30 @@
+var cachedLandReconciler;
+
+function getLandReconciler() {
+  if (typeof cachedLandReconciler === 'function') {
+    return cachedLandReconciler;
+  }
+  const scope = typeof globalThis !== 'undefined'
+    ? globalThis
+    : (typeof global !== 'undefined' ? global : undefined);
+  if (scope && typeof scope.reconcileLandResourceValue === 'function') {
+    cachedLandReconciler = scope.reconcileLandResourceValue;
+    return cachedLandReconciler;
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    try {
+      const resourceModule = require('../resource.js');
+      if (resourceModule && typeof resourceModule.reconcileLandResourceValue === 'function') {
+        cachedLandReconciler = resourceModule.reconcileLandResourceValue;
+        return cachedLandReconciler;
+      }
+    } catch (error) {
+      cachedLandReconciler = null;
+    }
+  }
+  return cachedLandReconciler;
+}
+
 class UndergroundExpansionProject extends AndroidProject {
   getScaledCost() {
     const cost = super.getScaledCost();
@@ -48,9 +75,9 @@ class UndergroundExpansionProject extends AndroidProject {
 
   complete() {
     super.complete();
-    if (typeof terraforming !== 'undefined' && resources?.surface?.land) {
-      const increase = (terraforming.initialLand || 0) / 10000
-      resources.surface.land.value += increase;
+    const reconcile = getLandReconciler();
+    if (typeof reconcile === 'function') {
+      reconcile();
     }
   }
 }

--- a/tests/orbitalRingLandIncrease.test.js
+++ b/tests/orbitalRingLandIncrease.test.js
@@ -15,17 +15,19 @@ describe('Orbital Ring project land effect', () => {
     };
     ctx.terraforming = { initialLand: 100 };
     vm.createContext(ctx);
+    ctx.globalThis = ctx;
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     const tdpCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'TerraformingDurationProject.js'), 'utf8');
     const orbCode = fs.readFileSync(path.join(__dirname, '..', 'src/js/projects', 'OrbitalRingProject.js'), 'utf8');
     const spaceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'space.js'), 'utf8');
+    const resourceCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resource.js'), 'utf8');
     vm.runInContext(projectsCode + '; this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
     vm.runInContext(tdpCode + '; this.TerraformingDurationProject = TerraformingDurationProject;', ctx);
     vm.runInContext(orbCode + '; this.OrbitalRingProject = OrbitalRingProject;', ctx);
     vm.runInContext(spaceCode + '; this.SpaceManager = SpaceManager;', ctx);
+    vm.runInContext(resourceCode + '; this.reconcileLandResourceValue = reconcileLandResourceValue;', ctx);
     ctx.spaceManager = new ctx.SpaceManager({ mars: {} });
     ctx.spaceManager.planetStatuses.mars.terraformed = true;
-    ctx.globalThis = ctx;
     return ctx;
   }
 
@@ -34,6 +36,7 @@ describe('Orbital Ring project land effect', () => {
     const config = { name: 'orbitalRing', category: 'mega', cost: {}, duration: 1, description: '', repeatable: true, unlocked: true, attributes: {} };
     const project = new ctx.OrbitalRingProject(config, 'orbitalRing');
     project.complete();
+    ctx.reconcileLandResourceValue();
     expect(project.ringCount).toBe(1);
     expect(project.currentWorldHasRing).toBe(true);
     expect(ctx.spaceManager.planetStatuses.mars.orbitalRing).toBe(true);

--- a/tests/undergroundExpansionProject.test.js
+++ b/tests/undergroundExpansionProject.test.js
@@ -16,9 +16,12 @@ describe('Underground Land Expansion project', () => {
     ctx.buildings = { oreMine: { count: 1 } };
     ctx.terraforming = { initialLand: 1000 };
     vm.createContext(ctx);
+    ctx.globalThis = ctx;
     vm.runInContext(fs.readFileSync(projectsPath, 'utf8') + '; this.Project = Project;', ctx);
     vm.runInContext(fs.readFileSync(androidPath, 'utf8') + '; this.AndroidProject = AndroidProject;', ctx);
     vm.runInContext(fs.readFileSync(ugPath, 'utf8') + '; this.UndergroundExpansionProject = UndergroundExpansionProject;', ctx);
+    vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resource.js')), ctx);
+    ctx.reconcileLandResourceValue = ctx.reconcileLandResourceValue || ctx.globalThis.reconcileLandResourceValue;
     return ctx;
   }
 
@@ -37,6 +40,8 @@ describe('Underground Land Expansion project', () => {
     vm.runInContext(fs.readFileSync(projectsPath, 'utf8') + '; this.Project = Project;', ctx);
     vm.runInContext(fs.readFileSync(androidPath, 'utf8') + '; this.AndroidProject = AndroidProject;', ctx);
     vm.runInContext(fs.readFileSync(ugPath, 'utf8') + '; this.UndergroundExpansionProject = UndergroundExpansionProject;', ctx);
+    vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'src/js', 'resource.js')), ctx);
+    ctx.reconcileLandResourceValue = ctx.reconcileLandResourceValue || ctx.globalThis.reconcileLandResourceValue;
     return { ctx, container: dom.window.document.getElementById('container') };
   }
 
@@ -53,7 +58,9 @@ describe('Underground Land Expansion project', () => {
     const ctx = createContext();
     const config = { name: 'undergroundExpansion', category: 'infrastructure', cost: {}, duration: 1, description: '', repeatable: true, maxRepeatCount: 1000, unlocked: true, attributes: {} };
     const project = new ctx.UndergroundExpansionProject(config, 'undergroundExpansion');
+    ctx.projectManager = { projects: { undergroundExpansion: project } };
     project.complete();
+    ctx.reconcileLandResourceValue();
     expect(ctx.resources.surface.land.value).toBeCloseTo(1000.1, 5);
     expect(project.repeatCount).toBe(1);
   });


### PR DESCRIPTION
## Summary
- centralize land reconciliation logic in `resource.js` so land derives from ring state and underground expansion progress
- have Orbital Ring and Underground Expansion projects trigger the reconciler via a shared helper that falls back to the resource module when needed
- update orbital ring and underground expansion tests to load the reconciler and expect the new derived land totals

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68dc055fbdb4832782c0cf4ce0cf2788