### PR TITLE
Add antimatter research unlock

### DIFF
--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -244,6 +244,24 @@ const researchParameters = {
           }
         ]
       },
+      {
+        id: 'antimatter_containment',
+        name: 'Antimatter Containment',
+        description: 'Unlocks antimatter farms and antimatter batteries.',
+        cost: { research: 100000000000 },
+        prerequisites: [],
+        requiredFlags: ['antimatterUnlocked'],
+        effects: [
+          { target: 'building', targetId: 'antimatterFarm', type: 'enable' },
+          { target: 'building', targetId: 'antimatterBattery', type: 'enable' },
+          {
+            target: 'resource',
+            resourceType: 'special',
+            targetId: 'antimatter',
+            type: 'enable'
+          }
+        ]
+      },
     ],
     industry: [
       {


### PR DESCRIPTION
## Summary
- add a late-game Antimatter Containment research gated behind the antimatter flag
- unlock the antimatter farm, antimatter battery, and the antimatter resource when the research completes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68de88066e2c832796e5059b504eb3fc