### PR TITLE
Reset galaxy faction cache state on load

### DIFF
--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -340,11 +340,14 @@ class GalaxyFaction {
     }
 
     loadState(state, manager) {
+        this.resetControlCache();
         this.updateFleetCapacity(manager);
         if (!state || state.id !== this.id) {
+            this.markControlDirty();
             return;
         }
         this.setFleetPower(state.fleetPower);
+        this.markControlDirty();
     }
 
     #rebuildConflictCaches(manager) {


### PR DESCRIPTION
## Summary
- reset cached galaxy faction sector lists whenever a faction state is loaded
- mark cache collections dirty so controlled, border, and neighbor data rebuild after loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc2cbb17cc8327870daba164fe297c