### PR TITLE
Add tooltip explaining Galactic Market sell shift control

### DIFF
--- a/src/js/projects/GalacticMarketProject.js
+++ b/src/js/projects/GalacticMarketProject.js
@@ -109,9 +109,15 @@ class GalacticMarketProject extends Project {
           updateIncrement(Math.max(1, Math.floor(elements.increment / 10)));
         });
 
-        createHeaderButton('x10', () => {
+        const multiplyButton = createHeaderButton('x10', () => {
           updateIncrement(elements.increment * 10);
         });
+
+        const tooltip = document.createElement('span');
+        tooltip.className = 'info-tooltip-icon';
+        tooltip.title = 'Press the - button to shift the increment from buying to selling, increasing the sell amount.';
+        tooltip.innerHTML = '&#9432;';
+        headerControls.insertBefore(tooltip, multiplyButton.nextSibling);
 
         headerRow.appendChild(headerControls);
       } else {


### PR DESCRIPTION
## Summary
- add an info tooltip next to the Galactic Market x10 control describing how the negative button shifts orders into selling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dfe67d41e48327ae6f5a3cdbae84b2