### PR TITLE
Include sector reward worlds in terraformed count

### DIFF
--- a/src/js/galaxy/galaxy.js
+++ b/src/js/galaxy/galaxy.js
@@ -820,6 +820,40 @@ class GalaxyManager extends EffectableEntity {
         return count;
     }
 
+    getControlledSectorWorldCount(factionId = galaxyUhfId) {
+        const targetFaction = factionId || galaxyUhfId;
+        let total = 0;
+        this.sectors.forEach((sector) => {
+            if (!this.#isFactionFullControlSector(sector, targetFaction)) {
+                return;
+            }
+            const rewards = sector?.getSectorReward?.();
+            if (!Array.isArray(rewards) || rewards.length === 0) {
+                return;
+            }
+            rewards.forEach((entry) => {
+                if (!entry) {
+                    return;
+                }
+                const amount = Number(entry.amount);
+                if (!Number.isFinite(amount) || amount <= 0) {
+                    return;
+                }
+                const typeText = entry.type ? String(entry.type).toLowerCase() : '';
+                const resourceText = entry.resourceId ? String(entry.resourceId).toLowerCase() : '';
+                const labelText = entry.label ? String(entry.label).toLowerCase() : '';
+                if (
+                    typeText.includes('world') ||
+                    resourceText.includes('world') ||
+                    (!typeText && !resourceText && labelText.includes('world'))
+                ) {
+                    total += amount;
+                }
+            });
+        });
+        return total;
+    }
+
     getFleetUpgradeCount(key) {
         const count = this.fleetUpgradePurchases[key];
         if (!Number.isFinite(count) || count <= 0) {

--- a/src/js/galaxy/galaxyUI.js
+++ b/src/js/galaxy/galaxyUI.js
@@ -998,10 +998,6 @@ function renderSelectedSectorDetails() {
         empty.textContent = 'No factions currently control this sector.';
         container.appendChild(empty);
 
-        const rewardRow = createStatRow('Reward');
-        rewardRow.statValue.textContent = '—';
-        container.appendChild(rewardRow.stat);
-
         const managementSection = doc.createElement('div');
         managementSection.className = 'galaxy-sector-panel__management';
 
@@ -1021,6 +1017,10 @@ function renderSelectedSectorDetails() {
             stat.append(statLabel, statValue);
             return { stat, statValue };
         };
+
+        const rewardRow = createStatRow('Reward');
+        rewardRow.statValue.textContent = '—';
+        container.appendChild(rewardRow.stat);
 
         const worldRow = createStatRow('Worlds');
         const fleetDefenseRow = createStatRow('Fleet Defense');

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -413,7 +413,11 @@ class SpaceManager extends EffectableEntity {
             ? projectManager.projects.orbitalRing.ringCount
             : 0;
         const extra = typeof this.extraTerraformedWorlds === 'number' ? this.extraTerraformedWorlds : 0;
-        return base + rings + extra;
+        const sectorWorlds = (typeof galaxyManager !== 'undefined' && galaxyManager?.getControlledSectorWorldCount)
+            ? galaxyManager.getControlledSectorWorldCount()
+            : 0;
+        const sectorBonus = Number.isFinite(sectorWorlds) ? Math.max(0, sectorWorlds) : 0;
+        return base + rings + extra + sectorBonus;
     }
 
     /**

--- a/tests/galaxyControlledWorldRewards.test.js
+++ b/tests/galaxyControlledWorldRewards.test.js
@@ -1,0 +1,52 @@
+const { loadGalaxyConstants } = require('./helpers/loadGalaxyConstants');
+const EffectableEntity = require('../src/js/effectable-entity');
+
+loadGalaxyConstants();
+
+global.EffectableEntity = EffectableEntity;
+global.spaceManager = {
+    getTerraformedPlanetCount: () => 0,
+    getWorldCountPerSector: () => 0
+};
+
+const { GalaxyManager } = require('../src/js/galaxy/galaxy');
+const { UHF_FACTION_ID } = require('../src/js/galaxy/faction');
+
+describe('GalaxyManager controlled sector world rewards', () => {
+    let manager;
+
+    beforeEach(() => {
+        manager = new GalaxyManager();
+        manager.initialize();
+    });
+
+    test('counts default world rewards when UHF has full control', () => {
+        const core = manager.getSector(0, 0);
+        const neighbor = manager.getSector(0, 1);
+
+        core.replaceControl({ [UHF_FACTION_ID]: 100 });
+        neighbor.replaceControl({ [UHF_FACTION_ID]: 50 });
+
+        expect(manager.getControlledSectorWorldCount()).toBe(2);
+    });
+
+    test('ignores sectors without full UHF control', () => {
+        const sector = manager.getSector(1, 0);
+        sector.replaceControl({ [UHF_FACTION_ID]: 60, cewinsii: 40 });
+
+        expect(manager.getControlledSectorWorldCount()).toBe(0);
+    });
+
+    test('counts custom rewards that reference worlds by label', () => {
+        const sector = manager.getSector(1, -1);
+        sector.setReward([{ label: 'Colony World', amount: 3 }]);
+        sector.replaceControl({ [UHF_FACTION_ID]: 75 });
+
+        expect(manager.getControlledSectorWorldCount()).toBe(3);
+    });
+});
+
+afterAll(() => {
+    delete global.EffectableEntity;
+    delete global.spaceManager;
+});

--- a/tests/spaceManagerTerraformedCount.test.js
+++ b/tests/spaceManagerTerraformedCount.test.js
@@ -66,6 +66,24 @@ describe('SpaceManager terraformed planet counting', () => {
     delete global.spaceManager;
     delete global.addEffect;
   });
+
+  test('includes worlds from fully controlled UHF sectors', () => {
+    const sm = new SpaceManager({ mars: {} });
+    sm.planetStatuses.mars.terraformed = true;
+
+    const previousGalaxyManager = global.galaxyManager;
+    const mockManager = { getControlledSectorWorldCount: jest.fn().mockReturnValue(2) };
+    global.galaxyManager = mockManager;
+
+    expect(sm.getTerraformedPlanetCount()).toBe(3);
+    expect(mockManager.getControlledSectorWorldCount).toHaveBeenCalled();
+
+    if (previousGalaxyManager) {
+      global.galaxyManager = previousGalaxyManager;
+    } else {
+      delete global.galaxyManager;
+    }
+  });
 });
 
 delete global.EffectableEntity;


### PR DESCRIPTION
## Summary
- add a GalaxyManager helper to total habitable-world rewards from fully controlled sectors
- fold those sector rewards into SpaceManager.getTerraformedPlanetCount and fix the galaxy details panel stat helper ordering
- extend unit coverage for terraformed counts and add new tests for the sector reward aggregation

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_b_68e174cf68b48327959cba2d8ff0fb62