### PR TITLE
Use temperature trend for disposal automation

### DIFF
--- a/src/js/projects/SpaceDisposalProject.js
+++ b/src/js/projects/SpaceDisposalProject.js
@@ -5,6 +5,16 @@ class SpaceDisposalProject extends SpaceExportBaseProject {
     this.massDriverShipEquivalency = this.attributes.massDriverShipEquivalency ?? 10;
   }
 
+  getAutomationTemperatureReading() {
+    if (typeof terraforming !== 'undefined' && terraforming.temperature) {
+      const trend = terraforming.temperature.trendValue;
+      if (Number.isFinite(trend)) {
+        return trend;
+      }
+    }
+    return super.getAutomationTemperatureReading();
+  }
+
   getExportRateLabel(baseLabel) {
     return 'Resource Disposal';
   }

--- a/src/js/projects/SpaceExportBaseProject.js
+++ b/src/js/projects/SpaceExportBaseProject.js
@@ -7,6 +7,14 @@ class SpaceExportBaseProject extends SpaceshipProject {
     this.disablePressureThreshold = 0;
     this.pressureUnit = 'kPa';
   }
+
+  getAutomationTemperatureReading() {
+    if (typeof terraforming !== 'undefined' && terraforming.temperature) {
+      const reading = terraforming.temperature.value;
+      return Number.isFinite(reading) ? reading : 0;
+    }
+    return 0;
+  }
   renderUI(container) {
     super.renderUI(container);
     if (this.attributes.disposable) {
@@ -340,11 +348,9 @@ class SpaceExportBaseProject extends SpaceshipProject {
 
   shouldAutomationDisable() {
     if (this.disableBelowTemperature) {
-      if (typeof terraforming !== 'undefined' && terraforming.temperature) {
-        const temp = terraforming.temperature.value || 0;
-        if (temp <= this.disableTemperatureThreshold) {
-          return true;
-        }
+      const temp = this.getAutomationTemperatureReading();
+      if (temp <= this.disableTemperatureThreshold) {
+        return true;
       }
     }
     if (this.disableBelowPressure && this.selectedDisposalResource?.category === 'atmospheric' &&
@@ -369,11 +375,9 @@ class SpaceExportBaseProject extends SpaceshipProject {
     if (!super.canStart()) return false;
 
     if (this.disableBelowTemperature) {
-      if (typeof terraforming !== 'undefined' && terraforming.temperature) {
-        const temp = terraforming.temperature.value || 0;
-        if (temp <= this.disableTemperatureThreshold) {
-          return false;
-        }
+      const temp = this.getAutomationTemperatureReading();
+      if (temp <= this.disableTemperatureThreshold) {
+        return false;
       }
     }
 

--- a/tests/spaceDisposalTemperatureDisable.test.js
+++ b/tests/spaceDisposalTemperatureDisable.test.js
@@ -18,7 +18,7 @@ describe('SpaceDisposalProject temperature disable', () => {
     vm.runInContext(disposalSubclass + '; this.SpaceDisposalProject = SpaceDisposalProject;', ctx);
 
     ctx.resources = { colony:{}, atmospheric:{}, surface:{}, underground:{}, special: { spaceships: { value: 1 } } };
-    ctx.terraforming = { temperature: { value: 300 } };
+    ctx.terraforming = { temperature: { value: 300, trendValue: 300 } };
     global.resources = ctx.resources;
     global.terraforming = ctx.terraforming;
     global.projectManager = { isBooleanFlagSet: () => false };
@@ -26,6 +26,8 @@ describe('SpaceDisposalProject temperature disable', () => {
 
   test('cannot start when below threshold', () => {
     const config = { name:'Dispose', category:'resources', cost:{}, duration:1, description:'', repeatable:true, maxRepeatCount:Infinity, unlocked:true, attributes:{ spaceExport:true, disposalAmount:1 } };
+    ctx.terraforming.temperature.value = 305;
+    ctx.terraforming.temperature.trendValue = 300;
     const project = new ctx.SpaceDisposalProject(config, 'dispose');
     project.assignedSpaceships = 1;
     project.disableBelowTemperature = true;
@@ -35,6 +37,8 @@ describe('SpaceDisposalProject temperature disable', () => {
 
   test('can start when above threshold', () => {
     const config = { name:'Dispose', category:'resources', cost:{}, duration:1, description:'', repeatable:true, maxRepeatCount:Infinity, unlocked:true, attributes:{ spaceExport:true, disposalAmount:1 } };
+    ctx.terraforming.temperature.value = 295;
+    ctx.terraforming.temperature.trendValue = 305;
     const project = new ctx.SpaceDisposalProject(config, 'dispose');
     project.assignedSpaceships = 1;
     project.disableBelowTemperature = true;

--- a/tests/spaceProjectAutomation.test.js
+++ b/tests/spaceProjectAutomation.test.js
@@ -52,7 +52,7 @@ describe('continuous spaceship project automation', () => {
       surface: { liquidWater: stubResource(0) }
     };
     ctx.terraforming = {
-      temperature: { value: 400 },
+      temperature: { value: 400, trendValue: 400 },
       celestialParameters: { gravity: 1, radius: 1 }
     };
     ctx.calculateAtmosphericPressure = (amount) => amount * 1000;
@@ -152,14 +152,15 @@ describe('continuous spaceship project automation', () => {
     project.applyCostAndGain(1000, changes);
     applyChanges(ctx.resources, changes);
     expect(ctx.resources.atmospheric.greenhouseGas.value).toBeLessThan(10000);
-    ctx.terraforming.temperature.value = 300; // below threshold
+    ctx.terraforming.temperature.trendValue = 300; // below threshold despite actual value
     project.update(1000);
     changes = createChanges(ctx.resources);
     project.applyCostAndGain(1000, changes);
     applyChanges(ctx.resources, changes);
     expect(project.isActive).toBe(false);
     const ghgAfterStop = ctx.resources.atmospheric.greenhouseGas.value;
-    ctx.terraforming.temperature.value = 400; // above threshold
+    ctx.terraforming.temperature.value = 320; // actual temperature remains below threshold
+    ctx.terraforming.temperature.trendValue = 400; // trend recovers above threshold
     if (project.autoStart && !project.isActive && project.canStart()) {
       project.start(ctx.resources);
     }


### PR DESCRIPTION
## Summary
- add a shared helper for spaceship export projects to read their automation temperature threshold
- make the resource disposal project prefer the atmospheric trend temperature when automating
- extend disposal automation tests to cover trend-based checks

## Testing
- CI=true npm test -- --runTestsByPath tests/spaceProjectAutomation.test.js tests/spaceDisposalTemperatureDisable.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e2c8049de8832796057d21491e44b5