### PR TITLE
Add configurable particle accelerator radius

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,3 +240,6 @@ The planet visualiser has been modularised into files covering core setup, light
 - UHF fleet defense now divides available border strength evenly instead of weighting distribution by threat levels.
 - Galaxy operations now feature an Auto launch toggle beside the Launch button that automatically deploys eligible missions, and operations last five minutes by default.
 - Galaxy operations panel now displays total mission duration and real-time remaining launch time to clarify commitments.
+
+- Particle Accelerator mega project now lets players set a custom radius with controls, scales material costs by circumference,
+  and records the largest completed accelerator.

--- a/src/js/project-parameters.js
+++ b/src/js/project-parameters.js
@@ -482,7 +482,9 @@ const projectParameters = {
     repeatable: true,
     maxRepeatCount: Infinity,
     unlocked: false,
-    attributes: {}
+    attributes: {
+      minimumRadiusEarth: 1
+    }
   },
   disposeResources : {
     type: 'SpaceDisposalProject',

--- a/src/js/projects/ParticleAcceleratorProject.js
+++ b/src/js/projects/ParticleAcceleratorProject.js
@@ -1,12 +1,240 @@
+const EARTH_RADIUS_METERS = 6_371_000;
+const TWO_PI = Math.PI * 2;
+const MATERIAL_COST_PER_METER = 100;
+const HALF_MATERIAL_SPLIT = 0.5;
+
 class ParticleAcceleratorProject extends Project {
   constructor(config, name) {
     super(config, name);
     this.acceleratorCount = 0;
+    this.minimumRadiusEarth = config?.attributes?.minimumRadiusEarth ?? 1;
+    this.selectedRadiusEarth = this.minimumRadiusEarth;
+    this.bestRadiusEarth = 0;
+    this.lastCompletedRadiusEarth = 0;
+    this.uiElements = null;
+  }
+
+  renderUI(container) {
+    const card = document.createElement('div');
+    card.classList.add('info-card');
+
+    const header = document.createElement('div');
+    header.classList.add('card-header');
+    const title = document.createElement('span');
+    title.classList.add('card-title');
+    title.textContent = 'Accelerator Design';
+    header.appendChild(title);
+    card.appendChild(header);
+
+    const body = document.createElement('div');
+    body.classList.add('card-body');
+
+    const statsGrid = document.createElement('div');
+    statsGrid.classList.add('stats-grid', 'two-col');
+
+    const radiusLabel = document.createElement('span');
+    radiusLabel.classList.add('stat-label');
+    radiusLabel.textContent = 'Target Radius:';
+    const radiusValue = document.createElement('span');
+    radiusValue.classList.add('stat-value');
+    statsGrid.append(radiusLabel, radiusValue);
+
+    const circumferenceLabel = document.createElement('span');
+    circumferenceLabel.classList.add('stat-label');
+    circumferenceLabel.textContent = 'Circumference:';
+    const circumferenceValue = document.createElement('span');
+    circumferenceValue.classList.add('stat-value');
+    statsGrid.append(circumferenceLabel, circumferenceValue);
+
+    const bestLabel = document.createElement('span');
+    bestLabel.classList.add('stat-label');
+    bestLabel.textContent = 'Largest Built:';
+    const bestValue = document.createElement('span');
+    bestValue.classList.add('stat-value');
+    statsGrid.append(bestLabel, bestValue);
+
+    const lastLabel = document.createElement('span');
+    lastLabel.classList.add('stat-label');
+    lastLabel.textContent = 'Last Completion:';
+    const lastValue = document.createElement('span');
+    lastValue.classList.add('stat-value');
+    statsGrid.append(lastLabel, lastValue);
+
+    const alloyLabel = document.createElement('span');
+    alloyLabel.classList.add('stat-label');
+    alloyLabel.textContent = 'Superalloy Cost:';
+    const alloyValue = document.createElement('span');
+    alloyValue.classList.add('stat-value');
+    statsGrid.append(alloyLabel, alloyValue);
+
+    const superconLabel = document.createElement('span');
+    superconLabel.classList.add('stat-label');
+    superconLabel.textContent = 'Superconductor Cost:';
+    const superconValue = document.createElement('span');
+    superconValue.classList.add('stat-value');
+    statsGrid.append(superconLabel, superconValue);
+
+    body.appendChild(statsGrid);
+
+    const controls = document.createElement('div');
+    controls.classList.add('thruster-power-controls');
+
+    const buttonRow = document.createElement('div');
+    buttonRow.classList.add('main-buttons');
+
+    const zeroButton = document.createElement('button');
+    zeroButton.textContent = '0';
+    buttonRow.appendChild(zeroButton);
+
+    const minusButton = document.createElement('button');
+    minusButton.textContent = '-1';
+    buttonRow.appendChild(minusButton);
+
+    const plusButton = document.createElement('button');
+    plusButton.textContent = '+1';
+    buttonRow.appendChild(plusButton);
+
+    controls.appendChild(buttonRow);
+
+    const multiplierRow = document.createElement('div');
+    multiplierRow.classList.add('multiplier-container');
+
+    const divButton = document.createElement('button');
+    divButton.textContent = '/10';
+    multiplierRow.appendChild(divButton);
+
+    const mulButton = document.createElement('button');
+    mulButton.textContent = 'x10';
+    multiplierRow.appendChild(mulButton);
+
+    controls.appendChild(multiplierRow);
+
+    body.appendChild(controls);
+
+    const notice = document.createElement('div');
+    notice.classList.add('project-warning');
+    body.appendChild(notice);
+
+    card.appendChild(body);
+    container.appendChild(card);
+
+    zeroButton.addEventListener('click', () => this.setRadiusEarth(this.minimumRadiusEarth));
+    minusButton.addEventListener('click', () => this.adjustRadiusEarth(-1));
+    plusButton.addEventListener('click', () => this.adjustRadiusEarth(1));
+    mulButton.addEventListener('click', () => this.scaleRadiusEarth(10));
+    divButton.addEventListener('click', () => this.scaleRadiusEarth(0.1));
+
+    this.uiElements = {
+      card,
+      radiusValue,
+      circumferenceValue,
+      bestValue,
+      lastValue,
+      alloyValue,
+      superconValue,
+      buttons: [zeroButton, minusButton, plusButton, mulButton, divButton],
+      notice
+    };
+
+    this.updateUI();
+  }
+
+  updateUI() {
+    const elements = this.uiElements;
+    if (!elements) {
+      return;
+    }
+
+    const formatter = this.getFormatter();
+    const radiusDisplay = formatter.format(this.selectedRadiusEarth);
+    const circumference = this.getSelectedCircumferenceMeters();
+    const circumferenceDisplay = formatter.format(circumference);
+    const bestDisplay = this.bestRadiusEarth > 0 ? formatter.format(this.bestRadiusEarth) : '—';
+    const lastDisplay = this.lastCompletedRadiusEarth > 0 ? formatter.format(this.lastCompletedRadiusEarth) : '—';
+    const materialCost = this.getPerMaterialCost();
+    const materialDisplay = formatter.format(materialCost);
+
+    elements.radiusValue.textContent = `${radiusDisplay} Earth radii`;
+    elements.circumferenceValue.textContent = `${circumferenceDisplay} m`;
+    elements.bestValue.textContent = bestDisplay === '—' ? bestDisplay : `${bestDisplay} Earth radii`;
+    elements.lastValue.textContent = lastDisplay === '—' ? lastDisplay : `${lastDisplay} Earth radii`;
+    elements.alloyValue.textContent = `${materialDisplay} t`;
+    elements.superconValue.textContent = `${materialDisplay} t`;
+
+    const disabled = this.isActive;
+    elements.buttons.forEach(button => {
+      button.disabled = disabled;
+    });
+
+    const needsIncrease = this.bestRadiusEarth > 0 && this.selectedRadiusEarth <= this.bestRadiusEarth;
+    elements.notice.textContent = needsIncrease ? 'Increase the radius to beat your previous accelerator.' : '';
+    elements.notice.style.display = needsIncrease ? 'block' : 'none';
+  }
+
+  getFormatter() {
+    if (!this.numberFormatter) {
+      this.numberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+    }
+    return this.numberFormatter;
+  }
+
+  setRadiusEarth(value) {
+    if (this.isActive) {
+      return;
+    }
+    const minimum = this.minimumRadiusEarth;
+    const target = value > minimum ? value : minimum;
+    this.selectedRadiusEarth = target;
+    this.updateUI();
+    globalThis?.updateProjectUI?.(this.name);
+  }
+
+  adjustRadiusEarth(delta) {
+    this.setRadiusEarth(this.selectedRadiusEarth + delta);
+  }
+
+  scaleRadiusEarth(multiplier) {
+    this.setRadiusEarth(this.selectedRadiusEarth * multiplier);
+  }
+
+  getSelectedRadiusMeters() {
+    return this.selectedRadiusEarth * EARTH_RADIUS_METERS;
+  }
+
+  getSelectedCircumferenceMeters() {
+    return this.getSelectedRadiusMeters() * TWO_PI;
+  }
+
+  getPerMaterialCost() {
+    return this.getSelectedCircumferenceMeters() * MATERIAL_COST_PER_METER * HALF_MATERIAL_SPLIT;
+  }
+
+  getScaledCost() {
+    const colony = {};
+    const superalloyMultiplier = this.getEffectiveCostMultiplier('colony', 'superalloy');
+    const superconductorsMultiplier = this.getEffectiveCostMultiplier('colony', 'superconductors');
+    const basePerMaterial = this.getPerMaterialCost();
+    colony.superalloy = basePerMaterial * superalloyMultiplier;
+    colony.superconductors = basePerMaterial * superconductorsMultiplier;
+    return { colony };
+  }
+
+  canStart(resources) {
+    if (!super.canStart(resources)) {
+      return false;
+    }
+    return this.selectedRadiusEarth > this.bestRadiusEarth;
   }
 
   complete() {
     super.complete();
     this.acceleratorCount = this.repeatCount;
+    this.lastCompletedRadiusEarth = this.selectedRadiusEarth;
+    if (this.lastCompletedRadiusEarth > this.bestRadiusEarth) {
+      this.bestRadiusEarth = this.lastCompletedRadiusEarth;
+    }
+    this.updateUI();
+    globalThis?.updateProjectUI?.(this.name);
   }
 
   getCompletedCount() {
@@ -14,22 +242,39 @@ class ParticleAcceleratorProject extends Project {
   }
 
   saveState() {
-    return { ...super.saveState(), acceleratorCount: this.acceleratorCount };
+    return {
+      ...super.saveState(),
+      acceleratorCount: this.acceleratorCount,
+      selectedRadiusEarth: this.selectedRadiusEarth,
+      bestRadiusEarth: this.bestRadiusEarth,
+      lastCompletedRadiusEarth: this.lastCompletedRadiusEarth
+    };
   }
 
   loadState(state = {}) {
     if (Object.keys(state).length === 0) {
       this.acceleratorCount = 0;
+      this.selectedRadiusEarth = this.minimumRadiusEarth;
+      this.bestRadiusEarth = 0;
+      this.lastCompletedRadiusEarth = 0;
+      this.updateUI();
       return;
     }
     super.loadState(state);
     this.acceleratorCount = state.acceleratorCount ?? 0;
+    this.selectedRadiusEarth = state.selectedRadiusEarth ?? this.minimumRadiusEarth;
+    this.bestRadiusEarth = state.bestRadiusEarth ?? 0;
+    this.lastCompletedRadiusEarth = state.lastCompletedRadiusEarth ?? 0;
+    this.updateUI();
   }
 
   saveTravelState() {
     const state = {
       acceleratorCount: this.acceleratorCount,
       repeatCount: this.repeatCount,
+      selectedRadiusEarth: this.selectedRadiusEarth,
+      bestRadiusEarth: this.bestRadiusEarth,
+      lastCompletedRadiusEarth: this.lastCompletedRadiusEarth
     };
     if (this.isActive) {
       state.isActive = true;
@@ -42,12 +287,16 @@ class ParticleAcceleratorProject extends Project {
   loadTravelState(state = {}) {
     this.acceleratorCount = state.acceleratorCount ?? 0;
     this.repeatCount = state.repeatCount ?? this.acceleratorCount;
+    this.selectedRadiusEarth = state.selectedRadiusEarth ?? this.minimumRadiusEarth;
+    this.bestRadiusEarth = state.bestRadiusEarth ?? 0;
+    this.lastCompletedRadiusEarth = state.lastCompletedRadiusEarth ?? 0;
     this.isActive = false;
     if (state.isActive) {
       this.isActive = true;
       this.remainingTime = state.remainingTime ?? this.remainingTime;
       this.startingDuration = state.startingDuration ?? this.getEffectiveDuration();
     }
+    this.updateUI();
   }
 }
 

--- a/tests/particleAcceleratorProject.test.js
+++ b/tests/particleAcceleratorProject.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const { JSDOM } = require('jsdom');
 const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('Particle Accelerator project', () => {
@@ -16,21 +17,25 @@ describe('Particle Accelerator project', () => {
     expect(project.category).toBe('mega');
     expect(project.repeatable).toBe(true);
     expect(project.maxRepeatCount).toBe(Infinity);
-    expect(project.cost.colony.metal).toBe(5_000_000_000);
-    expect(project.cost.colony.components).toBe(2_000_000_000);
-    expect(project.cost.colony.electronics).toBe(500_000_000);
-    expect(project.cost.colony.superconductors).toBe(100_000_000);
-    expect(project.duration).toBe(420000);
+    expect(project.cost.colony.superalloy).toBe(50);
+    expect(project.cost.colony.superconductors).toBe(50);
+    expect(project.duration).toBe(600000);
+    expect(project.attributes.minimumRadiusEarth).toBe(1);
   });
 
-  test('tracks completion count through save and travel', () => {
+  test('tracks radius selection, cost scaling, and persistence', () => {
     const ctx = {
       console,
       EffectableEntity,
       addEffect: () => {},
       globalGameIsLoadingFromSave: false,
       projectElements: {},
-      resources: {},
+      resources: {
+        colony: {
+          superalloy: { value: Number.POSITIVE_INFINITY, displayName: 'Superalloy' },
+          superconductors: { value: Number.POSITIVE_INFINITY, displayName: 'Superconductors' }
+        }
+      },
     };
     vm.createContext(ctx);
 
@@ -45,28 +50,113 @@ describe('Particle Accelerator project', () => {
 
     const config = ctx.projectParameters.particleAccelerator;
     const project = new ctx.ParticleAcceleratorProject(config, 'particleAccelerator');
-    expect(project.getCompletedCount()).toBe(0);
+    project.unlocked = true;
+    expect(project.selectedRadiusEarth).toBe(1);
 
+    const earthRadiusMeters = 6_371_000;
+    const circumference = 2 * Math.PI * earthRadiusMeters;
+    const expectedPerMaterial = circumference * 100 * 0.5;
+    const baseCost = project.getScaledCost();
+    expect(baseCost.colony.superalloy).toBeCloseTo(expectedPerMaterial, 5);
+    expect(baseCost.colony.superconductors).toBeCloseTo(expectedPerMaterial, 5);
+
+    project.setRadiusEarth(2);
+    const largerCost = project.getScaledCost();
+    expect(largerCost.colony.superalloy).toBeCloseTo(expectedPerMaterial * 2, 5);
+    expect(largerCost.colony.superconductors).toBeCloseTo(expectedPerMaterial * 2, 5);
+
+    project.isActive = true;
+    project.setRadiusEarth(4);
+    expect(project.selectedRadiusEarth).toBe(2);
+    project.isActive = false;
+
+    project.setRadiusEarth(5);
+    expect(project.canStart()).toBe(true);
     project.complete();
-    project.complete();
-    expect(project.getCompletedCount()).toBe(2);
-    expect(project.repeatCount).toBe(2);
+    expect(project.getCompletedCount()).toBe(1);
+    expect(project.repeatCount).toBe(1);
+    expect(project.bestRadiusEarth).toBe(5);
+    expect(project.lastCompletedRadiusEarth).toBe(5);
+    expect(project.canStart()).toBe(false);
+
+    project.adjustRadiusEarth(1);
+    expect(project.selectedRadiusEarth).toBe(6);
+    expect(project.canStart()).toBe(true);
 
     const savedState = project.saveState();
-    expect(savedState.acceleratorCount).toBe(2);
+    expect(savedState.acceleratorCount).toBe(1);
+    expect(savedState.bestRadiusEarth).toBe(5);
+    expect(savedState.selectedRadiusEarth).toBe(6);
 
     const restored = new ctx.ParticleAcceleratorProject(config, 'particleAccelerator');
     restored.loadState(savedState);
-    expect(restored.getCompletedCount()).toBe(2);
-    expect(restored.repeatCount).toBe(2);
+    expect(restored.getCompletedCount()).toBe(1);
+    expect(restored.repeatCount).toBe(1);
+    expect(restored.bestRadiusEarth).toBe(5);
+    expect(restored.selectedRadiusEarth).toBe(6);
 
     const travelState = project.saveTravelState();
-    expect(travelState.acceleratorCount).toBe(2);
-    expect(travelState.repeatCount).toBe(2);
+    expect(travelState.acceleratorCount).toBe(1);
+    expect(travelState.repeatCount).toBe(1);
+    expect(travelState.bestRadiusEarth).toBe(5);
 
     const travelled = new ctx.ParticleAcceleratorProject(config, 'particleAccelerator');
     travelled.loadTravelState(travelState);
-    expect(travelled.getCompletedCount()).toBe(2);
-    expect(travelled.repeatCount).toBe(2);
+    expect(travelled.getCompletedCount()).toBe(1);
+    expect(travelled.repeatCount).toBe(1);
+    expect(travelled.bestRadiusEarth).toBe(5);
+    expect(travelled.selectedRadiusEarth).toBe(6);
+  });
+
+  test('radius controls update UI and disable during construction', () => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { window } = dom;
+    const { document } = window;
+    const ctx = {
+      console,
+      EffectableEntity,
+      addEffect: () => {},
+      globalGameIsLoadingFromSave: false,
+      projectElements: {},
+      resources: {
+        colony: {
+          superalloy: { value: Number.POSITIVE_INFINITY, displayName: 'Superalloy' },
+          superconductors: { value: Number.POSITIVE_INFINITY, displayName: 'Superconductors' }
+        }
+      },
+      document,
+      window,
+      Intl: window.Intl,
+    };
+    vm.createContext(ctx);
+
+    const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+
+    const projectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ParticleAcceleratorProject.js'), 'utf8');
+    vm.runInContext(projectCode + '; this.ParticleAcceleratorProject = ParticleAcceleratorProject;', ctx);
+
+    const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
+    vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
+
+    const config = ctx.projectParameters.particleAccelerator;
+    const project = new ctx.ParticleAcceleratorProject(config, 'particleAccelerator');
+    const container = document.createElement('div');
+    project.renderUI(container);
+
+    const notice = project.uiElements.notice;
+    expect(notice.textContent).toBe('');
+
+    project.setRadiusEarth(2);
+    project.complete();
+    expect(notice.textContent).toContain('Increase the radius');
+
+    project.isActive = true;
+    project.updateUI();
+    expect(project.uiElements.buttons.every(button => button.disabled)).toBe(true);
+
+    project.isActive = false;
+    project.updateUI();
+    expect(project.uiElements.buttons.every(button => button.disabled)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add radius controls for the particle accelerator project, scaling costs by circumference and tracking the best completion
- persist selected and best radii through saves/travel while blocking repeats that do not beat the previous build
- cover the new behaviour with particle accelerator tests and document the update in AGENTS

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68deba4d9d3c83279926d2c5a7f199e0