### PR TITLE
Allow fleet power to exceed capacity limits

### DIFF
--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -132,8 +132,8 @@ class GalaxyFaction {
         if (!Number.isFinite(numericValue)) {
             return;
         }
-        const clamped = Math.max(0, Math.min(this.fleetCapacity, numericValue));
-        this.fleetPower = clamped;
+        const sanitizedValue = Math.max(0, numericValue);
+        this.fleetPower = sanitizedValue;
     }
 
     updateFleetCapacity(manager) {
@@ -198,12 +198,14 @@ class GalaxyFaction {
         }
         const capacity = this.fleetCapacity;
         if (capacity <= 0) {
-            this.fleetPower = 0;
+            if (this.fleetPower < 0) {
+                this.fleetPower = 0;
+            }
             return;
         }
-        const currentPower = Math.max(0, Math.min(capacity, this.fleetPower));
-        if (currentPower === capacity) {
-            this.fleetPower = capacity;
+        const currentPower = Math.max(0, this.fleetPower);
+        if (currentPower >= capacity) {
+            this.fleetPower = currentPower;
             return;
         }
         const seconds = deltaTime / 1000;
@@ -224,7 +226,12 @@ class GalaxyFaction {
         const multiplier = 1 - penalty;
         const delta = baseChange * multiplier;
         const nextPower = currentPower + delta;
-        this.fleetPower = Math.max(0, Math.min(capacity, nextPower));
+        const increasedPower = Math.max(0, nextPower);
+        if (increasedPower >= capacity) {
+            this.fleetPower = capacity;
+            return;
+        }
+        this.fleetPower = increasedPower;
     }
 
     markControlDirty() {

--- a/tests/galaxyFactionFleetPower.test.js
+++ b/tests/galaxyFactionFleetPower.test.js
@@ -77,7 +77,7 @@ describe('GalaxyFaction fleet power and capacity', () => {
         expect(faction.fleetPower).toBeCloseTo(expected);
     });
 
-    it('clamps fleet power when capacity drops', () => {
+    it('retains fleet power when capacity drops', () => {
         const contestedSector = new GalaxySector({ q: 2, r: -1 });
         contestedSector.setControl('ally', 100);
 
@@ -85,13 +85,14 @@ describe('GalaxyFaction fleet power and capacity', () => {
         const manager = createManager({ sectors: [contestedSector] });
 
         faction.initializeFleetPower(manager);
-        expect(faction.fleetPower).toBeGreaterThan(0);
+        const startingPower = faction.fleetPower;
+        expect(startingPower).toBeGreaterThan(0);
 
         contestedSector.clearControl('ally');
 
         faction.update(1000, manager);
 
         expect(faction.fleetCapacity).toBe(0);
-        expect(faction.fleetPower).toBe(0);
+        expect(faction.fleetPower).toBe(startingPower);
     });
 });


### PR DESCRIPTION
## Summary
- allow galaxy factions to keep existing fleet strength when capacity decreases by avoiding clamps
- adjust the fleet power test to verify capacity drops do not remove stored power

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68e06bec78308327bf0b73ba9974ca27