### PR TITLE
Add antimatter battery fill action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ The planet visualiser has been modularised into files covering core setup, light
 - Colony research tiers two through six now grant aerostat colonies +10 comfort each via a new `addComfort` effect type.
 - Adrien Solis now offers a permanent Terraforming measurements research unlock in his shop once chapter 18.4d is completed.
 - Introduced an Antimatter Battery structure that stores a quadrillion units of energy for 1000 metal and 100 superconductors.
+- Antimatter Battery now offers a Fill action that converts antimatter into stored energy at the same rate produced by antimatter farms.
 - Added an Antimatter Farm energy building that converts 2 quadrillion energy into the new locked Antimatter special resource.
 - Building and colony consumption now derive from a shared `getConsumption` helper so effect-driven upkeep is computed dynamica
   lly without mutating base data.

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
     <script src="src/js/buildings/dysonReceiver.js"></script>
     <script src="src/js/buildings/MultiRecipesBuilding.js"></script>
     <script src="src/js/buildings/WaterTank.js"></script>
+    <script src="src/js/buildings/AntimatterBattery.js"></script>
     <script src="src/js/colony.js"></script>
     <script src="src/js/buildings/aerostat.js"></script>
     <script src="src/js/buildingUI.js"></script>

--- a/src/js/building.js
+++ b/src/js/building.js
@@ -905,7 +905,8 @@ const constructors = {
   solarPanel: 'solarPanel',
   windTurbine: 'windTurbine',
   boschReactor: 'MultiRecipesBuilding',
-  waterTank: 'WaterTank'
+  waterTank: 'WaterTank',
+  antimatterBattery: 'AntimatterBattery'
 };
 
 function loadConstructor(name) {

--- a/src/js/buildings/AntimatterBattery.js
+++ b/src/js/buildings/AntimatterBattery.js
@@ -1,0 +1,137 @@
+const ENERGY_PER_ANTIMATTER = 2_000_000_000_000_000;
+
+let exportedAntimatterHelpers = null;
+if (
+  typeof window === 'undefined' &&
+  typeof module !== 'undefined' &&
+  module.exports
+) {
+  exportedAntimatterHelpers = require('../special/antimatter.js');
+}
+
+class AntimatterBattery extends Building {
+  constructor(config, buildingName) {
+    super(config, buildingName);
+    this._cachedUI = null;
+  }
+
+  initializeCustomUI(context = {}) {
+    const { leftContainer, hideButton } = context;
+    if (!leftContainer || !hideButton || !globalThis.document) {
+      return;
+    }
+
+    const cache = context.cachedElements || {};
+    let { fillButton } = cache;
+    if (!fillButton) {
+      fillButton = globalThis.document.createElement('button');
+      fillButton.textContent = 'Fill';
+      fillButton.classList.add('fill-button');
+      fillButton.addEventListener('click', event => {
+        event.stopPropagation();
+        this.fillFromAntimatter();
+      });
+      cache.fillButton = fillButton;
+    }
+
+    hideButton.insertAdjacentElement('afterend', fillButton);
+
+    this._cachedUI = cache;
+    this.updateUI(cache);
+  }
+
+  updateUI(elements = {}) {
+    if (elements !== this._cachedUI && elements.fillButton) {
+      this._cachedUI = elements;
+    }
+
+    const button = elements.fillButton || this._cachedUI?.fillButton;
+    if (!button) {
+      return;
+    }
+
+    const antimatter = resources?.special?.antimatter || null;
+    const energy = resources?.colony?.energy || null;
+    const missingEnergy = energy ? Math.max(0, energy.cap - energy.value) : 0;
+    const fillRate = this.getFillRate();
+    const energyPerAntimatter = this.getEnergyPerAntimatter();
+    const hasResources = antimatter && energy;
+    const hasActiveBattery = this.active > 0;
+
+    button.disabled =
+      !hasResources ||
+      !hasActiveBattery ||
+      antimatter.value <= 0 ||
+      missingEnergy <= 0 ||
+      fillRate <= 0 ||
+      energyPerAntimatter <= 0;
+    button.style.display = this.unlocked && !this.isHidden ? 'inline-block' : 'none';
+  }
+
+  getFillRate() {
+    const terraformedWorlds = globalThis.spaceManager?.getTerraformedPlanetCount?.() ?? 0;
+    const ratePerWorld = this.getAntimatterRatePerWorld();
+    return terraformedWorlds * ratePerWorld;
+  }
+
+  getEnergyPerAntimatter() {
+    return ENERGY_PER_ANTIMATTER;
+  }
+
+  getAntimatterRatePerWorld() {
+    if (
+      exportedAntimatterHelpers &&
+      exportedAntimatterHelpers.ANTIMATTER_PER_TERRAFORMED_WORLD !== undefined
+    ) {
+      return exportedAntimatterHelpers.ANTIMATTER_PER_TERRAFORMED_WORLD;
+    }
+    return globalThis.ANTIMATTER_PER_TERRAFORMED_WORLD ?? 0;
+  }
+
+  fillFromAntimatter() {
+    const antimatter = resources?.special?.antimatter || null;
+    const energy = resources?.colony?.energy || null;
+    if (!antimatter || !energy || this.active <= 0) {
+      return;
+    }
+
+    const fillRate = this.getFillRate();
+    const energyPerAntimatter = this.getEnergyPerAntimatter();
+    if (fillRate <= 0 || energyPerAntimatter <= 0) {
+      return;
+    }
+
+    const missingEnergy = Math.max(0, energy.cap - energy.value);
+    if (missingEnergy <= 0) {
+      return;
+    }
+
+    const availableAntimatter = antimatter.value;
+    if (availableAntimatter <= 0) {
+      return;
+    }
+
+    const potentialEnergyFromRate = fillRate * energyPerAntimatter;
+    const potentialEnergyFromStock = availableAntimatter * energyPerAntimatter;
+    const energyGain = Math.min(missingEnergy, potentialEnergyFromRate, potentialEnergyFromStock);
+
+    if (energyGain <= 0) {
+      return;
+    }
+
+    const antimatterConsumed = energyGain / energyPerAntimatter;
+    antimatter.decrease(antimatterConsumed);
+    energy.increase(energyGain);
+    energy.enable?.();
+
+    globalThis.updateResourceDisplay?.(resources);
+    globalThis.updateStructureDisplay?.(structures);
+    this.updateUI(this._cachedUI || {});
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { AntimatterBattery };
+} else {
+  globalThis.AntimatterBattery = AntimatterBattery;
+}

--- a/tests/antimatterBattery.test.js
+++ b/tests/antimatterBattery.test.js
@@ -1,12 +1,22 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const jsdomPath = path.join(process.execPath, '..', '..', 'lib', 'node_modules', 'jsdom');
+const { JSDOM } = require(jsdomPath);
 
 const EffectableEntity = require('../src/js/effectable-entity.js');
 global.EffectableEntity = EffectableEntity;
 const { initializeBuildings, Building } = require('../src/js/building.js');
 global.Building = Building;
 global.initializeBuildingTabs = () => {};
+
+const { AntimatterBattery } = require('../src/js/buildings/AntimatterBattery.js');
+global.AntimatterBattery = AntimatterBattery;
+const { Resource } = require('../src/js/resource.js');
+const {
+  ANTIMATTER_PER_TERRAFORMED_WORLD,
+} = require('../src/js/special/antimatter.js');
+const ENERGY_PER_ANTIMATTER = 2_000_000_000_000_000;
 
 describe('Antimatter Battery building', () => {
   test('parameters store a quadrillion energy and are locked by default', () => {
@@ -60,12 +70,129 @@ describe('Antimatter Battery building', () => {
 
       const buildings = initializeBuildings(params);
 
-      expect(buildings.antimatterBattery).toBeInstanceOf(Building);
+      expect(buildings.antimatterBattery).toBeInstanceOf(AntimatterBattery);
       expect(global.resources.colony.energy.updateStorageCap).toHaveBeenCalled();
     } finally {
       global.resources = previousResources;
       global.buildings = previousBuildings;
       global.maintenanceFraction = previousMaintenanceFraction;
     }
+  });
+
+  describe('custom UI and fill action', () => {
+    let dom;
+    let battery;
+
+    beforeEach(() => {
+      dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+      global.window = dom.window;
+      global.document = dom.window.document;
+
+      global.resources = {
+        colony: {
+          energy: new Resource({
+            name: 'energy',
+            category: 'colony',
+            hasCap: true,
+            baseCap: 0,
+            unlocked: true,
+          }),
+        },
+        special: {
+          antimatter: new Resource({
+            name: 'antimatter',
+            category: 'special',
+            hasCap: true,
+            baseCap: 0,
+            unlocked: true,
+          }),
+        },
+      };
+
+      global.resources.colony.energy.value = 0;
+      global.resources.special.antimatter.value = 200;
+
+      global.structures = {};
+      global.buildings = {};
+      global.maintenanceFraction = 1;
+      global.unlockResource = () => {};
+      global.spaceManager = {
+        getTerraformedPlanetCount: () => 2,
+      };
+
+      const config = {
+        name: 'Antimatter Battery',
+        category: 'storage',
+        description: '',
+        cost: { colony: { metal: 1000, superconductors: 100 } },
+        consumption: {},
+        production: {},
+        storage: { colony: { energy: 1_000_000_000_000_000 } },
+        dayNightActivity: false,
+        canBeToggled: true,
+        requiresMaintenance: true,
+        requiresProductivity: false,
+        requiresWorker: 0,
+        maintenanceFactor: 2,
+        unlocked: true,
+      };
+
+      battery = new AntimatterBattery(config, 'antimatterBattery');
+      global.structures.antimatterBattery = battery;
+      global.buildings.antimatterBattery = battery;
+      battery.count = 1;
+      battery.active = 1;
+      global.resources.colony.energy.updateStorageCap();
+    });
+
+    afterEach(() => {
+      dom.window.close();
+      delete global.window;
+      delete global.document;
+      delete global.resources;
+      delete global.structures;
+      delete global.buildings;
+      delete global.maintenanceFraction;
+      delete global.unlockResource;
+      delete global.spaceManager;
+    });
+
+    test('initializeCustomUI wires fill button and updates disabled state', () => {
+      const leftContainer = global.document.createElement('div');
+      const hideButton = global.document.createElement('button');
+      leftContainer.appendChild(hideButton);
+      const cachedElements = {};
+
+      battery.initializeCustomUI({ leftContainer, hideButton, cachedElements });
+
+      const fillButton = cachedElements.fillButton;
+      expect(fillButton).toBeDefined();
+      expect(hideButton.nextSibling).toBe(fillButton);
+
+      battery.updateUI(cachedElements);
+      expect(fillButton.disabled).toBe(false);
+
+      global.resources.special.antimatter.value = 0;
+      battery.updateUI(cachedElements);
+      expect(fillButton.disabled).toBe(true);
+    });
+
+    test('fillFromAntimatter consumes antimatter and adds stored energy', () => {
+      const energyBefore = global.resources.colony.energy.value;
+      const antimatterBefore = global.resources.special.antimatter.value;
+
+      battery.fillFromAntimatter();
+
+      const expectedRate = 2 * ANTIMATTER_PER_TERRAFORMED_WORLD;
+      const expectedEnergyGain = Math.min(
+        global.resources.colony.energy.cap - energyBefore,
+        expectedRate * ENERGY_PER_ANTIMATTER,
+        antimatterBefore * ENERGY_PER_ANTIMATTER,
+      );
+
+      expect(global.resources.colony.energy.value).toBeCloseTo(energyBefore + expectedEnergyGain);
+      const expectedAntimatter = antimatterBefore - expectedEnergyGain / ENERGY_PER_ANTIMATTER;
+      expect(global.resources.special.antimatter.value).toBeCloseTo(expectedAntimatter);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated AntimatterBattery building subclass with a Fill action that converts stored antimatter into colony energy
- register and load the new building script so the UI exposes the Fill button only when the battery is built and resources are available
- expand the antimatter battery tests to cover the custom UI behaviour and resource conversion

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_68e58c9c13388327827e3bfb043906eb