### PR TITLE
Allow UHF to remain attackable below sector threshold

### DIFF
--- a/src/js/galaxy/factionAI.js
+++ b/src/js/galaxy/factionAI.js
@@ -370,7 +370,8 @@ class GalaxyFactionAI extends GalaxyFactionBaseClass {
             return 0;
         }
         const originalCount = this.#resolveInitialControlledCount(faction);
-        if (originalCount > 0 && controlledCount <= originalCount * 0.5) {
+        const threatFactionId = faction?.id || factionId;
+        if (threatFactionId !== uhfFactionId && originalCount > 0 && controlledCount <= originalCount * 0.5) {
             return 0;
         }
         return controlledCount;


### PR DESCRIPTION
## Summary
- adjust galaxy faction threat evaluation so the UHF remains a valid target even when below half of its original sectors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ddcae8efc88327a631ea2673dac143