### PR TITLE
Add Galactic Market advanced research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ The planet visualiser has been modularised into files covering core setup, light
 - Introduced a Water Tank storage structure that specializes in water capacity, includes an Empty action to dump reserves onto the surface, and moved water capacity off the general Storage Depot.
 - Antimatter is now produced automatically based on terraformed worlds and capped at ten hours of output.
 - Antimatter stockpiles now persist when travelling between planets, matching alien artifact preservation.
+- Introduced a Galactic Market Concordat advanced research that unlocks the Galactic Market project while permanently retiring cargo rockets and metal exports.
 
 - Added a Galaxy subtab beneath Space, unlocked in Venus chapter 20.13 with a persistent GalaxyManager and placeholder UI.
 - Galaxy sectors now track faction control through dedicated GalaxyFaction and GalaxySector classes, coloring the map by the dominant controller.

--- a/src/js/projects/CargoRocketProject.js
+++ b/src/js/projects/CargoRocketProject.js
@@ -605,11 +605,21 @@ class CargoRocketProject extends Project {
 }
 
 function parseSelectionQuantity(value) {
+  if (value && typeof value === 'object') {
+    if (value !== value.value && (typeof value.value === 'number' || typeof value.value === 'string')) {
+      return parseSelectionQuantity(value.value);
+    }
+  }
   if (Number.isFinite(value)) {
     if (value <= 0) return 0;
     return Math.floor(value);
   }
-  const text = `${value ?? ''}`.trim();
+  let text;
+  try {
+    text = String(value ?? '').trim();
+  } catch (error) {
+    return 0;
+  }
   if (text === '') return 0;
   const parsed = Number.parseInt(text, 10);
   if (!Number.isFinite(parsed)) return 0;

--- a/src/js/research-parameters.js
+++ b/src/js/research-parameters.js
@@ -1630,6 +1630,32 @@ const researchParameters = {
         ]
       },
       {
+        id: 'galactic_market',
+        name: 'Galactic Market Concordat',
+        description: 'Establishes permanent trade ties with the wider galaxy, replacing crude exports with a managed market.',
+        cost: { advancedResearch: 300000 },
+        prerequisites: [],
+        effects: [
+          {
+            target: 'project',
+            targetId: 'galactic_market',
+            type: 'enable'
+          },
+          {
+            target: 'project',
+            targetId: 'cargo_rocket',
+            type: 'permanentProjectDisable',
+            value: true
+          },
+          {
+            target: 'project',
+            targetId: 'exportResources',
+            type: 'permanentProjectDisable',
+            value: true
+          }
+        ]
+      },
+      {
         id: 'mechanical_assistance',
         name: 'Mechanical Assistance',
         description: 'Enables a new colony slider to provide mechanical assistance to partially counter the effects of high gravity.  The slider will only appear on high gravity worlds.',

--- a/tests/galacticMarketResearch.test.js
+++ b/tests/galacticMarketResearch.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const researchPath = path.join(__dirname, '..', 'src/js', 'research-parameters.js');
+const code = fs.readFileSync(researchPath, 'utf8');
+
+describe('Galactic Market advanced research', () => {
+  test('enables the market project and retires legacy exports', () => {
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(code + '; this.researchParameters = researchParameters;', ctx);
+
+    const advanced = ctx.researchParameters.advanced;
+    const research = advanced.find(item => item.id === 'galactic_market');
+    expect(research).toBeDefined();
+    expect(research.cost.advancedResearch).toBe(300000);
+
+    const enableMarket = research.effects.find(effect => (
+      effect.target === 'project' &&
+      effect.targetId === 'galactic_market' &&
+      effect.type === 'enable'
+    ));
+    expect(enableMarket).toBeDefined();
+
+    const disableCargo = research.effects.find(effect => (
+      effect.target === 'project' &&
+      effect.targetId === 'cargo_rocket' &&
+      effect.type === 'permanentProjectDisable'
+    ));
+    expect(disableCargo).toBeDefined();
+    expect(disableCargo.value).toBe(true);
+
+    const disableExport = research.effects.find(effect => (
+      effect.target === 'project' &&
+      effect.targetId === 'exportResources' &&
+      effect.type === 'permanentProjectDisable'
+    ));
+    expect(disableExport).toBeDefined();
+    expect(disableExport.value).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a Galactic Market Concordat advanced research entry that unlocks the market project and permanently retires cargo rockets and metal exports
- harden parseSelectionQuantity so galactic market inputs handle object-backed values without crashing
- cover the new research with a dedicated unit test and document the feature in AGENTS.md

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68dfe072bd608327a7199ad7c78c3672