### PR TITLE
Improve travel auto-start reset handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Do not use globalThis.  It never ever ends up working out because the objects you are looking for are never actually attached to it.  Use the global variable directly instead, or adapt your test accordingly.
 - Keep code short, concise and easily readable.  Avoid any unnecessary checks for objects that should obviously exist.
 - When taking screenshots, if you want it to succeed, you must modify DEBUG_MODE from src/js/debug_constants.js to true, otherwise you will not be able to skip the intro cutscene.
+- Added a travel auto-start reset preference for Dyson Swarm and Space Storage projects.
 
 # Overview of code
 This repository contains a browser-based incremental game written in JavaScript. The

--- a/__tests__/projects-travel.test.js
+++ b/__tests__/projects-travel.test.js
@@ -1,0 +1,90 @@
+const EffectableEntity = require('../src/js/effectable-entity');
+
+describe('ProjectManager auto-start travel behaviour', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  const createManager = () => {
+    global.EffectableEntity = EffectableEntity;
+    const { ProjectManager } = require('../src/js/projects.js');
+    const manager = new ProjectManager();
+    manager.initializeProjects({
+      dysonSwarmReceiver: {
+        name: 'Dyson Swarm',
+        category: 'mega',
+        cost: { colony: { metal: 1 } },
+        duration: 1000,
+        description: '',
+        repeatable: false,
+        unlocked: true,
+        attributes: { canUseSpaceStorage: true },
+      },
+      spaceStorage: {
+        name: 'Space Storage',
+        category: 'mega',
+        cost: { colony: { metal: 1 } },
+        duration: 1000,
+        description: '',
+        repeatable: true,
+        unlocked: true,
+        attributes: { spaceStorage: true, canUseSpaceStorage: true },
+      },
+    });
+    return manager;
+  };
+
+  afterEach(() => {
+    delete global.gameSettings;
+    delete global.Project;
+    delete global.ProjectManager;
+    delete global.projectManager;
+    delete global.EffectableEntity;
+    jest.resetModules();
+  });
+
+  it('persists the uncheck preference through save/load cycles', () => {
+    const manager = createManager();
+    manager.projects.spaceStorage.autoStartUncheckOnTravel = true;
+
+    const saved = manager.saveState();
+
+    const restored = createManager();
+    restored.loadState(saved);
+
+    expect(restored.projects.spaceStorage.autoStartUncheckOnTravel).toBe(true);
+  });
+
+  it('clears auto-start on travel even when preservation is enabled', () => {
+    const manager = createManager();
+    const dyson = manager.projects.dysonSwarmReceiver;
+    dyson.autoStart = true;
+    dyson.autoStartUncheckOnTravel = true;
+
+    const travelState = manager.saveTravelState();
+
+    const afterTravel = createManager();
+    global.gameSettings = { preserveProjectAutoStart: true };
+    afterTravel.projects.dysonSwarmReceiver.autoStart = true;
+
+    afterTravel.loadTravelState(travelState);
+
+    expect(afterTravel.projects.dysonSwarmReceiver.autoStart).toBe(false);
+    expect(afterTravel.projects.dysonSwarmReceiver.autoStartUncheckOnTravel).toBe(true);
+  });
+
+  it('forces auto-start off if a legacy travel state kept it enabled', () => {
+    const manager = createManager();
+    global.gameSettings = { preserveProjectAutoStart: true };
+    manager.projects.spaceStorage.autoStart = true;
+
+    manager.loadTravelState({
+      spaceStorage: {
+        autoStart: true,
+        autoStartUncheckOnTravel: true,
+      },
+    });
+
+    expect(manager.projects.spaceStorage.autoStart).toBe(false);
+  });
+});

--- a/src/js/projectsUI.js
+++ b/src/js/projectsUI.js
@@ -332,6 +332,23 @@ function createProjectItem(project) {
   autoStartLabel.textContent = 'Auto start';
   autoStartCheckboxContainer.appendChild(autoStartCheckbox);
   autoStartCheckboxContainer.appendChild(autoStartLabel);
+  const showTravelReset = project.name === 'dysonSwarmReceiver' || project.attributes?.spaceStorage;
+  let autoStartTravelResetCheckbox = null;
+  let autoStartTravelResetLabel = null;
+  if (showTravelReset) {
+    autoStartTravelResetCheckbox = document.createElement('input');
+    autoStartTravelResetCheckbox.type = 'checkbox';
+    autoStartTravelResetCheckbox.id = `${project.name}-auto-start-travel-reset`;
+    autoStartTravelResetCheckbox.checked = project.autoStartUncheckOnTravel === true;
+    autoStartTravelResetCheckbox.addEventListener('change', (event) => {
+      project.autoStartUncheckOnTravel = event.target.checked;
+    });
+    autoStartTravelResetLabel = document.createElement('label');
+    autoStartTravelResetLabel.htmlFor = autoStartTravelResetCheckbox.id;
+    autoStartTravelResetLabel.textContent = 'Uncheck on travelling';
+    autoStartCheckboxContainer.appendChild(autoStartTravelResetCheckbox);
+    autoStartCheckboxContainer.appendChild(autoStartTravelResetLabel);
+  }
   automationSettingsContainer.appendChild(autoStartCheckboxContainer);
   cardFooter.appendChild(automationSettingsContainer);
 
@@ -347,6 +364,8 @@ function createProjectItem(project) {
     autoStartCheckbox: autoStartCheckbox,
     autoStartCheckboxContainer: autoStartCheckboxContainer,
     autoStartLabel: autoStartLabel,
+    autoStartTravelResetCheckbox: autoStartTravelResetCheckbox,
+    autoStartTravelResetLabel: autoStartTravelResetLabel,
     automationSettingsContainer: automationSettingsContainer,
     cardFooter: cardFooter,
     upButton: upButton,
@@ -671,6 +690,9 @@ function updateProjectUI(projectName) {
   // Set the auto-start checkbox state based on the project data
   if (elements.autoStartCheckbox) {
     elements.autoStartCheckbox.checked = project.autoStart || false;
+  }
+  if (elements.autoStartTravelResetCheckbox) {
+    elements.autoStartTravelResetCheckbox.checked = project.autoStartUncheckOnTravel === true;
   }
   if (elements.autoStartLabel) {
     const continuous = project.isContinuous();


### PR DESCRIPTION
## Summary
- initialise the "Uncheck on travelling" UI toggle from project state and cache it alongside other automation controls
- export Project and ProjectManager for tests and keep the travel reset logic clearing auto-start before refreshing the UI
- add regression tests covering save/load persistence and travel auto-start clearing when the reset option is enabled

## Testing
- CI=true npm test 2>&1 | tee test.log

------
https://chatgpt.com/codex/tasks/task_b_6902985a21fc832791b38df0b25eb222