### PR TITLE
Fix manual galaxy defense assignment display

### DIFF
--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -362,12 +362,22 @@ class GalaxyFaction {
         return capacity;
     }
 
-    getDefenseAssignment(sectorKey) {
+    getManualDefenseAssignment(sectorKey) {
         if (!sectorKey || this.id !== UHF_FACTION_ID) {
             return 0;
         }
         const manual = this.defenseAssignments.get(sectorKey);
-        const manualValue = Number.isFinite(manual) && manual > 0 ? manual : 0;
+        if (!Number.isFinite(manual) || manual <= 0) {
+            return 0;
+        }
+        return manual;
+    }
+
+    getDefenseAssignment(sectorKey) {
+        if (!sectorKey || this.id !== UHF_FACTION_ID) {
+            return 0;
+        }
+        const manualValue = this.getManualDefenseAssignment(sectorKey);
         const auto = this.autoDefenseAssignments?.get?.(sectorKey);
         const autoValue = Number.isFinite(auto) && auto > 0 ? auto : 0;
         const total = manualValue + autoValue;

--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -429,6 +429,14 @@ class GalaxyManager extends EffectableEntity {
         return this.#computeDefensePower(sector, attackerId);
     }
 
+    getManualDefenseAssignment(sectorKey, factionId = galaxyUhfId) {
+        const faction = this.getFaction(factionId);
+        if (!faction || typeof faction.getManualDefenseAssignment !== 'function') {
+            return 0;
+        }
+        return faction.getManualDefenseAssignment(sectorKey);
+    }
+
     getDefenseAssignment(sectorKey, factionId = galaxyUhfId) {
         const faction = this.getFaction(factionId);
         if (!faction || typeof faction.getDefenseAssignment !== 'function') {

--- a/src/js/galaxy/galaxyUI.js
+++ b/src/js/galaxy/galaxyUI.js
@@ -1468,11 +1468,11 @@ function updateSectorDefenseSection() {
         cache.defenseReservationValue.textContent = `Ops Pool: ${formatDefenseInteger(operational)}`;
     }
 
-    const assigned = manager.getDefenseAssignment
-        ? manager.getDefenseAssignment(sector.key, UHF_FACTION_KEY)
+    const manualAssigned = manager.getManualDefenseAssignment
+        ? manager.getManualDefenseAssignment(sector.key, UHF_FACTION_KEY)
         : 0;
     const scale = faction?.getDefenseScale ? faction.getDefenseScale(manager) : 0;
-    const effective = assigned > 0 && scale > 0 ? assigned * scale : 0;
+    const effective = manualAssigned > 0 && scale > 0 ? manualAssigned * scale : 0;
     const totalAssigned = manager.getDefenseAssignmentTotal
         ? manager.getDefenseAssignmentTotal(UHF_FACTION_KEY)
         : 0;
@@ -1481,7 +1481,7 @@ function updateSectorDefenseSection() {
     updateDefenseStepDisplay(step);
 
     if (cache.defenseAssignedValue) {
-        cache.defenseAssignedValue.textContent = `Assigned: ${formatDefenseInteger(assigned)}`;
+        cache.defenseAssignedValue.textContent = `Assigned: ${formatDefenseInteger(manualAssigned)}`;
     }
     if (cache.defenseEffectiveValue) {
         cache.defenseEffectiveValue.textContent = `Effective: ${formatDefenseInteger(effective)}`;
@@ -1491,7 +1491,7 @@ function updateSectorDefenseSection() {
     }
 
     if (cache.defenseInput) {
-        cache.defenseInput.value = `${Math.max(0, Math.round(assigned))}`;
+        cache.defenseInput.value = `${Math.max(0, Math.round(manualAssigned))}`;
         cache.defenseInput.disabled = false;
     }
     if (cache.defenseButtons) {
@@ -1540,8 +1540,8 @@ function handleDefenseButtonClick(event) {
         return;
     }
     const key = selection.key;
-    const current = manager.getDefenseAssignment
-        ? manager.getDefenseAssignment(key, UHF_FACTION_KEY)
+    const current = manager.getManualDefenseAssignment
+        ? manager.getManualDefenseAssignment(key, UHF_FACTION_KEY)
         : 0;
     let target = current;
     let step = getDefenseStepForSector(key);
@@ -1699,8 +1699,8 @@ function updateHexDefenseDisplay(hex, sector, manager, uhfFaction) {
         return false;
     })();
 
-    const hasManualDefense = manager.getDefenseAssignment
-        ? manager.getDefenseAssignment(sector.key, UHF_FACTION_KEY) > 0
+    const hasManualDefense = manager.getManualDefenseAssignment
+        ? manager.getManualDefenseAssignment(sector.key, UHF_FACTION_KEY) > 0
         : false;
 
     const shouldShowUhf = isUhfControlled && (contestedWithUhf || hasEnemyNeighbor || hasManualDefense);


### PR DESCRIPTION
## Summary
- add a getter for manual defense assignments so automation is tracked separately
- expose the manual assignment getter through the galaxy manager
- update the galaxy defense UI to display and manipulate only the manual assignment values

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68ddcec731f48327a6ed9a05df1857f6