### PR TITLE
Focus Umbra chapter 21.1 on the hazards subtab

### DIFF
--- a/src/js/effectable-entity.js
+++ b/src/js/effectable-entity.js
@@ -617,6 +617,7 @@ function addOrRemoveEffect(effect, action) {
     'researchManager' : researchManager,
     'solisManager' : solisManager,
     'spaceManager' : spaceManager,
+    'space': spaceManager,
     'warpGateCommand' : warpGateCommand,
     'rwgManager': typeof rwgManager !== 'undefined' ? rwgManager : undefined,
     'nanotechManager': typeof nanotechManager !== 'undefined' ? nanotechManager : undefined,

--- a/src/js/space.js
+++ b/src/js/space.js
@@ -555,6 +555,21 @@ class SpaceManager extends EffectableEntity {
         }
     }
 
+    activateTab(tabId) {
+        const tabElement = document.querySelector(`[data-tab="${tabId}"]`);
+        const tabContentElement = document.getElementById(tabId);
+
+        if (!tabElement || !tabContentElement) {
+            return;
+        }
+
+        document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
+
+        tabElement.classList.add('active');
+        tabContentElement.classList.add('active');
+    }
+
     /**
      * Gets the full status object for a specific planet.
      * @param {string} planetKey - The key of the planet.

--- a/src/js/story/umbra.js
+++ b/src/js/story/umbra.js
@@ -29,6 +29,21 @@ progressUmbra.chapters.push(
         type: 'booleanFlag',
         flagId: 'hazardsUnlocked',
         value: true
+      },
+      {
+        target: 'space',
+        targetId: 'terraforming',
+        type: 'activateTab',
+        onLoad: false
+      },
+      {
+        target: 'space',
+        type: 'activateSubtab',
+        subtabClass: 'terraforming-subtab',
+        contentClass: 'terraforming-subtab-content',
+        targetId: 'hazard-terraforming',
+        unhide: true,
+        onLoad: false
       }
     ]
   },


### PR DESCRIPTION
## Summary
- allow story rewards targeting `space` to route activateTab and activateSubtab effects through the space manager
- add a tab activation helper to the space manager so rewards can steer the UI
- update Umbra chapter 21.1 to open the terraforming tab and hazards subtab when the reward triggers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6907a83484648327af552bfb95172d14