### PR TITLE
Show galaxy operation durations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,3 +238,4 @@ The planet visualiser has been modularised into files covering core setup, light
 - AI-controlled galaxy factions now stockpile surplus strength above a defensiveness threshold and launch randomized 5–15% capacity operations every minute once the reserve is met, still prioritizing contested or neighboring enemy sectors.
 - UHF fleet defense now divides available border strength evenly instead of weighting distribution by threat levels.
 - Galaxy operations now feature an Auto launch toggle beside the Launch button that automatically deploys eligible missions, and operations last five minutes by default.
+- Galaxy operations panel now displays total mission duration and real-time remaining launch time to clarify commitments.

--- a/src/css/galaxy.css
+++ b/src/css/galaxy.css
@@ -985,6 +985,35 @@
   line-height: 1;
 }
 
+.galaxy-operations-form__duration {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: #bed4ff;
+  font-variant-numeric: tabular-nums;
+}
+
+.galaxy-operations-form__duration-label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+  color: #8fb6f9;
+}
+
+.galaxy-operations-form__duration-value {
+  font-weight: 600;
+  color: #f5f9ff;
+}
+
+.galaxy-operations-form__duration--remaining {
+  color: #d5e5ff;
+}
+
+.galaxy-operations-form__duration--remaining .galaxy-operations-form__duration-label {
+  color: #9fc8ff;
+}
+
 .galaxy-operations-summary {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- surface default and running operation durations in the galaxy operations panel
- extend the UI and styling to show total time and live remaining time while launches run
- document the new galaxy operations duration display in the project notes

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68de8addb65483278bfb1a6aa7447966