### PR TITLE
Ensure antimatter persists across planet travel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ The planet visualiser has been modularised into files covering core setup, light
   lly without mutating base data.
 - Introduced a Water Tank storage structure that specializes in water capacity, includes an Empty action to dump reserves onto the surface, and moved water capacity off the general Storage Depot.
 - Antimatter is now produced automatically based on terraformed worlds and capped at ten hours of output.
+- Antimatter stockpiles now persist when travelling between planets, matching alien artifact preservation.
 
 - Added a Galaxy subtab beneath Space, unlocked in Venus chapter 20.13 with a persistent GalaxyManager and placeholder UI.
 - Galaxy sectors now track faction control through dedicated GalaxyFaction and GalaxySector classes, coloring the map by the dominant controller.

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -146,6 +146,7 @@ function initializeGameState(options = {}) {
   let savedAlienArtifact = null;
   let savedProjectTravelState = null;
   let savedConstructionOffice = null;
+  let savedAntimatter = null;
   if (preserveManagers && typeof projectManager !== 'undefined' && typeof projectManager.saveTravelState === 'function') {
     savedProjectTravelState = projectManager.saveTravelState();
   }
@@ -165,6 +166,13 @@ function initializeGameState(options = {}) {
     savedAlienArtifact = {
       value: resources.special.alienArtifact.value,
       unlocked: resources.special.alienArtifact.unlocked,
+    };
+  }
+  if (preserveManagers && resources && resources.special && resources.special.antimatter) {
+    savedAntimatter = {
+      value: resources.special.antimatter.value,
+      unlocked: resources.special.antimatter.unlocked,
+      enabled: resources.special.antimatter.enabled,
     };
   }
   tabManager = new TabManager({
@@ -225,6 +233,13 @@ function initializeGameState(options = {}) {
   if (savedAlienArtifact) {
     resources.special.alienArtifact.value = savedAlienArtifact.value;
     resources.special.alienArtifact.unlocked = savedAlienArtifact.unlocked;
+  }
+  if (savedAntimatter) {
+    resources.special.antimatter.value = savedAntimatter.value;
+    resources.special.antimatter.unlocked = savedAntimatter.unlocked;
+    if (Object.prototype.hasOwnProperty.call(savedAntimatter, 'enabled')) {
+      resources.special.antimatter.enabled = savedAntimatter.enabled;
+    }
   }
   buildings = initializeBuildings(buildingsParameters);
   projectManager = new ProjectManager();


### PR DESCRIPTION
## Summary
- preserve the antimatter special resource when traveling by saving and restoring its state alongside other preserved resources
- document the antimatter travel persistence update in the repository notes

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dfc253d2008327b5ec6cf14b4c1557