### PR TITLE
Refactor scanner worker batching

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
     <script src="src/js/projects.js"></script>
     <script src="src/js/projects/SpaceshipProject.js"></script>
     <script src="src/js/projects/TerraformingDurationProject.js"></script>
+    <script src="src/js/projects/WorkerCapacityBatchProject.js"></script>
     <script src="src/js/projects/ScannerProject.js"></script>
     <script src="src/js/projects/SpaceMiningProject.js"></script>
     <script src="src/js/projects/SpaceMirrorAdvancedOversight.js"></script>

--- a/src/js/projects/WorkerCapacityBatchProject.js
+++ b/src/js/projects/WorkerCapacityBatchProject.js
@@ -1,0 +1,102 @@
+class WorkerCapacityBatchProject extends Project {
+  constructor(config, name) {
+    super(config, name);
+    this.buildCount = 1;
+    this.activeBuildCount = 1;
+    this.autoMax = true;
+    this.workersPerCompletion = this.attributes?.workersPerCompletion ?? null;
+  }
+
+  getWorkersPerCompletion() {
+    return this.workersPerCompletion ?? this.attributes?.workersPerCompletion ?? 10000;
+  }
+
+  getWorkerCapLimit() {
+    const workers = resources?.colony?.workers?.cap ?? 0;
+    const perCompletion = this.getWorkersPerCompletion();
+    const maxByWorkers = perCompletion > 0 ? Math.ceil(workers / perCompletion) : Infinity;
+    if (this.maxRepeatCount === Infinity) {
+      return maxByWorkers;
+    }
+    return Math.max(Math.min(maxByWorkers, this.maxRepeatCount), 1);
+  }
+
+  getEffectiveBuildCount(count = this.buildCount) {
+    const remaining = this.maxRepeatCount === Infinity
+      ? Infinity
+      : this.maxRepeatCount - this.repeatCount;
+    return Math.max(0, Math.min(count, remaining));
+  }
+
+  getBatchCostMultiplier() {
+    if (this.isActive) {
+      return this.activeBuildCount || 1;
+    }
+    const cappedCount = Math.min(this.buildCount, this.getWorkerCapLimit());
+    return this.getEffectiveBuildCount(cappedCount);
+  }
+
+  getScaledCost() {
+    const base = super.getScaledCost();
+    const count = this.getBatchCostMultiplier();
+    const scaled = {};
+    for (const category in base) {
+      scaled[category] = {};
+      for (const resource in base[category]) {
+        scaled[category][resource] = base[category][resource] * count;
+      }
+    }
+    return scaled;
+  }
+
+  adjustBuildCount(delta) {
+    const limit = this.getWorkerCapLimit();
+    this.buildCount = Math.max(0, Math.min(this.buildCount + delta, limit));
+  }
+
+  setBuildCount(value) {
+    const limit = this.getWorkerCapLimit();
+    this.buildCount = Math.max(0, Math.min(value, limit));
+  }
+
+  setMaxBuildCount() {
+    this.setBuildCount(this.getWorkerCapLimit());
+  }
+
+  start(resources) {
+    const limit = this.getWorkerCapLimit();
+    const cappedCount = Math.min(this.buildCount, limit);
+    this.activeBuildCount = this.getEffectiveBuildCount(cappedCount);
+    return super.start(resources);
+  }
+
+  complete() {
+    const completions = this.activeBuildCount || 1;
+    for (let i = 0; i < completions; i++) {
+      super.complete();
+    }
+    this.activeBuildCount = 1;
+  }
+
+  saveState() {
+    return {
+      ...super.saveState(),
+      buildCount: this.buildCount,
+      activeBuildCount: this.activeBuildCount,
+      autoMax: this.autoMax,
+      workersPerCompletion: this.workersPerCompletion,
+    };
+  }
+
+  loadState(state) {
+    super.loadState(state);
+    this.buildCount = state.buildCount ?? this.buildCount;
+    this.activeBuildCount = state.activeBuildCount ?? this.activeBuildCount;
+    this.autoMax = state.autoMax ?? this.autoMax;
+    this.workersPerCompletion = state.workersPerCompletion ?? this.workersPerCompletion;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = WorkerCapacityBatchProject;
+}

--- a/tests/scannerProject.test.js
+++ b/tests/scannerProject.test.js
@@ -15,12 +15,14 @@ describe('ScannerProject scanning effect', () => {
 
   test('update sets scanning strength from repeat count', () => {
     const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+    const workerBatchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'WorkerCapacityBatchProject.js'), 'utf8');
     const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
     const ctx = { console, EffectableEntity };
     ctx.oreScanner = { adjustScanningStrength: jest.fn(), startScan: jest.fn() };
     ctx.resources = { colony: { workers: { cap: 20000 } } };
     vm.createContext(ctx);
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(workerBatchCode + '; this.WorkerCapacityBatchProject = WorkerCapacityBatchProject;', ctx);
     vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
 
 

--- a/tests/scannerProjectAutoMax.test.js
+++ b/tests/scannerProjectAutoMax.test.js
@@ -5,6 +5,7 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('ScannerProject auto max', () => {
   const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  const workerBatchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'WorkerCapacityBatchProject.js'), 'utf8');
   const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
 
   function createContext() {
@@ -19,6 +20,7 @@ describe('ScannerProject auto max', () => {
     };
     vm.createContext(ctx);
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(workerBatchCode + '; this.WorkerCapacityBatchProject = WorkerCapacityBatchProject;', ctx);
     vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
     global.resources = ctx.resources;
     return ctx;
@@ -39,14 +41,14 @@ describe('ScannerProject auto max', () => {
     };
     const project = new ctx.ScannerProject(config, 'scan');
     project.update(0);
-    expect(project.buildCount).toBe(2);
+    expect(project.buildCount).toBe(1);
     ctx.resources.colony.workers.cap = 20000;
     project.update(0);
-    expect(project.buildCount).toBe(4);
+    expect(project.buildCount).toBe(2);
     project.autoMax = false;
     ctx.resources.colony.workers.cap = 30000;
     project.update(0);
-    expect(project.buildCount).toBe(4);
+    expect(project.buildCount).toBe(2);
   });
 });
 

--- a/tests/scannerProjectBuildCount.test.js
+++ b/tests/scannerProjectBuildCount.test.js
@@ -5,6 +5,7 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 
 describe('ScannerProject build count', () => {
   const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+  const workerBatchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'WorkerCapacityBatchProject.js'), 'utf8');
   const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
 
   function createContext() {
@@ -19,6 +20,7 @@ describe('ScannerProject build count', () => {
     };
     vm.createContext(ctx);
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(workerBatchCode + '; this.WorkerCapacityBatchProject = WorkerCapacityBatchProject;', ctx);
     vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
     global.resources = ctx.resources;
     global.oreScanner = ctx.oreScanner;

--- a/tests/scannerProjectRate.test.js
+++ b/tests/scannerProjectRate.test.js
@@ -9,6 +9,8 @@ describe('ScannerProject auto-start cost rate', () => {
     vm.createContext(ctx);
     const projCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
     vm.runInContext(projCode + '; this.Project = Project;', ctx);
+    const workerBatchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'WorkerCapacityBatchProject.js'), 'utf8');
+    vm.runInContext(workerBatchCode + '; this.WorkerCapacityBatchProject = WorkerCapacityBatchProject;', ctx);
     const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
     vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
     const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');

--- a/tests/scannerProjectUIUpdate.test.js
+++ b/tests/scannerProjectUIUpdate.test.js
@@ -7,6 +7,7 @@ const EffectableEntity = require('../src/js/effectable-entity.js');
 
 const effectCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'effectable-entity.js'), 'utf8');
 const projectsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects.js'), 'utf8');
+const workerBatchCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'WorkerCapacityBatchProject.js'), 'utf8');
 const scannerCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'projects', 'ScannerProject.js'), 'utf8');
 const paramsCode = fs.readFileSync(path.join(__dirname, '..', 'src/js', 'project-parameters.js'), 'utf8');
 
