### PR TITLE
Add colony auto-upgrade automation option

### DIFF
--- a/src/js/autobuild.js
+++ b/src/js/autobuild.js
@@ -432,6 +432,7 @@ function captureAutoBuildSettings(structures) {
             basis: s.autoBuildBasis,
             priority: s.autoBuildPriority,
             autoActive: s.autoActiveEnabled,
+            autoUpgrade: s.autoUpgradeEnabled,
         };
     }
 }
@@ -446,6 +447,7 @@ function restoreAutoBuildSettings(structures) {
             s.autoActiveEnabled = savedAutoBuildSettings[name].autoActive !== undefined
                 ? savedAutoBuildSettings[name].autoActive
                 : true;
+            s.autoUpgradeEnabled = !!savedAutoBuildSettings[name].autoUpgrade;
         } else {
             s.autoBuildBasis = 'population';
             s.autoBuildPriority = false;
@@ -453,6 +455,43 @@ function restoreAutoBuildSettings(structures) {
         }
         s.autoBuildEnabled = false;
         s.autoActiveEnabled = false;
+        s.autoUpgradeEnabled = false;
+    }
+}
+
+function getAffordableUpgradeCount(colony, maxCount) {
+    let best = 0;
+    let low = 1;
+    let high = maxCount;
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        if (colony.canAffordUpgrade(mid)) {
+            best = mid;
+            low = mid + 1;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return best;
+}
+
+function autoUpgradeColonies(buildings) {
+    for (const key in buildings) {
+        const structure = buildings[key];
+        if (!structure || !structure.autoUpgradeEnabled) continue;
+        if (!structure.getNextTierName || !structure.canAffordUpgrade || !structure.upgrade) continue;
+        const nextName = structure.getNextTierName();
+        if (!nextName) continue;
+        const next = colonies[nextName];
+        if (!next || !next.unlocked) continue;
+
+        while (structure.count >= 10) {
+            const maxByCount = Math.floor(structure.count / 10);
+            if (maxByCount <= 0) break;
+            const upgradeCount = getAffordableUpgradeCount(structure, maxByCount);
+            if (!upgradeCount) break;
+            if (!structure.upgrade(upgradeCount)) break;
+        }
     }
 }
 
@@ -463,6 +502,7 @@ function autoBuild(buildings, delta = 0) {
         return;
     }
     autobuildCostTracker.update(delta);
+    autoUpgradeColonies(buildings);
     const population = resources.colony.colonists.value;
     const workerCap = resources.colony.workers?.cap || 0;
     const buildableBuildings = [];

--- a/src/js/colony.js
+++ b/src/js/colony.js
@@ -48,6 +48,7 @@ class Colony extends Building {
       }
     }
     this.happiness = 0.5;
+    this.autoUpgradeEnabled = false;
   }
 
   rebuildFilledNeeds() {
@@ -107,7 +108,8 @@ class Colony extends Building {
       filledNeeds: { ...this.filledNeeds },
       luxuryResourcesEnabled: { ...this.luxuryResourcesEnabled },
       obsolete: this.obsolete,
-      happiness: this.happiness
+      happiness: this.happiness,
+      autoUpgradeEnabled: this.autoUpgradeEnabled
     };
   }
 
@@ -133,6 +135,11 @@ class Colony extends Building {
     }
     if ('happiness' in state) {
       this.happiness = state.happiness;
+    }
+    if ('autoUpgradeEnabled' in state) {
+      this.autoUpgradeEnabled = state.autoUpgradeEnabled;
+    } else {
+      this.autoUpgradeEnabled = false;
     }
 
     this.rebuildFilledNeeds();

--- a/src/js/structuresUI.js
+++ b/src/js/structuresUI.js
@@ -464,6 +464,26 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   autoBuildTargetContainer.appendChild(autoBuildTarget);
   cached.autoBuildTarget = autoBuildTarget;
 
+  let autoUpgradeContainer = null;
+  if (isColony) {
+    autoUpgradeContainer = document.createElement('label');
+    autoUpgradeContainer.classList.add('auto-upgrade-container');
+    autoUpgradeContainer.style.display = 'none';
+
+    const autoUpgradeCheckbox = document.createElement('input');
+    autoUpgradeCheckbox.type = 'checkbox';
+    autoUpgradeCheckbox.classList.add('auto-upgrade-checkbox');
+    autoUpgradeCheckbox.addEventListener('change', () => {
+      structure.autoUpgradeEnabled = autoUpgradeCheckbox.checked;
+    });
+
+    autoUpgradeContainer.appendChild(autoUpgradeCheckbox);
+    autoUpgradeContainer.appendChild(document.createTextNode('Auto-upgrade'));
+
+    structureUIElements[structure.name].autoUpgradeCheckbox = autoUpgradeCheckbox;
+    structureUIElements[structure.name].autoUpgradeContainer = autoUpgradeContainer;
+  }
+
   const autoBuildPriorityLabel = document.createElement('label');
   autoBuildPriorityLabel.textContent = 'Prioritize';
   const autoBuildPriority = document.createElement('input');
@@ -479,6 +499,10 @@ function createStructureRow(structure, buildCallback, toggleCallback, isColony) 
   structureUIElements[structure.name].autoBuildPriority = autoBuildPriority;
 
   autoBuildContainer.appendChild(autoBuildTargetContainer);
+
+  if (autoUpgradeContainer) {
+    autoBuildContainer.appendChild(autoUpgradeContainer);
+  }
 
   const setActiveContainer = document.createElement('div');
   setActiveContainer.classList.add('auto-build-setactive-container');
@@ -1020,6 +1044,18 @@ function updateDecreaseButtonText(button, buildCount) {
         }
         if (els.autoActiveCheckbox) {
           els.autoActiveCheckbox.checked = structure.autoActiveEnabled;
+        }
+
+        const autoUpgradeContainer = els.autoUpgradeContainer;
+        if (autoUpgradeContainer) {
+          const nextName = structure.getNextTierName?.();
+          const next = nextName ? colonies[nextName] : null;
+          const showAutoUpgrade = !!(next && next.unlocked);
+          autoUpgradeContainer.style.display = showAutoUpgrade ? 'flex' : 'none';
+          const checkbox = els.autoUpgradeCheckbox;
+          if (checkbox) {
+            checkbox.checked = showAutoUpgrade && structure.autoUpgradeEnabled;
+          }
         }
 
         structure.updateUI?.(els);


### PR DESCRIPTION
## Summary
- add an auto-upgrade checkbox to colony autobuild controls when an unlocked upgrade tier exists
- persist each colony's auto-upgrade preference with save/load and autobuild state helpers
- run colony upgrades before other autobuild work so enabled tiers convert 10 lower colonies into 1 higher tier automatically

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68e58ab3c4148327af17993dd9d9a591