### PR TITLE
Add tooltip explaining Galactic Market sell price saturation

### DIFF
--- a/src/js/projects/GalacticMarketProject.js
+++ b/src/js/projects/GalacticMarketProject.js
@@ -61,7 +61,10 @@ class GalacticMarketProject extends Project {
       { text: 'Buy Amount' },
       { type: 'controls' },
       { text: 'Sell Amount' },
-      { text: 'Sell Price' },
+      {
+        text: 'Sell Price',
+        tooltip: 'Sell prices fall as you approach the saturation amount, so higher sell orders lower the payout per unit.',
+      },
       { text: 'Saturation Amount' },
     ];
 
@@ -114,6 +117,13 @@ class GalacticMarketProject extends Project {
       } else {
         const span = document.createElement('span');
         span.textContent = config.text;
+        if (config.tooltip) {
+          const tooltip = document.createElement('span');
+          tooltip.className = 'info-tooltip-icon';
+          tooltip.title = config.tooltip;
+          tooltip.innerHTML = '&#9432;';
+          span.appendChild(tooltip);
+        }
         headerRow.appendChild(span);
       }
     });


### PR DESCRIPTION
## Summary
- add an info tooltip to the Galactic Market sell price column so players understand how saturation reduces payouts

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_b_68dfe47e96888327bacfa29a2d4de737