### PR TITLE
Include bioworkers in worker tooltip breakdown

### DIFF
--- a/src/js/lifeUI.js
+++ b/src/js/lifeUI.js
@@ -38,7 +38,7 @@ function getLifeManagerSafe() {
 
 function isBioworkforceUnlocked() {
   const manager = getLifeManagerSafe();
-  return manager.isBooleanFlagSet('bioworkforce');
+  return manager?.isBooleanFlagSet?.('bioworkforce') ?? false;
 }
 
 function getConvertedDisplay(attributeName, attribute) {

--- a/src/js/population.js
+++ b/src/js/population.js
@@ -157,20 +157,10 @@ class PopulationModule extends EffectableEntity {
 
     const availableAndroids = Math.max(0, effectiveAndroids - assignedAndroids);
 
-    let bioworkforceWorkers = 0;
-    try {
-      if (lifeDesigner && lifeDesigner.currentDesign && lifeDesigner.currentDesign.bioworkforce) {
-        const bioworkforcePoints = lifeDesigner.currentDesign.bioworkforce.value;
-        if (bioworkforcePoints > 0 && resources.surface && resources.surface.biomass) {
-          const biomassValue = resources.surface.biomass.value;
-          bioworkforceWorkers = Math.floor(biomassValue * bioworkforcePoints * 0.00001);
-        }
-      }
-    } catch (error) {
-      bioworkforceWorkers = 0;
-    }
-
-    const workerCap = Math.floor(ratio * this.populationResource.value) + availableAndroids + bioworkforceWorkers;
+    const workerCap =
+      Math.floor(ratio * this.populationResource.value) +
+      availableAndroids +
+      this.getBioworkerContribution();
     this.workerResource.cap = workerCap;
 
     // Adjust the worker value if it exceeds the cap
@@ -225,5 +215,25 @@ class PopulationModule extends EffectableEntity {
 
   applyWorkerRatio(effect){
     this.workerRatio = effect.value;
+  }
+
+  getBioworkerContribution() {
+    try {
+      const design = lifeDesigner.currentDesign;
+      if (!design || !design.bioworkforce) {
+        return 0;
+      }
+      const points = design.bioworkforce.value;
+      if (points <= 0) {
+        return 0;
+      }
+      const biomass = resources.surface?.biomass;
+      if (!biomass || biomass.value <= 0) {
+        return 0;
+      }
+      return Math.floor(biomass.value * points * 0.00001);
+    } catch (error) {
+      return 0;
+    }
   }
 }

--- a/src/js/resourceUI.js
+++ b/src/js/resourceUI.js
@@ -473,6 +473,22 @@ function updateWorkerAssignments(assignmentsDiv) {
     const workers = Math.max(effective - assigned, 0);
     const androidText = `${formatNumber(workers, true)} from androids`;
     if (androidDiv.textContent !== androidText) androidDiv.textContent = androidText;
+
+    const bioworkers = populationModule.getBioworkerContribution?.() || 0;
+    let bioworkerDiv = assignmentsDiv._bioworkerDiv;
+    if (bioworkers > 0) {
+      if (!bioworkerDiv) {
+        bioworkerDiv = document.createElement('div');
+        assignmentsDiv._bioworkerDiv = bioworkerDiv;
+      }
+      if (bioworkerDiv.parentNode !== assignmentsDiv || bioworkerDiv.nextSibling !== androidDiv) {
+        assignmentsDiv.insertBefore(bioworkerDiv, androidDiv);
+      }
+      const bioworkerText = `${formatNumber(bioworkers, true)} from bioworkers`;
+      if (bioworkerDiv.textContent !== bioworkerText) bioworkerDiv.textContent = bioworkerText;
+    } else if (bioworkerDiv && bioworkerDiv.parentNode === assignmentsDiv) {
+      assignmentsDiv.removeChild(bioworkerDiv);
+    }
   }
 
   const assignments = [];


### PR DESCRIPTION
## Summary
- add the bioworker contribution to the worker resource tooltip when present
- expose a PopulationModule helper for computing bioworker contributions and reuse it for worker cap math
- guard the bioworkforce UI flag lookup when the life manager is unavailable

## Testing
- CI=true npm test 2>&1 | tee test.log *(fails: tests/geologicalBurialCO2.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68e194310bd883279ee6156bb9170f2e