### PR TITLE
Add Mega Particle Accelerator research and project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ The atmosphere model now handles methane–oxygen combustion, calcite aerosol de
 The planet visualiser has been modularised into files covering core setup, lighting, surfaces, clouds, ships, environments, and debug controls. This separation keeps rendering responsibilities focused and simplifies future extensions.
 
 ## Updates
+- Added a Mega Particle Accelerator advanced research that unlocks an infinitely repeatable Particle Accelerator megaproject.
 - Random World Generator honours per-archetype orbit lock lists, keeping Venus-like worlds in the hot band while preserving their sulfuric haze and parched atmosphere.
 - High-gravity worlds now apply compounded building and colony cost multipliers, and the Terraforming Others panel shows the current gravity alongside any active gravity penalty.
 - Autobuild now highlights resources that stalled construction with an orange exclamation mark in the resource list.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -464,8 +464,27 @@ const projectParameters = {
       spaceStorage: true,
       costPerShip: { colony: { metal : 100_000, energy: 250_000_000 } },
       transportPerShip: 1_000_000,
-      canUseSpaceStorage: true 
+      canUseSpaceStorage: true
     }
+  },
+  particleAccelerator: {
+    type: 'ParticleAcceleratorProject',
+    name: 'Particle Accelerator',
+    category: 'mega',
+    cost: {
+      colony: {
+        metal: 5_000_000_000,
+        components: 2_000_000_000,
+        electronics: 500_000_000,
+        superconductors: 100_000_000
+      }
+    },
+    duration: 420000,
+    description: 'Channel staggering amounts of power into an enormous accelerator to open new avenues of high energy experimentation.',
+    repeatable: true,
+    maxRepeatCount: Infinity,
+    unlocked: false,
+    attributes: {}
   },
   disposeResources : {
     type: 'SpaceDisposalProject',

--- a/src/js/projects/ParticleAcceleratorProject.js
+++ b/src/js/projects/ParticleAcceleratorProject.js
@@ -1,0 +1,69 @@
+class ParticleAcceleratorProject extends Project {
+  constructor(config, name) {
+    super(config, name);
+    this.acceleratorCount = 0;
+  }
+
+  complete() {
+    super.complete();
+    this.acceleratorCount = this.repeatCount;
+  }
+
+  getCompletedCount() {
+    return this.acceleratorCount;
+  }
+
+  saveState() {
+    return { ...super.saveState(), acceleratorCount: this.acceleratorCount };
+  }
+
+  loadState(state = {}) {
+    if (Object.keys(state).length === 0) {
+      this.acceleratorCount = 0;
+      return;
+    }
+    super.loadState(state);
+    this.acceleratorCount = state.acceleratorCount ?? 0;
+  }
+
+  saveTravelState() {
+    const state = {
+      acceleratorCount: this.acceleratorCount,
+      repeatCount: this.repeatCount,
+    };
+    if (this.isActive) {
+      state.isActive = true;
+      state.remainingTime = this.remainingTime;
+      state.startingDuration = this.startingDuration;
+    }
+    return state;
+  }
+
+  loadTravelState(state = {}) {
+    this.acceleratorCount = state.acceleratorCount ?? 0;
+    this.repeatCount = state.repeatCount ?? this.acceleratorCount;
+    this.isActive = false;
+    if (state.isActive) {
+      this.isActive = true;
+      this.remainingTime = state.remainingTime ?? this.remainingTime;
+      this.startingDuration = state.startingDuration ?? this.getEffectiveDuration();
+    }
+  }
+}
+
+const scope = globalThis;
+if (scope) {
+  scope.ParticleAcceleratorProject = ParticleAcceleratorProject;
+}
+
+const commonJsModule = (() => {
+  try {
+    return module;
+  } catch (error) {
+    return null;
+  }
+})();
+
+if (commonJsModule?.exports) {
+  commonJsModule.exports = ParticleAcceleratorProject;
+}

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1616,6 +1616,20 @@ const researchParameters = {
         ]
       },
       {
+        id: 'mega_particle_accelerator',
+        name: 'Mega Particle Accelerator',
+        description: 'Unlocks a new megastructure that can assist in boosting advanced research gains.',
+        cost: { advancedResearch: 250000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'project',
+            targetId: 'particleAccelerator',
+            type: 'enable'
+          }
+        ]
+      },
+      {
         id: 'mechanical_assistance',
         name: 'Mechanical Assistance',
         description: 'Enables a new colony slider to provide mechanical assistance to partially counter the effects of high gravity.  The slider will only appear on high gravity worlds.',

--- a/tests/megaParticleAcceleratorResearch.test.js
+++ b/tests/megaParticleAcceleratorResearch.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Mega Particle Accelerator research', () => {
+  test('exists in advanced research with correct cost and unlock effect', () => {
+    const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+    const code = fs.readFileSync(researchPath, 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+
+    const advanced = ctx.researchParameters.advanced;
+    const research = advanced.find(item => item.id === 'mega_particle_accelerator');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(250000);
+    expect(research.description).toBe('Unlocks a new megastructure that can assist in boosting advanced research gains.');
+    const effect = research.effects.find(effect => effect.target === 'project' && effect.targetId === 'particleAccelerator' && effect.type === 'enable');
+    expect(effect).toBeDefined();
+  });
+});

