### PR TITLE
Use hex color for Okoth faction

### DIFF
--- a/src/js/galaxy/factions-parameters.js
+++ b/src/js/galaxy/factions-parameters.js
@@ -108,7 +108,7 @@ const galaxyFactionParameters = [
     {
         id: 'okoth',
         name: 'Okoth',
-        color: 'red',
+        color: '#ef4444',
         defensiveness: 0.5,
         autoOperationRange: {
             min: 0.1,


### PR DESCRIPTION
## Summary
- update the Okoth faction definition to use a hex color value
- ensures the faction renders consistently red across browsers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68df23c6093483279b1753b232e1472a