### PR TITLE
Add label to research auto toggle

### DIFF
--- a/src/js/researchUI.js
+++ b/src/js/researchUI.js
@@ -59,7 +59,7 @@ function updateAllResearchButtons(researchData) {
         researchData[tab].forEach((researchItem) => {
             const elements = researchElementCache.get(researchItem.id);
             if (!elements) return;
-            const { button, costEl, descEl, container, autoCheckbox } = elements;
+            const { button, costEl, descEl, container, autoCheckbox, autoCheckboxLabel } = elements;
 
             if (researchItem.isResearched) {
                 container.classList.add('completed-research');
@@ -86,7 +86,11 @@ function updateAllResearchButtons(researchData) {
             if (autoCheckbox) {
                 const unlocked = researchManager.autoResearchEnabled ||
                     researchManager.isBooleanFlagSet('autoResearchEnabled');
-                autoCheckbox.style.display = unlocked ? '' : 'none';
+                if (autoCheckboxLabel) {
+                    autoCheckboxLabel.style.display = unlocked ? '' : 'none';
+                } else {
+                    autoCheckbox.style.display = unlocked ? '' : 'none';
+                }
                 if (unlocked) {
                     autoCheckbox.checked = researchManager.isAutoResearchEnabled(
                         researchManager.currentAutoResearchPreset,
@@ -301,6 +305,7 @@ function loadResearchCategory(category) {
         }
 
         let autoCheckbox = null;
+        let autoCheckboxLabel = null;
         if (category !== 'advanced') {
             autoCheckbox = document.createElement('input');
             autoCheckbox.type = 'checkbox';
@@ -324,8 +329,15 @@ function loadResearchCategory(category) {
             });
             const unlocked = researchManager.autoResearchEnabled ||
                 researchManager.isBooleanFlagSet('autoResearchEnabled');
-            autoCheckbox.style.display = unlocked ? '' : 'none';
-            researchContainer.appendChild(autoCheckbox);
+            autoCheckboxLabel = document.createElement('label');
+            autoCheckboxLabel.classList.add('research-auto-checkbox-label');
+            autoCheckboxLabel.appendChild(autoCheckbox);
+            autoCheckboxLabel.appendChild(document.createTextNode('Auto Research'));
+            autoCheckboxLabel.style.display = unlocked ? '' : 'none';
+            autoCheckboxLabel.addEventListener('click', (event) => {
+                event.stopPropagation();
+            });
+            researchContainer.appendChild(autoCheckboxLabel);
         }
 
         // Append button, cost, and description to the research container
@@ -342,6 +354,7 @@ function loadResearchCategory(category) {
             costEl: researchCost,
             descEl: researchDescription,
             autoCheckbox,
+            autoCheckboxLabel,
         });
     });
 }


### PR DESCRIPTION
## Summary
- wrap the research auto checkbox in a label so the text "Auto Research" appears beside it
- ensure the label visibility updates with the auto research unlock state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6907ce5a2498832798d6249139872a83