### PR TITLE
Remove star entry for rogue Solis Prime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,3 +302,6 @@ The planet visualiser has been modularised into files covering core setup, light
 - Lifters now provide an automation toggle to permit colony energy usage when Dyson overflow energy cannot sustain operations.
 - Random worlds that include hazards now grant double RWG effects when terraformed, and the RWG UI displays the hazard bonus as an added count.
 - Added a Warpnet advanced research that unlocks a permanent colony slider for global research boosts.
+
+## Feature updates
+- Added Solis Prime as a rogue story planet that relies on background radiation for luminosity.

--- a/src/js/planet-parameters.js
+++ b/src/js/planet-parameters.js
@@ -978,6 +978,23 @@ const umbraOverrides = {
   }
 };
 
+const solisPrimeOverrides = {
+  name: 'Solis Prime',
+  celestialParameters: {
+    distanceFromSun: 0,
+    gravity: 9.12,
+    radius: 6020,
+    mass: 4.6e24,
+    albedo: 0.14,
+    rotationPeriod: 19,
+    starLuminosity: 0,
+    rogue: true
+  },
+  visualization: {
+    baseColor: '#1f2433',
+  }
+};
+
 // --- Parameter Retrieval Logic ---
 
 const planetSpecificOverrides = {
@@ -987,7 +1004,8 @@ const planetSpecificOverrides = {
   ganymede: ganymedeOverrides,
   vega2: vega2Overrides,
   venus: venusOverrides,
-  umbra: umbraOverrides
+  umbra: umbraOverrides,
+  solisprime: solisPrimeOverrides
   // Add future planets here by defining their override objects
 };
 // Expose overrides for modules needing raw planet data
@@ -1010,7 +1028,13 @@ function getPlanetParameters(planetName) {
   }
 
   // Perform a deep merge of defaults and the specific planet's overrides
-  return deepMerge(defaultPlanetParameters, overrides);
+  const mergedParameters = deepMerge(defaultPlanetParameters, overrides);
+
+  if (mergedParameters.celestialParameters && mergedParameters.celestialParameters.rogue) {
+    delete mergedParameters.star;
+  }
+
+  return mergedParameters;
 }
 
 // --- Export Structure ---
@@ -1026,6 +1050,7 @@ const planetParameters = {
     vega2: getPlanetParameters('vega2'),
     venus: getPlanetParameters('venus'),
     umbra: getPlanetParameters('umbra'),
+    solisprime: getPlanetParameters('solisprime'),
 };
 
 // If the codebase evolves to use the getPlanetParameters function directly,


### PR DESCRIPTION
## Summary
- remove explicit star definition from Solis Prime so it behaves as a true rogue world
- clear merged planet parameters of any star data whenever celestial parameters mark a planet as rogue

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ce8a4eb7c8327bd64bdeeee5aec17)