### PR TITLE
Cap wind turbine arrays by initial land

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -903,6 +903,7 @@ const constructors = {
   biodome: 'Biodome',
   dysonReceiver: 'dysonReceiver',
   solarPanel: 'solarPanel',
+  windTurbine: 'windTurbine',
   boschReactor: 'MultiRecipesBuilding',
   waterTank: 'WaterTank'
 };

--- a/src/js/buildings/windTurbine.js
+++ b/src/js/buildings/windTurbine.js
@@ -1,0 +1,75 @@
+class WindTurbine extends Building {
+  build(buildCount = 1, activate = true) {
+    let initialLand = 0;
+    try {
+      if (Number.isFinite(terraforming.initialLand)) {
+        initialLand = terraforming.initialLand;
+      }
+    } catch (error) {
+      initialLand = 0;
+    }
+    const cap = Math.floor(initialLand / 50);
+    const remaining = cap - this.count;
+    if (remaining <= 0) {
+      return false;
+    }
+    const allowed = Math.min(buildCount, remaining);
+    return super.build(allowed, activate);
+  }
+
+  _ensureTooltip(cache) {
+    if (!cache) return;
+
+    let countEl = cache.countEl;
+    if (!countEl || !countEl.isConnected) {
+      const row = cache.row;
+      if (!row) return;
+      countEl =
+        row.querySelector(`#${this.name}-count-active`) ||
+        row.querySelector(`#${this.name}-count`);
+      if (!countEl) return;
+      cache.countEl = countEl;
+    }
+
+    let tooltip = cache.countTooltip;
+    if (!tooltip) {
+      tooltip = document.createElement('span');
+      tooltip.classList.add('info-tooltip-icon');
+      tooltip.title =
+        'Wind turbine arrays are limited to 1 per 50 units of initial land.';
+      tooltip.innerHTML = '&#9432;';
+      cache.countTooltip = tooltip;
+    }
+
+    if (!tooltip.isConnected) {
+      countEl.parentElement.insertBefore(tooltip, countEl.nextSibling);
+    }
+  }
+
+  initUI(_, cache) {
+    this._ensureTooltip(cache);
+  }
+
+  updateUI(cache) {
+    this._ensureTooltip(cache);
+  }
+}
+
+const moduleExports = (() => {
+  try {
+    return module.exports;
+  } catch (error) {
+    return null;
+  }
+})();
+
+if (moduleExports) {
+  moduleExports.WindTurbine = WindTurbine;
+  moduleExports.windTurbine = WindTurbine;
+} else {
+  const root = Function('return this')();
+  if (root) {
+    root.WindTurbine = WindTurbine;
+    root.windTurbine = WindTurbine;
+  }
+}

--- a/tests/windTurbineBuilding.test.js
+++ b/tests/windTurbineBuilding.test.js
@@ -1,0 +1,140 @@
+const EffectableEntity = require('../src/js/effectable-entity.js');
+global.EffectableEntity = EffectableEntity;
+const { initializeBuildings, Building } = require('../src/js/building.js');
+global.Building = Building;
+const { WindTurbine } = require('../src/js/buildings/windTurbine.js');
+global.initializeBuildingTabs = () => {};
+
+describe('Wind Turbine Array building', () => {
+  let previousResources;
+  let previousBuildings;
+  let previousMaintenanceFraction;
+  let previousTerraforming;
+  let previousDayNightCycle;
+
+  const createResource = () => ({
+    value: 1_000_000,
+    cap: 1_000_000,
+    decrease: jest.fn(),
+    increase: jest.fn(),
+    reserve: jest.fn(),
+    release: jest.fn(),
+    updateStorageCap: jest.fn()
+  });
+
+  beforeEach(() => {
+    previousResources = global.resources;
+    previousBuildings = global.buildings;
+    previousMaintenanceFraction = global.maintenanceFraction;
+    previousTerraforming = global.terraforming;
+    previousDayNightCycle = global.dayNightCycle;
+
+    const metal = createResource();
+    const components = createResource();
+
+    global.resources = {
+      colony: {
+        metal,
+        components,
+        energy: { updateStorageCap: jest.fn() }
+      },
+      surface: {
+        land: {
+          value: 0,
+          reserved: 0,
+          reserve: jest.fn(),
+          release: jest.fn()
+        }
+      },
+      underground: {}
+    };
+    global.buildings = {};
+    global.maintenanceFraction = 1;
+    global.terraforming = { initialLand: 1000 };
+    global.dayNightCycle = { isDay: () => true };
+  });
+
+  afterEach(() => {
+    if (previousResources === undefined) {
+      delete global.resources;
+    } else {
+      global.resources = previousResources;
+    }
+
+    if (previousBuildings === undefined) {
+      delete global.buildings;
+    } else {
+      global.buildings = previousBuildings;
+    }
+
+    if (previousMaintenanceFraction === undefined) {
+      delete global.maintenanceFraction;
+    } else {
+      global.maintenanceFraction = previousMaintenanceFraction;
+    }
+
+    if (previousTerraforming === undefined) {
+      delete global.terraforming;
+    } else {
+      global.terraforming = previousTerraforming;
+    }
+
+    if (previousDayNightCycle === undefined) {
+      delete global.dayNightCycle;
+    } else {
+      global.dayNightCycle = previousDayNightCycle;
+    }
+  });
+
+  test('initializeBuildings uses the WindTurbine subclass', () => {
+    const params = {
+      windTurbine: {
+        name: 'Wind Turbine Array',
+        category: 'energy',
+        description: 'Harnesses wind to provide steady energy production.',
+        cost: { colony: { metal: 25, components: 5 } },
+        consumption: {},
+        production: { colony: { energy: 400000 } },
+        storage: {},
+        dayNightActivity: false,
+        canBeToggled: true,
+        requiresMaintenance: true,
+        maintenanceFactor: 1,
+        requiresWorker: 0,
+        unlocked: false
+      }
+    };
+
+    const buildings = initializeBuildings(params);
+
+    expect(buildings.windTurbine).toBeInstanceOf(WindTurbine);
+  });
+
+  test('build enforces the 1 per 50 land cap', () => {
+    const params = {
+      windTurbine: {
+        name: 'Wind Turbine Array',
+        category: 'energy',
+        description: 'Harnesses wind to provide steady energy production.',
+        cost: { colony: { metal: 25, components: 5 } },
+        consumption: {},
+        production: { colony: { energy: 400000 } },
+        storage: {},
+        dayNightActivity: false,
+        canBeToggled: true,
+        requiresMaintenance: true,
+        maintenanceFactor: 1,
+        requiresWorker: 0,
+        unlocked: false
+      }
+    };
+
+    const buildings = initializeBuildings(params);
+    const wind = buildings.windTurbine;
+
+    expect(wind.build(25)).toBe(true);
+    expect(wind.count).toBe(20);
+    expect(wind.build(1)).toBe(false);
+    expect(wind.count).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated WindTurbine building subclass that limits construction to 1 array per 50 units of initial land and surfaces a tooltip explaining the cap
- register the new subclass with the building initializer so wind turbine arrays use the capped logic
- cover the new behaviour with unit tests that verify the subclass is used and that build attempts respect the land-based limit

## Testing
- CI=true npm test 2>&1 | tee test.log *(fails: tests/geologicalBurialCO2.test.js)*
- CI=true npx jest tests/windTurbineBuilding.test.js


------
https://chatgpt.com/codex/tasks/task_b_68e1b6ed04748327b30d8b7c31f8868c