### PR TITLE
Ensure permanently disabled projects stay hidden

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ The atmosphere model now handles methane–oxygen combustion, calcite aerosol de
 The planet visualiser has been modularised into files covering core setup, lighting, surfaces, clouds, ships, environments, and debug controls. This separation keeps rendering responsibilities focused and simplifies future extensions.
 
 ## Updates
+- Added a `permanentProjectDisable` effect that removes projects from the UI and project manager updates when triggered.
 - Added a Mega Particle Accelerator advanced research that unlocks an infinitely repeatable Particle Accelerator megaproject.
 - Random World Generator honours per-archetype orbit lock lists, keeping Venus-like worlds in the hot band while preserving their sulfuric haze and parched atmosphere.
 - High-gravity worlds now apply compounded building and colony cost multipliers, and the Terraforming Others panel shows the current gravity alongside any active gravity penalty.

--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -135,6 +135,9 @@ class EffectableEntity {
         case 'enableContent':
           this.enableContent(effect.targetId);
           break;
+        case 'permanentProjectDisable':
+          this.applyPermanentProjectDisable?.(effect);
+          break;
         case 'activateTab':
           this.activateTab(effect.targetId)
           break;
@@ -503,10 +506,13 @@ class EffectableEntity {
         }
       }
 
-      applyLifeGrowthMultiplier(effect) {
+  applyLifeGrowthMultiplier(effect) {
         // multiplier effects are computed on demand in LifeManager
       }
 
+
+    applyPermanentProjectDisable(effect) {
+    }
 
     // Method to apply a boolean flag effect
     applyBooleanFlag(effect) {

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -17,6 +17,7 @@ class Project extends EffectableEntity {
     this.isPaused = false; // Whether the project is paused due to missing sustain cost
     this.shortfallLastTick = false; // Tracks if resource consumption failed last tick
     this.alertedWhenUnlocked = this.unlocked ? true : false;
+    this.permanentlyDisabled = false;
   }
 
   initializeFromConfig(config, name) {
@@ -117,8 +118,23 @@ class Project extends EffectableEntity {
   }
 
   applyActiveEffects(firstTime = true) {
+    const wasDisabled = this.permanentlyDisabled === true;
+    this.permanentlyDisabled = false;
     super.applyActiveEffects(firstTime);
     this.updateDurationFromEffects();
+    if (wasDisabled !== (this.permanentlyDisabled === true)) {
+      globalThis?.updateProjectUI?.(this.name);
+    }
+  }
+
+  applyPermanentProjectDisable(effect) {
+    const shouldDisable = effect?.value !== false;
+    this.permanentlyDisabled = shouldDisable;
+    if (shouldDisable) {
+      this.isActive = false;
+      this.isPaused = false;
+    }
+    globalThis?.updateProjectUI?.(this.name);
   }
 
   isContinuous() {
@@ -156,6 +172,9 @@ class Project extends EffectableEntity {
   }
 
   canStart() {
+    if (this.isPermanentlyDisabled()) {
+      return false;
+    }
     if (!this.unlocked){
       return false;
     }
@@ -312,6 +331,9 @@ class Project extends EffectableEntity {
   }
 
   resume() {
+    if (this.isPermanentlyDisabled()) {
+      return false;
+    }
     if (this.isPaused && !this.isCompleted && this.hasSustainResources()) {
       this.isActive = true;
       this.isPaused = false;
@@ -321,6 +343,11 @@ class Project extends EffectableEntity {
   }
 
   update(deltaTime) {
+    if (this.isPermanentlyDisabled()) {
+      this.isActive = false;
+      this.isPaused = false;
+      return;
+    }
     if (!this.isActive || this.isCompleted || this.isPaused) return;
 
     if (
@@ -441,7 +468,11 @@ class Project extends EffectableEntity {
   // By default projects are visible when unlocked, but subclasses
   // can override this to remain visible in other states.
   isVisible() {
-    return this.unlocked;
+    return this.unlocked && !this.isPermanentlyDisabled();
+  }
+
+  isPermanentlyDisabled() {
+    return this.permanentlyDisabled === true;
   }
 
   enable() {
@@ -669,6 +700,10 @@ class ProjectManager extends EffectableEntity {
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
 
+      if (project?.isPermanentlyDisabled?.()) {
+        continue;
+      }
+
       if (!this.isProjectRelevantToCurrentPlanet(project)) {
         continue;
       }
@@ -710,6 +745,9 @@ class ProjectManager extends EffectableEntity {
   applyCostAndGain(deltaTime = 1000, accumulatedChanges, productivity = 1) {
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
+      if (project?.isPermanentlyDisabled?.()) {
+        continue;
+      }
       if (!this.isProjectRelevantToCurrentPlanet(project)) {
         continue;
       }
@@ -748,6 +786,9 @@ class ProjectManager extends EffectableEntity {
     const totals = { cost: {}, gain: {} };
     for (const projectName in this.projects) {
       const project = this.projects[projectName];
+      if (project?.isPermanentlyDisabled?.()) {
+        continue;
+      }
       if (typeof project.estimateCostAndGain === 'function') {
         const { cost = {}, gain = {} } = project.estimateCostAndGain(deltaTime) || {};
         for (const category in cost) {
@@ -774,6 +815,9 @@ class ProjectManager extends EffectableEntity {
     for (const name in this.projects) {
       const project = this.projects[name];
       if (project === exclude) continue;
+      if (project?.isPermanentlyDisabled?.()) {
+        continue;
+      }
       if (typeof project.assignedSpaceships === 'number') {
         total += project.assignedSpaceships;
       }
@@ -786,6 +830,9 @@ class ProjectManager extends EffectableEntity {
     for (const name in this.projects) {
       const project = this.projects[name];
       if (project === exclude) continue;
+      if (project?.isPermanentlyDisabled?.()) {
+        continue;
+      }
       if (typeof project.assignedAndroids === 'number') {
         total += project.assignedAndroids;
       }
@@ -797,6 +844,9 @@ class ProjectManager extends EffectableEntity {
     const assignments = [];
     for (const name in this.projects) {
       const project = this.projects[name];
+      if (project?.isPermanentlyDisabled?.()) {
+        continue;
+      }
       if (project && project.assignedAndroids > 0) {
         assignments.push([project.displayName || name, project.assignedAndroids]);
       }

--- a/src/js/projects/dysonswarm.js
+++ b/src/js/projects/dysonswarm.js
@@ -13,6 +13,9 @@ class DysonSwarmReceiverProject extends TerraformingDurationProject {
 
   // Visible either when unlocked or when collectors already exist
   isVisible() {
+    if (this.isPermanentlyDisabled()) {
+      return false;
+    }
     return this.unlocked || this.collectors > 0;
   }
 

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -348,15 +348,15 @@ function getOrCreateCategoryContainer(category) {
 function moveProject(projectName, direction, shiftKey = false) {
     const project = projectManager.projects[projectName];
     const category = project.category || 'general';
-    const categoryProjects = projectManager
-      .getProjectStatuses()
-      .filter(p => (p.category || 'general') === category);
-    const visibleIndexes = [];
-    categoryProjects.forEach((p, idx) => {
-      if (typeof p.isVisible === 'function' ? p.isVisible() : p.unlocked) {
-        visibleIndexes.push(idx);
-      }
-    });
+  const categoryProjects = projectManager
+    .getProjectStatuses()
+    .filter(p => (p.category || 'general') === category);
+  const visibleIndexes = [];
+  categoryProjects.forEach((p, idx) => {
+    if (!(p.isPermanentlyDisabled?.()) && (typeof p.isVisible === 'function' ? p.isVisible() : p.unlocked)) {
+      visibleIndexes.push(idx);
+    }
+  });
     const fromIndexFull = categoryProjects.findIndex(p => p.name === projectName);
     const fromVisiblePos = visibleIndexes.indexOf(fromIndexFull);
 
@@ -525,7 +525,7 @@ function updateProjectUI(projectName) {
       (typeof spaceManager !== 'undefined' &&
         spaceManager.getCurrentPlanetKey &&
         spaceManager.getCurrentPlanetKey() === project.attributes.planet);
-    const visible = typeof project.isVisible === 'function' ? project.isVisible() : project.unlocked;
+    const visible = !(project.isPermanentlyDisabled?.()) && (typeof project.isVisible === 'function' ? project.isVisible() : project.unlocked);
     if (visible && planetOk) {
       projectItem.style.display = 'block';
     } else {
@@ -757,7 +757,7 @@ function updateProjectUI(projectName) {
     .getProjectStatuses()
     .filter(p => (p.category || 'general') === category);
   const categoryProjects = categoryProjectsAll.filter(p =>
-    typeof p.isVisible === 'function' ? p.isVisible() : p.unlocked
+    !(p.isPermanentlyDisabled?.()) && (typeof p.isVisible === 'function' ? p.isVisible() : p.unlocked)
   );
   const currentIndex = categoryProjects.findIndex(p => p.name === projectName);
 
@@ -861,6 +861,7 @@ function updateStoryProjectsVisibility() {
          spaceManager.getCurrentPlanetKey() === p.attributes.planet);
       return (
         p.category === 'story' &&
+        !(p.isPermanentlyDisabled?.()) &&
         (typeof p.isVisible === 'function' ? p.isVisible() : p.unlocked) &&
         planetOk
       );
@@ -896,6 +897,7 @@ function updateMegaProjectsVisibility() {
       return (
         p.category === 'mega' &&
         planetOk &&
+        !(p.isPermanentlyDisabled?.()) &&
         (typeof p.isVisible === 'function' ? p.isVisible() : p.unlocked)
       );
     });

--- a/tests/projectPermanentDisableEffect.test.js
+++ b/tests/projectPermanentDisableEffect.test.js
@@ -1,0 +1,153 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EffectableEntity = require('../src/js/effectable-entity.js');
+
+function loadModuleIntoContext(ctx, relativePath, exportName) {
+  const code = fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8');
+  vm.runInContext(code, ctx);
+  if (exportName) {
+    vm.runInContext(`this.${exportName} = ${exportName};`, ctx);
+  }
+}
+
+function createProjectContext() {
+  const ctx = {
+    console,
+    EffectableEntity,
+    globalGameIsLoadingFromSave: false,
+    formatNumber: n => n,
+    formatBigInteger: n => n,
+    formatTotalCostDisplay: () => '',
+    formatTotalResourceGainDisplay: () => '',
+    formatTotalMaintenanceDisplay: () => '',
+    calculateProjectProductivities: () => ({}),
+    projectElements: {},
+    resources: {
+      colony: {},
+      special: {},
+      surface: {},
+      atmospheric: {},
+    },
+    buildings: {},
+    colonies: {},
+  };
+
+  vm.createContext(ctx);
+
+  loadModuleIntoContext(ctx, 'src/js/projects.js');
+  vm.runInContext('this.Project = Project; this.ProjectManager = ProjectManager;', ctx);
+
+  return ctx;
+}
+
+function createProject(ctx, overrides = {}) {
+  const config = {
+    name: 'Test Project',
+    category: 'general',
+    cost: {},
+    duration: 1000,
+    description: '',
+    repeatable: false,
+    maxRepeatCount: 1,
+    unlocked: true,
+    attributes: {},
+    ...overrides,
+  };
+  return new ctx.Project(config, overrides.key || 'testProject');
+}
+
+describe('permanent project disable effect', () => {
+  test('effect marks project as disabled and prevents interaction', () => {
+    const ctx = createProjectContext();
+    const project = createProject(ctx, { key: 'alpha' });
+
+    expect(project.isPermanentlyDisabled()).toBe(false);
+    expect(project.isVisible()).toBe(true);
+    expect(project.canStart()).toBe(true);
+
+    project.addEffect({
+      type: 'permanentProjectDisable',
+      value: true,
+      effectId: 'disable-alpha',
+      sourceId: 'testEffect',
+    });
+
+    expect(project.isPermanentlyDisabled()).toBe(true);
+    expect(project.isVisible()).toBe(false);
+    expect(project.canStart()).toBe(false);
+  });
+
+  test('removing the effect re-enables the project', () => {
+    const ctx = createProjectContext();
+    const project = createProject(ctx, { key: 'beta' });
+
+    project.addEffect({
+      type: 'permanentProjectDisable',
+      value: true,
+      effectId: 'disable-beta',
+      sourceId: 'testEffect',
+    });
+
+    project.removeEffect({ sourceId: 'testEffect' });
+
+    expect(project.isPermanentlyDisabled()).toBe(false);
+    expect(project.isVisible()).toBe(true);
+    expect(project.canStart()).toBe(true);
+  });
+
+  test('disabled projects are skipped during manager updates', () => {
+    const ctx = createProjectContext();
+    const manager = new ctx.ProjectManager();
+    ctx.projectManager = manager;
+
+    const project = createProject(ctx, { key: 'gamma' });
+    manager.projects.gamma = project;
+    manager.projectOrder = ['gamma'];
+
+    project.addEffect({
+      type: 'permanentProjectDisable',
+      value: true,
+      effectId: 'disable-gamma',
+      sourceId: 'testEffect',
+    });
+
+    project.update = jest.fn();
+
+    manager.updateProjects(1000);
+
+    expect(project.update).not.toHaveBeenCalled();
+  });
+
+  test('projects overriding visibility still hide when permanently disabled', () => {
+    const ctx = createProjectContext();
+    loadModuleIntoContext(ctx, 'src/js/projects/TerraformingDurationProject.js', 'TerraformingDurationProject');
+    loadModuleIntoContext(ctx, 'src/js/projects/dysonswarm.js', 'DysonSwarmReceiverProject');
+
+    const config = {
+      name: 'Dyson Swarm Receiver',
+      category: 'space',
+      cost: {},
+      duration: 1000,
+      description: '',
+      repeatable: false,
+      maxRepeatCount: 1,
+      unlocked: false,
+      attributes: {},
+    };
+
+    const project = new ctx.DysonSwarmReceiverProject(config, 'dysonSwarmReceiver');
+    project.collectors = 5;
+
+    expect(project.isVisible()).toBe(true);
+
+    project.addEffect({
+      type: 'permanentProjectDisable',
+      value: true,
+      effectId: 'disable-dyson',
+      sourceId: 'testEffect',
+    });
+
+    expect(project.isVisible()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the Dyson Swarm Receiver visibility override respects the permanent disable effect
- cover permanently disabled projects that override visibility with a regression test

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dfd3581ac8832797591c70593270bb