### PR TITLE
Increase strategic sector base power

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,5 +223,6 @@ The planet visualiser has been modularised into files covering core setup, light
 - Manual spaceship assignments can borrow ships from the active auto-assigned project when available, without disabling automation.
 - Celestial parameters now store a galaxy sector identifier, and random worlds roll a sector assignment that appears when the Galaxy Manager is active.
 - Galaxy sector base power values are configurable via `sector-parameters.js`, including a 1000 power core sector override.
+- Boosted base power to 10000 for sectors R5-29, R5-19, R4-13, R4-09, and R6-05, and set their adjacent sectors to 2000 to reinforce nearby defenses.
 - AI-controlled galaxy factions now stockpile surplus strength above a defensiveness threshold and launch randomized 5–15% capacity operations every minute once the reserve is met, still prioritizing contested or neighboring enemy sectors.
 - UHF fleet defense now divides available border strength evenly instead of weighting distribution by threat levels.

--- a/src/js/galaxy/sector-parameters.js
+++ b/src/js/galaxy/sector-parameters.js
@@ -50,6 +50,48 @@ const R507_SECTOR_COORDINATES = [
 ];
 const R507_SECTOR_BASE_VALUE = 100;
 
+const STRATEGIC_SECTOR_COORDINATES = [
+    { q: 3, r: 2 },
+    { q: -5, r: 3 },
+    { q: -4, r: 0 },
+    { q: 0, r: -4 },
+    { q: 6, r: -4 }
+];
+const STRATEGIC_SECTOR_BASE_VALUE = 10000;
+const STRATEGIC_NEIGHBOR_COORDINATES = [
+    { q: 3, r: 1 },
+    { q: 2, r: 2 },
+    { q: 2, r: 3 },
+    { q: 3, r: 3 },
+    { q: 4, r: 2 },
+    { q: 4, r: 1 },
+    { q: -5, r: 2 },
+    { q: -6, r: 3 },
+    { q: -6, r: 4 },
+    { q: -5, r: 4 },
+    { q: -4, r: 3 },
+    { q: -4, r: 2 },
+    { q: -4, r: -1 },
+    { q: -5, r: 0 },
+    { q: -5, r: 1 },
+    { q: -4, r: 1 },
+    { q: -3, r: 0 },
+    { q: -3, r: -1 },
+    { q: 0, r: -5 },
+    { q: -1, r: -4 },
+    { q: -1, r: -3 },
+    { q: 0, r: -3 },
+    { q: 1, r: -4 },
+    { q: 1, r: -5 },
+    { q: 6, r: -5 },
+    { q: 5, r: -4 },
+    { q: 5, r: -3 },
+    { q: 6, r: -3 },
+    { q: 7, r: -4 },
+    { q: 7, r: -5 }
+];
+const STRATEGIC_NEIGHBOR_BASE_VALUE = 2000;
+
 const overrides = {};
 
 function registerOverrides(coordinates, value) {
@@ -63,6 +105,8 @@ registerOverrides(FIRST_RING_COORDINATES, FIRST_RING_BASE_VALUE);
 registerOverrides(R507_RADIUS_ONE_COORDINATES, R507_RADIUS_ONE_BASE_VALUE);
 registerOverrides(R507_RADIUS_TWO_COORDINATES, R507_RADIUS_TWO_BASE_VALUE);
 registerOverrides(R507_SECTOR_COORDINATES, R507_SECTOR_BASE_VALUE);
+registerOverrides(STRATEGIC_SECTOR_COORDINATES, STRATEGIC_SECTOR_BASE_VALUE);
+registerOverrides(STRATEGIC_NEIGHBOR_COORDINATES, STRATEGIC_NEIGHBOR_BASE_VALUE);
 overrides['R5-07'] = { value: R507_SECTOR_BASE_VALUE };
 
 const galaxySectorParameters = {


### PR DESCRIPTION
## Summary
- raise the base power of galaxy sectors R5-29, R5-19, R4-13, R4-09, and R6-05 to 10000
- assign a 2000 base power override to each immediate neighbour of those sectors
- document the new power overrides in AGENTS.md

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ddcb5bb72c83278e037fd40ac5a442