@@ -32,6 +33,7 @@ describe('ScannerProject UI update', () => {
     vm.createContext(ctx);
     vm.runInContext(effectCode + '; this.EffectableEntity = EffectableEntity;', ctx);
     vm.runInContext(projectsCode + '; this.Project = Project;', ctx);
+    vm.runInContext(workerBatchCode + '; this.WorkerCapacityBatchProject = WorkerCapacityBatchProject;', ctx);
     vm.runInContext(scannerCode + '; this.ScannerProject = ScannerProject;', ctx);
     vm.runInContext(paramsCode + '; this.projectParameters = projectParameters;', ctx);
 
@@ -42,7 +44,7 @@ describe('ScannerProject UI update', () => {
     project.updateUI();
 
     expect(project.el.val.textContent).toBe('1');
-    expect(project.el.max.textContent).toBe('3');
+    expect(project.el.max.textContent).toBe('2');
     expect(project.el.dVal.textContent).toBe('0');
     expect(project.el.dMax.textContent).toBe('10');
     expect(project.el.bPlus.textContent).toBe('+1');


### PR DESCRIPTION
## Summary
- add a WorkerCapacityBatchProject base that centralizes worker-cap batching with configurable ratios
- refactor ScannerProject to extend the shared helper and document the 10,000 workers per satellite limit
- update scanner project tests to use the helper and reflect the new batching behaviour

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68e58c8aab688327ae53c1fdc4ce54bc