### PR TITLE
Feat/automation sharing

### DIFF
--- a/src/css/automation.css
+++ b/src/css/automation.css
@@ -1586,3 +1586,137 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Import dialog */
+.automation-import-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 6000;
+}
+
+.automation-import-dialog-overlay.is-visible {
+  display: flex;
+}
+
+.automation-import-dialog-window {
+  width: min(720px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  background: #fff;
+  color: #1a1f2e;
+  border: 1px solid #d0d6e4;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-sizing: border-box;
+}
+
+.automation-import-dialog-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #1a1f2e;
+}
+
+.automation-import-dialog-description {
+  margin: 0;
+  font-size: 13px;
+  color: #5a6478;
+  white-space: pre-line;
+}
+
+.automation-import-dialog-textarea {
+  width: 100%;
+  min-height: 200px;
+  resize: vertical;
+  box-sizing: border-box;
+  background: #f7f9fc;
+  border: 1px solid #c4cad7;
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 12px;
+  font-family: monospace;
+  color: #1a1f2e;
+}
+
+.automation-import-dialog-textarea:focus {
+  outline: none;
+  border-color: #7ba0f0;
+  box-shadow: 0 0 0 2px rgba(123, 160, 240, 0.2);
+}
+
+.automation-import-dialog-message {
+  min-height: 18px;
+  font-size: 13px;
+  color: #c0392b;
+}
+
+.automation-import-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.automation-import-dialog-cancel,
+.automation-import-dialog-confirm {
+  border: 1px solid #c4cad7;
+  border-radius: 4px;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+
+.automation-import-dialog-cancel {
+  background: #f1f4f9;
+  color: #3a4460;
+}
+
+.automation-import-dialog-cancel:hover {
+  background: #e2e7f2;
+}
+
+.automation-import-dialog-confirm {
+  background: #3f7bf7;
+  border-color: #3f7bf7;
+  color: #fff;
+}
+
+.automation-import-dialog-confirm:hover {
+  background: #2d63e0;
+  border-color: #2d63e0;
+}
+
+/* Global toolbar */
+.automation-global-toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 10px 0 6px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid #e0e5ef;
+}
+
+.automation-global-export,
+.automation-global-import {
+  border: 1px solid #c4cad7;
+  background: #f1f4f9;
+  border-radius: 4px;
+  padding: 5px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s ease, transform 0.08s ease;
+  color: #3a4460;
+}
+
+.automation-global-export:hover,
+.automation-global-import:hover {
+  background: #e2e7f2;
+  transform: translateY(-1px);
+}

--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -1143,6 +1143,71 @@ body.dark-mode {
     border-color: #444;
 }
 
