### PR TITLE
Add nanocolony warnings for sandless and oreless planets

### DIFF
--- a/src/css/colonies.css
+++ b/src/css/colonies.css
@@ -340,6 +340,13 @@ input[type="range"].pretty-slider::-moz-range-thumb {
   padding-bottom: 6px;
 }
 
+#nanocolony-container .nanotech-stage-warning {
+  margin-left: 8px;
+  color: #c77a16;
+  font-size: 0.9em;
+  display: none;
+}
+
 #nanocolony-container .nanotech-slider-grid {
   display: grid;
   gap: 12px;

--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -159,6 +159,10 @@
     border-bottom-color: #444;
 }
 
+.dark-mode #nanocolony-container .nanotech-stage-warning {
+    color: #f3c969;
+}
+
 .dark-mode #nanocolony-container .nanotech-slider-card .slider-title,
 .dark-mode #nanocolony-container .nanotech-slider-card .slider-values {
     color: #f0f0f0;


### PR DESCRIPTION
## Summary
- limit nanocolony glass production to silicon input on sandless planets and components production to metal input when no ore deposits
- show warning indicators on nanocolony stage headers explaining the caps
- add styling for the new warnings in both regular and dark modes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921d1d8cb948327957ae0ed75cf3adf)