### PR TITLE
Fix galaxy tests after constant refactor

### DIFF
--- a/tests/galaxyFactionDefense.test.js
+++ b/tests/galaxyFactionDefense.test.js
@@ -1,3 +1,7 @@
+const { loadGalaxyConstants } = require('./helpers/loadGalaxyConstants');
+
+loadGalaxyConstants();
+
 const { GalaxyFaction } = require('../src/js/galaxy/faction');
 const { GalaxySector } = require('../src/js/galaxy/sector');
 

--- a/tests/galaxyFactionFleetPower.test.js
+++ b/tests/galaxyFactionFleetPower.test.js
@@ -1,3 +1,7 @@
+const { loadGalaxyConstants } = require('./helpers/loadGalaxyConstants');
+
+loadGalaxyConstants();
+
 const { GalaxyFaction } = require('../src/js/galaxy/faction');
 const { GalaxySector } = require('../src/js/galaxy/sector');
 
@@ -40,12 +44,12 @@ describe('GalaxyFaction fleet power and capacity', () => {
 
         faction.initializeFleetPower(manager);
 
-        expect(faction.fleetCapacity).toBe(400);
+        expect(faction.fleetCapacity).toBe(4000);
         expect(faction.fleetPower).toBe(0);
 
         faction.update(600000, manager);
 
-        expect(faction.fleetPower).toBeCloseTo(400 * (600 / 3600));
+        expect(faction.fleetPower).toBeCloseTo(4000 * (600 / 3600));
     });
 
     it('applies an asymptotic penalty above half capacity', () => {
@@ -53,11 +57,11 @@ describe('GalaxyFaction fleet power and capacity', () => {
         const manager = createManager({ terraformedWorlds: 5 });
 
         faction.initializeFleetPower(manager);
-        faction.setFleetPower(375);
+        faction.setFleetPower(3750);
 
         faction.update(3600000, manager);
 
-        expect(faction.fleetPower).toBeCloseTo(437.5);
+        expect(faction.fleetPower).toBeCloseTo(4375);
     });
 
     it('clamps fleet power when capacity drops', () => {

--- a/tests/galaxyHexDefenseDisplay.test.js
+++ b/tests/galaxyHexDefenseDisplay.test.js
@@ -1,4 +1,5 @@
 const { JSDOM } = require('jsdom');
+const { loadGalaxyConstants } = require('./helpers/loadGalaxyConstants');
 
 const UHF_ICON = '\u{1F6E1}\u{FE0F}';
 const ALIEN_ICON = '\u2620\uFE0F';
@@ -16,6 +17,8 @@ describe('Galaxy map defense display', () => {
 
     beforeEach(() => {
         jest.resetModules();
+
+        loadGalaxyConstants();
 
         dom = new JSDOM('<!DOCTYPE html><div id="space-galaxy"></div>', { runScripts: 'outside-only' });
         global.window = dom.window;

--- a/tests/galaxyOperationDefenderLosses.test.js
+++ b/tests/galaxyOperationDefenderLosses.test.js
@@ -1,4 +1,7 @@
+const { loadGalaxyConstants } = require('./helpers/loadGalaxyConstants');
 const EffectableEntity = require('../src/js/effectable-entity');
+
+loadGalaxyConstants();
 
 global.EffectableEntity = EffectableEntity;
 

--- a/tests/galaxyOperationLossEstimate.test.js
+++ b/tests/galaxyOperationLossEstimate.test.js
@@ -1,4 +1,7 @@
+const { loadGalaxyConstants } = require('./helpers/loadGalaxyConstants');
 const EffectableEntity = require('../src/js/effectable-entity');
+
+loadGalaxyConstants();
 
 global.EffectableEntity = EffectableEntity;
 

--- a/tests/helpers/loadGalaxyConstants.js
+++ b/tests/helpers/loadGalaxyConstants.js
@@ -1,0 +1,29 @@
+const LOADED_FLAG = '__galaxyConstantsLoaded__';
+
+function loadGalaxyConstants() {
+    if (global[LOADED_FLAG]) {
+        return;
+    }
+
+    global.GALAXY_RADIUS = 6;
+    global.GALAXY_OPERATION_DURATION_MS = 600000;
+    global.FULL_CONTROL_EPSILON = 1e-6;
+    global.FLEET_UPGRADE_INCREMENT = 0.1;
+    global.UHF_FACTION_ID = 'uhf';
+    global.factionDefaultSectorValue = 100;
+    global.REPLACEMENT_SECONDS = 3600;
+    global.BORDER_CONTROL_EPSILON = 1e-6;
+    global.BORDER_HEX_NEIGHBOR_DIRECTIONS = [
+        { q: 1, r: 0 },
+        { q: 1, r: -1 },
+        { q: 0, r: -1 },
+        { q: -1, r: 0 },
+        { q: -1, r: 1 },
+        { q: 0, r: 1 }
+    ];
+    global.HEX_NEIGHBOR_DIRECTIONS = global.BORDER_HEX_NEIGHBOR_DIRECTIONS;
+
+    global[LOADED_FLAG] = true;
+}
+
+module.exports = { loadGalaxyConstants };


### PR DESCRIPTION
## Summary
- load the galaxy constants in unit tests through a shared helper so globals are defined during CommonJS execution
- update galaxy-related test expectations for the new sector default values

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd852687cc8327a1ea98a5a76a4cda