+.dark-mode .automation-import-dialog-window {
+    background: #111827;
+    color: #e7ecf7;
+    border-color: #2d3a50;
+}
+
+.dark-mode .automation-import-dialog-title {
+    color: #e7ecf7;
+}
+
+.dark-mode .automation-import-dialog-description {
+    color: #8fa3c8;
+}
+
+.dark-mode .automation-import-dialog-textarea {
+    background: #0d1522;
+    border-color: #32435f;
+    color: #e7ecf7;
+}
+
+.dark-mode .automation-import-dialog-textarea:focus {
+    border-color: #74a0ff;
+    box-shadow: 0 0 0 2px rgba(116, 160, 255, 0.2);
+}
+
+.dark-mode .automation-import-dialog-message {
+    color: #f1a0a0;
+}
+
+.dark-mode .automation-import-dialog-cancel {
+    background: #1a2538;
+    border-color: #2b3a53;
+    color: #e7ecf7;
+}
+
+.dark-mode .automation-import-dialog-cancel:hover {
+    background: #24324a;
+}
+
+.dark-mode .automation-import-dialog-confirm {
+    background: linear-gradient(180deg, #2d63ff 0%, #1d3fb6 100%);
+    border-color: #3f7bf7;
+    color: #fff;
+}
+
+.dark-mode .automation-import-dialog-confirm:hover {
+    background: linear-gradient(180deg, #3f7bf7 0%, #2d63ff 100%);
+}
+
+.dark-mode .automation-global-toolbar {
+    border-bottom-color: #2d3a50;
+}
+
+.dark-mode .automation-global-export,
+.dark-mode .automation-global-import {
+    background: #1a2538;
+    border-color: #2b3a53;
+    color: #e7ecf7;
+}
+
+.dark-mode .automation-global-export:hover,
+.dark-mode .automation-global-import:hover {
+    background: #24324a;
+}
+
 .dark-mode .automation-card {
     background: linear-gradient(180deg, #161b26 0%, #0f141d 100%);
     border-color: #2d3a50;

--- a/src/js/automation/automationLifeUI.js
+++ b/src/js/automation/automationLifeUI.js
@@ -24,6 +24,9 @@ function buildAutomationLifeUI() {
   card.appendChild(body);
 
   const presetRow = createAutomationPresetRow(body);
+  const lifeTransferButtons = createAutomationPresetTransferButtons('life-automation-preset');
+  presetRow.presetRow.appendChild(lifeTransferButtons.importButton);
+  presetRow.presetRow.appendChild(lifeTransferButtons.exportButton);
 
   const purchaseSection = document.createElement('div');
   purchaseSection.classList.add('life-automation-section');
@@ -127,6 +130,8 @@ function buildAutomationLifeUI() {
   automationElements.lifeSeedButton = seedButton;
   automationElements.lifeDesignEnableCheckbox = designEnable;
   automationElements.lifeDeployNowButton = deployNowButton;
+  automationElements.lifeImportPresetButton = lifeTransferButtons.importButton;
+  automationElements.lifeExportPresetButton = lifeTransferButtons.exportButton;
 
   attachLifeAutomationHandlers();
 }
@@ -153,7 +158,9 @@ function updateLifeAutomationUI() {
     lifeDeployInput,
     lifeSeedRow,
     lifeDesignEnableCheckbox,
-    lifeDeployNowButton
+    lifeDeployNowButton,
+    lifeImportPresetButton,
+    lifeExportPresetButton
   } = automationElements;
   const manager = automationManager;
   const automation = manager.lifeAutomation;
@@ -203,6 +210,8 @@ function updateLifeAutomationUI() {
     : null;
   const canDeploy = deployCandidate && deployCandidate.canSurviveAnywhere();
   lifeDeployNowButton.disabled = !canDeploy;
+  lifeImportPresetButton.disabled = false;
+  lifeExportPresetButton.disabled = !activePreset;
 
   // Only rebuild purchase container if no input within is focused
   const purchaseActiveElement = document.activeElement;
@@ -384,6 +393,33 @@ function attachLifeAutomationHandlers() {
     automation.forceDeployDesign(preset.id);
     queueAutomationUIRefresh();
     updateAutomationUI();
+  });
+
+  automationElements.lifeExportPresetButton.addEventListener('click', () => {
+    const automation = automationManager.lifeAutomation;
+    const preset = automation.getActivePreset();
+    exportAutomationPresetToClipboard('life', automation.exportPreset(preset.id), automationElements.lifeExportPresetButton);
+  });
+
+  automationElements.lifeImportPresetButton.addEventListener('click', () => {
+    openAutomationPresetImportDialog({
+      title: getAutomationCardText('importLifePresetTitle', {}, 'Import Life Preset'),
+      description: getAutomationCardText(
+        'importPresetDescription',
+        {},
+        'Paste an exported preset string below. Import adds it as a new preset.'
+      ),
+      onImport: (text) => {
+        const parsed = parseAutomationPresetTransferPayload(text, 'life');
+        if (!parsed.ok) {
+          return parsed;
+        }
+        automationManager.lifeAutomation.importPreset(parsed.preset);
+        queueAutomationUIRefresh();
+        updateAutomationUI();
+        return { ok: true };
+      }
+    });
   });
 }
 

--- a/src/js/automation/automationScriptUI.js
+++ b/src/js/automation/automationScriptUI.js
@@ -127,7 +127,8 @@ function buildScriptAutomationUI() {
   deleteButton.classList.add('script-automation-delete');
   deleteButton.textContent = getAutomationCardText('scriptDelete', {}, 'Delete');
 
-  scriptRow.append(scriptSelect, scriptName, newButton, duplicateButton, deleteButton);
+  const scriptTransferButtons = createAutomationPresetTransferButtons('script-automation-script');
+  scriptRow.append(scriptSelect, scriptName, newButton, duplicateButton, deleteButton, scriptTransferButtons.importButton, scriptTransferButtons.exportButton);
   body.appendChild(scriptRow);
 
   const linesContainer = document.createElement('div');
@@ -158,6 +159,8 @@ function buildScriptAutomationUI() {
   automationElements.scriptDeleteButton = deleteButton;
   automationElements.scriptLinesContainer = linesContainer;
   automationElements.scriptAddLineButton = addLineButton;
+  automationElements.scriptImportButton = scriptTransferButtons.importButton;
+  automationElements.scriptExportButton = scriptTransferButtons.exportButton;
 
   wireScriptAutomationEvents();
 }
@@ -285,6 +288,39 @@ function wireScriptAutomationEvents() {
     forceScriptAutomationRefresh = true;
     queueAutomationUIRefresh();
   });
+
+  els.scriptExportButton.addEventListener('click', () => {
+    const automation = getScriptAutomation();
+    const script = automation?.getSelectedScript();
+    if (!automation || !script) return;
+    exportAutomationPresetToClipboard('script', automation.exportScript(script.id), els.scriptExportButton);
+  });
+
+  els.scriptImportButton.addEventListener('click', () => {
+    openAutomationPresetImportDialog({
+      title: getAutomationCardText('importScriptTitle', {}, 'Import Script'),
+      description: getAutomationCardText(
+        'importPresetDescription',
+        {},
+        'Paste an exported preset string below. Import adds it as a new preset.'
+      ),
+      onImport: (text) => {
+        const parsed = parseAutomationPresetTransferPayload(text, 'script');
+        if (!parsed.ok) {
+          return parsed;
+        }
+        const automation = getScriptAutomation();
+        if (!automation) {
+          return { ok: false, error: getAutomationCardText('importPresetFailed', {}, 'Could not import that preset.') };
+        }
+        automation.importScript(parsed.preset);
+        forceScriptAutomationRefresh = true;
+        queueAutomationUIRefresh();
+        updateAutomationUI();
+        return { ok: true };
+      }
+    });
+  });
 }
 
 function updateScriptAutomationUI() {
@@ -364,6 +400,8 @@ function updateScriptAutomationUI() {
   automationElements.scriptPauseButton.disabled = !automation.running;
   automationElements.scriptStepButton.disabled = !automation.enabled || !script;
   automationElements.scriptResetButton.disabled = !script;
+  automationElements.scriptImportButton.disabled = false;
+  automationElements.scriptExportButton.disabled = !script;
 
   const displayLineId = automation.getDisplayLineId ? automation.getDisplayLineId() : automation.pcLineId;
   const currentLine = script?.lines.find(line => line.id === displayLineId);

--- a/src/js/automation/automationShipUI.js
+++ b/src/js/automation/automationShipUI.js
@@ -140,6 +140,9 @@ function buildAutomationShipUI() {
   card.appendChild(body);
 
   const presetRow = createAutomationPresetRow(body);
+  const shipTransferButtons = createAutomationPresetTransferButtons('ship-automation-preset');
+  presetRow.presetRow.appendChild(shipTransferButtons.importButton);
+  presetRow.presetRow.appendChild(shipTransferButtons.exportButton);
 
   const stepsContainer = document.createElement('div');
   stepsContainer.classList.add('automation-steps');
@@ -163,6 +166,8 @@ function buildAutomationShipUI() {
   automationElements.showPresetInSidebarCheckbox = presetRow.showInSidebarCheckbox;
   automationElements.stepsContainer = stepsContainer;
   automationElements.addStepButton = addStepButton;
+  automationElements.shipImportPresetButton = shipTransferButtons.importButton;
+  automationElements.shipExportPresetButton = shipTransferButtons.exportButton;
 
   attachAutomationHandlers();
 }
@@ -259,6 +264,12 @@ function updateShipAutomationUI() {
     forceShipStepsRefresh = false;
   }
   addStepButton.disabled = !activePreset || activePreset.steps.length >= 10;
+  if (automationElements.shipImportPresetButton) {
+    automationElements.shipImportPresetButton.disabled = false;
+  }
+  if (automationElements.shipExportPresetButton) {
+    automationElements.shipExportPresetButton.disabled = !activePreset;
+  }
 }
 
 function attachAutomationHandlers() {
@@ -376,6 +387,43 @@ function attachAutomationHandlers() {
       forceShipStepsRefresh = true;
       queueAutomationUIRefresh();
       updateAutomationUI();
+    });
+  }
+
+  const { shipExportPresetButton, shipImportPresetButton } = automationElements;
+  if (shipExportPresetButton) {
+    shipExportPresetButton.addEventListener('click', () => {
+      if (!automationManager || !automationManager.spaceshipAutomation) return;
+      const automation = automationManager.spaceshipAutomation;
+      const preset = automation.getActivePreset();
+      if (!preset) return;
+      exportAutomationPresetToClipboard('ship', automation.exportPreset(preset.id), shipExportPresetButton);
+    });
+  }
+  if (shipImportPresetButton) {
+    shipImportPresetButton.addEventListener('click', () => {
+      openAutomationPresetImportDialog({
+        title: getAutomationCardText('importShipPresetTitle', {}, 'Import Ship Preset'),
+        description: getAutomationCardText(
+          'importPresetDescription',
+          {},
+          'Paste an exported preset string below. Import adds it as a new preset.'
+        ),
+        onImport: (text) => {
+          const parsed = parseAutomationPresetTransferPayload(text, 'ship');
+          if (!parsed.ok) {
+            return parsed;
+          }
+          if (!automationManager || !automationManager.spaceshipAutomation) {
+            return { ok: false, error: getAutomationCardText('importPresetFailed', {}, 'Could not import that preset.') };
+          }
+          automationManager.spaceshipAutomation.importPreset(parsed.preset);
+          forceShipStepsRefresh = true;
+          queueAutomationUIRefresh();
+          updateAutomationUI();
+          return { ok: true };
+        }
+      });
     });
   }
 }

--- a/src/js/automation/automationUI.js
+++ b/src/js/automation/automationUI.js
@@ -57,6 +57,8 @@ const automationElements = {
   scriptDeleteButton: null,
   scriptLinesContainer: null,
   scriptAddLineButton: null,
+  scriptImportButton: null,
+  scriptExportButton: null,
   shipAssignment: null,
   shipAssignmentStatus: null,
   shipAssignmentDescription: null,
@@ -72,6 +74,8 @@ const automationElements = {
   showPresetInSidebarCheckbox: null,
   stepsContainer: null,
   addStepButton: null,
+  shipImportPresetButton: null,
+  shipExportPresetButton: null,
   lifeDesign: null,
   lifeDesignStatus: null,
   lifeDesignDescription: null,
@@ -94,6 +98,10 @@ const automationElements = {
   lifeSeedButton: null,
   lifeDesignEnableCheckbox: null,
   lifeDeployNowButton: null,
+  lifeImportPresetButton: null,
+  lifeExportPresetButton: null,
+  globalExportButton: null,
+  globalImportButton: null,
   researchAutomation: null,
   researchAutomationStatus: null,
   researchAutomationDescription: null,
@@ -2084,6 +2092,131 @@ function openAutomationPresetImportDialog(options) {
   dialog.textarea.focus();
 }
 
+function buildAutomationGlobalPayload() {
+  const manager = automationManager;
+  return JSON.stringify({
+    format: 'terraforming-titans-all-automations',
+    version: 1,
+    autoTravel: manager.autoTravelAutomation ? manager.autoTravelAutomation.saveState() : null,
+    lifeAutomation: manager.lifeAutomation ? manager.lifeAutomation.saveState() : null,
+    spaceshipAutomation: manager.spaceshipAutomation ? manager.spaceshipAutomation.saveState() : null,
+    scriptAutomation: manager.scriptAutomation ? manager.scriptAutomation.saveState() : null,
+    buildingsAutomation: manager.buildingsAutomation ? manager.buildingsAutomation.saveState() : null,
+    researchAutomation: manager.researchAutomation ? manager.researchAutomation.saveState() : null,
+    projectsAutomation: manager.projectsAutomation ? manager.projectsAutomation.saveState() : null,
+    colonyAutomation: manager.colonyAutomation ? manager.colonyAutomation.saveState() : null
+  }, null, 2);
+}
+
+function exportAllAutomationsToClipboard(button) {
+  const payload = buildAutomationGlobalPayload();
+  copyTextToClipboard(payload, {
+    promptLabel: getAutomationCardText('exportAllAutomationsPrompt', {}, 'Copy all automations string:'),
+    onSuccess: () => {
+      setAutomationTransferButtonFeedback(
+        button,
+        getAutomationCardText('exportPresetCopied', {}, 'Copied')
+      );
+    }
+  });
+}
+
+function importAllAutomationsFromPayload(text) {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) {
+    return {
+      ok: false,
+      error: getAutomationCardText('importPresetEmptyError', {}, 'Paste a preset string first.')
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    return {
+      ok: false,
+      error: getAutomationCardText('importPresetInvalidJsonError', {}, 'That preset string is not valid JSON.')
+    };
+  }
+  if (!parsed || parsed.format !== 'terraforming-titans-all-automations') {
+    return {
+      ok: false,
+      error: getAutomationCardText('importAllWrongFormatError', {}, 'That string is not a valid all-automations export.')
+    };
+  }
+  const manager = automationManager;
+  if (parsed.autoTravel && manager.autoTravelAutomation) {
+    manager.autoTravelAutomation.loadState(parsed.autoTravel);
+  }
+  if (parsed.lifeAutomation && manager.lifeAutomation) {
+    manager.lifeAutomation.loadState(parsed.lifeAutomation);
+  }
+  if (parsed.spaceshipAutomation && manager.spaceshipAutomation) {
+    manager.spaceshipAutomation.loadState(parsed.spaceshipAutomation);
+  }
+  if (parsed.scriptAutomation && manager.scriptAutomation) {
+    manager.scriptAutomation.loadState(parsed.scriptAutomation);
+  }
+  if (parsed.buildingsAutomation && manager.buildingsAutomation) {
+    manager.buildingsAutomation.loadState(parsed.buildingsAutomation);
+  }
+  if (parsed.researchAutomation && manager.researchAutomation) {
+    manager.researchAutomation.loadState(parsed.researchAutomation);
+  }
+  if (parsed.projectsAutomation && manager.projectsAutomation) {
+    manager.projectsAutomation.loadState(parsed.projectsAutomation);
+  }
+  if (parsed.colonyAutomation && manager.colonyAutomation) {
+    manager.colonyAutomation.loadState(parsed.colonyAutomation);
+  }
+  return { ok: true };
+}
+
+function buildAutomationGlobalToolbar() {
+  const container = automationElements.container;
+  if (!container) {
+    return;
+  }
+  const toolbar = document.createElement('div');
+  toolbar.classList.add('automation-global-toolbar');
+
+  const exportButton = document.createElement('button');
+  exportButton.textContent = getAutomationCardText('exportAllAutomationsButton', {}, 'Export All Automations');
+  exportButton.classList.add('automation-global-export');
+  exportButton.addEventListener('click', () => {
+    exportAllAutomationsToClipboard(exportButton);
+  });
+
+  const importButton = document.createElement('button');
+  importButton.textContent = getAutomationCardText('importAllAutomationsButton', {}, 'Import All Automations');
+  importButton.classList.add('automation-global-import');
+  importButton.addEventListener('click', () => {
+    openAutomationPresetImportDialog({
+      title: getAutomationCardText('importAllAutomationsTitle', {}, 'Import All Automations'),
+      description: getAutomationCardText(
+        'importAllAutomationsDescription',
+        {},
+        'Paste an exported all-automations string below.\nThis will replace all current automation settings.'
+      ),
+      importButtonText: getAutomationCardText('importAllAutomationsButton', {}, 'Import All Automations'),
+      onImport: (text) => {
+        const result = importAllAutomationsFromPayload(text);
+        if (!result.ok) {
+          return result;
+        }
+        queueAutomationUIRefresh();
+        updateAutomationUI();
+        return { ok: true };
+      }
+    });
+  });
+
+  toolbar.append(exportButton, importButton);
+  container.insertBefore(toolbar, container.firstChild);
+  automationElements.globalExportButton = exportButton;
+  automationElements.globalImportButton = importButton;
+}
+
 function createAutomationPresetRow(body) {
   const presetRow = document.createElement('div');
   presetRow.classList.add('automation-preset-row');
@@ -2216,6 +2349,7 @@ function initializeAutomationUI() {
     return;
   }
   cacheAutomationElements();
+  buildAutomationGlobalToolbar();
   buildAutoTravelUI();
   buildScriptAutomationUI();
   buildAutomationShipUI();

--- a/src/js/automation/automationUI.js
+++ b/src/js/automation/automationUI.js
@@ -1983,54 +1983,32 @@ function ensureAutomationPresetImportDialog() {
   }
 
   const overlay = document.createElement('div');
-  overlay.style.position = 'fixed';
-  overlay.style.inset = '0';
-  overlay.style.background = 'rgba(0, 0, 0, 0.6)';
-  overlay.style.display = 'none';
-  overlay.style.alignItems = 'center';
-  overlay.style.justifyContent = 'center';
-  overlay.style.zIndex = '6000';
+  overlay.classList.add('automation-import-dialog-overlay');
 
   const windowEl = document.createElement('div');
-  windowEl.style.width = 'min(720px, calc(100vw - 32px))';
-  windowEl.style.maxHeight = 'calc(100vh - 32px)';
-  windowEl.style.overflow = 'auto';
-  windowEl.style.background = '#1f1f1f';
-  windowEl.style.color = '#f0f0f0';
-  windowEl.style.border = '1px solid rgba(255, 255, 255, 0.18)';
-  windowEl.style.borderRadius = '10px';
-  windowEl.style.padding = '16px';
-  windowEl.style.boxShadow = '0 16px 40px rgba(0, 0, 0, 0.45)';
+  windowEl.classList.add('automation-import-dialog-window');
 
   const title = document.createElement('h3');
-  title.style.margin = '0 0 8px';
-  title.style.fontSize = '18px';
+  title.classList.add('automation-import-dialog-title');
 
   const description = document.createElement('p');
-  description.style.margin = '0 0 12px';
-  description.style.whiteSpace = 'pre-line';
+  description.classList.add('automation-import-dialog-description');
 
   const textarea = document.createElement('textarea');
-  textarea.style.width = '100%';
-  textarea.style.minHeight = '240px';
-  textarea.style.resize = 'vertical';
-  textarea.style.boxSizing = 'border-box';
-  textarea.style.marginBottom = '8px';
+  textarea.classList.add('automation-import-dialog-textarea');
 
   const message = document.createElement('div');
-  message.style.minHeight = '20px';
-  message.style.marginBottom = '12px';
-  message.style.color = '#ff9a9a';
+  message.classList.add('automation-import-dialog-message');
 
   const actions = document.createElement('div');
-  actions.style.display = 'flex';
-  actions.style.justifyContent = 'flex-end';
-  actions.style.gap = '8px';
+  actions.classList.add('automation-import-dialog-actions');
 
   const cancelButton = document.createElement('button');
+  cancelButton.classList.add('automation-import-dialog-cancel');
   cancelButton.textContent = getAutomationCardText('cancelButton', {}, 'Cancel');
 
   const importButton = document.createElement('button');
+  importButton.classList.add('automation-import-dialog-confirm');
   importButton.textContent = getAutomationCardText('importPresetButton', {}, 'Import');
 
   actions.append(cancelButton, importButton);
@@ -2050,7 +2028,7 @@ function ensureAutomationPresetImportDialog() {
   };
 
   const closeDialog = () => {
-    overlay.style.display = 'none';
+    overlay.classList.remove('is-visible');
     message.textContent = '';
     textarea.value = '';
     automationPresetImportDialog.onImport = null;
@@ -2088,7 +2066,7 @@ function openAutomationPresetImportDialog(options) {
   dialog.message.textContent = '';
   dialog.textarea.value = '';
   dialog.onImport = options.onImport;
-  dialog.overlay.style.display = 'flex';
+  dialog.overlay.classList.add('is-visible');
   dialog.textarea.focus();
 }
 

--- a/src/js/automation/life-automation.js
+++ b/src/js/automation/life-automation.js
@@ -1108,6 +1108,68 @@ class LifeAutomation {
     const rounded = Math.round(parsed * 100) / 100;
     return Math.max(0, Math.min(100, rounded));
   }
+
+  exportPreset(presetId) {
+    const preset = this.getPresetById(Number(presetId));
+    if (!preset) {
+      return null;
+    }
+    return {
+      name: preset.name,
+      showInSidebar: preset.showInSidebar !== false,
+      purchaseSettings: Object.fromEntries(
+        Object.entries(preset.purchaseSettings).map(([key, value]) => [key, { ...value }])
+      ),
+      purchaseEnabled: !!preset.purchaseEnabled,
+      designSteps: preset.designSteps.map(step => ({
+        id: step.id,
+        mode: step.mode,
+        limit: step.limit,
+        entries: step.entries.map(entry => ({
+          id: entry.id,
+          attribute: entry.attribute,
+          weight: entry.weight,
+          cap: entry.cap,
+          capMode: entry.capMode,
+          zones: this.normalizeTemperatureZoneSettings(entry.zones)
+        }))
+      })),
+      deployImprovement: preset.deployImprovement,
+      designEnabled: !!preset.designEnabled
+    };
+  }
+
+  importPreset(presetData = {}) {
+    const id = this.nextPresetId++;
+    const purchaseSettings = this.createDefaultPurchaseSettings();
+    const savedSettings = presetData.purchaseSettings || {};
+    Object.keys(purchaseSettings).forEach(category => {
+      const setting = savedSettings[category] || {};
+      const threshold = this.normalizePurchaseThreshold(
+        Number(setting.threshold) || purchaseSettings[category].threshold
+      );
+      const maxCost = Number(setting.maxCost) || 0;
+      purchaseSettings[category] = {
+        enabled: !!setting.enabled,
+        threshold,
+        maxCost: maxCost > 0 ? maxCost : null
+      };
+    });
+    const steps = (presetData.designSteps || []).map(step => this.normalizeDesignStep(step));
+    const importedPreset = {
+      id,
+      name: presetData.name || `Preset ${id}`,
+      showInSidebar: presetData.showInSidebar !== false,
+      purchaseSettings,
+      purchaseEnabled: presetData.purchaseEnabled !== false,
+      designSteps: steps,
+      deployImprovement: Math.max(0, Math.floor(Number(presetData.deployImprovement) || 0)),
+      designEnabled: presetData.designEnabled !== false
+    };
+    this.presets.push(importedPreset);
+    this.activePresetId = importedPreset.id;
+    return importedPreset.id;
+  }
 }
 
 try {

--- a/src/js/automation/script-automation.js
+++ b/src/js/automation/script-automation.js
@@ -1106,4 +1106,46 @@ class ScriptAutomation {
     for (const key in value) clone[key] = this.deepClone(value[key]);
     return clone;
   }
+
+  exportScript(scriptId) {
+    const script = this.scripts.find(item => item.id === Number(scriptId));
+    if (!script) {
+      return null;
+    }
+    return this.deepClone(script);
+  }
+
+  importScript(scriptData = {}) {
+    const id = this.nextScriptId++;
+    const rawScript = {
+      id,
+      name: scriptData.name || `Script ${id}`,
+      lines: Array.isArray(scriptData.lines) && scriptData.lines.length
+        ? scriptData.lines.map(line => {
+            const oldId = line.id;
+            const newId = this.nextLineId++;
+            return { ...this.deepClone(line), id: newId, _oldId: oldId };
+          })
+        : [this.createLine('if')]
+    };
+    const lineIdMap = {};
+    rawScript.lines.forEach(line => {
+      if (line._oldId) {
+        lineIdMap[line._oldId] = line.id;
+      }
+      delete line._oldId;
+    });
+    rawScript.lines.forEach(line => {
+      line.linkedIfLineId = line.linkedIfLineId ? lineIdMap[line.linkedIfLineId] || null : null;
+    });
+    const normalizedScript = {
+      id: rawScript.id,
+      name: rawScript.name,
+      lines: rawScript.lines.map(line => this.normalizeLine(line))
+    };
+    this.normalizeLinkedElseLines(normalizedScript);
+    this.scripts.push(normalizedScript);
+    this.selectedScriptId = normalizedScript.id;
+    return normalizedScript.id;
+  }
 }

--- a/src/js/automation/spaceship-automation.js
+++ b/src/js/automation/spaceship-automation.js
@@ -1201,6 +1201,59 @@ class SpaceshipAutomation {
     this.ensureDefaultPreset();
     this.recordCurrentlyAvailableTargets();
   }
+
+  exportPreset(presetId) {
+    const preset = this.getPresetById(Number(presetId));
+    if (!preset) {
+      return null;
+    }
+    return {
+      name: preset.name,
+      showInSidebar: preset.showInSidebar !== false,
+      steps: preset.steps.map(step => ({
+        id: step.id,
+        limit: step.limit,
+        mode: step.mode,
+        entries: step.entries.map(entry => ({ ...entry }))
+      }))
+    };
+  }
+
+  importPreset(presetData = {}) {
+    const id = this.nextPresetId++;
+    const importedPreset = {
+      id,
+      name: presetData.name || `Preset ${id}`,
+      showInSidebar: presetData.showInSidebar !== false,
+      steps: Array.isArray(presetData.steps) ? presetData.steps.map(step => {
+        const lv = step.limit === null || step.limit === undefined ? null : this.sanitizeShipCount(Number(step.limit));
+        let mode = step.mode || 'fill';
+        if (mode !== 'cappedMin' && mode !== 'cappedMax' && mode !== 'remainingPercent' && lv === null) {
+          mode = 'cappedMax';
+        }
+        return {
+          id: step.id,
+          limit: (mode === 'cappedMin' || mode === 'cappedMax') ? null : (mode === 'remainingPercent'
+            ? (lv === null ? 100 : Math.min(Math.max(lv, 0), 100))
+            : lv),
+          mode,
+          entries: Array.isArray(step.entries) ? step.entries.map(entry => {
+            const weight = Number(entry.weight);
+            const max = Number(entry.max);
+            return {
+              projectId: entry.projectId,
+              weight: Number.isFinite(weight) && weight > 0 ? weight : 0,
+              max: Number.isFinite(max) && max > 0 ? max : null,
+              maxMode: entry.maxMode || 'absolute'
+            };
+          }) : []
+        };
+      }) : []
+    };
+    this.presets.push(importedPreset);
+    this.activePresetId = importedPreset.id;
+    return importedPreset.id;
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Feat: Automation sharing — export & import for life, ship, script, and global

  Automations had no way to be shared between saves or players. Each preset and
  script lived only in local state with no way out.

  ### What's new

  **Per-automation transfer buttons** are added to each automation panel:

  - **Life automation** — export/import individual presets by ID
  - **Ship automation** — export/import individual assignment presets by ID
  - **Script automation** — export/import individual scripts; line IDs are
    remapped on import to avoid collisions with existing scripts

  **Global toolbar** sits at the top of the automation tab with two buttons:

  - *Export All* — bundles every life preset, ship preset, and script into a
    single JSON payload copied to clipboard
  - *Import All* — accepts that same payload and merges everything in at once,
    skipping entries that already exist

  ### Styling

  The import dialog and all new buttons are fully styled with CSS classes (no
  inline styles), respecting both light and dark mode. The dialog overlay,
  window, textarea, action buttons, and status message each have dedicated
  classes following the existing automation stylesheet conventions.

May require a double check for styling since this PR is based on main and not the dark mode fixes one