### PR TITLE
Align ops pool with auto defense assignments

### DIFF
--- a/tests/galaxyFactionDefense.test.js
+++ b/tests/galaxyFactionDefense.test.js
@@ -85,8 +85,10 @@ describe('GalaxyFaction defense calculations', () => {
 
         const baseDefense = 100 * 3 * 1.5;
         expect(alphaDefense).toBeCloseTo(baseDefense + 300);
-        const reservation = Math.min(300, capacity, faction.fleetPower);
-        expect(faction.getOperationalFleetPower(manager)).toBeCloseTo(Math.max(0, faction.fleetPower - reservation));
+        const operationsPool = faction.getOperationalFleetPower(manager);
+        const autoAssignment = faction.autoDefenseAssignments.get(sectorAlpha.key) || 0;
+        expect(operationsPool).toBeCloseTo(autoAssignment);
+        expect(operationsPool).toBeCloseTo(faction.autoDefenseTotal);
     });
 
     it('uses sector base value as defense for non-UHF factions', () => {


### PR DESCRIPTION
## Summary
- synchronize defense reservations with the latest assignments and cap them by available fleet power
- base the UHF operations pool on auto defense allocations and clamp auto assignments to the available fleet
- update the galaxy faction defense test to expect the operations pool to match auto assignments

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68ddd03ef5d48327981f6f7cc8743314