### PR TITLE
Increase visibility of space attack warning

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -306,7 +306,10 @@ body.journal-collapsed .tab-content {
 }
 
 .space-tab-warning.is-visible {
-    display: inline;
+    display: inline-flex;
+    align-items: center;
+    font-size: 2em;
+    line-height: 1;
 }
 
 .journal.collapsed {


### PR DESCRIPTION
## Summary
- enlarge the space tab attack warning indicator to improve visibility during attacks

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68ddc946c3908327b054aa23ade9f22d