### PR TITLE
Stop life density decay from altering atmospheric resources

### DIFF
--- a/src/js/life.js
+++ b/src/js/life.js
@@ -689,6 +689,19 @@ class LifeManager extends EffectableEntity {
                 const baseMaxDensity = BASE_MAX_BIOMASS_DENSITY;
                 const densityMultiplier = 1 + spaceEfficiencyValue;
                 const maxBiomassForZone = zoneArea * baseMaxDensity * densityMultiplier;
+
+                if (maxBiomassForZone <= 0 || zonalBiomass > maxBiomassForZone) {
+                    const targetOverflowDecay = Math.min(zonalBiomass, zonalBiomass * 0.01 * secondsMultiplier);
+                    if (targetOverflowDecay > 0) {
+                        decayBiomass -= targetOverflowDecay;
+
+                        if (secondsMultiplier > 0 && targetOverflowDecay > 1e-9) {
+                            const decayRateMultiplier = 1 / secondsMultiplier;
+                            if (resources.surface.biomass) resources.surface.biomass.modifyRate(-targetOverflowDecay * decayRateMultiplier, 'Life Density Decay', 'life');
+                        }
+                    }
+                }
+
                 const logisticFactor = maxBiomassForZone > 0 ? Math.max(0, 1 - zonalBiomass / maxBiomassForZone) : 0;
                 const tempMultiplier = design.temperatureGrowthMultiplierZone(zoneName);
                 const actualGrowthRate = zonalMaxGrowthRate * logisticFactor * tempMultiplier * growthFactor;


### PR DESCRIPTION
## Summary
- remove atmospheric resource bookkeeping from the forced biomass density decay routine so it only trims biomass

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e18f8a308c8327999e1be6614f8187