### PR TITLE
Limit Dyson receivers by swarm capacity

### DIFF
--- a/src/js/buildings/dysonReceiver.js
+++ b/src/js/buildings/dysonReceiver.js
@@ -1,4 +1,91 @@
 class DysonReceiver extends Building {
+  build(buildCount = 1, activate = true) {
+    const project = projectManager?.projects?.dysonSwarmReceiver;
+    if (!project) {
+      return super.build(buildCount, activate);
+    }
+
+    const perBuilding = this.production?.colony?.energy || 0;
+    const totalEnergy = (project.collectors || 0) * (project.energyPerCollector || 0);
+
+    if (perBuilding <= 0) {
+      return super.build(buildCount, activate);
+    }
+
+    const cap = Math.max(Math.floor(totalEnergy / perBuilding), 0);
+    const remaining = cap - this.count;
+
+    if (remaining <= 0) {
+      return false;
+    }
+
+    const allowed = Math.min(buildCount, remaining);
+    return super.build(allowed, activate);
+  }
+
+  _ensureTooltip(cache) {
+    if (!cache || typeof document === 'undefined') return null;
+
+    let { countEl } = cache;
+    if (!countEl || !countEl.isConnected) {
+      const { row } = cache;
+      if (!row) return null;
+      countEl =
+        row.querySelector(`#${this.name}-count-active`) ||
+        row.querySelector(`#${this.name}-count`);
+      if (!countEl) return null;
+      cache.countEl = countEl;
+    }
+
+    let tooltip = cache.countTooltip;
+    if (!tooltip) {
+      tooltip = document.createElement('span');
+      tooltip.classList.add('info-tooltip-icon');
+      tooltip.innerHTML = '&#9432;';
+      cache.countTooltip = tooltip;
+    }
+
+    if (!tooltip.isConnected) {
+      countEl.parentElement.insertBefore(tooltip, countEl.nextSibling);
+    }
+
+    return tooltip;
+  }
+
+  _updateTooltip(cache) {
+    const tooltip = this._ensureTooltip(cache);
+    if (!tooltip) return;
+
+    const project = projectManager?.projects?.dysonSwarmReceiver;
+    if (!project || !project.isCompleted) {
+      tooltip.title = 'Complete the Dyson Swarm Receiver project to unlock receivers.';
+      return;
+    }
+
+    const collectors = project.collectors || 0;
+    const perBuilding = this.production?.colony?.energy || 0;
+    const energyPerCollector = project.energyPerCollector || 0;
+    const totalEnergy = collectors * energyPerCollector;
+    const cap = perBuilding > 0 ? Math.floor(totalEnergy / perBuilding) : 0;
+
+    if (collectors <= 0 || cap <= 0) {
+      tooltip.title = 'Build Dyson Swarm collectors to increase receiver capacity.';
+      return;
+    }
+
+    const formattedCollectors = collectors.toLocaleString('en-US');
+    const formattedCap = cap.toLocaleString('en-US');
+    tooltip.title = `Dyson receivers are capped by swarm collectors. ${formattedCollectors} collectors allow ${formattedCap} receivers.`;
+  }
+
+  initUI(_, cache) {
+    this._updateTooltip(cache);
+  }
+
+  updateUI(cache) {
+    this._updateTooltip(cache);
+  }
+
   updateProductivity(resources, deltaTime) {
     const { targetProductivity } = this.computeBaseProductivity(resources, deltaTime);
     if (this.active === 0) {

--- a/src/js/projects/MegaHeatSinkProject.js
+++ b/src/js/projects/MegaHeatSinkProject.js
@@ -101,7 +101,7 @@
     }
 
     calculateCoolingPerSecond() {
-      const effectiveCount = Math.max(1, this.repeatCount || 0);
+      const effectiveCount = Math.max(0.1, this.repeatCount || 0);
       const terra = terraforming;
       const area = terra?.celestialParameters?.surfaceArea;
       if (!terra || !Number.isFinite(area) || area <= 0) {

--- a/tests/dysonReceiverBuildCap.test.js
+++ b/tests/dysonReceiverBuildCap.test.js
@@ -1,0 +1,86 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { Building } = require('../src/js/building.js');
+global.Building = Building;
+const { dysonReceiver: DysonReceiver } = require('../src/js/buildings/dysonReceiver.js');
+
+function createReceiver() {
+  const config = {
+    name: 'Dyson Receiver',
+    category: 'energy',
+    cost: {},
+    consumption: {},
+    production: { colony: { energy: 100 } },
+    storage: {},
+    dayNightActivity: false,
+    canBeToggled: true,
+    requiresMaintenance: false,
+    maintenanceFactor: 1,
+    requiresDeposit: null,
+    requiresWorker: 0,
+    unlocked: true
+  };
+  return new DysonReceiver(config, 'dysonReceiver');
+}
+
+describe('Dyson Receiver build cap', () => {
+  const originalResources = global.resources;
+  const originalBuildings = global.buildings;
+  const originalProjectManager = global.projectManager;
+  const originalMaintenanceFraction = global.maintenanceFraction;
+  const originalDayNightCycle = global.dayNightCycle;
+
+  beforeEach(() => {
+    global.resources = {
+      colony: {},
+      surface: { land: { value: 0, reserved: 0, reserve() {}, release() {} } },
+      underground: {}
+    };
+    global.buildings = {};
+    global.projectManager = {
+      projects: {
+        dysonSwarmReceiver: {
+          isCompleted: true,
+          collectors: 0,
+          energyPerCollector: 100
+        }
+      }
+    };
+    global.maintenanceFraction = 0;
+    global.dayNightCycle = { isDay: () => true };
+  });
+
+  afterEach(() => {
+    global.projectManager = originalProjectManager;
+    global.resources = originalResources;
+    global.buildings = originalBuildings;
+    global.maintenanceFraction = originalMaintenanceFraction;
+    global.dayNightCycle = originalDayNightCycle;
+  });
+
+  test('cannot build receivers without sufficient swarm capacity', () => {
+    const building = createReceiver();
+    expect(building.build(1)).toBe(false);
+
+    global.projectManager.projects.dysonSwarmReceiver.collectors = 1;
+    expect(building.build(1)).toBe(true);
+    expect(building.count).toBe(1);
+
+    global.projectManager.projects.dysonSwarmReceiver.collectors = 1;
+    expect(building.build(1)).toBe(false);
+  });
+
+  test('caps bulk construction requests to remaining capacity', () => {
+    const building = createReceiver();
+    global.projectManager.projects.dysonSwarmReceiver.collectors = 5;
+
+    expect(building.build(10)).toBe(true);
+    expect(building.count).toBe(5);
+
+    expect(building.build(10)).toBe(false);
+
+    global.projectManager.projects.dysonSwarmReceiver.collectors = 10;
+    expect(building.build(10)).toBe(true);
+    expect(building.count).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- cap Dyson Receiver construction to the Dyson Swarm collector energy budget and surface the limit via a tooltip
- add unit coverage confirming the receiver cap behavior when swarm capacity changes
- align the Mega Heat Sink fallback cooling calculation with its intended minimum repeat count behavior

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68e1358304ec8327b76bbed5fe9063b1