### PR TITLE
Hide ship trading research when galactic market active

### DIFF
--- a/src/js/researchUI.js
+++ b/src/js/researchUI.js
@@ -25,6 +25,20 @@ let cachedToggleButtons = [];
 // Flag to rebuild caches when invalidated
 let researchUICacheInvalidated = true;
 
+function hasActiveDisableFlag(researchItem) {
+    if (!researchItem || !researchItem.disableFlag) {
+        return false;
+    }
+    const manager = researchManager;
+    if (!manager || !manager.isBooleanFlagSet) {
+        return false;
+    }
+    const flags = Array.isArray(researchItem.disableFlag)
+        ? researchItem.disableFlag
+        : [researchItem.disableFlag];
+    return flags.some(flag => manager.isBooleanFlagSet(flag));
+}
+
 function formatResearchCost(cost) {
     const parts = [];
     if (cost.research) {
@@ -56,6 +70,8 @@ function updateAllResearchButtons(researchData) {
             }
 
             const isVisible = visibleIds.has(researchItem.id);
+            const hiddenByDisableFlag = !researchItem.isResearched && hasActiveDisableFlag(researchItem);
+            container.style.display = hiddenByDisableFlag ? 'none' : '';
             updateResearchButtonText(button, researchItem, isVisible);
             if (costEl && descEl) {
                 if (isVisible) {
@@ -267,6 +283,10 @@ function loadResearchCategory(category) {
         const researchCost = document.createElement('p');
         researchCost.classList.add('research-cost');
         researchCost.textContent = isVisible ? `Cost: ${formatResearchCost(research.cost)}` : 'Cost: ???';
+
+        if (!research.isResearched && hasActiveDisableFlag(research)) {
+            researchContainer.style.display = 'none';
+        }
 
         // Append button, cost, and description to the research container
         researchContainer.appendChild(researchButton);

--- a/tests/researchDisableFlagVisibility.test.js
+++ b/tests/researchDisableFlagVisibility.test.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const path = require('path');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
+const vm = require('vm');
+
+const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
+const researchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'research.js'), 'utf8');
+const researchUICode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'researchUI.js'), 'utf8');
+
+describe('research disable flag visibility', () => {
+  function buildContext() {
+    const dom = new JSDOM(`<!DOCTYPE html>
+      <div id="energy-research-buttons"></div>
+      <div id="industry-research-buttons"></div>
+      <div id="colonization-research-buttons"></div>
+      <div id="terraforming-research-buttons"></div>
+      <div id="advanced-research-buttons"></div>`, { runScripts: 'outside-only' });
+    const ctx = dom.getInternalVMContext();
+    ctx.document = dom.window.document;
+    ctx.console = console;
+    ctx.formatNumber = () => '';
+    ctx.canAffordResearch = () => true;
+    ctx.resources = { colony: { research: { value: 0 }, advancedResearch: { value: 0 } } };
+    ctx.globalGameIsLoadingFromSave = false;
+    ctx.currentPlanetParameters = {
+      resources: {
+        surface: { liquidMethane: { initialValue: 1 }, hydrocarbonIce: { initialValue: 0 } },
+        atmospheric: { atmosphericMethane: { initialValue: 0 } },
+        underground: { geothermal: { maxDeposits: 1 } },
+      },
+    };
+    vm.createContext(ctx);
+    vm.runInContext(`${effectCode}\n${researchCode}\n${researchUICode}; this.EffectableEntity = EffectableEntity; this.ResearchManager = ResearchManager; this.loadResearchCategory = loadResearchCategory; this.updateResearchUI = updateResearchUI;`, ctx);
+
+    const params = {
+      energy: [],
+      industry: [],
+      colonization: [
+        {
+          id: 'trading',
+          name: 'Ship trading',
+          description: 'Allows ship trading.',
+          cost: { research: 100 },
+          prerequisites: [],
+          effects: [],
+          disableFlag: 'galacticMarket',
+        },
+        {
+          id: 'hab',
+          name: 'Habitat upgrades',
+          description: 'Adds habitats.',
+          cost: { research: 200 },
+          prerequisites: [],
+          effects: [],
+        },
+      ],
+      terraforming: [],
+      advanced: [],
+    };
+
+    ctx.researchManager = new ctx.ResearchManager(params);
+    return { dom, ctx };
+  }
+
+  test('renders other research but hides entries gated by an active disable flag', () => {
+    const { dom, ctx } = buildContext();
+    ctx.researchManager.booleanFlags.add('galacticMarket');
+    ctx.loadResearchCategory('colonization');
+
+    const items = Array.from(dom.window.document.querySelectorAll('#colonization-research-buttons .research-item'));
+    const visibleItems = items.filter(item => item.style.display !== 'none');
+    expect(visibleItems).toHaveLength(1);
+    expect(visibleItems[0].querySelector('.research-button').textContent).toBe('Habitat upgrades');
+  });
+
+  test('hides an existing entry once the disable flag becomes active', () => {
+    const { dom, ctx } = buildContext();
+    ctx.loadResearchCategory('colonization');
+
+    const tradingButton = dom.window.document.getElementById('research-trading');
+    expect(tradingButton).toBeTruthy();
+    const tradingContainer = tradingButton.parentElement;
+    expect(tradingContainer.style.display).toBe('');
+
+    ctx.researchManager.booleanFlags.add('galacticMarket');
+    ctx.updateResearchUI();
+
+    const refreshedTrading = dom.window.document.getElementById('research-trading');
+    expect(refreshedTrading.parentElement.style.display).toBe('none');
+    const otherContainer = dom.window.document.getElementById('research-hab').parentElement;
+    expect(otherContainer.style.display).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- hide Ship trading research rows when the galactic market flag is set so the entry no longer appears as an unknown item
- add disable flag handling in the research UI to keep entries hidden immediately and after UI refreshes
- cover the behaviour with a research disable flag visibility Jest test

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68e02034e884832786e2681a6b20dd33