### PR TITLE
Fix galaxy defense calculations and add summary

### DIFF
--- a/tests/galaxyHexDefenseDisplay.test.js
+++ b/tests/galaxyHexDefenseDisplay.test.js
@@ -145,7 +145,8 @@ describe('Galaxy map defense display', () => {
         const contestedValue = contestedEntry.querySelector('.galaxy-hex__defense-text').textContent;
         expect(contestedIcon).toBe(ALIEN_ICON);
         const formatDefense = (value) => new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(Math.round(value));
-        const expectedContestedValue = formatDefense(coreSector.getValue() + coreAssignment);
+        const sectorDefenseValue = alienFaction.getSectorDefense(coreSector, manager);
+        const expectedContestedValue = formatDefense(sectorDefenseValue + coreAssignment);
         expect(contestedValue).toBe(expectedContestedValue);
 
         const labelNode = coreHex.querySelector('.galaxy-hex__label');
@@ -186,5 +187,10 @@ describe('Galaxy map defense display', () => {
         expect(values[0].textContent).toBe(expectedSectorDefense);
         expect(values[1].textContent).toBe(expectedFleetDefense);
         expect(values[2].textContent).toBe(expectedTotalDefense);
+
+        const summary = manager.getSectorDefenseSummary(coreSector, 'uhf');
+        expect(summary.basePower).toBeCloseTo(sectorDefenseValue, 5);
+        expect(summary.fleetPower).toBeCloseTo(coreAssignment, 5);
+        expect(summary.totalPower).toBeCloseTo(sectorDefenseValue + coreAssignment, 5);
     });
 });


### PR DESCRIPTION
## Summary
- add a reusable sector defense summary that separates base control power from stationed fleets
- use the new summary when resolving operation defense, map badges, and the enemy panel so totals include fleet assignments
- update galaxy defense display tests to expect scaled sector power and verify the new summary helper

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68de8126f24c8327a1025cf91855caf7