### PR TITLE
Ensure R5-07 sector override uses label key

### DIFF
--- a/src/js/galaxy/sector-parameters.js
+++ b/src/js/galaxy/sector-parameters.js
@@ -45,6 +45,10 @@ const R507_RADIUS_TWO_COORDINATES = [
     { q: 4, r: -3 }
 ];
 const R507_RADIUS_TWO_BASE_VALUE = 500;
+const R507_SECTOR_COORDINATES = [
+    { q: 4, r: -5 }
+];
+const R507_SECTOR_BASE_VALUE = 100;
 
 const overrides = {};
 
@@ -58,6 +62,8 @@ registerOverrides(CORE_COORDINATES, CORE_BASE_VALUE);
 registerOverrides(FIRST_RING_COORDINATES, FIRST_RING_BASE_VALUE);
 registerOverrides(R507_RADIUS_ONE_COORDINATES, R507_RADIUS_ONE_BASE_VALUE);
 registerOverrides(R507_RADIUS_TWO_COORDINATES, R507_RADIUS_TWO_BASE_VALUE);
+registerOverrides(R507_SECTOR_COORDINATES, R507_SECTOR_BASE_VALUE);
+overrides['R5-07'] = { value: R507_SECTOR_BASE_VALUE };
 
 const galaxySectorParameters = {
     defaultValue: DEFAULT_SECTOR_VALUE,


### PR DESCRIPTION
## Summary
- register the R5-07 override using the sector label key so the 100 power value is applied consistently

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dd87e6030883279cff6f265723346f