### PR TITLE
Respect automation shutdown when calculating building rates

### DIFF
--- a/src/js/building.js
+++ b/src/js/building.js
@@ -28,6 +28,8 @@ class Building extends EffectableEntity {
     this.currentConsumption = {};
     this.currentMaintenance = {};
 
+    this._automationActivityMultiplier = 1;
+
     // Reversal system
     this.reversalAvailable = !!config.reversalAvailable;
     this.reverseEnabled = false;
@@ -504,6 +506,14 @@ class Building extends EffectableEntity {
     return this.canAffordDeposit(buildCount) && this.canAffordLand(buildCount);
   }
 
+  setAutomationActivityMultiplier(value) {
+    this._automationActivityMultiplier = value <= 0 ? 0 : 1;
+  }
+
+  getAutomationActivityMultiplier() {
+    return this._automationActivityMultiplier <= 0 ? 0 : 1;
+  }
+
   canAffordDeposit(amount = 1){
     if (this.requiresDeposit) {
       for (const deposit in this.requiresDeposit.underground) {
@@ -701,12 +711,15 @@ class Building extends EffectableEntity {
   }
 
   updateProductivity(resources, deltaTime) {
+    this.setAutomationActivityMultiplier(1);
+
     const { targetProductivity: baseTarget } = this.computeBaseProductivity(
       resources,
       deltaTime
     );
 
     if (this.active === 0) {
+      this.setAutomationActivityMultiplier(0);
       this.productivity = 0;
       return;
     }

--- a/src/js/buildings/Biodome.js
+++ b/src/js/buildings/Biodome.js
@@ -1,11 +1,14 @@
 class Biodome extends Building {
   updateProductivity(resources, deltaTime) {
+    this.setAutomationActivityMultiplier(1);
+
     if (
       typeof lifeDesigner !== 'undefined' &&
       lifeDesigner.currentDesign &&
       typeof lifeDesigner.currentDesign.canSurviveAnywhere === 'function' &&
       !lifeDesigner.currentDesign.canSurviveAnywhere()
     ) {
+      this.setAutomationActivityMultiplier(0);
       this.productivity = 0;
       return;
     }

--- a/src/js/buildings/GhgFactory.js
+++ b/src/js/buildings/GhgFactory.js
@@ -15,6 +15,8 @@ class GhgFactory extends Building {
   }
 
   updateProductivity(resources, deltaTime) {
+    this.setAutomationActivityMultiplier(1);
+
     const {
       targetProductivity,
       hasAtmosphericOversight,
@@ -61,6 +63,7 @@ class GhgFactory extends Building {
     };
 
     if (this.active === 0) {
+      this.setAutomationActivityMultiplier(0);
       this.productivity = 0;
       return;
     }
@@ -85,10 +88,12 @@ class GhgFactory extends Building {
         // No reversal available: only push in the forward direction.
         // Early disable checks that do not require resource access.
         if (recipeKey === 'ghg' && currentTemp >= A) {
+          this.setAutomationActivityMultiplier(0);
           this.productivity = 0;
           return;
         }
         if (recipeKey === 'calcite' && currentTemp <= A) {
+          this.setAutomationActivityMultiplier(0);
           this.productivity = 0;
           return;
         }
@@ -116,10 +121,10 @@ class GhgFactory extends Building {
                 ), maxProduction);
                 this.reverseEnabled = false;
                 // Fallback: if solver cannot find a step but we are still above M, run at max allowed
-                const prod = (required > 0) ? (required / maxProduction) : (currentTemp > M ? 1 : 0);
-                this.productivity = Math.min(targetProductivity, prod);
-                return;
-              }
+              const prod = (required > 0) ? (required / maxProduction) : (currentTemp > M ? 1 : 0);
+              this.productivity = Math.min(targetProductivity, prod);
+              return;
+            }
 
               // Inside the range: maintain enough to offset decay at the midpoint mass
               const halfLife = (typeof CALCITE_HALF_LIFE_SECONDS !== 'undefined') ? CALCITE_HALF_LIFE_SECONDS : 240;
@@ -245,6 +250,7 @@ class GhgFactory extends Building {
               return;
             }
           }
+          this.setAutomationActivityMultiplier(0);
           this.productivity = 0;
           return;
         }

--- a/src/js/buildings/OxygenFactory.js
+++ b/src/js/buildings/OxygenFactory.js
@@ -14,6 +14,8 @@ class OxygenFactory extends Building {
   }
 
   updateProductivity(resources, deltaTime) {
+    this.setAutomationActivityMultiplier(1);
+
     const {
       targetProductivity: baseTarget,
       hasAtmosphericOversight,
@@ -22,6 +24,7 @@ class OxygenFactory extends Building {
     } = this.computeBaseProductivity(resources, deltaTime);
 
     if (this.active === 0) {
+      this.setAutomationActivityMultiplier(0);
       this.productivity = 0;
       return;
     }
@@ -44,6 +47,7 @@ class OxygenFactory extends Building {
         terraforming.celestialParameters.radius
       );
       if (currentPa >= targetPa) {
+        this.setAutomationActivityMultiplier(0);
         this.productivity = 0;
         return;
       }

--- a/src/js/buildings/dysonReceiver.js
+++ b/src/js/buildings/dysonReceiver.js
@@ -87,14 +87,18 @@ class DysonReceiver extends Building {
   }
 
   updateProductivity(resources, deltaTime) {
+    this.setAutomationActivityMultiplier(1);
+
     const { targetProductivity } = this.computeBaseProductivity(resources, deltaTime);
     if (this.active === 0) {
+      this.setAutomationActivityMultiplier(0);
       this.productivity = 0;
       return;
     }
     const project = projectManager?.projects?.dysonSwarmReceiver;
     const perBuilding = this.production?.colony?.energy || 0;
     if (!project || !project.isCompleted || project.collectors <= 0 || perBuilding <= 0) {
+      this.setAutomationActivityMultiplier(0);
       this.productivity = 0;
       return;
     }

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -384,11 +384,12 @@ function calculateProductionRates(deltaTime, buildings) {
 
   for (const buildingName in buildings) {
     const building = buildings[buildingName];
+    const automationMultiplier = building.getAutomationActivityMultiplier?.() ?? 1;
 
     // Calculate scaled production rates
     for (const category in building.production) {
       for (const resource in building.production[category]) {
-        const actualProduction = (building.production[category][resource] || 0) * building.active * building.getProductionRatio() * building.getEffectiveProductionMultiplier() * building.getEffectiveResourceProductionMultiplier(category, resource);
+        const actualProduction = (building.production[category][resource] || 0) * building.active * building.getProductionRatio() * building.getEffectiveProductionMultiplier() * building.getEffectiveResourceProductionMultiplier(category, resource) * automationMultiplier;
         // Specify 'building' as the rateType
         resources[category][resource].modifyRate(actualProduction, building.displayName, 'building');
       }
@@ -399,7 +400,7 @@ function calculateProductionRates(deltaTime, buildings) {
       for (const resource in building.consumption[category]) {
         const entry = building.getConsumptionResource ? building.getConsumptionResource(category, resource) : { amount: building.consumption[category][resource] };
         const amount = entry.amount || 0;
-        const actualConsumption = amount * building.active * building.getConsumptionRatio() * building.getEffectiveConsumptionMultiplier() * building.getEffectiveResourceConsumptionMultiplier(category, resource);
+        const actualConsumption = amount * building.active * building.getConsumptionRatio() * building.getEffectiveConsumptionMultiplier() * building.getEffectiveResourceConsumptionMultiplier(category, resource) * automationMultiplier;
         // Specify 'building' as the rateType
         resources[category][resource].modifyRate(-actualConsumption, building.displayName, 'building');
       }
@@ -410,7 +411,7 @@ function calculateProductionRates(deltaTime, buildings) {
     for (const resource in maintenanceCost) {
       const sourceData = resources.colony[resource];
       if (!sourceData || !sourceData.maintenanceConversion) continue;
-      const base = maintenanceCost[resource] * building.active * building.productivity;
+      const base = maintenanceCost[resource] * building.active * building.productivity * automationMultiplier;
       const conversionValue = sourceData.conversionValue || 1;
       for (const targetCategory in sourceData.maintenanceConversion) {
         const targetResource = sourceData.maintenanceConversion[targetCategory];


### PR DESCRIPTION
## Summary
- add an automation activity multiplier to the base Building class and propagate it through building-specific productivity overrides so automated shutdowns are flagged
- factor the automation activity multiplier into calculateProductionRates so production, consumption, and maintenance conversions ignore buildings that automation has paused

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e68405ef248327a48fe5e0d6d86e26