### PR TITLE
Evenly distribute UHF fleet defense

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,3 +224,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - Celestial parameters now store a galaxy sector identifier, and random worlds roll a sector assignment that appears when the Galaxy Manager is active.
 - Galaxy sector base power values are configurable via `sector-parameters.js`, including a 1000 power core sector override.
 - AI-controlled galaxy factions now stockpile surplus strength above a defensiveness threshold and launch randomized 5–15% capacity operations every minute once the reserve is met, still prioritizing contested or neighboring enemy sectors.
+- UHF fleet defense now divides available border strength evenly instead of weighting distribution by threat levels.

--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -361,12 +361,10 @@ class GalaxyFaction {
         const hasBorderPresence = borderCount > 0 && this.borderSectorLookup?.has?.(sector.key);
         let distributedFleet = 0;
         if (hasBorderPresence && borderCount > 0) {
-            const assigned = this.getBorderFleetAssignment?.(sector.key);
-            if (Number.isFinite(assigned) && assigned > 0) {
-                distributedFleet = assigned;
-            } else {
-                const availablePower = Number.isFinite(this.fleetPower) ? Math.max(0, this.fleetPower) : 0;
-                distributedFleet = availablePower / borderCount;
+            const availablePower = Number.isFinite(this.fleetPower) ? Math.max(0, this.fleetPower) : 0;
+            if (availablePower > 0) {
+                const evenShare = availablePower / borderCount;
+                distributedFleet = Number.isFinite(evenShare) && evenShare > 0 ? evenShare : 0;
             }
         }
         const totalDefense = upgradedDefense + distributedFleet;


### PR DESCRIPTION
## Summary
- ensure UHF fleet defense shares available border strength evenly instead of threat weighting.
- document the UHF defense distribution change in the project instructions.

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dd928d7ab08327bd1a2bd12b7815ce