### PR TITLE
Add sector reward defense bonus for UHF

### DIFF
--- a/src/js/galaxy/faction.js
+++ b/src/js/galaxy/faction.js
@@ -591,8 +591,13 @@ class GalaxyFaction {
             }
             return sanitizedValue * share;
         }
-        const worldCount = manager?.getTerraformedWorldCountForSector?.(sector) ?? 0;
-        const baseDefense = worldCount > 0 ? 100 * worldCount : 0;
+        const providedWorldCount = Number(manager?.getTerraformedWorldCountForSector?.(sector));
+        const terraformedWorlds = Number.isFinite(providedWorldCount) && providedWorldCount > 0
+            ? providedWorldCount
+            : 0;
+        const rewardBonusWorlds = manager?.hasAcquiredSectorReward?.(sector) === true ? 1 : 0;
+        const combinedWorlds = terraformedWorlds + rewardBonusWorlds;
+        const baseDefense = combinedWorlds > 0 ? 100 * combinedWorlds : 0;
         const capacityMultiplier = manager?.getFleetCapacityMultiplier?.() ?? 1;
         const sanitizedMultiplier = capacityMultiplier > 0 ? capacityMultiplier : 1;
         const upgradedDefense = baseDefense * sanitizedMultiplier;

--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -377,6 +377,7 @@ class GalaxyManager extends EffectableEntity {
                     return;
                 }
                 this.#applyControlMapToSector(sector, sectorData.control);
+                sector.setRewardAcquired?.(sectorData.rewardAcquired === true);
             });
         }
         const factionStateMap = new Map();
@@ -444,6 +445,17 @@ class GalaxyManager extends EffectableEntity {
 
     getSectors() {
         return Array.from(this.sectors.values());
+    }
+
+    hasAcquiredSectorReward(sectorReference) {
+        const sector = this.#resolveSectorReference(sectorReference);
+        return sector?.hasRewardAcquired?.() === true;
+    }
+
+    setSectorRewardAcquired({ sectorKey, acquired = true } = {}) {
+        const sector = this.#resolveSectorReference(sectorKey);
+        sector?.setRewardAcquired?.(acquired === true);
+        return sector?.hasRewardAcquired?.() === true;
     }
 
     getSectorsReward(sectorReferences) {

--- a/src/js/galaxy/galaxyUI.js
+++ b/src/js/galaxy/galaxyUI.js
@@ -998,10 +998,6 @@ function renderSelectedSectorDetails() {
         empty.textContent = 'No factions currently control this sector.';
         container.appendChild(empty);
 
-        const rewardRow = createStatRow('Reward');
-        rewardRow.statValue.textContent = '—';
-        container.appendChild(rewardRow.stat);
-
         const managementSection = doc.createElement('div');
         managementSection.className = 'galaxy-sector-panel__management';
 
@@ -1021,6 +1017,10 @@ function renderSelectedSectorDetails() {
             stat.append(statLabel, statValue);
             return { stat, statValue };
         };
+
+        const rewardRow = createStatRow('Reward');
+        rewardRow.statValue.textContent = '—';
+        container.appendChild(rewardRow.stat);
 
         const worldRow = createStatRow('Worlds');
         const fleetDefenseRow = createStatRow('Fleet Defense');

--- a/src/js/galaxy/sector.js
+++ b/src/js/galaxy/sector.js
@@ -1,5 +1,5 @@
 class GalaxySector {
-    constructor({ q, r, control, value, defaultValue, reward } = {}) {
+    constructor({ q, r, control, value, defaultValue, reward, rewardAcquired } = {}) {
         this.q = Number.isFinite(q) ? q : 0;
         this.r = Number.isFinite(r) ? r : 0;
         this.key = GalaxySector.createKey(this.q, this.r);
@@ -8,6 +8,7 @@ class GalaxySector {
         this.value = this.#sanitizeValue(value, this.defaultValue);
         this.control = {};
         this.reward = this.#sanitizeReward(reward);
+        this.rewardAcquired = rewardAcquired === true;
         if (control) {
             this.replaceControl(control);
         }
@@ -103,6 +104,14 @@ class GalaxySector {
             return [];
         }
         return GalaxySector.#cloneRewardEntries(this.reward);
+    }
+
+    setRewardAcquired(acquired) {
+        this.rewardAcquired = acquired === true;
+    }
+
+    hasRewardAcquired() {
+        return this.rewardAcquired === true;
     }
 
     setControl(factionId, rawValue) {
@@ -284,7 +293,8 @@ class GalaxySector {
             q: this.q,
             r: this.r,
             control: { ...this.control },
-            value: this.value
+            value: this.value,
+            rewardAcquired: this.rewardAcquired === true
         };
     }
 }

--- a/tests/galaxyFactionDefense.test.js
+++ b/tests/galaxyFactionDefense.test.js
@@ -108,6 +108,21 @@ describe('GalaxyFaction defense calculations', () => {
         expect(faction.getSectorDefense(contested, manager)).toBe(baseValue);
     });
 
+    it('grants additional defense from acquired sector rewards', () => {
+        const faction = new GalaxyFaction({ id: 'uhf', name: 'UHF' });
+        const sector = new GalaxySector({ q: 3, r: 1 });
+        sector.setControl('uhf', 100);
+
+        const manager = {
+            getTerraformedWorldCountForSector: () => 0,
+            getFleetCapacityMultiplier: () => 2,
+            hasAcquiredSectorReward: () => true
+        };
+
+        const defense = faction.getSectorDefense(sector, manager);
+        expect(defense).toBe(200);
+    });
+
     it('scales assigned defenses when fleet power is insufficient', () => {
         const faction = new GalaxyFaction({ id: 'uhf', name: 'UHF' });
         faction.fleetPower = 120;


### PR DESCRIPTION
## Summary
- track whether sectors have claimed rewards and expose helpers on the galaxy manager
- treat a claimed sector reward as one additional terraformed world when computing UHF defense
- cover the new behaviour with a unit test and fix the reward row initialization order in the sector panel UI

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68e1749409e4832798ab3bde9c245d54