### PR TITLE
Adjust galaxy AI targeting for weakened factions

### DIFF
--- a/src/js/galaxy/factionAI.js
+++ b/src/js/galaxy/factionAI.js
@@ -365,7 +365,27 @@ class GalaxyFactionAI extends GalaxyFactionBaseClass {
         if (!Array.isArray(controlledKeys)) {
             return 0;
         }
-        return controlledKeys.length;
+        const controlledCount = controlledKeys.length;
+        if (!(controlledCount > 0)) {
+            return 0;
+        }
+        const originalCount = this.#resolveInitialControlledCount(faction);
+        if (originalCount > 0 && controlledCount <= originalCount * 0.5) {
+            return 0;
+        }
+        return controlledCount;
+    }
+
+    #resolveInitialControlledCount(faction) {
+        const originalCount = this.#coerceOriginalCount(faction?.originalControlledSectorCount);
+        if (originalCount !== null && originalCount > 0) {
+            return originalCount;
+        }
+        const startingSectors = faction?.getStartingSectors?.();
+        if (Array.isArray(startingSectors) && startingSectors.length > 0) {
+            return startingSectors.length;
+        }
+        return 0;
     }
 
     #distributeFleetToBorders(manager) {


### PR DESCRIPTION
## Summary
- prevent galaxy faction AI from selecting targets that control half or less of their initial sectors
- fall back to starting sector counts when original control history is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ddc969db208327b73e17ebd3b7b590