### PR TITLE
Rename hazard severityHigh to severityAbove

### DIFF
--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -960,7 +960,7 @@ const umbraOverrides = {
         max: 303.15,
         unit: 'K',
         severityBelow: 0.0025,
-        severityHigh: 0.0050
+        severityAbove: 0.0050
       },
       radiationPreference: { min: 0, max: 0.01, unit: 'mSv/day', severity: 100 },
       penalties: {

--- a/src/js/terraforming/hazard.js
+++ b/src/js/terraforming/hazard.js
@@ -582,7 +582,7 @@ class HazardManager {
 
     const defaultSeverity = Number.isFinite(entry.severity) ? entry.severity : 1;
     const severityBelow = Number.isFinite(entry.severityBelow) ? entry.severityBelow : defaultSeverity;
-    const severityHigh = Number.isFinite(entry.severityHigh) ? entry.severityHigh : defaultSeverity;
+    const severityAbove = Number.isFinite(entry.severityAbove) ? entry.severityAbove : defaultSeverity;
 
     const hasMin = Number.isFinite(entry.min);
     const hasMax = Number.isFinite(entry.max);
@@ -597,7 +597,7 @@ class HazardManager {
     }
 
     if (hasMax && value > entry.max) {
-      const severity = Number.isFinite(severityHigh) ? severityHigh : 0;
+      const severity = Number.isFinite(severityAbove) ? severityAbove : 0;
       if (!severity) {
         return 0;
       }

--- a/src/js/terraforming/hazardUI.js
+++ b/src/js/terraforming/hazardUI.js
@@ -137,8 +137,8 @@ function formatSeverityDetails(entry) {
     details.push(`Severity Below ×${formatNumeric(entry.severityBelow, 3)}`);
   }
 
-  if (Number.isFinite(entry.severityHigh)) {
-    details.push(`Severity High ×${formatNumeric(entry.severityHigh, 3)}`);
+  if (Number.isFinite(entry.severityAbove)) {
+    details.push(`Severity Above ×${formatNumeric(entry.severityAbove, 3)}`);
   }
 
   if (!details.length && Number.isFinite(entry.severity)) {


### PR DESCRIPTION
## Summary
- rename hazard severityHigh configuration keys to severityAbove for above-threshold penalties
- update hazard UI formatting and calculations to use the new severityAbove label

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6907b0c170b8832789d2fc1b31acdbfb