### PR TITLE
Handle blank pressure inputs for space mining

### DIFF
--- a/src/js/projects/SpaceMiningProject.js
+++ b/src/js/projects/SpaceMiningProject.js
@@ -77,6 +77,12 @@ class SpaceMiningProject extends SpaceshipProject {
     input.addEventListener('input', () => {
       const val = parseFloat(input.value);
       const unitProp = `${key}Unit`;
+      if (!Number.isFinite(val)) {
+        input.value = this[unitProp] === 'Pa'
+          ? this[thresholdProp] * 1000
+          : this[thresholdProp];
+        return;
+      }
       this[thresholdProp] = this[unitProp] === 'Pa' ? (val / 1000) : val;
     });
     control.appendChild(input);


### PR DESCRIPTION
## Summary
- prevent blank pressure inputs from forcing pressure thresholds to NaN by restoring the last valid value when the field is empty

## Testing
- CI=true npm test 2>&1 | tee test.log

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691e7fb4fd048327ae6a0c64ae4424a3)