### PR TITLE
Adjust galaxy operation odds and apply defender losses

### DIFF
--- a/tests/galaxyOperationDefenderLosses.test.js
+++ b/tests/galaxyOperationDefenderLosses.test.js
@@ -1,0 +1,103 @@
+const EffectableEntity = require('../src/js/effectable-entity');
+
+global.EffectableEntity = EffectableEntity;
+
+const { GalaxyManager } = require('../src/js/galaxy/galaxy');
+const { GalaxyFaction } = require('../src/js/galaxy/faction');
+const { GalaxySector } = require('../src/js/galaxy/sector');
+
+describe('Galaxy operation defender losses', () => {
+    let manager;
+    let sector;
+
+    beforeEach(() => {
+        manager = new GalaxyManager();
+        manager.factions.clear();
+        manager.sectors.clear();
+        manager.operations.clear();
+
+        global.spaceManager = {
+            getTerraformedPlanetCount: () => 0,
+            getWorldCountPerSector: () => 0
+        };
+
+        sector = new GalaxySector({ q: 0, r: 0 });
+        sector.setControl('uhf', 10);
+        sector.setControl('enemy', 90);
+        manager.sectors.set(sector.key, sector);
+
+        const uhf = new GalaxyFaction({ id: 'uhf', name: 'UHF' });
+        uhf.fleetCapacity = 1000;
+        uhf.setFleetPower(500);
+        manager.factions.set('uhf', uhf);
+    });
+
+    afterEach(() => {
+        delete global.spaceManager;
+    });
+
+    test('applies defender fleet losses on success', () => {
+        const enemy = new GalaxyFaction({ id: 'enemy', name: 'Enemy Faction' });
+        enemy.fleetCapacity = 300;
+        enemy.setFleetPower(200);
+        enemy.getSectorDefense = () => 60;
+        enemy.update = () => {};
+        manager.factions.set('enemy', enemy);
+
+        const operation = manager.startOperation({
+            sectorKey: sector.key,
+            factionId: 'uhf',
+            assignedPower: 120,
+            durationMs: 1000
+        });
+        expect(operation).not.toBeNull();
+
+        manager.update(1000);
+
+        expect(operation.result).toBe('success');
+        const defenderLoss = operation.defenderLosses.find((entry) => entry.factionId === 'enemy');
+        expect(defenderLoss).toBeDefined();
+        expect(defenderLoss.loss).toBeCloseTo(60);
+        expect(enemy.fleetPower).toBeCloseTo(140);
+    });
+
+    test('distributes losses across defenders and clamps to available fleet', () => {
+        const enemyA = new GalaxyFaction({ id: 'enemy', name: 'Enemy A' });
+        enemyA.fleetCapacity = 200;
+        enemyA.setFleetPower(50);
+        enemyA.getSectorDefense = () => 30;
+        enemyA.update = () => {};
+
+        const enemyB = new GalaxyFaction({ id: 'enemyB', name: 'Enemy B' });
+        enemyB.fleetCapacity = 150;
+        enemyB.setFleetPower(60);
+        enemyB.getSectorDefense = () => 90;
+        enemyB.update = () => {};
+
+        sector.setControl('enemy', 45);
+        sector.setControl('enemyB', 45);
+
+        manager.factions.set('enemy', enemyA);
+        manager.factions.set('enemyB', enemyB);
+
+        const operation = manager.startOperation({
+            sectorKey: sector.key,
+            factionId: 'uhf',
+            assignedPower: 240,
+            durationMs: 1000
+        });
+        expect(operation).not.toBeNull();
+
+        manager.update(1000);
+
+        expect(operation.result).toBe('success');
+        const lossA = operation.defenderLosses.find((entry) => entry.factionId === 'enemy');
+        const lossB = operation.defenderLosses.find((entry) => entry.factionId === 'enemyB');
+        expect(lossA).toBeDefined();
+        expect(lossA.loss).toBeCloseTo(30);
+        expect(lossB).toBeDefined();
+        expect(lossB.loss).toBeCloseTo(60);
+        expect(enemyA.fleetPower).toBeCloseTo(20);
+        expect(enemyB.fleetPower).toBeCloseTo(0);
+    });
+});

--- a/tests/galaxyOperationLossEstimate.test.js
+++ b/tests/galaxyOperationLossEstimate.test.js
@@ -20,10 +20,9 @@ describe('GalaxyManager operation loss estimate', () => {
         expect(estimate.offensePower).toBeCloseTo(120);
         expect(estimate.reservedPower).toBeCloseTo(120);
         expect(estimate.defensePower).toBeCloseTo(60);
-        expect(estimate.successChance).toBeCloseTo(120 / (120 + 60));
-        expect(estimate.failureChance).toBeCloseTo(1 - (120 / (120 + 60)));
-        const expectedSuccessLoss = Math.min(120, (60 * 60) / (120 + 60));
-        expect(estimate.successLoss).toBeCloseTo(expectedSuccessLoss);
+        expect(estimate.successChance).toBe(1);
+        expect(estimate.failureChance).toBe(0);
+        expect(estimate.successLoss).toBe(0);
         expect(estimate.failureLoss).toBeCloseTo(120);
     });
 
@@ -42,10 +41,33 @@ describe('GalaxyManager operation loss estimate', () => {
         expect(estimate).not.toBeNull();
         expect(estimate.offensePower).toBeCloseTo(80);
         expect(estimate.reservedPower).toBeCloseTo(80);
-        const expectedChance = 80 / (80 + 40);
-        expect(estimate.successChance).toBeCloseTo(expectedChance);
-        const expectedSuccessLoss = Math.min(80, (40 * 40) / (80 + 40));
-        expect(estimate.successLoss).toBeCloseTo(expectedSuccessLoss);
+        expect(estimate.successChance).toBe(1);
+        expect(estimate.successLoss).toBe(0);
         expect(estimate.failureLoss).toBeCloseTo(80);
+    });
+
+    test('returns zero chance when offense is lower than defense and scales linearly', () => {
+        const manager = new GalaxyManager();
+        const sectorKey = '2,0';
+        manager.sectors.set(sectorKey, {});
+        const lowEstimate = manager.getOperationLossEstimate({
+            sectorKey,
+            factionId: 'uhf',
+            assignedPower: 40,
+            reservedPower: 40,
+            defensePower: 60
+        });
+        expect(lowEstimate.successChance).toBe(0);
+        expect(lowEstimate.failureChance).toBe(1);
+
+        const midEstimate = manager.getOperationLossEstimate({
+            sectorKey,
+            factionId: 'uhf',
+            assignedPower: 90,
+            reservedPower: 90,
+            defensePower: 60
+        });
+        expect(midEstimate.successChance).toBeCloseTo((90 - 60) / 60);
+        expect(midEstimate.failureChance).toBeCloseTo(1 - ((90 - 60) / 60));
     });
 });


### PR DESCRIPTION
## Summary
- make galaxy operation success odds zero below the defender power and scale linearly between one and two times the defense
- apply proportional fleet losses to defending factions, persisting the results with operation saves
- update loss estimate expectations and add tests covering the new odds and defender loss handling

## Testing
- CI=true npm test -- galaxyOperation

------
https://chatgpt.com/codex/tasks/task_b_68dd6caccdb883279e8f109de4ee320c