### PR TITLE
Hide ship trading research when galactic market active

### DIFF
--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -856,6 +856,7 @@ const researchParameters = {
         description: 'Allows the export of metal via a new special project and purchase of ships via the cargo rocket special project.  Cargo rockets become continuous, consuming funding and delivering purchases in real time.',
         cost: { research: 50000000 },
         prerequisites: [],
+        disableFlag: 'galacticMarket',
         effects: [
             {
               target: 'resource',

--- a/src/js/research.js
+++ b/src/js/research.js
@@ -145,6 +145,14 @@ class Research {
       if (research.category === 'advanced' && !this.isBooleanFlagSet('advancedResearchUnlocked')) {
         return false;
       }
+      if (research.disableFlag) {
+        const flags = Array.isArray(research.disableFlag)
+          ? research.disableFlag
+          : [research.disableFlag];
+        if (flags.some(flag => this.isBooleanFlagSet(flag))) {
+          return false;
+        }
+      }
       if (research.requiresMethane && !this.planetHasMethane()) {
         return false;
       }


### PR DESCRIPTION
## Summary
- add a disable flag check so research hidden when associated flags are active
- gate ship trading research behind the galacticMarket disable flag so it disappears once the market is online

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_b_68dfe20bf348832783bd2b2378358995