### PR TITLE
Refine galaxy faction auto-operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,4 +223,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Manual spaceship assignments can borrow ships from the active auto-assigned project when available, without disabling automation.
 - Celestial parameters now store a galaxy sector identifier, and random worlds roll a sector assignment that appears when the Galaxy Manager is active.
 - Galaxy sector base power values are configurable via `sector-parameters.js`, including a 1000 power core sector override.
-- AI-controlled galaxy factions now automatically launch 100-power operations every minute when they have sufficient fleet power, focusing on contested or neighboring enemy sectors.
+- AI-controlled galaxy factions now stockpile surplus strength above a defensiveness threshold and launch randomized 5–15% capacity operations every minute once the reserve is met, still prioritizing contested or neighboring enemy sectors.


### PR DESCRIPTION
## Summary
- enforce a defensive fleet reserve before AI factions launch automated galaxy operations
- randomize AI auto-operation power targets between 5% and 15% of current fleet capacity and regenerate after use
- document the revised AI behavior in AGENTS.md

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd71fe7acc8327816f09a22dae7f8f