--- a/tests/particleAcceleratorProject.test.js
+++ b/tests/particleAcceleratorProject.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+describe('Particle Accelerator project', () => {
+  test('defined in parameters with expected configuration', () => {
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const project = ctx.projectParameters.particleAccelerator;
+    expect(project).toBeDefined();
+    expect(project.type).toBe('ParticleAcceleratorProject');
+    expect(project.category).toBe('mega');
+    expect(project.repeatable).toBe(true);
+    expect(project.maxRepeatCount).toBe(Infinity);
+    expect(project.cost.colony.metal).toBe(5_000_000_000);
+    expect(project.cost.colony.components).toBe(2_000_000_000);
+    expect(project.cost.colony.electronics).toBe(500_000_000);
+    expect(project.cost.colony.superconductors).toBe(100_000_000);
+    expect(project.duration).toBe(420000);
+  });
+
+  test('tracks completion count through save and travel', () => {
+    const ctx = {
+      console,
+      EffectableEntity,
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false,
+      projectElements: {},
+      resources: {},
+    };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ParticleAcceleratorProject.js'), 'utf8');
+    vm.runInContext(projectCode + '; this.ParticleAcceleratorProject = ParticleAcceleratorProject;', ctx);
+
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.particleAccelerator;
+    const project = new ctx.ParticleAcceleratorProject(config, 'particleAccelerator');
+    expect(project.getCompletedCount()).toBe(0);
+
+    project.complete();
+    project.complete();
+    expect(project.getCompletedCount()).toBe(2);
+    expect(project.repeatCount).toBe(2);
+
+    const savedState = project.saveState();
+    expect(savedState.acceleratorCount).toBe(2);
+
+    const restored = new ctx.ParticleAcceleratorProject(config, 'particleAccelerator');
+    restored.loadState(savedState);
+    expect(restored.getCompletedCount()).toBe(2);
+    expect(restored.repeatCount).toBe(2);
+
+    const travelState = project.saveTravelState();
+    expect(travelState.acceleratorCount).toBe(2);
+    expect(travelState.repeatCount).toBe(2);
+
+    const travelled = new ctx.ParticleAcceleratorProject(config, 'particleAccelerator');
+    travelled.loadTravelState(travelState);
+    expect(travelled.getCompletedCount()).toBe(2);
+    expect(travelled.repeatCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Mega Particle Accelerator advanced research entry that enables the Particle Accelerator megaproject
- introduce a dedicated ParticleAcceleratorProject class with repeat tracking and persistence plus project parameters
- cover the new research unlock and project behaviour with focused unit tests

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68deb65f745083279bf9f644b7eea76b