### PR TITLE
Scale faction AI fleet capacity with electronic adoption

### DIFF
--- a/src/js/galaxy/factionAI.js
+++ b/src/js/galaxy/factionAI.js
@@ -50,6 +50,27 @@ class GalaxyFactionAI extends GalaxyFactionBaseClass {
         this.#distributeFleetToBorders(manager);
     }
 
+    updateFleetCapacity(manager) {
+        super.updateFleetCapacity(manager);
+        const baseCapacity = Number.isFinite(this.fleetCapacity) ? Math.max(0, this.fleetCapacity) : 0;
+        if (!(baseCapacity > 0)) {
+            this.fleetCapacity = 0;
+            return;
+        }
+        const adoption = this.#coerceAdoption(this.electronicAdoption);
+        const sanitizedAdoption = adoption !== null ? adoption : 0;
+        const multiplier = 1 + sanitizedAdoption * 10;
+        if (!(multiplier > 0)) {
+            this.fleetCapacity = baseCapacity;
+            return;
+        }
+        const adjustedCapacity = baseCapacity * multiplier;
+        this.fleetCapacity = adjustedCapacity;
+        if (this.fleetPower > adjustedCapacity) {
+            this.fleetPower = adjustedCapacity;
+        }
+    }
+
     getBorderFleetAssignment(sectorKey) {
         if (!sectorKey) {
             return 0;


### PR DESCRIPTION
## Summary
- multiply faction AI fleet capacity by a factor derived from electronic adoption
- sanitize the electronic adoption value before applying the fleet capacity multiplier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd8257c0948327b4a311378ace192c