### PR TITLE
Fix geological burial CO2 depletion test

### DIFF
--- a/tests/geologicalBurialCO2.test.js
+++ b/tests/geologicalBurialCO2.test.js
@@ -36,7 +36,11 @@ describe('geological burial slows when CO2 depleted', () => {
         polar: { liquid: 1 }
       },
       getMagnetosphereStatus: () => true,
-      celestialParameters: { surfaceArea: 1, gravity: 1, radius: 1 },
+      // Give the planet enough surface area so biomass is below the
+      // overflow threshold. Otherwise the generic density decay logic
+      // removes biomass even when burial is disabled, which obscures
+      // the behaviour we want to test.
+      celestialParameters: { surfaceArea: 6000, gravity: 1, radius: 1 },
       calculateZonalSolarPanelMultiplier: () => 1,
       getEcumenopolisLandFraction: () => 0,
       getEffectiveLifeFraction: () => 0.5


### PR DESCRIPTION
## Summary
- increase the mocked planet surface area in the geological burial test to prevent generic overflow decay from triggering
- document why the enlarged surface area is needed so the test isolates geological burial behavior

## Testing
- npm test -- geologicalBurialCO2.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e1b942ed7c83279f80f3fc3621828f