### PR TITLE
Weight border fleet assignments by threat

### DIFF
--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -359,9 +359,16 @@ class GalaxyFaction {
         const borderKeys = this.getBorderSectorKeys(manager);
         const borderCount = borderKeys.length;
         const hasBorderPresence = borderCount > 0 && this.borderSectorLookup?.has?.(sector.key);
-        const distributedFleet = hasBorderPresence && borderCount > 0
-            ? (Number.isFinite(this.fleetPower) ? Math.max(0, this.fleetPower) / borderCount : 0)
-            : 0;
+        let distributedFleet = 0;
+        if (hasBorderPresence && borderCount > 0) {
+            const assigned = this.getBorderFleetAssignment?.(sector.key);
+            if (Number.isFinite(assigned) && assigned > 0) {
+                distributedFleet = assigned;
+            } else {
+                const availablePower = Number.isFinite(this.fleetPower) ? Math.max(0, this.fleetPower) : 0;
+                distributedFleet = availablePower / borderCount;
+            }
+        }
         const totalDefense = upgradedDefense + distributedFleet;
         return Number.isFinite(totalDefense) && totalDefense > 0 ? totalDefense : 0;
     }


### PR DESCRIPTION
## Summary
- distribute AI border fleet strength using threat-weighted shares instead of even splits
- fall back to equal distribution when all threats are zero and surface assignments through getSectorDefense

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dd9174453c83278ecc05ed90dbed6d