### PR TITLE
Apply particle accelerator research boost effect

### DIFF
--- a/src/js/projects/ParticleAcceleratorProject.js
+++ b/src/js/projects/ParticleAcceleratorProject.js
@@ -192,6 +192,28 @@ class ParticleAcceleratorProject extends Project {
     return 5 * Math.log10(safeRadius);
   }
 
+  getResearchBoostSourceId() {
+    return `${this.name}-advancedResearchBoost`;
+  }
+
+  applyResearchBoostEffect() {
+    const sourceId = this.getResearchBoostSourceId();
+    const boostPercent = this.bestRadiusMeters > 0 ? this.calculateResearchBoost(this.bestRadiusMeters) : 0;
+    if (boostPercent <= 0) {
+      removeEffect({ target: 'researchManager', sourceId });
+      return;
+    }
+    const multiplier = 1 + (boostPercent / 100);
+    addEffect({
+      target: 'researchManager',
+      type: 'advancedResearchBoost',
+      value: multiplier,
+      effectId: sourceId,
+      sourceId,
+      name: `${this.displayName} Research Boost`
+    });
+  }
+
   getSelectedRadiusMeters() {
     return this.selectedRadiusMeters;
   }
@@ -227,6 +249,7 @@ class ParticleAcceleratorProject extends Project {
     if (this.selectedRadiusMeters > this.bestRadiusMeters) {
       this.bestRadiusMeters = this.selectedRadiusMeters;
     }
+    this.applyResearchBoostEffect();
     this.updateUI();
     globalThis?.updateProjectUI?.(this.name);
   }
@@ -252,6 +275,7 @@ class ParticleAcceleratorProject extends Project {
       this.bestRadiusMeters = 0;
       this.radiusStepMeters = this.defaultStepMeters;
       this.updateUI();
+      this.applyResearchBoostEffect();
       return;
     }
     super.loadState(state);
@@ -275,6 +299,7 @@ class ParticleAcceleratorProject extends Project {
       ? savedStepMeters
       : this.defaultStepMeters;
     this.updateUI();
+    this.applyResearchBoostEffect();
   }
 
   saveTravelState() {
@@ -321,6 +346,7 @@ class ParticleAcceleratorProject extends Project {
       this.startingDuration = state.startingDuration ?? this.getEffectiveDuration();
     }
     this.updateUI();
+    this.applyResearchBoostEffect();
   }
 
   setRadiusEarth(value) {

--- a/src/js/research.js
+++ b/src/js/research.js
@@ -52,9 +52,26 @@ class Research {
       const count = spaceManager.getTerraformedPlanetCount();
       if (count <= 0) return;
 
-      const rate = count; // 1 per second per terraformed planet
+      const multiplier = this.calculateAdvancedResearchMultiplier();
+      const rate = count * multiplier; // 1 per second per terraformed planet scaled by effects
       resources.colony.advancedResearch.increase((rate * deltaTime) / 1000);
       resources.colony.advancedResearch.modifyRate(rate, 'Research Manager', 'research');
+    }
+
+    calculateAdvancedResearchMultiplier() {
+      return this.activeEffects.reduce((multiplier, effect) => {
+        if (effect.type === 'advancedResearchBoost') {
+          return multiplier * effect.value;
+        }
+        return multiplier;
+      }, 1);
+    }
+
+    applyEffect(effect) {
+      if (effect.type === 'advancedResearchBoost') {
+        return;
+      }
+      super.applyEffect(effect);
     }
 
     saveState() {

--- a/tests/researchManager.test.js
+++ b/tests/researchManager.test.js
@@ -1,0 +1,73 @@
+const previousEffectableEntity = global.EffectableEntity;
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { ResearchManager } = require('../src/js/research.js');
+
+describe('ResearchManager advanced research multiplier', () => {
+  let originalResources;
+  let originalSpaceManager;
+
+  beforeEach(() => {
+    originalResources = global.resources;
+    originalSpaceManager = global.spaceManager;
+  });
+
+  afterEach(() => {
+    global.resources = originalResources;
+    global.spaceManager = originalSpaceManager;
+  });
+
+  afterAll(() => {
+    global.EffectableEntity = previousEffectableEntity;
+  });
+
+  test('calculateAdvancedResearchMultiplier stacks boost effects', () => {
+    const manager = new ResearchManager({ general: [] });
+    const increase = jest.fn();
+    const modifyRate = jest.fn();
+    global.resources = {
+      colony: {
+        advancedResearch: {
+          unlocked: true,
+          increase,
+          modifyRate
+        }
+      }
+    };
+    global.spaceManager = {
+      getTerraformedPlanetCount: () => 2
+    };
+
+    manager.addAndReplace({
+      type: 'advancedResearchBoost',
+      value: 1.5,
+      effectId: 'boost-1',
+      sourceId: 'boost-1'
+    });
+
+    expect(manager.calculateAdvancedResearchMultiplier()).toBeCloseTo(1.5);
+    manager.update(1000);
+    expect(increase).toHaveBeenCalledWith(3);
+    expect(modifyRate).toHaveBeenCalledWith(3, 'Research Manager', 'research');
+
+    increase.mockClear();
+    modifyRate.mockClear();
+
+    manager.addAndReplace({
+      type: 'advancedResearchBoost',
+      value: 1.2,
+      effectId: 'boost-2',
+      sourceId: 'boost-2'
+    });
+
+    expect(manager.calculateAdvancedResearchMultiplier()).toBeCloseTo(1.8);
+    manager.update(1000);
+    expect(increase).toHaveBeenCalledTimes(1);
+    expect(increase.mock.calls[0][0]).toBeCloseTo(3.6);
+    expect(modifyRate).toHaveBeenCalledTimes(1);
+    const [rateValue, rateSource, rateCategory] = modifyRate.mock.calls[0];
+    expect(rateValue).toBeCloseTo(3.6);
+    expect(rateSource).toBe('Research Manager');
+    expect(rateCategory).toBe('research');
+  });
+});


### PR DESCRIPTION
## Summary
- apply the Particle Accelerator's research boost as an effect on the research manager during completion, save load, and travel load
- compute advanced research multipliers from manager effects so boosts affect passive gain, with regression tests covering the behavior

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68dece514aac8327833bba218a77c012