### PR TITLE
Add automatic galaxy faction operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,3 +223,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Manual spaceship assignments can borrow ships from the active auto-assigned project when available, without disabling automation.
 - Celestial parameters now store a galaxy sector identifier, and random worlds roll a sector assignment that appears when the Galaxy Manager is active.
 - Galaxy sector base power values are configurable via `sector-parameters.js`, including a 1000 power core sector override.
+- AI-controlled galaxy factions now automatically launch 100-power operations every minute when they have sufficient fleet power, focusing on contested or neighboring enemy sectors.

--- a/src/js/galaxy/factionAI.js
+++ b/src/js/galaxy/factionAI.js
@@ -1,3 +1,6 @@
+const AUTO_OPERATION_INTERVAL_MS = 60000;
+const AUTO_OPERATION_POWER = 100;
+
 let GalaxyFactionBaseClass = globalScope?.GalaxyFaction;
 let uhfFactionId = globalScope?.UHF_FACTION_ID ?? 'uhf';
 
@@ -9,6 +12,7 @@ class GalaxyFactionAI extends GalaxyFactionBaseClass {
     constructor(options = {}) {
         super(options);
         this.borderFleetAssignments = new Map();
+        this.autoOperationTimer = 0;
     }
 
     update(deltaTime, manager) {
@@ -17,6 +21,7 @@ class GalaxyFactionAI extends GalaxyFactionBaseClass {
             this.borderFleetAssignments.clear();
             return;
         }
+        this.#updateAutoOperations(deltaTime, manager);
         this.#distributeFleetToBorders(manager);
     }
 
@@ -26,6 +31,100 @@ class GalaxyFactionAI extends GalaxyFactionBaseClass {
         }
         const assignment = this.borderFleetAssignments.get(sectorKey);
         return Number.isFinite(assignment) && assignment > 0 ? assignment : 0;
+    }
+
+    #updateAutoOperations(deltaTime, manager) {
+        if (!Number.isFinite(deltaTime) || deltaTime <= 0) {
+            return;
+        }
+        this.autoOperationTimer += deltaTime;
+        if (this.autoOperationTimer < AUTO_OPERATION_INTERVAL_MS) {
+            return;
+        }
+        while (this.autoOperationTimer >= AUTO_OPERATION_INTERVAL_MS) {
+            this.autoOperationTimer -= AUTO_OPERATION_INTERVAL_MS;
+            this.#launchAutoOperation(manager);
+        }
+    }
+
+    #launchAutoOperation(manager) {
+        const launcher = manager?.startOperation;
+        if (typeof launcher !== 'function') {
+            return false;
+        }
+        if (!(this.fleetPower >= AUTO_OPERATION_POWER)) {
+            return false;
+        }
+        const targetKey = this.#pickAutoOperationTarget(manager);
+        if (!targetKey) {
+            return false;
+        }
+        const operation = launcher.call(manager, {
+            sectorKey: targetKey,
+            factionId: this.id,
+            assignedPower: AUTO_OPERATION_POWER
+        });
+        return !!operation;
+    }
+
+    #pickAutoOperationTarget(manager) {
+        const contested = this.getContestedSectorKeys(manager);
+        const neighbors = this.getNeighborEnemySectorKeys(manager);
+        const candidates = new Set();
+        if (Array.isArray(contested)) {
+            contested.forEach((key) => {
+                if (key) {
+                    candidates.add(key);
+                }
+            });
+        }
+        if (Array.isArray(neighbors)) {
+            neighbors.forEach((key) => {
+                if (key) {
+                    candidates.add(key);
+                }
+            });
+        }
+        if (!candidates.size) {
+            return null;
+        }
+        const validTargets = Array.from(candidates).filter((key) => this.#isEnemySectorKey(key, manager));
+        if (!validTargets.length) {
+            return null;
+        }
+        const index = Math.floor(Math.random() * validTargets.length);
+        return validTargets[index] || null;
+    }
+
+    #isEnemySectorKey(key, manager) {
+        const sector = this.#getSectorFromKey(key, manager);
+        if (!sector) {
+            return false;
+        }
+        const breakdown = sector.getControlBreakdown?.();
+        if (!Array.isArray(breakdown) || !breakdown.length) {
+            return false;
+        }
+        if (manager?.getOperationForSector?.(key)?.status === 'running') {
+            return false;
+        }
+        return breakdown.some((entry) => entry?.factionId && entry.factionId !== this.id);
+    }
+
+    #getSectorFromKey(key, manager) {
+        if (!key) {
+            return null;
+        }
+        const parts = key.split(',');
+        if (parts.length !== 2) {
+            return null;
+        }
+        const q = Number(parts[0]);
+        const r = Number(parts[1]);
+        if (!Number.isFinite(q) || !Number.isFinite(r)) {
+            return null;
+        }
+        return manager?.getSector?.(q, r) || null;
     }
 
     #distributeFleetToBorders(manager) {


### PR DESCRIPTION
## Summary
- add timed fleet operations for AI-controlled galaxy factions, launching 100-power strikes every 60 seconds when they have enough fleet strength
- target contested or bordering enemy sectors while skipping locations already under an active operation
- record the new behaviour in the root AGENTS log

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dc30d8c0388327810d2c73642f09f3